### PR TITLE
Node Helper Functions

### DIFF
--- a/lib/sda/node.go
+++ b/lib/sda/node.go
@@ -286,6 +286,16 @@ func (n *Node) RegisterHandler(c interface{}) error {
 	return nil
 }
 
+// RegisterHandlers registers a list of given handlers by calling RegisterHandler above
+func (n *Node) RegisterHandlers(handlers []interface{}) error {
+	for _, h := range handlers {
+		if err := n.RegisterHandler(h); err != nil {
+			return fmt.Errorf("Error, could not register handler: " + err.Error())
+		}
+	}
+	return nil
+}
+
 // ProtocolInstance returns the instance of the running protocol
 func (n *Node) ProtocolInstance() ProtocolInstance {
 	return n.instance

--- a/protocols/jvss/handlers.go
+++ b/protocols/jvss/handlers.go
@@ -102,10 +102,10 @@ func (jv *JVSS) handleSecConf(m WSecConfMsg) error {
 	secret.numConfs++
 	secret.mtx.Unlock()
 
-	dbg.Lvl2(fmt.Sprintf("Node %d: %s confirmations %d/%d", jv.nodeIdx(), msg.SID, secret.numConfs, len(jv.nodeList)))
+	dbg.Lvl2(fmt.Sprintf("Node %d: %s confirmations %d/%d", jv.Node.Index(), msg.SID, secret.numConfs, len(jv.Node.List())))
 
 	// Check if we have enough confirmations to proceed
-	if (secret.numConfs == len(jv.nodeList)) && (msg.SID == LTSS || msg.SID == SID(fmt.Sprintf("%s%d", STSS, jv.nodeIdx()))) {
+	if (secret.numConfs == len(jv.Node.List())) && (msg.SID == LTSS || msg.SID == SID(fmt.Sprintf("%s%d", STSS, jv.Node.Index()))) {
 		jv.secretsDone <- true
 	}
 
@@ -123,12 +123,12 @@ func (jv *JVSS) handleSigReq(m WSigReqMsg) error {
 
 	// Send it back to initiator
 	resp := &SigRespMsg{
-		Src: jv.nodeIdx(),
+		Src: jv.Node.Index(),
 		SID: msg.SID,
 		Sig: ps,
 	}
 
-	if err := jv.SendTo(jv.nodeList[msg.Src], resp); err != nil {
+	if err := jv.SendTo(jv.Node.List()[msg.Src], resp); err != nil {
 		return err
 	}
 
@@ -148,7 +148,7 @@ func (jv *JVSS) handleSigResp(m WSigRespMsg) error {
 	}
 	secret.sigs[msg.Src] = msg.Sig
 
-	dbg.Lvl2(fmt.Sprintf("Node %d: %s signatures %d/%d", jv.nodeIdx(), msg.SID, len(secret.sigs), len(jv.nodeList)))
+	dbg.Lvl2(fmt.Sprintf("Node %d: %s signatures %d/%d", jv.Node.Index(), msg.SID, len(secret.sigs), len(jv.Node.List())))
 
 	// Create Schnorr signature once we received enough partial signatures
 	if jv.info.T == len(secret.sigs) {

--- a/protocols/jvss/jvss.go
+++ b/protocols/jvss/jvss.go
@@ -88,7 +88,7 @@ func NewJVSS(node *sda.Node) (sda.ProtocolInstance, error) {
 		jv.handleSigReq,
 		jv.handleSigResp,
 	}
-	err := jv.RegisterHandlers(h)
+	err := jv.RegisterHandlers(h...)
 
 	return jv, err
 }

--- a/protocols/jvss/jvss.go
+++ b/protocols/jvss/jvss.go
@@ -82,19 +82,15 @@ func NewJVSS(node *sda.Node) (sda.ProtocolInstance, error) {
 	}
 
 	// Setup message handlers
-	handlers := []interface{}{
+	h := []interface{}{
 		jv.handleSecInit,
 		jv.handleSecConf,
 		jv.handleSigReq,
 		jv.handleSigResp,
 	}
-	for _, h := range handlers {
-		if err := jv.RegisterHandler(h); err != nil {
-			return nil, fmt.Errorf("Error, could not register handler: " + err.Error())
-		}
-	}
+	err := jv.RegisterHandlers(h)
 
-	return jv, nil
+	return jv, err
 }
 
 // Start initiates the JVSS protocol by setting up a long-term shared secret

--- a/protocols/jvss/jvss_test.go
+++ b/protocols/jvss/jvss_test.go
@@ -20,7 +20,7 @@ func TestJVSS(t *testing.T) {
 	_, _, tree := local.GenTree(int(nodes), false, true, true)
 	defer local.CloseAll()
 
-	dbg.TestOutput(true, 1)
+	dbg.TestOutput(testing.Verbose(), 1)
 
 	dbg.Lvl1("JVSS - starting")
 	leader, err := local.CreateNewNodeName(name, tree)

--- a/protocols/randhound/handlers.go
+++ b/protocols/randhound/handlers.go
@@ -137,7 +137,7 @@ func (rh *RandHound) handleI1(i1 WI1) error {
 
 	// If we are not a leaf, forward i1 to children
 	if !rh.Node.IsLeaf() {
-		if err := rh.sendToChildren(&i1.I1); err != nil {
+		if err := rh.SendToChildren(&i1.I1); err != nil {
 			return err
 		}
 	}
@@ -158,7 +158,7 @@ func (rh *RandHound) handleI1(i1 WI1) error {
 	rh.Peer.rs = rs
 
 	rh.Peer.r1 = &R1{
-		Src: rh.nodeIdx(),
+		Src: rh.index(),
 		HI1: rh.hash(
 			rh.SID,
 			rh.GID,
@@ -166,14 +166,14 @@ func (rh *RandHound) handleI1(i1 WI1) error {
 		),
 		HRs: rh.hash(rh.Peer.rs),
 	}
-	return rh.SendTo(rh.Parent(), rh.Peer.r1)
+	return rh.SendToParent(rh.Peer.r1)
 }
 
 func (rh *RandHound) handleR1(r1 WR1) error {
 
 	// If we are not the root, forward r1 to parent
 	if !rh.Node.IsRoot() {
-		if err := rh.SendTo(rh.Parent(), &r1.R1); err != nil {
+		if err := rh.SendToParent(&r1.R1); err != nil {
 			return err
 		}
 	} else {
@@ -193,7 +193,7 @@ func (rh *RandHound) handleR1(r1 WR1) error {
 				SID: rh.SID,
 				Rc:  rh.Leader.rc,
 			}
-			if err := rh.sendToChildren(rh.Leader.i2); err != nil {
+			if err := rh.SendToChildren(rh.Leader.i2); err != nil {
 				return err
 			}
 		}
@@ -205,14 +205,14 @@ func (rh *RandHound) handleI2(i2 WI2) error {
 
 	// If we are not a leaf, forward i2 to children
 	if !rh.Node.IsLeaf() {
-		if err := rh.sendToChildren(&i2.I2); err != nil {
+		if err := rh.SendToChildren(&i2.I2); err != nil {
 			return err
 		}
 	}
 
 	// Verify session ID
 	if !bytes.Equal(rh.SID, i2.I2.SID) {
-		return fmt.Errorf("I2: peer %d received message with incorrect session ID", rh.nodeIdx())
+		return fmt.Errorf("I2: peer %d received message with incorrect session ID", rh.index())
 	}
 
 	rh.Peer.i2 = &i2.I2
@@ -233,21 +233,21 @@ func (rh *RandHound) handleI2(i2 WI2) error {
 	}
 
 	rh.Peer.r2 = &R2{
-		Src: rh.nodeIdx(),
+		Src: rh.index(),
 		HI2: rh.hash(
 			rh.SID,
 			rh.Peer.i2.Rc),
 		Rs:   rh.Peer.rs,
 		Deal: db,
 	}
-	return rh.SendTo(rh.Parent(), rh.Peer.r2)
+	return rh.SendToParent(rh.Peer.r2)
 }
 
 func (rh *RandHound) handleR2(r2 WR2) error {
 
 	// If we are not the root, forward r2 to parent
 	if !rh.Node.IsRoot() {
-		if err := rh.SendTo(rh.Parent(), &r2.R2); err != nil {
+		if err := rh.SendToParent(&r2.R2); err != nil {
 			return err
 		}
 	} else {
@@ -279,7 +279,7 @@ func (rh *RandHound) handleR2(r2 WR2) error {
 				SID: rh.SID,
 				R2s: rh.Leader.r2,
 			}
-			return rh.sendToChildren(rh.Leader.i3)
+			return rh.SendToChildren(rh.Leader.i3)
 		}
 	}
 	return nil
@@ -289,14 +289,14 @@ func (rh *RandHound) handleI3(i3 WI3) error {
 
 	// If we are not a leaf, forward i3 to children
 	if !rh.Node.IsLeaf() {
-		if err := rh.sendToChildren(&i3.I3); err != nil {
+		if err := rh.SendToChildren(&i3.I3); err != nil {
 			return err
 		}
 	}
 
 	// Verify session ID
 	if !bytes.Equal(rh.SID, i3.I3.SID) {
-		return fmt.Errorf("I3: peer %d received message with incorrect session ID", rh.nodeIdx())
+		return fmt.Errorf("I3: peer %d received message with incorrect session ID", rh.index())
 	}
 
 	rh.Peer.i3 = &i3.I3
@@ -323,7 +323,7 @@ func (rh *RandHound) handleI3(i3 WI3) error {
 
 		// Determine other peers who chose the current peer as a trustee
 		shareIdx, _ := rh.chooseTrustees(rh.Peer.i2.Rc, r2.Rs)
-		if j, ok := shareIdx[rh.nodeIdx()]; ok { // j is the share index we received from the ith peer
+		if j, ok := shareIdx[rh.index()]; ok { // j is the share index we received from the ith peer
 			resp, err := deal.ProduceResponse(int(j), longPair)
 			if err != nil {
 				return err
@@ -342,20 +342,20 @@ func (rh *RandHound) handleI3(i3 WI3) error {
 	}
 
 	rh.Peer.r3 = &R3{
-		Src: rh.nodeIdx(),
+		Src: rh.index(),
 		HI3: rh.hash(
 			rh.SID,
 			rh.Peer.r2.HI2), // TODO: is this enough?
 		Responses: responses,
 	}
-	return rh.SendTo(rh.Parent(), rh.Peer.r3)
+	return rh.SendToParent(rh.Peer.r3)
 }
 
 func (rh *RandHound) handleR3(r3 WR3) error {
 
 	// If we are not the root, forward r3 to parent
 	if !rh.Node.IsRoot() {
-		if err := rh.SendTo(rh.Parent(), &r3.R3); err != nil {
+		if err := rh.SendToParent(&r3.R3); err != nil {
 			return err
 		}
 	} else {
@@ -391,7 +391,7 @@ func (rh *RandHound) handleR3(r3 WR3) error {
 				SID:     rh.SID,
 				Invalid: rh.Leader.invalid,
 			}
-			return rh.sendToChildren(rh.Leader.i4)
+			return rh.SendToChildren(rh.Leader.i4)
 		}
 	}
 	return nil
@@ -401,21 +401,21 @@ func (rh *RandHound) handleI4(i4 WI4) error {
 
 	// If we are not a leaf, forward i4 to children
 	if !rh.Node.IsLeaf() {
-		if err := rh.sendToChildren(&i4.I4); err != nil {
+		if err := rh.SendToChildren(&i4.I4); err != nil {
 			return err
 		}
 	}
 
 	// Verify session ID
 	if !bytes.Equal(rh.SID, i4.I4.SID) {
-		return fmt.Errorf("I4: peer %d received message with incorrect session ID", rh.nodeIdx())
+		return fmt.Errorf("I4: peer %d received message with incorrect session ID", rh.index())
 	}
 
 	rh.Peer.i4 = &i4.I4
 
 	// Remove all invalid shares and prepare hash buffer
 	buf := new(bytes.Buffer)
-	invalid := rh.Peer.i4.Invalid[rh.nodeIdx()]
+	invalid := rh.Peer.i4.Invalid[rh.index()]
 	for _, dealerIdx := range *invalid {
 		delete(rh.Peer.shares, dealerIdx)
 		if err := binary.Write(buf, binary.LittleEndian, dealerIdx); err != nil {
@@ -424,20 +424,20 @@ func (rh *RandHound) handleI4(i4 WI4) error {
 	}
 
 	rh.Peer.r4 = &R4{
-		Src: rh.nodeIdx(),
+		Src: rh.index(),
 		HI4: rh.hash(
 			rh.SID,
 			buf.Bytes()),
 		Shares: rh.Peer.shares,
 	}
-	return rh.SendTo(rh.Parent(), rh.Peer.r4)
+	return rh.SendToParent(rh.Peer.r4)
 }
 
 func (rh *RandHound) handleR4(r4 WR4) error {
 
 	// If we are not the root, forward r4 to parent
 	if !rh.Node.IsRoot() {
-		if err := rh.SendTo(rh.Parent(), &r4.R4); err != nil {
+		if err := rh.SendToParent(&r4.R4); err != nil {
 			return err
 		}
 	} else {

--- a/protocols/randhound/randhound.go
+++ b/protocols/randhound/randhound.go
@@ -112,7 +112,7 @@ func NewRandHound(node *sda.Node) (sda.ProtocolInstance, error) {
 		rh.handleI3, rh.handleR3,
 		rh.handleI4, rh.handleR4,
 	}
-	err := rh.RegisterHandlers(h)
+	err := rh.RegisterHandlers(h...)
 
 	return rh, err
 }

--- a/protocols/randhound/randhound.go
+++ b/protocols/randhound/randhound.go
@@ -163,7 +163,7 @@ func (rh *RandHound) Start() error {
 		HRc:     rh.hash(rh.Leader.rc),
 	}
 
-	return rh.sendToChildren(rh.Leader.i1)
+	return rh.SendToChildren(rh.Leader.i1)
 }
 
 func (rh *RandHound) newSession(public abstract.Point, purpose string, time time.Time) (*Session, []byte, error) {
@@ -213,7 +213,7 @@ func (rh *RandHound) newGroup(nodes uint32, trustees uint32) (*Group, []byte, er
 	}
 
 	// Include public keys of all nodes into group ID
-	for _, x := range rh.Tree().List() {
+	for _, x := range rh.List() {
 		pub, err := x.Entity.Public.MarshalBinary()
 		if err != nil {
 			return nil, nil, err

--- a/protocols/randhound/randhound.go
+++ b/protocols/randhound/randhound.go
@@ -8,7 +8,6 @@ package randhound
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"time"
 
 	"github.com/dedis/cothority/lib/sda"
@@ -107,19 +106,15 @@ func NewRandHound(node *sda.Node) (sda.ProtocolInstance, error) {
 	}
 
 	// Setup message handlers
-	handlers := []interface{}{
+	h := []interface{}{
 		rh.handleI1, rh.handleR1,
 		rh.handleI2, rh.handleR2,
 		rh.handleI3, rh.handleR3,
 		rh.handleI4, rh.handleR4,
 	}
-	for _, h := range handlers {
-		if err := rh.RegisterHandler(h); err != nil {
-			return nil, errors.New("Couldn't register handler: " + err.Error())
-		}
-	}
+	err := rh.RegisterHandlers(h)
 
-	return rh, nil
+	return rh, err
 }
 
 // Setup configures a RandHound instance by creating group and session

--- a/protocols/randhound/utils.go
+++ b/protocols/randhound/utils.go
@@ -72,7 +72,7 @@ func (rh *RandHound) chooseTrustees(Rc, Rs []byte) (map[uint32]uint32, []abstrac
 	// Choose trustees uniquely
 	shareIdx := make(map[uint32]uint32)
 	trustees := make([]abstract.Point, rh.Group.K)
-	tns := rh.Tree().List()
+	tns := rh.List()
 	j := uint32(0)
 	for uint32(len(shareIdx)) < rh.Group.K {
 		i := uint32(random.Uint64(prng) % uint64(len(tns)))
@@ -90,17 +90,8 @@ func (rh *RandHound) hash(bytes ...[]byte) []byte {
 	return abstract.Sum(rh.Node.Suite(), bytes...)
 }
 
-func (rh *RandHound) nodeIdx() uint32 {
-	return uint32(rh.Node.TreeNode().EntityIdx)
-}
-
-func (rh *RandHound) sendToChildren(msg interface{}) error {
-	for _, c := range rh.Children() {
-		if err := rh.SendTo(c, msg); err != nil {
-			return err
-		}
-	}
-	return nil
+func (rh *RandHound) index() uint32 {
+	return uint32(rh.Node.Index())
 }
 
 func (rh *RandHound) generateTranscript() {} // TODO


### PR DESCRIPTION
This PR introduces various helper functions and constructions in `node.go` and addresses #249, #295,  #335.
- Added a field `treeNodeList` in `node.go`
- Added the following functions:
    - `SendToParent(...)`
    - `SendToChildren(...)`
    - `SendToRoot(...)`
    - `Broadcast(...)`
    - `List()`: To get a list of all TreeNodes
    - `Index()`: To get the index of the calling node in the above list / `EntityList`
    - `RegisterHandlers(...)`: To register a list of SDA handlers

Moreover, it includes the changes in JVSS and RandHound.