### PR TITLE
changed name to reflect default nowait

### DIFF
--- a/cothority.go
+++ b/cothority.go
@@ -66,7 +66,7 @@ func main() {
 	if err != nil {
 		dbg.Fatal("Couldn't get host:", err)
 	}
-	host.ListenAndWait()
+	host.ListenAndBind()
 	host.StartProcessMessages()
 	host.WaitForClose()
 }

--- a/cothority.go
+++ b/cothority.go
@@ -66,7 +66,7 @@ func main() {
 	if err != nil {
 		dbg.Fatal("Couldn't get host:", err)
 	}
-	host.Listen()
+	host.ListenAndWait()
 	host.StartProcessMessages()
 	host.WaitForClose()
 }

--- a/lib/sda/host.go
+++ b/lib/sda/host.go
@@ -180,10 +180,10 @@ func (h *Host) listen(wait bool) {
 	}
 }
 
-// ListenAndWait starts listening and returns once it could connect to itself.
+// ListenAndBind starts listening and returns once it could connect to itself.
 // This can fail in the case of running inside a container or virtual machine
 // using port-forwarding to an internal IP.
-func (h *Host) ListenAndWait() {
+func (h *Host) ListenAndBind() {
 	h.listen(true)
 }
 
@@ -551,7 +551,7 @@ func SetupHostsMock(s abstract.Suite, addresses ...string) []*Host {
 	var hosts []*Host
 	for _, add := range addresses {
 		h := newHostMock(s, add)
-		h.ListenAndWait()
+		h.ListenAndBind()
 		h.StartProcessMessages()
 		hosts = append(hosts, h)
 	}

--- a/lib/sda/host.go
+++ b/lib/sda/host.go
@@ -180,14 +180,16 @@ func (h *Host) listen(wait bool) {
 	}
 }
 
-// Listen starts listening and returns once it could connect to itself
-func (h *Host) Listen() {
+// ListenAndWait starts listening and returns once it could connect to itself.
+// This can fail in the case of running inside a container or virtual machine
+// using port-forwarding to an internal IP.
+func (h *Host) ListenAndWait() {
 	h.listen(true)
 }
 
-// ListenNoblock only starts listening and returns without waiting for the
-// listening to be active
-func (h *Host) ListenNoblock() {
+// Listen only starts listening and returns without waiting for the
+// listening to be active.
+func (h *Host) Listen() {
 	h.listen(false)
 }
 
@@ -549,7 +551,7 @@ func SetupHostsMock(s abstract.Suite, addresses ...string) []*Host {
 	var hosts []*Host
 	for _, add := range addresses {
 		h := newHostMock(s, add)
-		h.Listen()
+		h.ListenAndWait()
 		h.StartProcessMessages()
 		hosts = append(hosts, h)
 	}

--- a/lib/sda/host_test.go
+++ b/lib/sda/host_test.go
@@ -31,7 +31,7 @@ func TestHostClose(t *testing.T) {
 	dbg.TestOutput(testing.Verbose(), 4)
 	h1 := sda.NewLocalHost(2000)
 	h2 := sda.NewLocalHost(2001)
-	h1.Listen()
+	h1.ListenAndWait()
 	_, err := h2.Connect(h1.Entity)
 	if err != nil {
 		t.Fatal("Couldn't Connect()", err)
@@ -46,7 +46,7 @@ func TestHostClose(t *testing.T) {
 	}
 	dbg.Lvl3("Finished first connection, starting 2nd")
 	h3 := sda.NewLocalHost(2002)
-	h3.Listen()
+	h3.ListenAndWait()
 	c, err := h2.Connect(h3.Entity)
 	if err != nil {
 		t.Fatal(h2, "Couldn Connect() to", h3)
@@ -365,7 +365,7 @@ func TestAutoConnection(t *testing.T) {
 	dbg.TestOutput(testing.Verbose(), 4)
 	h1 := sda.NewLocalHost(2000)
 	h2 := sda.NewLocalHost(2001)
-	h2.Listen()
+	h2.ListenAndWait()
 
 	defer h1.Close()
 	defer h2.Close()

--- a/lib/sda/host_test.go
+++ b/lib/sda/host_test.go
@@ -31,7 +31,7 @@ func TestHostClose(t *testing.T) {
 	dbg.TestOutput(testing.Verbose(), 4)
 	h1 := sda.NewLocalHost(2000)
 	h2 := sda.NewLocalHost(2001)
-	h1.ListenAndWait()
+	h1.ListenAndBind()
 	_, err := h2.Connect(h1.Entity)
 	if err != nil {
 		t.Fatal("Couldn't Connect()", err)
@@ -46,7 +46,7 @@ func TestHostClose(t *testing.T) {
 	}
 	dbg.Lvl3("Finished first connection, starting 2nd")
 	h3 := sda.NewLocalHost(2002)
-	h3.ListenAndWait()
+	h3.ListenAndBind()
 	c, err := h2.Connect(h3.Entity)
 	if err != nil {
 		t.Fatal(h2, "Couldn Connect() to", h3)
@@ -365,7 +365,7 @@ func TestAutoConnection(t *testing.T) {
 	dbg.TestOutput(testing.Verbose(), 4)
 	h1 := sda.NewLocalHost(2000)
 	h2 := sda.NewLocalHost(2001)
-	h2.ListenAndWait()
+	h2.ListenAndBind()
 
 	defer h1.Close()
 	defer h2.Close()

--- a/lib/sda/local.go
+++ b/lib/sda/local.go
@@ -257,7 +257,7 @@ func GenLocalHosts(n int, connect bool, processMessages bool) []*Host {
 	}
 	root := hosts[0]
 	for _, host := range hosts {
-		host.Listen()
+		host.ListenAndWait()
 		dbg.Lvl3("Listening on", host.Entity.First(), host.Entity.Id)
 		if processMessages {
 			host.StartProcessMessages()

--- a/lib/sda/local.go
+++ b/lib/sda/local.go
@@ -257,7 +257,7 @@ func GenLocalHosts(n int, connect bool, processMessages bool) []*Host {
 	}
 	root := hosts[0]
 	for _, host := range hosts {
-		host.ListenAndWait()
+		host.ListenAndBind()
 		dbg.Lvl3("Listening on", host.Entity.First(), host.Entity.Id)
 		if processMessages {
 			host.StartProcessMessages()

--- a/simul/cothority/cothority.go
+++ b/simul/cothority/cothority.go
@@ -62,7 +62,7 @@ func main() {
 		host := sc.Host
 		measures[i] = monitor.NewCounterIOMeasure("bandwidth", host)
 		dbg.Lvl3(hostAddress, "Starting host", host.Entity.Addresses)
-		host.ListenNoblock()
+		host.Listen()
 		host.StartProcessMessages()
 		sim, err := sda.NewSimulation(simul, sc.Config)
 		if err != nil {


### PR DESCRIPTION
As we saw in the case of `cosi_cli`, it can be confusing to have a `host.Listen` that waits to be able to connect to itself. So this does rename

- `host.Listen` to `host.ListenAndWait`
- `host.ListenNoBlock` to `host.Listen`