### PR TITLE
taking 'go'-call away from StartNewNode

### DIFF
--- a/lib/sda/overlay.go
+++ b/lib/sda/overlay.go
@@ -139,7 +139,7 @@ func (o *Overlay) StartNewNode(protocolID ProtocolID, tree *Tree) (*Node, error)
 	}
 	// start it
 	dbg.Lvl3("Starting new node at", o.host.Entity.Addresses)
-	go node.StartProtocol()
+	node.StartProtocol()
 	return node, nil
 }
 

--- a/lib/sda/protocol_test.go
+++ b/lib/sda/protocol_test.go
@@ -26,7 +26,7 @@ type ProtocolTest struct {
 func NewProtocolTest(n *sda.Node) (sda.ProtocolInstance, error) {
 	return &ProtocolTest{
 		Node:     n,
-		StartMsg: make(chan string),
+		StartMsg: make(chan string, 1),
 		DispMsg:  make(chan string),
 	}, nil
 }


### PR DESCRIPTION
that way a

```
StartNewNode
```

is the same as

```
n := CreateNewNode
n.StartProtocol
```