### PR TITLE
Global binding

### DIFF
--- a/app/conode/config.go
+++ b/app/conode/config.go
@@ -123,7 +123,7 @@ func readHostFile(file string) ([]string, []string, error) {
 			return nil, nil, errors.New(fmt.Sprintf("Hostfile misformatted at line %s", ln))
 		}
 		// add it HOSTS -> PUBLIC KEY
-		h, err := cliutils.UpsertPort(spl[0], defs.DefaultPort)
+		h, err := cliutils.GlobalBind(spl[0], defs.DefaultPort)
 		if err != nil {
 			dbg.Fatal("Error reading address in host file :", spl[0], err)
 		}

--- a/app/conode/config.go
+++ b/app/conode/config.go
@@ -123,7 +123,7 @@ func readHostFile(file string) ([]string, []string, error) {
 			return nil, nil, errors.New(fmt.Sprintf("Hostfile misformatted at line %s", ln))
 		}
 		// add it HOSTS -> PUBLIC KEY
-		h, err := cliutils.GlobalBind(spl[0], defs.DefaultPort)
+		h, err := cliutils.VerifyPort(spl[0], defs.DefaultPort)
 		if err != nil {
 			dbg.Fatal("Error reading address in host file :", spl[0], err)
 		}

--- a/app/conode/conode.go
+++ b/app/conode/conode.go
@@ -9,7 +9,6 @@ import (
 	dbg "github.com/dedis/cothority/lib/debug_lvl"
 	"github.com/dedis/crypto/abstract"
 	"github.com/dedis/crypto/edwards"
-	"os/signal"
 )
 
 // Which suite to use
@@ -40,7 +39,6 @@ var commands []cli.Command = make([]cli.Command, 0)
 func registerCommand(com cli.Command) {
 	commands = append(commands, com)
 }
-
 
 func main() {
 	conode := cli.NewApp()
@@ -103,7 +101,7 @@ func KeyGeneration(key, address string) {
 	if address == "" {
 		dbg.Fatal("You must call keygen with ipadress !")
 	}
-	address, err := cliutils.UpsertPort(address, defs.DefaultPort)
+	address, err := cliutils.GlobalBind(address, defs.DefaultPort)
 	if err != nil {
 		dbg.Fatal(err)
 	}

--- a/app/conode/conode.go
+++ b/app/conode/conode.go
@@ -101,7 +101,7 @@ func KeyGeneration(key, address string) {
 	if address == "" {
 		dbg.Fatal("You must call keygen with ipadress !")
 	}
-	address, err := cliutils.GlobalBind(address, defs.DefaultPort)
+	address, err := cliutils.VerifyPort(address, defs.DefaultPort)
 	if err != nil {
 		dbg.Fatal(err)
 	}

--- a/app/conode/run.go
+++ b/app/conode/run.go
@@ -70,7 +70,7 @@ func RunServer(address string, conf *app.ConfigConode) {
 
 	var err error
 	// make sure address has a port or insert default one
-	address, err = cliutils.GlobalBind(address, defs.DefaultPort)
+	address, err = cliutils.VerifyPort(address, defs.DefaultPort)
 	if err != nil {
 		dbg.Fatal(err)
 	}

--- a/app/conode/run.go
+++ b/app/conode/run.go
@@ -70,7 +70,7 @@ func RunServer(address string, conf *app.ConfigConode) {
 
 	var err error
 	// make sure address has a port or insert default one
-	address, err = cliutils.UpsertPort(address, defs.DefaultPort)
+	address, err = cliutils.GlobalBind(address, defs.DefaultPort)
 	if err != nil {
 		dbg.Fatal(err)
 	}

--- a/app/conode/run_locally
+++ b/app/conode/run_locally
@@ -10,9 +10,8 @@ rm -rf $KEY_DIR
 mkdir $KEY_DIR
 
 for a in $( seq 1 $NUMBER ); do
-  PORT=$(( 20000 + $a * 10 ))
-  ./conode keygen localhost:$PORT
-   -key $KEYS$a
+  PORT=$(( 2000 + $a * 10 ))
+  ./conode keygen localhost:$PORT -key $KEYS$a
 done
 cat $KEYS*.pub >> $HOSTLIST
 

--- a/lib/cliutils/addresses.go
+++ b/lib/cliutils/addresses.go
@@ -17,10 +17,10 @@ func init() {
 	addressRegexp = regexp.MustCompile(`^[^:]*(:)(\d{1,5})?$`)
 }
 
-// Upsert port checks if an address contains a port. If it does not, it add the
+// Checks if an address contains a port. If it does not, it add the
 // given port to that and returns the new address. If it does, it returns
 // directly. Both operation checks if the port is correct.
-func UpsertPort(address, port string) (string, error) {
+func VerifyPort(address, port string) (string, error) {
 	// address does not contains a port
 	if subs := addressRegexp.FindStringSubmatch(address); len(subs) == 0 {
 		return address + ":" + port, checkPort(port)
@@ -33,12 +33,12 @@ func UpsertPort(address, port string) (string, error) {
 }
 
 // Returns the global-binding address
-func GlobalBind(address, port string)(string, error){
-	addr, err := UpsertPort(address, port)
-	if err != nil{
-		return "", err
+func GlobalBind(address string)(string, error){
+	addr := strings.Split(address, ":")
+	if len(addr) != 2 {
+		return "", errors.New("Not a host:port address")
 	}
-	return "0.0.0.0:" + strings.Split(addr, ":")[1], nil
+	return "0.0.0.0:" + addr[1], nil
 }
 
 // Simply returns an error if the port is invalid

--- a/lib/cliutils/addresses.go
+++ b/lib/cliutils/addresses.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 // This file handles manipulations of IP address with ports
@@ -29,6 +30,15 @@ func UpsertPort(address, port string) (string, error) {
 		return address, checkPort(subs[2])
 	}
 	return address, errors.New("Could not anaylze address ><")
+}
+
+// Returns the global-binding address
+func GlobalBind(address, port string)(string, error){
+	addr, err := UpsertPort(address, port)
+	if err != nil{
+		return "", err
+	}
+	return "0.0.0.0:" + strings.Split(addr, ":")[1], nil
 }
 
 // Simply returns an error if the port is invalid

--- a/lib/cliutils/addresses_test.go
+++ b/lib/cliutils/addresses_test.go
@@ -9,17 +9,17 @@ func TestUpsertPort(t *testing.T) {
 	medium := "abs:"
 	bad := "abs"
 	port := "1000"
-	if na, err := UpsertPort(good, port); err != nil {
+	if na, err := VerifyPort(good, port); err != nil {
 		t.Error("upsert should not gen any error", err)
 	} else if na != good {
 		t.Error("address should not have changed with a port number inside it")
 	}
-	if na, err := UpsertPort(medium, port); err != nil {
+	if na, err := VerifyPort(medium, port); err != nil {
 		t.Error("upsert should not gen any error", err)
 	} else if na != medium+port {
 		t.Error("address should generated is not correct: added port")
 	}
-	if na, err := UpsertPort(medium, port); err != nil {
+	if na, err := VerifyPort(medium, port); err != nil {
 		t.Error("upsert should not gen any error", err)
 	} else if na != bad+":"+port {
 		t.Error("address should generated is not correct: added port and :")

--- a/lib/coconet/tcphost.go
+++ b/lib/coconet/tcphost.go
@@ -12,6 +12,7 @@ import (
 	dbg "github.com/dedis/cothority/lib/debug_lvl"
 	"github.com/dedis/crypto/abstract"
 	"golang.org/x/net/context"
+	"github.com/dedis/cothority/lib/cliutils"
 )
 
 // Ensure that TCPHost satisfies the Host interface.
@@ -102,7 +103,11 @@ func (s *StringMarshaler) UnmarshalBinary(b []byte) error {
 func (h *TCPHost) Listen() error {
 	var err error
 	dbg.Lvl3("Starting to listen on", h.name)
-	ln, err := net.Listen("tcp4", h.name)
+	address, err := cliutils.GlobalBind(h.name)
+	if err != nil{
+		dbg.Fatal("Didn't get global binding for ", address, err)
+	}
+	ln, err := net.Listen("tcp4", address)
 	if err != nil {
 		log.Println("failed to listen:", err)
 		return err


### PR DESCRIPTION
Use 0.0.0.0 as binding address so we can run it more easy on virtual machines that have an internal private IP which is mapped to a public IP.