### PR TITLE
fixes issue #141: `dbg.Errorf()` no longer `os.Exit()`s

### DIFF
--- a/lib/dbg/debug_lvl.go
+++ b/lib/dbg/debug_lvl.go
@@ -153,7 +153,6 @@ func Fatalf(f string, args ...interface{}) {
 
 func Errorf(f string, args ...interface{}) {
 	Lvlf(0, f, args...)
-	os.Exit(1)
 }
 
 func Warnf(f string, args ...interface{}) {


### PR DESCRIPTION
should not have any side effects: `dbg.Errorf()` currently isn't used at all