### PR TITLE
Asynchronous message handling

### DIFF
--- a/lib/sda/export_test.go
+++ b/lib/sda/export_test.go
@@ -48,3 +48,11 @@ func (o *Overlay) TokenToNode(tok *Token) (*Node, bool) {
 	v, ok := o.nodes[tok.Id()]
 	return v, ok
 }
+
+func NewDispatcher(dispatch dispatchMethod) *dispatcher {
+	return newDispatcher(dispatch)
+}
+
+func (d *dispatcher) Run() {
+	d.run()
+}

--- a/lib/sda/local.go
+++ b/lib/sda/local.go
@@ -159,7 +159,12 @@ func (l *LocalTest) NewNode(tn *TreeNode, protName string) (*Node, error) {
 		TreeNodeID:   tn.Id,
 		RoundID:      uuid.NewV4(),
 	}
-	return NewNode(o, tok)
+	o.nodeLock.Lock()
+	defer o.nodeLock.Unlock()
+	n, err := NewNode(o, tok)
+	o.nodes[n.token.Id()] = n
+	o.nodeInfo[n.token.Id()] = false
+	return n, err
 }
 
 // GetNodes returns all Nodes that belong to a treeNode

--- a/lib/sda/node.go
+++ b/lib/sda/node.go
@@ -313,7 +313,7 @@ func (n *Node) DispatchChannel(msgSlice []*SDAData) error {
 	return nil
 }
 
-// DispatchMsg will dispatch this SDAData to the right instance
+// DispatchMsg will dispatch this SDAData to the protocol instance.
 func (n *Node) DispatchMsg(sdaMsg *SDAData) error {
 	// Decode the inner message here. In older versions, it was decoded before,
 	// but first there is no use to do it before, and then every protocols had

--- a/lib/sda/node.go
+++ b/lib/sda/node.go
@@ -618,6 +618,9 @@ func (w *worker) run() {
 	var stop bool
 	for !stop {
 		w.readyChan <- true
+		if stop {
+			break
+		}
 		select {
 		case msg := <-w.msgChan:
 			// this is the blocking function

--- a/lib/sda/node.go
+++ b/lib/sda/node.go
@@ -38,6 +38,8 @@ type Node struct {
 	// dispatcher of the messages so overlay can give message to node without
 	// blocking even if the overlaying protocol is still blocking.
 	dispatcher *dispatcher
+	// done boolen flag to know if this node has already been closed or not
+	done bool
 }
 
 // AggregateMessages (if set) tells to aggregate messages from all children
@@ -424,6 +426,9 @@ func (n *Node) Start() error {
 // Done returns a channel that must be given a bool when a protocol instance has
 // finished its work.
 func (n *Node) Done() {
+	if n.done {
+		return
+	}
 	if n.onDoneCallback != nil {
 		ok := n.onDoneCallback()
 		if !ok {
@@ -433,6 +438,7 @@ func (n *Node) Done() {
 	n.overlay.nodeDone(n.token)
 	n.dispatcher.stop()
 	dbg.Lvl3(n.Name(), "has finished. Deleting its resources")
+	n.done = true
 }
 
 // OnDoneCallback should be called if we want to control the Done() of the node.

--- a/lib/sda/node_test.go
+++ b/lib/sda/node_test.go
@@ -1,19 +1,19 @@
 package sda_test
 
 import (
-	"testing"
-	"time"
-
 	"github.com/dedis/cothority/lib/dbg"
 	"github.com/dedis/cothority/lib/network"
 	"github.com/dedis/cothority/lib/sda"
 	"github.com/dedis/cothority/protocols/manage"
 	"github.com/satori/go.uuid"
+	"testing"
+	"time"
 )
 
 func init() {
 	sda.ProtocolRegisterName("ProtocolChannels", NewProtocolChannels)
 	sda.ProtocolRegisterName("ProtocolHandlers", NewProtocolHandlers)
+	sda.ProtocolRegisterName("ProtocolBlocking", NewProtocolBlocking)
 	sda.ProtocolRegister(testID, NewProtocolTest)
 	Incoming = make(chan struct {
 		*sda.TreeNode
@@ -391,4 +391,137 @@ func (p *ProtocolHandlers) Dispatch() error {
 // relese ressources ==> call Done()
 func (p *ProtocolHandlers) Release() {
 	p.Done()
+}
+
+func TestProtocolBlocking(t *testing.T) {
+	defer dbg.AfterTest(t)
+
+	dbg.TestOutput(testing.Verbose(), 4)
+	h1, h2 := SetupTwoHosts(t, true)
+	defer h1.Close()
+	defer h2.Close()
+	// Add tree + entitylist
+	el := sda.NewEntityList([]*network.Entity{h1.Entity, h2.Entity})
+	h1.AddEntityList(el)
+	tree := el.GenerateBinaryTree()
+	h1.AddTree(tree)
+	h1.StartProcessMessages()
+
+	// Try directly StartNewProtocol
+	n1, err := h1.StartNewNodeName("ProtocolBlocking", tree)
+	if err != nil {
+		t.Fatal("Couldn't start protocol:", err)
+	}
+	n2, err := h1.StartNewNodeName("ProtocolBlocking", tree)
+	if err != nil {
+		t.Fatal("Couldn't start protocol:", err)
+	}
+
+	bp1 := n1.ProtocolInstance().(*BlockingProtocol)
+	bp2 := n2.ProtocolInstance().(*BlockingProtocol)
+
+	// checking function
+	var done = make(chan bool)
+	go func() {
+		for {
+			var done1 bool
+			var done2 bool
+			select {
+			case <-bp1.doneChan:
+				done1 = true
+				if !done2 {
+					t.Fatal("Node 1 should not have finished already")
+				} else {
+					done <- true
+					return
+				}
+			case <-bp2.doneChan:
+				done2 = true
+				if done1 {
+					t.Fatal("Node 2 should finish before node 1")
+				}
+				// release the blocking of node1
+				bp1.stopBlockChan <- true
+			}
+		}
+	}()
+
+	// say bp2 does not block
+	bp2.stopBlockChan <- true
+
+	// Send one message to n1
+	// bp1 should still block
+	network.RegisterMessageType(NodeTestMsg{})
+	slice, err := network.MarshalRegisteredType(&NodeTestMsg{3})
+	if err != nil {
+		t.Fatal("error for creating slice")
+	}
+
+	err = n1.DispatchMsg(&sda.SDAData{
+		MsgSlice: slice,
+		From: &sda.Token{
+			TreeID:     tree.Id,
+			TreeNodeID: tree.Root.Id,
+		}})
+	if err != nil {
+		t.Fatal("Could not send message to bp1")
+	}
+	// send one message to n2
+	// bp2 is already non blocking so it should go straight to bp2
+	err = n1.DispatchMsg(&sda.SDAData{
+		MsgSlice: slice,
+		From: &sda.Token{
+			TreeID:     tree.Id,
+			TreeNodeID: tree.Root.Id,
+		}})
+	if err != nil {
+		t.Fatal("Could not send message to bp2")
+	}
+	// wait the confirmation
+	select {
+	case <-done:
+		return
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Could not get protocols blocking working ..")
+	}
+}
+
+// BlockingProtocol is a protocol that will block until it receives a "continue"
+// signal on the continue channel. It is used for testing the asynchronous
+// & non blocking handling of the messages in sda.
+type BlockingProtocol struct {
+	*sda.Node
+	// the protocol will signal on this channel that it is done
+	doneChan chan bool
+	// stopBLockChan is used to signal the protocol to stop blocking the
+	// incoming messages on the Incoming chan
+	stopBlockChan chan bool
+}
+
+// this channel is used to tell to all the blocking protocols to finish
+var continueChan = make(chan bool)
+
+func NewProtocolBlocking(node *sda.Node) (sda.ProtocolInstance, error) {
+	bp := &BlockingProtocol{
+		Node:          node,
+		doneChan:      make(chan bool),
+		stopBlockChan: make(chan bool),
+	}
+
+	node.RegisterChannel(Incoming)
+	return bp, nil
+}
+
+func (bp *BlockingProtocol) Start() error {
+	return nil
+}
+
+func (bp *BlockingProtocol) Dispatch() error {
+	// first wait on stopBlockChan
+	<-bp.stopBlockChan
+	// Then wait on the actual message
+	<-Incoming
+	// then signal that you are done
+	bp.doneChan <- true
+	return nil
 }

--- a/lib/sda/node_test.go
+++ b/lib/sda/node_test.go
@@ -425,7 +425,6 @@ func TestProtocolBlocking(t *testing.T) {
 	go func() {
 		var done1 bool
 		var done2 bool
-
 		for {
 			select {
 			case <-bp1.doneChan:
@@ -435,8 +434,6 @@ func TestProtocolBlocking(t *testing.T) {
 				if !done2 {
 					t.Fatal("Node 1 should not have finished already")
 				} else {
-					n1.Done()
-					n2.Done()
 					done <- true
 					return
 				}

--- a/lib/sda/overlay.go
+++ b/lib/sda/overlay.go
@@ -85,10 +85,7 @@ func (o *Overlay) TransmitMsg(sdaMsg *SDAData) error {
 		return nil
 	}
 	o.nodeLock.Unlock()
-	err := node.DispatchMsg(sdaMsg)
-	if err != nil {
-		return err
-	}
+	node.DispatchMsg(sdaMsg)
 	return nil
 }
 

--- a/lib/sda/overlay.go
+++ b/lib/sda/overlay.go
@@ -280,6 +280,7 @@ func (o *Overlay) Close() {
 	o.nodeLock.RLock()
 	defer o.nodeLock.RUnlock()
 	for _, n := range o.nodes {
+		n.Done()
 		if err := n.ProtocolInstance().Shutdown(); err != nil {
 			dbg.Error("Error shutting down protocol", err)
 		}


### PR DESCRIPTION
Finally !
The incoming network messages are now buffered in the node and then dispatched as soon as possible to the protocol instance of the node.
Some might say "why don't just use buffered channel", well, you might be right BUT:
* With this approach we don't allocate as more than we need, and we can actually control our allocation if let's say there was a burst at some point, allocated a huge amount of memory, then it went back to normal, we *could* reduce the amount of memory by just taking a smaller chunk of the buffer and let the GC doing its job.
* It's inspired from [here](http://marcio.io/2015/07/handling-1-million-requests-per-minute-with-golang/). I kinda like their approach and took a simplified version. But in the long run, for all the messages that we are going to have (external api + tree/list handling + *many* protocol instances etc), it might make sense to implement something like this at a more lower level, at host.go with many *workers* doing the dispatching. So I see it as a training!
* I had fun doing it even if there was one ***** stupid bug.


If at any point you feel this is **overkill**, please **say so**! I am also OK to use a buffered channel and checking the `len(channel)` each time a new message arrives. Actually I did not know about the fact that we can query the actual *length* of a buffered channel before the jogging of this afternoon... :)