### PR TITLE
checks the DebugVisible before creating the string

### DIFF
--- a/lib/debug_lvl/debug_lvl.go
+++ b/lib/debug_lvl/debug_lvl.go
@@ -55,6 +55,9 @@ func Lvld(lvl int, args ...interface{}) {
 	Lvl(lvl, args...)
 }
 func Lvl(lvl int, args ...interface{}) {
+	if lvl > DebugVisible {
+		return
+	}
 	pc, _, line, _ := runtime.Caller(3)
 	name := regexpPaths.ReplaceAllString(runtime.FuncForPC(pc).Name(), "")
 	lineStr := fmt.Sprintf("%d", line)
@@ -83,7 +86,9 @@ func Lvl(lvl int, args ...interface{}) {
 }
 
 func Lvlf(lvl int, f string, args ...interface{}) {
-	Lvl(lvl, fmt.Sprintf(f, args...))
+	if lvl > DebugVisible {
+		Lvl(lvl, fmt.Sprintf(f, args...))
+	}
 }
 
 func Print(args ...interface{}) {
@@ -158,11 +163,11 @@ func Panicf(f string, args ...interface{}) {
 // Just add an additional "L" in front, and remove it later:
 // - easy hack to turn on other debug-messages
 // - easy removable by searching/replacing 'LLvl' with 'Lvl'
-func LLvl1(args ...interface{})            { Lvl(-1, args...) }
-func LLvl2(args ...interface{})            { Lvl(-1, args...) }
-func LLvl3(args ...interface{})            { Lvl(-1, args...) }
-func LLvl4(args ...interface{})            { Lvl(-1, args...) }
-func LLvl5(args ...interface{})            { Lvl(-1, args...) }
+func LLvl1(args ...interface{}) { Lvl(-1, args...) }
+func LLvl2(args ...interface{}) { Lvl(-1, args...) }
+func LLvl3(args ...interface{}) { Lvl(-1, args...) }
+func LLvl4(args ...interface{}) { Lvl(-1, args...) }
+func LLvl5(args ...interface{}) { Lvl(-1, args...) }
 func LLvlf1(f string, args ...interface{}) { Lvlf(-1, f, args...) }
 func LLvlf2(f string, args ...interface{}) { Lvlf(-1, f, args...) }
 func LLvlf3(f string, args ...interface{}) { Lvlf(-1, f, args...) }
@@ -182,14 +187,9 @@ func (f *DebugLvl) Format(entry *logrus.Entry) ([]byte, error) {
 
 		if Testing {
 			fmt.Print(b)
-			return nil, nil
 		} else {
 			return b.Bytes(), nil
 		}
-	} else {
-		if len(entry.Message) > 2048 && DebugVisible > 1 {
-			fmt.Printf("%d: (%s) - HUGE message of %d bytes not printed\n", lvl, caller, len(entry.Message))
-		}
-		return nil, nil
 	}
+	return nil, nil
 }

--- a/lib/debug_lvl/debug_lvl_test.go
+++ b/lib/debug_lvl/debug_lvl_test.go
@@ -9,15 +9,16 @@ func init(){
 }
 
 func ExampleLevel2() {
+	dbg.DebugVisible = 2
 	dbg.Lvl1("Level1")
-	dbg.Lvl3("Level2")
-	dbg.Lvl4("Level3")
+	dbg.Lvl2("Level2")
+	dbg.Lvl3("Level3")
 	dbg.Lvl4("Level4")
 	dbg.Lvl5("Level5")
 
 	// Output:
-	// 1: (            debug_lvl_test.ExampleLevel2: 0) - Level1
-	// 2: (            debug_lvl_test.ExampleLevel2: 0) - Level2
+	// 1: (            debug_lvl_test.ExampleLevel2:   0) - Level1
+	// 2: (            debug_lvl_test.ExampleLevel2:   0) - Level2
 }
 
 func thisIsAVeryLongFunctionNameThatWillOverflow(){
@@ -30,9 +31,9 @@ func ExampleLongFunctions() {
 	dbg.Lvl1("After")
 
 	// Output:
-	// 1: (     debug_lvl_test.ExampleLongFunctions: 0) - Before
-	// 1: (debug_lvl_test.thisIsAVeryLongFunctionNameThatWillOverflow: 0) - Overflow
-	// 1: (                       debug_lvl_test.ExampleLongFunctions: 0) - After
+	// 1: (     debug_lvl_test.ExampleLongFunctions:   0) - Before
+	// 1: (debug_lvl_test.thisIsAVeryLongFunctionNameThatWillOverflow:   0) - Overflow
+	// 1: (                       debug_lvl_test.ExampleLongFunctions:   0) - After
 }
 
 func ExampleLongFunctionsLimit() {
@@ -42,7 +43,7 @@ func ExampleLongFunctionsLimit() {
 	dbg.Lvl1("After")
 
 	// Output:
-	// 1: (debug_lvl_test.ExampleLongFunctionsLimit: 0) - Before
-	// 1: (debug_lvl_test.thisIsAVeryLongFunctionNameThatWillOverflow: 0) - Overflow
-	// 1: (debug_lvl_test.ExampleLongFunctionsLimit: 0) - After
+	// 1: (debug_lvl_test.ExampleLongFunctionsLimit:   0) - Before
+	// 1: (debug_lvl_test.thisIsAVeryLongFunctionNameThatWillOverflow:   0) - Overflow
+	// 1: (debug_lvl_test.ExampleLongFunctionsLimit:   0) - After
 }


### PR DESCRIPTION
Rewrote debug_lvl so that the functions return directly when the debug-level is lower than what is asked for. Before it created the string and only then did the check. But if the string is big (or huge, like printing the host-list of 8192 hosts...), this can delay a lot.