### PR TITLE
Merging `lib/crypto` from `cosi_cli` to `development`

### DIFF
--- a/lib/crypto/crypto_doc.go
+++ b/lib/crypto/crypto_doc.go
@@ -1,0 +1,13 @@
+// Package crypto offers some functions that are often used in our code.
+//
+// hash.go provides some utilities regarding the hashing of bytes, files or
+// stream. The most common way to use it is to call:
+// `HashStream(sha256.New(),stream)`. It will stream the input into the hash
+// function by chunks and output the final hash.
+//
+// schnorr.go provides some crypto-shortcuts: Schnorr signature and a Hash-function.
+// See https://en.wikipedia.org/wiki/Schnorr_signature
+//
+// It provides a way to sign a message using a private key and to verify the
+// signature using the public counter part.
+package crypto

--- a/lib/crypto/crypto_test.go
+++ b/lib/crypto/crypto_test.go
@@ -1,0 +1,16 @@
+package crypto_test
+
+import (
+	"flag"
+	"github.com/dedis/cothority/lib/dbg"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	dbg.TestOutput(testing.Verbose(), 4)
+	code := m.Run()
+	dbg.AfterTest(nil)
+	os.Exit(code)
+}

--- a/lib/crypto/hash.go
+++ b/lib/crypto/hash.go
@@ -1,0 +1,117 @@
+package crypto
+
+import (
+	"bytes"
+	"encoding"
+	"errors"
+	"fmt"
+	"github.com/dedis/cothority/lib/dbg"
+	"github.com/dedis/crypto/abstract"
+	h "hash"
+	"io"
+	"os"
+)
+
+// Hash simply returns the Hash of the slice of bytes given
+func Hash(hash h.Hash, buff []byte) ([]byte, error) {
+	_, err := hash.Write(buff)
+	return hash.Sum(nil), err
+}
+
+// DefaultChunkSize is the size of the chunk  used to read a stream
+const DefaultChunkSize = 1024
+
+// hashStream hashes a stream reading from it by chunks of DefaultChunkSize size.
+func hashStream(hash h.Hash, stream io.Reader, size int) ([]byte, error) {
+	b := make([]byte, size)
+	for {
+		n, errRead := stream.Read(b)
+		dbg.Lvl4("Read", n, "bytes of", size)
+		_, err := hash.Write(b[:n])
+		if err != nil {
+			return nil, err
+		}
+		if errRead == io.EOF || n < size {
+			break
+		}
+	}
+	return hash.Sum(nil), nil
+}
+
+// HashStream returns the hash of the stream reading from it chunk by chunk of
+// size DefaultChunkSize
+func HashStream(hash h.Hash, stream io.Reader) ([]byte, error) {
+	return hashStream(hash, stream, DefaultChunkSize)
+}
+
+// HashBytes returns the hash of the bytes
+func HashBytes(hash h.Hash, b []byte) ([]byte, error) {
+	return HashStream(hash, bytes.NewReader(b))
+}
+
+// HashStreamChunk will hash the stream using chunks of size chunkSize
+func HashStreamChunk(hash h.Hash, stream io.Reader, chunkSize int) ([]byte, error) {
+	if chunkSize < 1 {
+		return nil, errors.New("Wrong chunksize value")
+	}
+	return hashStream(hash, stream, chunkSize)
+}
+
+// HashFile will hash the file using the streaming approach with
+// DefaultChunkSize size of chunks
+func HashFile(hash h.Hash, file string) ([]byte, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	return HashStream(hash, f)
+
+}
+
+// HashFileChunk is similar to HashFile but using a chunkSize size of chunks for
+// reading.
+func HashFileChunk(hash h.Hash, file string, chunkSize int) ([]byte, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	return HashStreamChunk(hash, f, chunkSize)
+}
+
+// HashStreamSuite will hash the stream using the hashing function of the suite
+func HashStreamSuite(suite abstract.Suite, stream io.Reader) ([]byte, error) {
+	return HashStream(suite.Hash(), stream)
+}
+
+// HashFileSuite returns the hash of a file using the hashing function of the
+// suite given.
+func HashFileSuite(suite abstract.Suite, file string) ([]byte, error) {
+	return HashFile(suite.Hash(), file)
+}
+
+// HashArgs takes all args and returns the hash. Every arg has to implement
+// BinaryMarshaler or will be added using fmt.Sprint
+func HashArgs(hash h.Hash, args ...interface{}) ([]byte, error) {
+	var res, buf []byte
+	var err error
+	for _, a := range args {
+		if _, ok := a.(encoding.BinaryMarshaler); ok {
+			buf, err = a.(encoding.BinaryMarshaler).MarshalBinary()
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			buf = []byte(fmt.Sprint(a))
+		}
+		res, err = HashBytes(hash, buf)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+// HashArgsSuite makes a new hash from the suite and calls HashArgs
+func HashArgsSuite(suite abstract.Suite, args ...interface{}) ([]byte, error) {
+	return HashArgs(suite.Hash(), args...)
+}

--- a/lib/crypto/hash_test.go
+++ b/lib/crypto/hash_test.go
@@ -1,0 +1,137 @@
+package crypto_test
+
+import (
+	"bytes"
+	"github.com/dedis/cothority/lib/crypto"
+	"github.com/dedis/cothority/lib/dbg"
+	"github.com/dedis/crypto/edwards/ed25519"
+	"io/ioutil"
+	"testing"
+)
+
+var hashSuite = ed25519.NewAES128SHA256Ed25519(false)
+
+func TestHash(t *testing.T) {
+	buf := make([]byte, 245)
+	hashed, err := crypto.Hash(hashSuite.Hash(), buf)
+	if err != nil {
+		t.Fatal("Error hashing" + err.Error())
+	}
+	hasher := hashSuite.Hash()
+	hasher.Write(buf)
+	b := hasher.Sum(nil)
+	if !bytes.Equal(b, hashed) {
+		t.Fatal("Hashes are not equals")
+	}
+}
+
+func TestHashStream(t *testing.T) {
+	var buff bytes.Buffer
+	str := "Hello World"
+	buff.WriteString(str)
+	hashed, err := crypto.HashStream(hashSuite.Hash(), &buff)
+	if err != nil {
+		t.Fatal("error hashing" + err.Error())
+	}
+	h := hashSuite.Hash()
+	h.Write([]byte(str))
+	b := h.Sum(nil)
+	if !bytes.Equal(b, hashed) {
+		t.Fatal("hashes not equal")
+	}
+}
+
+func TestHashBytes(t *testing.T) {
+	str := "Hello World"
+	hashed, err := crypto.HashBytes(hashSuite.Hash(), []byte(str))
+	if err != nil {
+		t.Fatal("error hashing" + err.Error())
+	}
+	h := hashSuite.Hash()
+	h.Write([]byte(str))
+	b := h.Sum(nil)
+	if !bytes.Equal(b, hashed) {
+		t.Fatal("hashes not equal")
+	}
+}
+
+func TestHashFile(t *testing.T) {
+	tmpfile := "/tmp/hash_test.bin"
+	for _, i := range []int{16, 128, 1024} {
+		str := make([]byte, i)
+		err := ioutil.WriteFile(tmpfile, str, 0777)
+		if err != nil {
+			t.Fatal("Couldn't write file")
+		}
+
+		hash, err := crypto.HashFile(hashSuite.Hash(), tmpfile)
+		if err != nil {
+			t.Fatal("Couldn't hash", tmpfile, err)
+		}
+		if len(hash) != 32 {
+			t.Fatal("Length of sha256 should be 32")
+		}
+		hash2, err := crypto.HashFileSuite(hashSuite, tmpfile)
+		if bytes.Compare(hash, hash2) != 0 {
+			t.Fatal("HashFile and HashFileSuite should give the same result")
+		}
+	}
+}
+
+func TestHashChunk(t *testing.T) {
+	tmpfile := "/tmp/hash_test.bin"
+	str := make([]byte, 1234)
+	err := ioutil.WriteFile(tmpfile, str, 0777)
+	if err != nil {
+		t.Fatal("Couldn't write file")
+	}
+
+	for _, i := range []int{16, 128, 1024} {
+		dbg.Lvl3("Reading", i, "bytes")
+		hash, err := crypto.HashFileChunk(ed25519.NewAES128SHA256Ed25519(false).Hash(),
+			tmpfile, i)
+		if err != nil {
+			t.Fatal("Couldn't hash", tmpfile, err)
+		}
+		if len(hash) != 32 {
+			t.Fatal("Length of sha256 should be 32")
+		}
+	}
+}
+
+func TestHashSuite(t *testing.T) {
+	var buff bytes.Buffer
+	content := make([]byte, 100)
+	buff.Write(content)
+	var buff2 bytes.Buffer
+	buff2.Write(content)
+	hashed, err := crypto.HashStream(hashSuite.Hash(), &buff)
+	hashedSuite, err2 := crypto.HashStreamSuite(hashSuite, &buff2)
+	if err != nil || err2 != nil {
+		t.Fatal("error hashing" + err.Error() + err2.Error())
+	}
+	if !bytes.Equal(hashed, hashedSuite) {
+		t.Fatal("hashes not equals")
+	}
+}
+
+func TestHashArgs(t *testing.T) {
+	str1 := "cosi"
+	str2 := "rocks"
+	hash1, err := crypto.HashArgs(hashSuite.Hash(), str1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hash2, err := crypto.HashArgs(hashSuite.Hash(), str1, str1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare(hash1, hash2) == 0 {
+		t.Fatal("Making a hash from a string and stringstring should be different")
+	}
+	hash1, _ = crypto.HashArgsSuite(hashSuite, str1, str2)
+	hash2, _ = crypto.HashArgsSuite(hashSuite, str2, str1)
+	if bytes.Compare(hash1, hash2) == 0 {
+		t.Fatal("Making a hash from str1str2 should be different from str2str1")
+	}
+}

--- a/lib/crypto/hashid.go
+++ b/lib/crypto/hashid.go
@@ -5,21 +5,28 @@ import (
 	"errors"
 )
 
-type HashId []byte // Cryptographic hash content-IDs
+// HashID is the Cryptographic hash content-IDs
+type HashID []byte
 
-// for sorting arrays of HashIds
-type ByHashId []HashId
+// ByHashID is for sorting arrays of HashIds
+type ByHashID []HashID
 
-func (h ByHashId) Len() int           { return len(h) }
-func (h ByHashId) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
-func (h ByHashId) Less(i, j int) bool { return bytes.Compare(h[i], h[j]) < 0 }
+// Len returns the length of the byhashid
+func (h ByHashID) Len() int { return len(h) }
 
-func (id HashId) Bit(i uint) int {
+// Swap takes two hashes and inverts them
+func (h ByHashID) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+
+// Less checks if the first is less than the second
+func (h ByHashID) Less(i, j int) bool { return bytes.Compare(h[i], h[j]) < 0 }
+
+// Bit returns if the given bit is set or not
+func (id HashID) Bit(i uint) int {
 	return int(id[i>>3] >> (i & 7))
 }
 
-// Find the skip-chain level of an ID
-func (id *HashId) Level() int {
+// Level finds the skip-chain level of an ID
+func (id *HashID) Level() int {
 	var level uint
 	for id.Bit(level) == 0 {
 		level++
@@ -27,24 +34,26 @@ func (id *HashId) Level() int {
 	return int(level)
 }
 
-// Context for looking up content blobs by self-certifying HashId.
+// HashGet is the context for looking up content blobs by self-certifying HashId.
 // Implementations can be either local (same-node) or remote (cross-node).
 type HashGet interface {
 
-	// Lookup and return the binary blob for a given content HashId.
+	// Get lookups and returns the binary blob for a given content HashId.
 	// Checks and returns an error if the hash doesn't match the content;
 	// the caller doesn't need to check this correspondence.
-	Get(id HashId) ([]byte, error)
+	Get(id HashID) ([]byte, error)
 }
 
-// Simple local-only, map-based implementation of HashGet interface
+// HashMap is a simple local-only, map-based implementation of HashGet interface
 type HashMap map[string][]byte
 
-func (m HashMap) Put(id HashId, data []byte) {
+// Put adds an element to the hashmap
+func (m HashMap) Put(id HashID, data []byte) {
 	m[string(id)] = data
 }
 
-func (m HashMap) Get(id HashId) ([]byte, error) {
+// Get returns an element from the hashmap
+func (m HashMap) Get(id HashID) ([]byte, error) {
 	blob, ok := m[string(id)]
 	if !ok {
 		return nil, errors.New("HashId not found")

--- a/lib/crypto/proof.go
+++ b/lib/crypto/proof.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 )
 
+// HashFunc exports a hashfunction
 type HashFunc func() gohash.Hash
 
 // Proof-of-beforeness:
@@ -17,18 +18,18 @@ type HashFunc func() gohash.Hash
 
 // Proof is used for Local Merkle Trees (computed based on messages from clients)
 // One Proof sufficient for one leaf in a Local Merkle Tree
-type Proof []HashId
+type Proof []HashID
 
 // LevelProof is used for the Big Merkle Tree (computed from server commits)
 // A []LevelProof from root to server is sufficient proof
-type LevelProof []HashId
+type LevelProof []HashID
 
 type hashContext struct {
 	newHash func() gohash.Hash
 	hash    gohash.Hash
 }
 
-func (c *hashContext) hashNode(buf []byte, left, right HashId) []byte {
+func (c *hashContext) hashNode(buf []byte, left, right HashID) []byte {
 	if bytes.Compare(left, right) > 0 {
 		left, right = right, left
 	}
@@ -46,7 +47,7 @@ func (c *hashContext) hashNode(buf []byte, left, right HashId) []byte {
 	return s
 }
 
-// Given a Proof and the hash of the leaf, compute the hash of the root.
+// Calc - Given a Proof and the hash of the leaf, compute the hash of the root.
 // If the Proof is of length 0, simply returns leaf.
 func (p Proof) Calc(newHash HashFunc, leaf []byte) []byte {
 	c := hashContext{newHash: newHash}
@@ -66,7 +67,8 @@ func (p Proof) Check(newHash HashFunc, root, leaf []byte) bool {
 	return subtle.ConstantTimeCompare(chk, root) != 0
 }
 
-func CheckLocalProofs(newHash HashFunc, root HashId, leaves []HashId, proofs []Proof) bool {
+// CheckLocalProofs does something unknonw
+func CheckLocalProofs(newHash HashFunc, root HashID, leaves []HashID, proofs []Proof) bool {
 	// fmt.Println("Created mtRoot:", mtRoot)
 
 	for i := range proofs {
@@ -86,6 +88,7 @@ func CheckLocalProofs(newHash HashFunc, root HashId, leaves []HashId, proofs []P
 	return true
 }
 
+// PrintProof prints the proof
 func (p *Proof) PrintProof(proofNumber int) {
 	fmt.Println("Proof number=", proofNumber)
 	for _, x := range *p {
@@ -94,6 +97,7 @@ func (p *Proof) PrintProof(proofNumber int) {
 	// 	fmt.Println("\n")
 }
 
+// PrintProofs prints out all proofs
 func PrintProofs(proofs []Proof) {
 	for i, p := range proofs {
 		p.PrintProof(i)
@@ -107,11 +111,11 @@ func sibling(i int) int {
 	return i + 1
 }
 
-// Generate a Merkle proof tree for the given list of leaves,
+// ProofTree - Generates a Merkle proof tree for the given list of leaves,
 // yielding one output proof per leaf.
-func ProofTree(newHash func() gohash.Hash, leaves []HashId) (HashId, []Proof) {
+func ProofTree(newHash func() gohash.Hash, leaves []HashID) (HashID, []Proof) {
 	if len(leaves) == 0 {
-		return HashId(""), nil
+		return HashID(""), nil
 	}
 	// Determine the required tree depth
 	nleavesArg, nleaves := len(leaves), len(leaves)
@@ -129,7 +133,7 @@ func ProofTree(newHash func() gohash.Hash, leaves []HashId) (HashId, []Proof) {
 
 	// Build the Merkle tree
 	c := hashContext{newHash: newHash}
-	tree := make([][]HashId, depth+1)
+	tree := make([][]HashID, depth+1)
 	tree[depth] = leaves
 	nprev := nleaves
 	tprev := tree[depth]
@@ -138,7 +142,7 @@ func ProofTree(newHash func() gohash.Hash, leaves []HashId) (HashId, []Proof) {
 		nnode := nprev >> 1       // # new nodes at level i
 		// println("nprev", nprev, "nnext", nnext, "nnode", nnode)
 		// fmt.Println("nprev", nprev, "nnext", nnext, "nnode", nnode)
-		tree[d] = make([]HashId, nnext)
+		tree[d] = make([]HashID, nnext)
 		tnext := tree[d]
 		for i := 0; i < nnode; i++ {
 			tnext[i] = c.hashNode(nil, tprev[i*2], tprev[i*2+1])
@@ -156,7 +160,7 @@ func ProofTree(newHash func() gohash.Hash, leaves []HashId) (HashId, []Proof) {
 	// Some towards the end may end up being shorter than depth.
 	proofs := make([]Proof, nleaves)
 	for i := 0; i < nleaves; i++ {
-		p := make([]HashId, 0, depth)
+		p := make([]HashID, 0, depth)
 		// p = append(p, root)
 		for d := depth - 1; d >= 0; d-- {
 			h := tree[depth-d][sibling(i>>uint(d))]
@@ -180,7 +184,7 @@ type MerklePath struct {
 	Len int   // Length of relevant object in last-level blob
 }
 
-// Retrieve an object in a Merkle tree,
+// MerkleGet - Retrieves an object in a Merkle tree,
 // validating the entire path in the process.
 // Returns a slice of a buffer obtained from HashGet.Get(),
 // which might be shared and should be considered read-only.
@@ -196,7 +200,7 @@ func MerkleGet(suite abstract.Suite, root []byte, path MerklePath,
 		if end > len(blob) {
 			return nil, errors.New("bad Merkle tree pointer offset")
 		}
-		id := HashId(blob[beg:end])
+		id := HashID(blob[beg:end])
 		b, e := ctx.Get(id) // Lookup the next-level blob
 		if e != nil {
 			return nil, e
@@ -212,6 +216,3 @@ func MerkleGet(suite abstract.Suite, root []byte, path MerklePath,
 	}
 	return blob[beg:end], nil
 }
-
-//type MerkleLog struct {
-//}

--- a/lib/crypto/proof_test.go
+++ b/lib/crypto/proof_test.go
@@ -12,7 +12,7 @@ func TestPath(t *testing.T) {
 	hash := newHash()
 	n := 13
 
-	leaves := make([]crypto.HashId, n)
+	leaves := make([]crypto.HashID, n)
 	for i := range leaves {
 		leaves[i] = make([]byte, hash.Size())
 		for j := range leaves[i] {
@@ -39,7 +39,7 @@ func TestPathLong(t *testing.T) {
 	hash := newHash()
 	n := 100 // takes 6 secons
 	for k := 0; k < n; k++ {
-		leaves := make([]crypto.HashId, k)
+		leaves := make([]crypto.HashID, k)
 		for i := range leaves {
 			leaves[i] = make([]byte, hash.Size())
 			for j := range leaves[i] {

--- a/lib/crypto/schnorr.go
+++ b/lib/crypto/schnorr.go
@@ -1,8 +1,3 @@
-// Provides some crypto-shortcuts: Schnorr signature and a Hash-function.
-// See https://en.wikipedia.org/wiki/Schnorr_signature
-//
-// It provides a way to sign a message using a private key and to verify the
-// signature using the public counter part.
 package crypto
 
 import (
@@ -19,6 +14,7 @@ type SchnorrSig struct {
 	Response  abstract.Secret
 }
 
+// MarshalBinary is used for example in hashing
 func (ss *SchnorrSig) MarshalBinary() ([]byte, error) {
 	cbuf, err := ss.Challenge.MarshalBinary()
 	if err != nil {

--- a/protocols/byzcoin/blockchain/trblock.go
+++ b/protocols/byzcoin/blockchain/trblock.go
@@ -88,7 +88,7 @@ func NewHeader(transactions TransactionList, parent, parentKey string) *Header {
 	return hdr
 }
 func HashRootTransactions(transactions TransactionList) string {
-	var hashes []crypto.HashId
+	var hashes []crypto.HashID
 
 	for _, t := range transactions.Txs {
 		temp, _ := hex.DecodeString(t.Hash)


### PR DESCRIPTION
If we go with merging `cosi_cli` only into `master`, then we should have `lib/crypto` in `development`, as it simplifies somewhat the hashing.

Next step is to find all places where hashes are used and get them to use these hash-functions.