### PR TITLE
Check with simulation node

### DIFF
--- a/protocols/cosi/cosi.go
+++ b/protocols/cosi/cosi.go
@@ -50,8 +50,6 @@ type ProtocolCosi struct {
 	tempResponseLock *sync.Mutex
 	DoneCallback     func(chal abstract.Secret, response abstract.Secret)
 
-	// SIMULATION PURPOSE - do we need to verify the response or not
-	verifyResponse int
 	// hooks related to the various phase of the protocol.
 	// XXX NOT DEPLOYED YET / NOT IN USE.
 	// announcement hook
@@ -136,9 +134,8 @@ func (pc *ProtocolCosi) StartAnnouncement() error {
 	announcement := pc.Cosi.CreateAnnouncement()
 
 	out := &CosiAnnouncement{
-		From:           pc.treeNodeId,
-		VerifyResponse: pc.verifyResponse,
-		Announcement:   announcement,
+		From:         pc.treeNodeId,
+		Announcement: announcement,
 	}
 
 	return pc.sendAnnouncement(out)
@@ -167,10 +164,6 @@ func (pc *ProtocolCosi) handleAnnouncement(in *CosiAnnouncement) error {
 		From:         pc.treeNodeId,
 		Announcement: announcement,
 	}
-
-	// SIMULATION PURPOSE
-	pc.verifyResponse = in.VerifyResponse
-	out.VerifyResponse = in.VerifyResponse
 
 	// send the output to children
 	return pc.sendAnnouncement(out)
@@ -343,15 +336,15 @@ func (pc *ProtocolCosi) handleResponse(in *CosiResponse) error {
 	}
 
 	// Simulation feature => time the verification process.
-	if (pc.verifyResponse == 1 && pc.IsRoot()) || pc.verifyResponse == 2 {
-		dbg.Lvl3(pc.Name(), "(root=", pc.IsRoot(), ") Doing Response verification", pc.verifyResponse)
+	if (VerifyResponse == 1 && pc.IsRoot()) || VerifyResponse == 2 {
+		dbg.Lvl3(pc.Name(), "(root=", pc.IsRoot(), ") Doing Response verification", VerifyResponse)
 		// verify the responses at each level with the aggregate public key of this
 		// subtree.
 		if err := pc.Cosi.VerifyResponses(pc.TreeNode().PublicAggregateSubTree); err != nil {
 			return fmt.Errorf("%s Verifcation of responses failed:%s", pc.Name(), err)
 		}
 	} else {
-		dbg.Lvl3(pc.Name(), "(root=", pc.IsRoot(), ") Skipping Response verification", pc.verifyResponse)
+		dbg.Lvl3(pc.Name(), "(root=", pc.IsRoot(), ") Skipping Response verification", VerifyResponse)
 	}
 
 	out := &CosiResponse{

--- a/protocols/cosi/packets.go
+++ b/protocols/cosi/packets.go
@@ -11,21 +11,16 @@ import (
 
 // The main messages used by CoSi
 
+// see https://github.com/dedis/cothority/issues/260
+// 0 - no check at all
+// 1 - check only at root
+// 2 - check at each level of the tree
+var VerifyResponse = 1
+
 // Broadcasted message initiated and signed by proposer
 type CosiAnnouncement struct {
 	// From = TreeNodeId in the Tree
 	From uuid.UUID
-	// Tells to the node whether they should make the verification or not
-	// XXX XXX UGLY HACK XXX XXX
-	// Is to be removed during the next versions of SDA. Need that for the
-	// moment because no way to have external configuration for the intermediate
-	// and leaf nodes.
-	// see https://github.com/dedis/cothority/issues/260
-	// 0 - no check at all
-	// 1 - check only at root
-	// 2 - check at each level of the tree
-	VerifyResponse int
-
 	*cosi.Announcement
 }
 

--- a/protocols/cosi/simulation.go
+++ b/protocols/cosi/simulation.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	sda.SimulationRegister("CoSiSimulation", NewCoSiSimulation)
+	sda.SimulationRegister("CoSi", NewCoSiSimulation)
 	// default protocol initialization. See Run() for override this one for the
 	// root.
 	sda.ProtocolRegisterName("ProtocolCosi", func(node *sda.Node) (sda.ProtocolInstance, error) { return NewProtocolCosi(node) })
@@ -40,6 +40,15 @@ func (cs *CoSiSimulation) Setup(dir string, hosts []string) (*sda.SimulationConf
 	return sim, err
 }
 
+func (cs *CoSiSimulation) Node(sc *sda.SimulationConfig) error {
+	err := cs.SimulationBFTree.Node(sc)
+	if err != nil {
+		return err
+	}
+	VerifyResponse = cs.Checking
+	return nil
+}
+
 func (cs *CoSiSimulation) Run(config *sda.SimulationConfig) error {
 	size := len(config.EntityList.List)
 	msg := []byte("Hello World Cosi Simulation")
@@ -55,8 +64,6 @@ func (cs *CoSiSimulation) Run(config *sda.SimulationConfig) error {
 		}
 		// the protocol itself
 		proto := node.ProtocolInstance().(*ProtocolCosi)
-		// verification check
-		proto.verifyResponse = cs.Checking
 		// give the message to sign
 		proto.SigningMessage(msg)
 		// tell us when it is done

--- a/simul/platform/localhost.go
+++ b/simul/platform/localhost.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/dedis/cothority/lib/cliutils"
 	"github.com/dedis/cothority/lib/dbg"
-	"github.com/dedis/cothority/lib/monitor"
 	"github.com/dedis/cothority/lib/sda"
 	_ "github.com/dedis/cothority/protocols"
 	"strings"
@@ -54,6 +53,9 @@ type Localhost struct {
 	// errors go here:
 	errChan chan error
 
+	// Listening monitor port
+	monitorPort int
+
 	// SimulationConfig holds all things necessary for the run
 	sc *sda.SimulationConfig
 }
@@ -65,6 +67,7 @@ func (d *Localhost) Configure(pc *PlatformConfig) {
 	d.localDir = pwd
 	d.debug = pc.Debug
 	d.running = false
+	d.monitorPort = pc.MonitorPort
 	d.errChan = make(chan error)
 	if d.Simulation == "" {
 		dbg.Fatal("No simulation defined in simulation")
@@ -158,7 +161,7 @@ func (d *Localhost) Start(args ...string) error {
 		dbg.Lvl3("Starting", index)
 		host := "localhost" + strconv.Itoa(index)
 		cmdArgs := []string{"-address", host, "-monitor",
-			"localhost:" + strconv.Itoa(monitor.DefaultSinkPort),
+			"localhost:" + strconv.Itoa(d.monitorPort),
 			"-simul", d.Simulation,
 			"-debug", strconv.Itoa(dbg.DebugVisible()),
 		}

--- a/simul/runfiles/cosi_simple.toml
+++ b/simul/runfiles/cosi_simple.toml
@@ -1,4 +1,4 @@
-Simulation = "CoSiSimulation"
+Simulation = "CoSi"
 Servers = 16
 Bf = 8
 Rounds = 10

--- a/simul/runfiles/test_cosi.toml
+++ b/simul/runfiles/test_cosi.toml
@@ -1,4 +1,4 @@
-Simulation = "CoSiSimulation"
+Simulation = "CoSi"
 Servers = 16
 Bf = 4
 Rounds = 10

--- a/simul/runfiles/test_cosi_depth.toml
+++ b/simul/runfiles/test_cosi_depth.toml
@@ -1,4 +1,4 @@
-Simulation = "CoSiSimulation"
+Simulation = "CoSi"
 Servers = 16
 Bf = 4
 Rounds = 10

--- a/simul/runfiles/test_cosi_verification.toml
+++ b/simul/runfiles/test_cosi_verification.toml
@@ -1,0 +1,10 @@
+Servers = 8
+Simulation = "CoSi"
+Rounds = 5
+Depth = 3
+BF = 4
+
+Checking
+0
+1
+2

--- a/simul/simul.go
+++ b/simul/simul.go
@@ -168,6 +168,7 @@ func RunTest(rc platform.RunConfig) (monitor.Stats, error) {
 		dbg.Error(err)
 		return *rs, err
 	}
+	monitor.SinkPort = monitorPort
 	go func() {
 		if err := monitor.Listen(); err != nil {
 			dbg.Fatal("Could not monitor.Listen():", err)


### PR DESCRIPTION
Just as an example of how to use `Simulation.Node` - here I use a global variable in `lib/cosi` for the verification setting, which is of course not the very best way to do. But `Simulation.Node` is called before the Node is started. Should perhaps be renamed to `Simulation.Host` or `Simulation.Overlay`.