### PR TITLE
Exit upon validation

### DIFF
--- a/app/conode/README.md
+++ b/app/conode/README.md
@@ -8,7 +8,7 @@ signed hash together with the inclusion-proof.
 A simple program is given that can get the hash of a file signed and check
 the validity of a signature-file.
 
-## Limitations
+## Limitations / Disclaimer
 
 Some known limitations that we would like to address as soon as possible:
 
@@ -50,8 +50,8 @@ https://github.com/dedis/cothority/releases/latest
 
 and download the latest .tar.gz and untar it (replace with latest version)
 
-```wget http:///DeDiS/cothority/releases/download/0.5/conode-0.5.2.tar.gz
-tar xf conode-0.5.2.tar.gz```
+```wget http:///DeDiS/cothority/releases/download/0.5/conode-0.5.5.tar.gz
+tar xf conode-0.5.5.tar.gz```
 
 ### Create the keypair and validate the installation
 
@@ -70,15 +70,17 @@ running. If you want to quit the ```screen```, you can do so by typing
 
 ```screen -r conode```
 
+If everything goes well and your conode is active for at least 24h, it will 
+automatically exit, get the tree-information and start to run in
+conode-mode.
+
 ### Start your conode
 
-Once the installation has been verified, change back to the screen and abort
-the running conode with ```<ctrl>c```. Now you can run the real conode:
+Once the installation has been verified, it will change automatically into
+running mode. If at a later time you stop it and want to restart it, use
+the following command:
 
 ```./start-conode run```
-
-Because the ```config.toml``` which descsribes the other nodes is missing, it
-will download the newest package and install that one.
 
 ### Stamp some documents
 

--- a/app/conode/check.go
+++ b/app/conode/check.go
@@ -22,9 +22,21 @@ func init() {
 		Usage:       "Check a host to determine if it is a valid node to get incorporated into the cothority tree.",
 		Description: "It checks the public key given and the availability of the server. It will be contacted multiple times a day during 24 hours",
 		ArgsUsage:   "Public-key-file : file where reside the public key of the host to check",
+		Subcommands: []cli.Command{
+			{
+				Name:  "exit",
+				Usage: "Asks the remote node to exit",
+				Action: func(c *cli.Context) {
+					if c.Args().First() == "" {
+						dbg.Fatal("No public key file given for exit.")
+					}
+					CheckExit(c.Args().First())
+				},
+			},
+		},
 		Action: func(c *cli.Context) {
 			if c.Args().First() == "" {
-				dbg.Fatal("No public key file given !!")
+				dbg.Fatal("No public key file given for check.")
 			}
 			Check(c.Args().First())
 		},
@@ -34,18 +46,50 @@ func init() {
 
 // Main entry point for the check mode
 func Check(pubKeyFile string) {
+	// Verifies the remote host and returns the status
+	conn, ack := verifyHost(pubKeyFile)
+	defer conn.Close()
+
+	if err := suite.Write(conn, ack); err != nil {
+		dbg.Fatal("Error writing back the ACK : ", err)
+	}
+}
+
+// Main entry point for the check mode
+func CheckExit(pubKeyFile string) {
+	// Verifies the remote host and returns the status
+	conn, ack := verifyHost(pubKeyFile)
+	defer conn.Close()
+
+	// We only ask the node to exit if everything is OK
+	if ack.Code != SYS_OK{
+		dbg.Fatal("Not correct key-file?")
+	} else {
+		ack.Code = SYS_EXIT
+	}
+
+	// Finally send the message
+	dbg.Lvl1("Sending exit to node")
+	if err := suite.Write(conn, ack); err != nil {
+		dbg.Fatal("Error asking for exit : ", err)
+	}
+}
+
+// verifyHost will anaylze the systempacket information and verify the signature
+// It will return a ACK properly initialized with the right codes in it.
+func verifyHost(pubKeyFile string) (net.Conn, Ack ) {
 	//  get the right public key
 	pub, host, err := cliutils.ReadPubKey(suite, pubKeyFile)
 	if err != nil {
 		dbg.Fatal("Could not read the public key from the file : ", err)
 	}
 	dbg.Lvl1("Public key file read")
+
 	// Then get a connection
 	conn, err := net.Dial("tcp", host)
 	if err != nil {
 		dbg.Fatal("Error when getting the connection to the host : ", err)
 	}
-	defer conn.Close()
 
 	dbg.Lvl1("Verifier connected to the host. Validation in progress...")
 	// Get the system packet message
@@ -64,19 +108,6 @@ func Check(pubKeyFile string) {
 		dbg.Fatal("Error reading the signature :", err)
 	}
 
-	// analyse the results and send back the corresponding ack
-	ack := verifyHost(sys, sig, pub)
-	if err = suite.Write(conn, ack); err != nil {
-		dbg.Fatal("Error writing back the ACK : ", err)
-	}
-}
-
-// verifyHost will anaylze the systempacket information and verify the signature
-// Of course, it needs the public key to verify it
-// It will return a ACK properly initialized with the right codes in it.
-func verifyHost(sys SystemPacket, sig []byte, pub abstract.Point) Ack {
-	var ack Ack
-	ack.Type = TYPE_SYS
 	// First, encode the sys packet
 	var b bytes.Buffer
 	if err := suite.Write(&b, sys); err != nil {
@@ -84,9 +115,13 @@ func verifyHost(sys SystemPacket, sig []byte, pub abstract.Point) Ack {
 	}
 	X := make([]abstract.Point, 1)
 	X[0] = pub
+
 	// Verify signature
+	var ack Ack
+	ack.Type = TYPE_SYS
+	ack.Code = SYS_EXIT
 	if _, err := anon.Verify(suite, b.Bytes(), anon.Set(X), nil, sig); err != nil {
-		// Wrong sig ;(
+		// Wrong signature
 		ack.Code = SYS_WRONG_SIG
 		dbg.Lvl1("WARNING : signature provided is wrong.")
 	} else {
@@ -95,5 +130,5 @@ func verifyHost(sys SystemPacket, sig []byte, pub abstract.Point) Ack {
 		dbg.Lvl1("Host's signature verified and system seems healty. OK")
 	}
 
-	return ack
+	return conn, ack
 }

--- a/app/conode/conode.go
+++ b/app/conode/conode.go
@@ -62,11 +62,7 @@ func main() {
 		Usage:     "Create a new key pair and binding the public part to your address. ",
 		ArgsUsage: "ADRESS[:PORT] will be the address binded to the generated public key",
 		Action: func(c *cli.Context) {
-			if c.String("key") != "" {
-				KeyGeneration(c.String("key"), c.Args().First())
-			} else {
-				KeyGeneration(defaultKeyFile, c.Args().First())
-			}
+			KeyGeneration(c.String("key"), c.Args().First())
 		},
 		Flags: []cli.Flag{
 			cli.StringFlag{
@@ -102,6 +98,7 @@ func KeyGeneration(key, address string) {
 		dbg.Fatal("You must call keygen with ipadress !")
 	}
 	address, err := cliutils.VerifyPort(address, conode.DefaultPort)
+	dbg.Print("Address is", address)
 	if err != nil {
 		dbg.Fatal(err)
 	}

--- a/app/conode/packets.go
+++ b/app/conode/packets.go
@@ -10,11 +10,11 @@ type SystemPacket struct {
 }
 
 // A packet used to ACK a verification a protocol or whatever
-// It contains a first  Int to know of what kind of ACK are we talking about
+// It contains a first Int to know of what kind of ACK are we talking about
 // Then the second int represent the ACK status itself for this specific ACK
 type Ack struct {
-	Type int
-	Code int
+	Type int32
+	Code int32
 }
 
 // Theses consts represent the type of ACK we are reading
@@ -25,8 +25,9 @@ const (
 // These consts are there for meaningful interpretation of the reponse ACK after
 // an SystemPacket sent ;)
 const (
-	SYS_OK         = iota // everything is fine
-	SYS_WRONG_HOST        //hostname is not valid
+	SYS_OK = iota // everything is fine
+	SYS_WRONG_HOST        // hostname is not valid
 	SYS_WRONG_SOFT        // soft limits is not enough or wrong. See development team.
-	SYS_WRONG_SIG         // THe signature sent after systempacket is not valid
+	SYS_WRONG_SIG         // The signature sent after systempacket is not valid
+	SYS_EXIT    // Exit the program - should automatically update and run
 )

--- a/app/conode/start-conode
+++ b/app/conode/start-conode
@@ -14,6 +14,11 @@ main(){
     fi
     cat key.pub
     ./conode validate
+    if [ "$?" = "1" ]; then
+      echo Received exit-command - will update and run
+      update
+      exec ./start-conode run
+    fi
     ;;
   run)
     if [ ! -f config.toml ]; then

--- a/app/conode/start-conode
+++ b/app/conode/start-conode
@@ -8,7 +8,7 @@ main(){
   case "$1" in
   setup)
     if [ -f key.pub ]; then
-      echo "Key.pub already exists - if you want to re-create, please delete it first"
+      echo -e "\n*** Key.pub already exists - if you want to re-create, please delete it first\n"
     else
       ./conode keygen $2
     fi

--- a/lib/cliutils/addresses.go
+++ b/lib/cliutils/addresses.go
@@ -22,14 +22,18 @@ func init() {
 // directly. Both operation checks if the port is correct.
 func VerifyPort(address string, port int) (string, error) {
 	p := strconv.Itoa(port)
-	if subs := addressRegexp.FindStringSubmatch(address); len(subs) == 0 {
+	subs := addressRegexp.FindStringSubmatch(address)
+	switch{
+	case len(subs) == 0:
 		// address does not contain a port
 		return address + ":" + p, checkPort(port)
-	} else if len(subs) == 3 && subs[2] == "" { // we got a addres: style ..??
+	case len(subs) == 3 && subs[2] == "":
+		// we got a addres: style ..??
 		return address + p, checkPort(port)
-	} else if len(subs) == 3 { // we got full address already address:port
+	case len(subs) == 3:
+		// we got full address already address:port
 		sp, err := strconv.Atoi(subs[2])
-		if err != nil{
+		if err != nil {
 			return address, errors.New("Not a valid port-number given")
 		}
 		return address, checkPort(sp)

--- a/lib/cliutils/addresses_test.go
+++ b/lib/cliutils/addresses_test.go
@@ -2,27 +2,28 @@ package cliutils
 
 import (
 	"testing"
+	"strconv"
 )
 
-func TestUpsertPort(t *testing.T) {
+func TestVerifyPort(t *testing.T) {
 	good := "abs:104"
 	medium := "abs:"
 	bad := "abs"
-	port := "1000"
+	port := 1000
+	ports := strconv.Itoa(port)
 	if na, err := VerifyPort(good, port); err != nil {
-		t.Error("upsert should not gen any error", err)
+		t.Error("VerifyPort should not generate any error", err)
 	} else if na != good {
 		t.Error("address should not have changed with a port number inside it")
 	}
 	if na, err := VerifyPort(medium, port); err != nil {
-		t.Error("upsert should not gen any error", err)
-	} else if na != medium+port {
+		t.Error("VerifyPort should not gen any error", err)
+	} else if na != medium + ports {
 		t.Error("address should generated is not correct: added port")
 	}
-	if na, err := VerifyPort(medium, port); err != nil {
-		t.Error("upsert should not gen any error", err)
-	} else if na != bad+":"+port {
+	if na, err := VerifyPort(bad, port); err != nil {
+		t.Error("VerifyPort should not gen any error", err)
+	} else if na != bad + ":" + ports {
 		t.Error("address should generated is not correct: added port and :")
 	}
-
 }


### PR DESCRIPTION
Added a sub-command to ```conode check``` that allows the remote conode that is in validation-mode to exit, update the config.toml and restart.