### PR TITLE
Errorhandling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,8 @@ script:
   # linter:
   - go get -u github.com/golang/lint/golint
   - ./lint.sh
+  # check for missing error handling:
+  - go get -u github.com/kisielk/errcheck
+  - errcheck ./... | grep -v "_test.go"
   # do not run any test binary in parallel (see go help build for more info on the -p flag)
   - go test -v -race -p=1 ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   - go get -u github.com/golang/lint/golint
   - ./lint.sh
   # check for missing error handling:
-  - go get -u github.com/kisielk/errcheck
-  - errcheck ./... | grep -v "_test.go"
+  #- go get -u github.com/kisielk/errcheck
+  #- ./errcheck.sh
   # do not run any test binary in parallel (see go help build for more info on the -p flag)
   - go test -v -race -p=1 ./...

--- a/errcheck.sh
+++ b/errcheck.sh
@@ -5,7 +5,7 @@
 
 # list of lints we want to ensure:
 Ignore="_test.go"
-Out=`$GOPATH/bin/errcheck ./... | grep -v "($Ignore)"`
+Out=`$GOPATH/bin/errcheck ./... | grep -v "$Ignore"`
 
 # if the output isn't empty exit with an error
 if [ -z "$Out" ]; then

--- a/errcheck.sh
+++ b/errcheck.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# script checks for forgotten/missing error handling
+# make sure you installed errcheck first:
+# go get -u github.com/kisielk/errcheck
+
+# list of lints we want to ensure:
+Ignore="_test.go"
+Out=`$GOPATH/bin/errcheck ./... | grep -v "($Ignore)"`
+
+# if the output isn't empty exit with an error
+if [ -z "$Out" ]; then
+  exit 0;
+else
+  echo "--------------------------------------------------------"
+  echo "Error handling is missing:";
+  echo "$Out";
+  exit 1;
+fi

--- a/lib/crypto/key.go
+++ b/lib/crypto/key.go
@@ -18,17 +18,21 @@ func ReadPub64(suite abstract.Suite, r io.Reader) (abstract.Point, error) {
 // WritePub64 writes a public point to a base64 representation
 func WritePub64(suite abstract.Suite, w io.Writer, point abstract.Point) error {
 	enc := base64.NewEncoder(base64.StdEncoding, w)
-	err := suite.Write(enc, point)
-	enc.Close()
-	return err
+	return write64(suite, enc, point)
+}
+
+func write64(suite abstract.Suite, enc io.WriteCloser, data ...interface{}) {
+	errW := suite.Write(enc, data)
+	if err := enc.Close(); err != nil && errW == nil {
+		return err
+	}
+	return errW
 }
 
 // WriteSecret64 converts a secret key to a Base64-string
 func WriteSecret64(suite abstract.Suite, w io.Writer, secret abstract.Secret) error {
 	enc := base64.NewEncoder(base64.StdEncoding, w)
-	err := suite.Write(enc, secret)
-	enc.Close()
-	return err
+	return write64(suite, enc, secret)
 }
 
 // ReadSecret64 takes a Base64-encoded secret and returns that secret,

--- a/lib/crypto/key.go
+++ b/lib/crypto/key.go
@@ -21,9 +21,9 @@ func WritePub64(suite abstract.Suite, w io.Writer, point abstract.Point) error {
 	return write64(suite, enc, point)
 }
 
-func write64(suite abstract.Suite, enc io.WriteCloser, data ...interface{}) {
-	errW := suite.Write(enc, data)
-	if err := enc.Close(); err != nil && errW == nil {
+func write64(suite abstract.Suite, wc io.WriteCloser, data ...interface{}) error {
+	errW := suite.Write(wc, data)
+	if err := wc.Close(); err != nil && errW == nil {
 		return err
 	}
 	return errW

--- a/lib/crypto/key.go
+++ b/lib/crypto/key.go
@@ -22,11 +22,10 @@ func WritePub64(suite abstract.Suite, w io.Writer, point abstract.Point) error {
 }
 
 func write64(suite abstract.Suite, wc io.WriteCloser, data ...interface{}) error {
-	errW := suite.Write(wc, data)
-	if err := wc.Close(); err != nil && errW == nil {
+	if err := suite.Write(wc, data); err != nil {
 		return err
 	}
-	return errW
+	return wc.Close()
 }
 
 // WriteSecret64 converts a secret key to a Base64-string

--- a/lib/crypto/proof.go
+++ b/lib/crypto/proof.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"errors"
 	"fmt"
+	"github.com/dedis/cothority/lib/dbg"
 	"github.com/dedis/crypto/abstract"
 	gohash "hash"
 	"strconv"
@@ -40,8 +41,14 @@ func (c *hashContext) hashNode(buf []byte, left, right HashID) []byte {
 	}
 	h := c.hash
 
-	h.Write(left)
-	h.Write(right)
+	if n, err := h.Write(left); err != nil || n != len(left) {
+		dbg.Error("Written", n, "of", len(left), "bytes.")
+		dbg.Error(err)
+	}
+	if n, err := h.Write(right); err != nil || n != len(right) {
+		dbg.Error("Written", n, "of", len(right), "bytes.")
+		dbg.Error(err)
+	}
 
 	s := h.Sum(buf)
 	return s

--- a/lib/monitor/measure.go
+++ b/lib/monitor/measure.go
@@ -216,7 +216,9 @@ func send(v interface{}) error {
 
 // EndAndCleanup sends a message to end the logging and closes the connection
 func EndAndCleanup() {
-	send(NewSingleMeasure("end", 0))
+	if err := send(NewSingleMeasure("end", 0)); err != nil {
+		dbg.Error("Error while sending 'end' message:", err)
+	}
 	if err := connection.Close(); err != nil {
 		// at least tell that we could not close the connection:
 		dbg.Error("Could not close connecttion:", err)
@@ -232,7 +234,9 @@ func iiToF(sec int64, usec int64) float64 {
 // Returns the sytem and the user time so far.
 func getRTime() (tSys, tUsr float64) {
 	rusage := &syscall.Rusage{}
-	syscall.Getrusage(syscall.RUSAGE_SELF, rusage)
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, rusage); err != nil {
+		dbg.Error("Couldn't get rusage time:", err)
+	}
 	s, u := rusage.Stime, rusage.Utime
 	return iiToF(int64(s.Sec), int64(s.Usec)), iiToF(int64(u.Sec), int64(u.Usec))
 }

--- a/lib/monitor/monitor.go
+++ b/lib/monitor/monitor.go
@@ -124,7 +124,10 @@ func (m *Monitor) Listen() error {
 			// end of monitoring,
 			if len(m.conns) == 0 {
 				m.listenerLock.Lock()
-				m.listener.Close()
+				if err := m.listener.Close(); err != nil {
+					dbg.Error("Couldn't close listener:",
+						err)
+				}
 				m.listener = nil
 				finished = true
 				m.listenerLock.Unlock()
@@ -143,12 +146,16 @@ func (m *Monitor) Stop() {
 	dbg.Lvl2("Monitor Stop")
 	m.listenerLock.Lock()
 	if m.listener != nil {
-		m.listener.Close()
+		if err := m.listener.Close(); err != nil {
+			dbg.Error("Couldn't close listener:", err)
+		}
 	}
 	m.listenerLock.Unlock()
 	m.mutexConn.Lock()
 	for _, c := range m.conns {
-		c.Close()
+		if err := c.Close(); err != nil {
+			dbg.Error("Couldn't close connection:", err)
+		}
 	}
 	m.mutexConn.Unlock()
 

--- a/lib/monitor/proxy.go
+++ b/lib/monitor/proxy.go
@@ -96,9 +96,15 @@ func Proxy(redirection string) error {
 				nconn--
 				if nconn == 0 {
 					// everything is finished
-					serverEnc.Encode(NewSingleMeasure("end", 0))
-					serverConn.Close()
-					ln.Close()
+					if err := serverEnc.Encode(NewSingleMeasure("end", 0)); err != nil {
+						dbg.Error("Couldn't send 'end' message:", err)
+					}
+					if err := serverConn.Close(); err != nil {
+						dbg.Error("Couldn't close server connection:", err)
+					}
+					if err := ln.Close(); err != nil {
+						dbg.Error("Couldn't close listener:", err)
+					}
 					finished = true
 					break
 				}
@@ -152,7 +158,9 @@ func proxyConnection(conn net.Conn, done chan bool) {
 			break
 		}
 	}
-	conn.Close()
+	if err := conn.Close(); err != nil {
+		dbg.Error("Couldn't close connection:", err)
+	}
 	done <- true
 }
 

--- a/lib/network/struct.go
+++ b/lib/network/struct.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/dedis/cothority/lib/crypto"
+	"github.com/dedis/cothority/lib/dbg"
 	"github.com/dedis/cothority/lib/monitor"
 	"github.com/dedis/crypto/abstract"
 	"github.com/dedis/protobuf"
@@ -255,7 +256,9 @@ func (e *Entity) Equal(e2 *Entity) bool {
 // Toml converts an Entity to a Toml-structure
 func (e *Entity) Toml(suite abstract.Suite) *EntityToml {
 	var buf bytes.Buffer
-	crypto.WritePub64(suite, &buf, e.Public)
+	if err := crypto.WritePub64(suite, &buf, e.Public); err != nil {
+		dbg.Error("Error while writing public key:", err)
+	}
 	return &EntityToml{
 		Addresses: e.Addresses,
 		Public:    buf.String(),
@@ -264,7 +267,10 @@ func (e *Entity) Toml(suite abstract.Suite) *EntityToml {
 
 // Entity converts an EntityToml structure back to an Entity
 func (e *EntityToml) Entity(suite abstract.Suite) *Entity {
-	pub, _ := crypto.ReadPub64(suite, strings.NewReader(e.Public))
+	pub, err := crypto.ReadPub64(suite, strings.NewReader(e.Public))
+	if err != nil {
+		dbg.Error("Error while reading public key:", err)
+	}
 	return &Entity{
 		Public:    pub,
 		Addresses: e.Addresses,

--- a/lib/sda/host.go
+++ b/lib/sda/host.go
@@ -359,7 +359,12 @@ func (h *Host) processMessages() {
 				err = h.SendRaw(data.Entity, el)
 			} else {
 				dbg.Lvl2("Requested entityList that we don't have")
-				h.SendRaw(data.Entity, &EntityList{})
+				err := h.SendRaw(data.Entity, &EntityList{})
+				if err != nil {
+					dbg.Error("Couldn't send empty entity list from host:",
+						h.Entity.String(),
+						err)
+				}
 			}
 		// Host replied to our request of entitylist
 		case SendEntityListMessageID:

--- a/lib/sda/local.go
+++ b/lib/sda/local.go
@@ -146,7 +146,10 @@ func (l *LocalTest) CloseAll() {
 		}
 	}
 	for _, node := range l.Nodes {
-		node.Close()
+		if err := node.Close(); err != nil {
+			dbg.Error("Closing node", node.Name(), "gives error",
+				err)
+		}
 	}
 }
 

--- a/lib/sda/node.go
+++ b/lib/sda/node.go
@@ -205,6 +205,8 @@ func (n *Node) Suite() abstract.Suite {
 // RegisterChannel takes a channel with a struct that contains two
 // elements: a TreeNode and a message. It will send every message that are the
 // same type to this channel.
+// If you pass a pointer to the channel it will be automatically instantiated
+// for you.
 // This function handles also
 // - registration of the message-type
 // - aggregation or not of messages: if you give a channel of slices, the

--- a/lib/sda/node.go
+++ b/lib/sda/node.go
@@ -224,7 +224,7 @@ func (n *Node) RegisterChannel(c interface{}) error {
 	}
 	// Check we have the correct channel-type
 	if cr.Kind() != reflect.Chan {
-		return errors.New("Input is not channel")
+		return errors.New("Input is not channel but " + cr.Kind().String())
 	}
 	if cr.Elem().Kind() == reflect.Slice {
 		flags += AggregateMessages
@@ -294,17 +294,6 @@ func (n *Node) RegisterHandlers(handlers ...interface{}) error {
 	for _, h := range handlers {
 		if err := n.RegisterHandler(h); err != nil {
 			return errors.New("Error, could not register handler: " + err.Error())
-		}
-	}
-	return nil
-}
-
-// RegisterChannels registers a list of given channels by calling RegisterChannel
-func (n *Node) RegisterChannels(channels ...interface{}) error {
-	for _, c := range channels {
-		if err := n.RegisterChannel(c); err != nil {
-			return errors.New("Error, could not register channel: " +
-				err.Error())
 		}
 	}
 	return nil

--- a/lib/sda/node.go
+++ b/lib/sda/node.go
@@ -322,7 +322,12 @@ func (n *Node) protocolInstantiate() error {
 
 	var err error
 	n.instance, err = p(n)
-	go n.instance.Dispatch()
+	go func() {
+		if err := n.instance.Dispatch(); err != nil {
+			dbg.Error("Error while dispatching node", n.Info(), ":",
+				err)
+		}
+	}()
 	return err
 }
 

--- a/lib/sda/node.go
+++ b/lib/sda/node.go
@@ -297,6 +297,17 @@ func (n *Node) RegisterHandlers(handlers ...interface{}) error {
 	return nil
 }
 
+// RegisterChannels registers a list of given channels by calling RegisterChannel
+func (n *Node) RegisterChannels(channels ...interface{}) error {
+	for _, c := range channels {
+		if err := n.RegisterChannel(c); err != nil {
+			return errors.New("Error, could not register channel: " +
+				err.Error())
+		}
+	}
+	return nil
+}
+
 // ProtocolInstance returns the instance of the running protocol
 func (n *Node) ProtocolInstance() ProtocolInstance {
 	return n.instance

--- a/lib/sda/overlay.go
+++ b/lib/sda/overlay.go
@@ -139,13 +139,16 @@ func (o *Overlay) StartNewNode(protocolID ProtocolID, tree *Tree) (*Node, error)
 	}
 	// start it
 	dbg.Lvl3("Starting new node at", o.host.Entity.Addresses)
-	node.StartProtocol()
+	if err := node.StartProtocol(); err != nil {
+		dbg.Error("Error while starting protocol from node", node.Info(),
+			err)
+	}
 	return node, nil
 }
 
 // CreateNewNode is used when you want to create the node with the protocol
 // instance but do not want to start it yet. Use case are when you are root, you
-// want to specifiy some additional configuration for example.
+// want to specify some additional configuration for example.
 func (o *Overlay) CreateNewNode(protocolID ProtocolID, tree *Tree) (*Node, error) {
 	node, err := o.NewNodeEmpty(protocolID, tree)
 	if err != nil {

--- a/lib/sda/tree.go
+++ b/lib/sda/tree.go
@@ -2,7 +2,6 @@
 package sda
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"net"
@@ -563,21 +562,6 @@ func (t *TreeNode) Equal(t2 *TreeNode) bool {
 // String returns the current treenode's Id as a string.
 func (t *TreeNode) String() string {
 	return string(t.Id.String())
-}
-
-// Stringify returns a string containing the whole tree.
-func (t *TreeNode) Stringify() string {
-	var buf bytes.Buffer
-	var lastDepth int
-	fn := func(d int, n *TreeNode) {
-		if d > lastDepth {
-			buf.Write([]byte("\n\n"))
-		} else {
-			buf.Write([]byte(n.Id.String()))
-		}
-	}
-	t.Visit(0, fn)
-	return buf.String()
 }
 
 // Visit is a recursive function that allows for depth-first calling on all

--- a/protocols/byzcoin/blockchain/blkparser/utils.go
+++ b/protocols/byzcoin/blockchain/blkparser/utils.go
@@ -4,7 +4,8 @@ package blkparser
 import (
 	"crypto/sha256"
 	"fmt"
-	"github.com/dedis/cothority2/lib/dbg"
+
+	"github.com/dedis/cothority/lib/dbg"
 )
 
 // Get the Tx count, decode the variable length integer

--- a/protocols/byzcoin/blockchain/blkparser/utils.go
+++ b/protocols/byzcoin/blockchain/blkparser/utils.go
@@ -4,6 +4,7 @@ package blkparser
 import (
 	"crypto/sha256"
 	"fmt"
+	"github.com/dedis/cothority2/lib/dbg"
 )
 
 // Get the Tx count, decode the variable length integer
@@ -28,10 +29,14 @@ func DecodeVariableLengthInteger(raw []byte) (cnt int, cnt_size int) {
 
 func GetShaString(data []byte) (res string) {
 	sha := sha256.New()
-	sha.Write(data[:])
+	if _, err := sha.Write(data[:]); err != nil {
+		dbg.Error("Failed to hash data", err)
+	}
 	tmp := sha.Sum(nil)
 	sha.Reset()
-	sha.Write(tmp)
+	if _, err := sha.Write(tmp); err != nil {
+		dbg.Error("Failed to hash data", err)
+	}
 	hash := sha.Sum(nil)
 	res = HashString(hash)
 	return

--- a/protocols/byzcoin/blockchain/parser.go
+++ b/protocols/byzcoin/blockchain/parser.go
@@ -63,7 +63,9 @@ func SimulDirToBlockDir(dir string) string {
 	reg, _ := regexp.Compile("simul/.*")
 	blockDir := string(reg.ReplaceAll([]byte(dir), []byte("protocols/byzcoin/block")))
 	if _, err := os.Stat(blockDir); os.IsNotExist(err) {
-		os.Mkdir(blockDir, 0777)
+		if err := os.Mkdir(blockDir, 0777); err != nil {
+			dbg.Error("Couldn't create blocks directory", err)
+		}
 	}
 	return blockDir
 }
@@ -122,7 +124,9 @@ func EnsureBlockIsAvailable(dir string) error {
 		}
 	}
 	destDir := dir + "/blocks"
-	os.Mkdir(destDir, 0777)
+	if err := os.Mkdir(destDir, 0777); err != nil {
+		return err
+	}
 	cmd := exec.Command("cp", block, destDir)
 	if err := cmd.Start(); err != nil {
 		return err

--- a/protocols/byzcoin/blockchain/transactionlist.go
+++ b/protocols/byzcoin/blockchain/transactionlist.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"log"
 
+	"github.com/dedis/cothority/lib/dbg"
 	"github.com/dedis/cothority/protocols/byzcoin/blockchain/blkparser"
 )
 
@@ -17,10 +18,16 @@ type TransactionList struct {
 func (tl *TransactionList) HashSum() []byte {
 	h := sha256.New()
 	for _, tx := range tl.Txs {
-		h.Write([]byte(tx.Hash))
+		if _, err := h.Write([]byte(tx.Hash)); err != nil {
+			dbg.Error("Couldn't hash TX list", err)
+		}
 	}
-	binary.Write(h, binary.LittleEndian, tl.TxCnt)
-	binary.Write(h, binary.LittleEndian, tl.Fees)
+	if err := binary.Write(h, binary.LittleEndian, tl.TxCnt); err != nil {
+		dbg.Error("Couldn't hash TX list", err)
+	}
+	if err := binary.Write(h, binary.LittleEndian, tl.Fees); err != nil {
+		dbg.Error("Couldn't hash TX list", err)
+	}
 	return h.Sum(nil)
 }
 

--- a/protocols/byzcoin/blockchain/trblock.go
+++ b/protocols/byzcoin/blockchain/trblock.go
@@ -10,6 +10,7 @@ import (
 	"net"
 
 	"github.com/dedis/cothority/lib/crypto"
+	"github.com/dedis/cothority/lib/dbg"
 )
 
 type Block struct {
@@ -31,11 +32,21 @@ func (tr *TrBlock) MarshalBinary() ([]byte, error) {
 // Hash returns a hash representation of the block
 func (tr *TrBlock) HashSum() []byte {
 	h := sha256.New()
-	h.Write(tr.Magic[:])
-	binary.Write(h, binary.LittleEndian, tr.BlockSize)
-	h.Write([]byte(tr.HeaderHash))
-	h.Write(tr.Header.HashSum())
-	h.Write(tr.TransactionList.HashSum())
+	if _, err := h.Write(tr.Magic[:]); err != nil {
+		dbg.Error("Couldn't hash block:", err)
+	}
+	if err := binary.Write(h, binary.LittleEndian, tr.BlockSize); err != nil {
+		dbg.Error("Couldn't hash block:", err)
+	}
+	if _, err := h.Write([]byte(tr.HeaderHash)); err != nil {
+		dbg.Error("Couldn't hash block:", err)
+	}
+	if _, err := h.Write(tr.Header.HashSum()); err != nil {
+		dbg.Error("Couldn't hash block:", err)
+	}
+	if _, err := h.Write(tr.TransactionList.HashSum()); err != nil {
+		dbg.Error("Couldn't hash block:", err)
+	}
 	return h.Sum(nil)
 }
 
@@ -47,13 +58,21 @@ type Header struct {
 	LeaderId   net.IP
 }
 
-// Hash returns a hash representation of the header
+// HashSum returns a hash representation of the header
 func (h *Header) HashSum() []byte {
 	ha := sha256.New()
-	ha.Write([]byte(h.MerkleRoot))
-	ha.Write([]byte(h.Parent))
-	ha.Write([]byte(h.ParentKey))
-	ha.Write([]byte(h.PublicKey))
+	if _, err := ha.Write([]byte(h.MerkleRoot)); err != nil {
+		dbg.Error("Couldn't hash header", err)
+	}
+	if _, err := ha.Write([]byte(h.Parent)); err != nil {
+		dbg.Error("Couldn't hash header", err)
+	}
+	if _, err := ha.Write([]byte(h.ParentKey)); err != nil {
+		dbg.Error("Couldn't hash header", err)
+	}
+	if _, err := ha.Write([]byte(h.PublicKey)); err != nil {
+		dbg.Error("Couldn't hash header", err)
+	}
 	return ha.Sum(nil)
 }
 
@@ -107,7 +126,9 @@ func (trb *Block) Hash(h *Header) (res string) {
 func HashHeader(h *Header) string {
 	data := fmt.Sprintf("%v", h)
 	sha := sha256.New()
-	sha.Write([]byte(data))
+	if _, err := sha.Write([]byte(data)); err != nil {
+		dbg.Error("Couldn't hash header:", err)
+	}
 	hash := sha.Sum(nil)
 	return hex.EncodeToString(hash)
 }

--- a/protocols/byzcoin/byzcoin.go
+++ b/protocols/byzcoin/byzcoin.go
@@ -155,16 +155,23 @@ func NewByzCoinProtocol(n *sda.Node) (*ByzCoin, error) {
 	bz.viewChangeThreshold = int(math.Ceil(float64(len(bz.Tree().List())) * 2.0 / 3.0))
 
 	// register channels
-	chans := []interface{}{
-		&bz.announceChan,
-		&bz.commitChan,
-		&bz.challengePrepareChan,
-		&bz.challengeCommitChan,
-		&bz.responseChan,
-		&bz.viewchangeChan,
+	if err := n.RegisterChannel(&bz.announceChan); err != nil {
+		return bz, err
 	}
-	if err := n.RegisterChannels(chans); err != nil {
-		return nil, err
+	if err := n.RegisterChannel(&bz.commitChan); err != nil {
+		return bz, err
+	}
+	if err := n.RegisterChannel(&bz.challengePrepareChan); err != nil {
+		return bz, err
+	}
+	if err := n.RegisterChannel(&bz.challengeCommitChan); err != nil {
+		return bz, err
+	}
+	if err := n.RegisterChannel(&bz.responseChan); err != nil {
+		return bz, err
+	}
+	if err := n.RegisterChannel(&bz.viewchangeChan); err != nil {
+		return bz, err
 	}
 
 	n.OnDoneCallback(bz.nodeDone)

--- a/protocols/byzcoin/byzcoin.go
+++ b/protocols/byzcoin/byzcoin.go
@@ -155,12 +155,17 @@ func NewByzCoinProtocol(n *sda.Node) (*ByzCoin, error) {
 	bz.viewChangeThreshold = int(math.Ceil(float64(len(bz.Tree().List())) * 2.0 / 3.0))
 
 	// register channels
-	n.RegisterChannel(&bz.announceChan)
-	n.RegisterChannel(&bz.commitChan)
-	n.RegisterChannel(&bz.challengePrepareChan)
-	n.RegisterChannel(&bz.challengeCommitChan)
-	n.RegisterChannel(&bz.responseChan)
-	n.RegisterChannel(&bz.viewchangeChan)
+	chans := []interface{}{
+		&bz.announceChan,
+		&bz.commitChan,
+		&bz.challengePrepareChan,
+		&bz.challengeCommitChan,
+		&bz.responseChan,
+		&bz.viewchangeChan,
+	}
+	if err := n.RegisterChannels(chans); err != nil {
+		return nil, err
+	}
 
 	n.OnDoneCallback(bz.nodeDone)
 
@@ -633,9 +638,7 @@ func (bz *ByzCoin) handleResponsePrepare(bzr *Response) error {
 		if bz.onResponsePrepareDone != nil {
 			bz.onResponsePrepareDone()
 		}
-		bz.startChallengeCommit()
-
-		return nil
+		return bz.startChallengeCommit()
 	}
 	// send up
 	return bz.SendTo(bz.Parent(), bzrReturn)

--- a/protocols/byzcoin/byzcoin_simulation.go
+++ b/protocols/byzcoin/byzcoin_simulation.go
@@ -99,7 +99,8 @@ func (e *Simulation) Run(sdaConf *sda.SimulationConfig) error {
 	proto.RegisterOnDone(func() {
 		broadDone <- true
 	})
-	proto.Start()
+	// ignore error on purpose: Broadcast.Start() always returns nil
+	_ = proto.Start()
 	// wait
 	<-broadDone
 
@@ -141,10 +142,21 @@ func (e *Simulation) Run(sdaConf *sda.SimulationConfig) error {
 			done <- true
 		})
 		if e.Fail > 0 {
-			go bz.startAnnouncementPrepare()
+			go func() {
+				err := bz.startAnnouncementPrepare()
+				if err != nil {
+					dbg.Error("Error while starting "+
+						"announcment prepare:", err)
+				}
+			}()
 			// do not run bz.startAnnouncementCommit()
 		} else {
-			go bz.Start()
+			go func() {
+				if err := bz.Start(); err != nil {
+					dbg.Error("Couldn't start protocol",
+						err)
+				}
+			}()
 		}
 		// wait for the end
 		<-done

--- a/protocols/byzcoin/ntree/ntree.go
+++ b/protocols/byzcoin/ntree/ntree.go
@@ -65,11 +65,16 @@ func NewNtreeProtocol(node *sda.Node) (*Ntree, error) {
 		tempBlockSig:               new(NaiveBlockSignature),
 		tempSignatureResponse:      &RoundSignatureResponse{new(NaiveBlockSignature)},
 	}
-	node.RegisterChannel(&nt.announceChan)
-	node.RegisterChannel(&nt.blockSignatureChan)
-	node.RegisterChannel(&nt.roundSignatureRequestChan)
-	node.RegisterChannel(&nt.roundSignatureResponseChan)
 
+	chans := []interface{}{
+		&nt.announceChan,
+		&nt.blockSignatureChan,
+		&nt.roundSignatureRequestChan,
+		&nt.roundSignatureResponseChan,
+	}
+	if err := node.RegisterChannels(chans); err != nil {
+		return nil, err
+	}
 	go nt.listen()
 	return nt, nil
 }
@@ -88,7 +93,9 @@ func (nt *Ntree) Start() error {
 	dbg.Lvl3(nt.Name(), "Start()")
 	go byzcoin.VerifyBlock(nt.block, "", "", nt.verifyBlockChan)
 	for _, tn := range nt.Children() {
-		nt.SendTo(tn, &BlockAnnounce{nt.block})
+		if err := nt.SendTo(tn, &BlockAnnounce{nt.block}); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -115,7 +122,12 @@ func (nt *Ntree) listen() {
 				continue
 			}
 			for _, tn := range nt.Children() {
-				nt.SendTo(tn, &msg.BlockAnnounce)
+				err := nt.SendTo(tn, &msg.BlockAnnounce)
+				if err != nil {
+					dbg.Error(nt.Name(),
+						"couldn't send to", tn.Name(),
+						err)
+				}
 			}
 			// generate your own signature / exception and pass that up to the
 			// root
@@ -133,7 +145,11 @@ func (nt *Ntree) listen() {
 			}
 
 			for _, tn := range nt.Children() {
-				nt.SendTo(tn, &msg.RoundSignatureRequest)
+				err := nt.SendTo(tn, &msg.RoundSignatureRequest)
+				if err != nil {
+					dbg.Error(nt.Name(), "couldn't sent to",
+						tn.Name(), err)
+				}
 			}
 			// Decide if we want to sign this or not
 		case msg := <-nt.roundSignatureResponseChan:
@@ -205,7 +221,9 @@ func (nt *Ntree) startSignatureRequest(msg *NaiveBlockSignature) {
 	sigRequest := &RoundSignatureRequest{msg}
 	go nt.verifySignatureRequest(sigRequest)
 	for _, tn := range nt.Children() {
-		nt.SendTo(tn, sigRequest)
+		if err := nt.SendTo(tn, sigRequest); err != nil {
+			dbg.Error(nt.Name(), "couldn't send to", tn.Name(), err)
+		}
 	}
 }
 
@@ -290,7 +308,9 @@ func (nt *Ntree) handleRoundSignatureResponse(msg *RoundSignatureResponse) {
 		}
 		return
 	}
-	nt.SendTo(nt.Parent(), msg)
+	if err := nt.SendTo(nt.Parent(), msg); err != nil {
+		dbg.Error(nt.Name(), "couldn't send to", nt.Name(), err)
+	}
 }
 
 // RegisterOnDone is the callback that will be executed when the final signature

--- a/protocols/byzcoin/ntree/ntree.go
+++ b/protocols/byzcoin/ntree/ntree.go
@@ -66,15 +66,19 @@ func NewNtreeProtocol(node *sda.Node) (*Ntree, error) {
 		tempSignatureResponse:      &RoundSignatureResponse{new(NaiveBlockSignature)},
 	}
 
-	chans := []interface{}{
-		&nt.announceChan,
-		&nt.blockSignatureChan,
-		&nt.roundSignatureRequestChan,
-		&nt.roundSignatureResponseChan,
+	if err := node.RegisterChannel(&nt.announceChan); err != nil {
+		return nt, err
 	}
-	if err := node.RegisterChannels(chans); err != nil {
-		return nil, err
+	if err := node.RegisterChannel(&nt.blockSignatureChan); err != nil {
+		return nt, err
 	}
+	if err := node.RegisterChannel(&nt.roundSignatureRequestChan); err != nil {
+		return nt, err
+	}
+	if err := node.RegisterChannel(&nt.roundSignatureResponseChan); err != nil {
+		return nt, err
+	}
+
 	go nt.listen()
 	return nt, nil
 }

--- a/protocols/byzcoin/ntree/ntree_simulation.go
+++ b/protocols/byzcoin/ntree/ntree_simulation.go
@@ -81,7 +81,11 @@ func (e *Simulation) Run(sdaConf *sda.SimulationConfig) error {
 			done <- true
 		})
 
-		go nt.Start()
+		go func() {
+			if err := nt.Start(); err != nil {
+				dbg.Error("Couldn't start ntree protocol:", err)
+			}
+		}()
 		// wait for the end
 		<-done
 		dbg.Lvl3("Round", round, "finished")

--- a/protocols/byzcoin/pbft/pbft.go
+++ b/protocols/byzcoin/pbft/pbft.go
@@ -86,15 +86,19 @@ func NewProtocol(n *sda.Node) (*Protocol, error) {
 	pbft.prepMsgCount = 0
 	pbft.commitMsgCount = 0
 
-	chans := []interface{}{
-		&pbft.prePrepareChan,
-		&pbft.prepareChan,
-		&pbft.commitChan,
-		&pbft.finishChan,
+	if err := n.RegisterChannel(&pbft.prePrepareChan); err != nil {
+		return pbft, err
 	}
-	if err := n.RegisterChannels(chans); err != nil {
-		return nil, err
+	if err := n.RegisterChannel(&pbft.prepareChan); err != nil {
+		return pbft, err
 	}
+	if err := n.RegisterChannel(&pbft.commitChan); err != nil {
+		return pbft, err
+	}
+	if err := n.RegisterChannel(&pbft.finishChan); err != nil {
+		return pbft, err
+	}
+
 	return pbft, nil
 }
 

--- a/protocols/byzcoin/pbft/simulation.go
+++ b/protocols/byzcoin/pbft/simulation.go
@@ -87,7 +87,10 @@ func (e *Simulation) Run(sdaConf *sda.SimulationConfig) error {
 	proto.RegisterOnDone(func() {
 		broadDone <- true
 	})
-	proto.Start()
+
+	// ignore error on purpose: Start always returns nil
+	_ = proto.Start()
+
 	// wait
 	<-broadDone
 	dbg.Lvl3("Simulation can start!")

--- a/protocols/cosi/cosi.go
+++ b/protocols/cosi/cosi.go
@@ -94,11 +94,15 @@ func NewProtocolCosi(node *sda.Node) (sda.ProtocolInstance, error) {
 		tempResponseLock: new(sync.Mutex),
 	}
 	// Register the three channels we want to register and listens on
-	// By passing pointer = automatic instantiation
-	node.RegisterChannel(&pc.announce)
-	node.RegisterChannel(&pc.commit)
-	node.RegisterChannel(&pc.challenge)
-	node.RegisterChannel(&pc.response)
+	chans := []interface{}{
+		&pc.announce,
+		&pc.commit,
+		&pc.challenge,
+		&pc.response,
+	}
+	if err := node.RegisterChannels(chans); err != nil {
+		return nil, err
+	}
 
 	return pc, err
 }

--- a/protocols/cosi/cosi.go
+++ b/protocols/cosi/cosi.go
@@ -93,15 +93,19 @@ func NewProtocolCosi(node *sda.Node) (sda.ProtocolInstance, error) {
 		tempCommitLock:   new(sync.Mutex),
 		tempResponseLock: new(sync.Mutex),
 	}
-	// Register the three channels we want to register and listens on
-	chans := []interface{}{
-		&pc.announce,
-		&pc.commit,
-		&pc.challenge,
-		&pc.response,
+	// Register the channels we want to register and listens on
+
+	if err := node.RegisterChannel(&pc.announce); err != nil {
+		return pc, err
 	}
-	if err := node.RegisterChannels(chans); err != nil {
-		return nil, err
+	if err := node.RegisterChannel(&pc.commit); err != nil {
+		return pc, err
+	}
+	if err := node.RegisterChannel(&pc.challenge); err != nil {
+		return pc, err
+	}
+	if err := node.RegisterChannel(&pc.response); err != nil {
+		return pc, err
 	}
 
 	return pc, err

--- a/protocols/cosi/simulation.go
+++ b/protocols/cosi/simulation.go
@@ -86,7 +86,9 @@ func (cs *Simulation) Run(config *sda.SimulationConfig) error {
 			done <- true
 		}
 		proto.RegisterDoneCallback(fn)
-		proto.Start()
+		if err := proto.Start(); err != nil {
+			dbg.Error("Couldn't start protocol in round", round)
+		}
 		<-done
 	}
 	dbg.Lvl1("Simulation finished")

--- a/protocols/example/channels/example.go
+++ b/protocols/example/channels/example.go
@@ -45,7 +45,10 @@ func NewExampleChannels(n *sda.Node) (sda.ProtocolInstance, error) {
 func (p *ProtocolExampleChannels) Start() error {
 	dbg.Lvl3("Starting ExampleChannels")
 	for _, c := range p.Children() {
-		p.SendTo(c, &Announce{"Example is here"})
+		if err := p.SendTo(c, &Announce{"Example is here"}); err != nil {
+			dbg.Error(p.Info(), "failed to send Announcment to",
+				c.Name(), err)
+		}
 	}
 	return nil
 }
@@ -58,11 +61,20 @@ func (p *ProtocolExampleChannels) Dispatch() error {
 			if !p.IsLeaf() {
 				// If we have children, send the same message to all of them
 				for _, c := range p.Children() {
-					p.SendTo(c, &announcement.Announce)
+					err := p.SendTo(c, &announcement.Announce)
+					if err != nil {
+						dbg.Error(p.Info(),
+							"failed to send to",
+							c.Name(), err)
+					}
 				}
 			} else {
 				// If we're the leaf, start to reply
-				p.SendTo(p.Parent(), &Reply{1})
+				err := p.SendTo(p.Parent(), &Reply{1})
+				if err != nil {
+					dbg.Error(p.Info(), "failed to send reply to",
+						p.Parent().Name(), err)
+				}
 				return nil
 			}
 		case reply := <-p.ChannelReply:
@@ -73,7 +85,11 @@ func (p *ProtocolExampleChannels) Dispatch() error {
 			dbg.Lvl3(p.Entity().Addresses, "is done with total of", children)
 			if !p.IsRoot() {
 				dbg.Lvl3("Sending to parent")
-				p.SendTo(p.Parent(), &Reply{children})
+				err := p.SendTo(p.Parent(), &Reply{children})
+				if err != nil {
+					dbg.Error(p.Info(), "failed to reply to",
+						p.Parent().Name(), err)
+				}
 			} else {
 				dbg.Lvl3("Root-node is done - nbr of children found:", children)
 				p.ChildCount <- children

--- a/protocols/jvss/simulation.go
+++ b/protocols/jvss/simulation.go
@@ -50,7 +50,9 @@ func (jvs *Simulation) Run(config *sda.SimulationConfig) error {
 	proto := node.ProtocolInstance().(*JVSS)
 
 	dbg.Lvl1("Starting setup")
-	node.StartProtocol()
+	if err := node.StartProtocol(); err != nil {
+		return err
+	}
 	dbg.Lvl1("Setup done")
 
 	for round := 0; round < jvs.Rounds; round++ {

--- a/protocols/manage/broadcast.go
+++ b/protocols/manage/broadcast.go
@@ -53,13 +53,14 @@ func NewBroadcastProtocol(n *sda.Node) (sda.ProtocolInstance, error) {
 
 func (b *Broadcast) init(n *sda.Node) *Broadcast {
 	b.Node = n
-	chans := []interface{}{
-		&b.ackChan,
-		&b.announceChan,
-		&b.okChan,
+	if err := b.RegisterChannel(&b.ackChan); err != nil {
+		dbg.Error(b.Info(), "failed to register channel:", err)
 	}
-	if err := b.RegisterChannels(chans); err != nil {
-		dbg.Error(b.Info(), "failed to register channels:", err)
+	if err := b.RegisterChannel(&b.announceChan); err != nil {
+		dbg.Error(b.Info(), "failed to register channel:", err)
+	}
+	if err := b.RegisterChannel(&b.okChan); err != nil {
+		dbg.Error(b.Info(), "failed to register channel:", err)
 	}
 
 	lists := b.Tree().List()

--- a/protocols/manage/broadcast.go
+++ b/protocols/manage/broadcast.go
@@ -94,7 +94,9 @@ func (b *Broadcast) listen() {
 // Start will contact everyone and makes the connections
 func (b *Broadcast) Start() error {
 	for _, tn := range b.listNode {
-		b.SendTo(tn, &Announce{})
+		if err := b.SendTo(tn, &Announce{}); err != nil {
+			dbg.Error(b.Name(), "failed to send to", tn.Name(), err)
+		}
 	}
 	dbg.Lvl3(b.Name(), "Sent Announce to everyone")
 	return nil

--- a/protocols/manage/count.go
+++ b/protocols/manage/count.go
@@ -73,13 +73,14 @@ func NewCount(n *sda.Node) (sda.ProtocolInstance, error) {
 		timeout: 1024,
 	}
 	p.Count = make(chan int, 1)
-	chans := []interface{}{
-		&p.CountChan,
-		&p.PrepareCountChan,
-		&p.NodeIsUpChan,
+	if err := p.RegisterChannel(&p.CountChan); err != nil {
+		dbg.Error("Couldn't reister channel:", err)
 	}
-	if err := p.RegisterChannels(chans); err != nil {
-		return p, err
+	if err := p.RegisterChannel(&p.PrepareCountChan); err != nil {
+		dbg.Error("Couldn't reister channel:", err)
+	}
+	if err := p.RegisterChannel(&p.NodeIsUpChan); err != nil {
+		dbg.Error("Couldn't reister channel:", err)
 	}
 	return p, nil
 }

--- a/protocols/manage/count.go
+++ b/protocols/manage/count.go
@@ -73,9 +73,14 @@ func NewCount(n *sda.Node) (sda.ProtocolInstance, error) {
 		timeout: 1024,
 	}
 	p.Count = make(chan int, 1)
-	p.RegisterChannel(&p.CountChan)
-	p.RegisterChannel(&p.PrepareCountChan)
-	p.RegisterChannel(&p.NodeIsUpChan)
+	chans := []interface{}{
+		&p.CountChan,
+		&p.PrepareCountChan,
+		&p.NodeIsUpChan,
+	}
+	if err := p.RegisterChannels(chans); err != nil {
+		return p, err
+	}
 	return p, nil
 }
 
@@ -104,7 +109,11 @@ func (p *ProtocolCount) Dispatch() error {
 			running = false
 		case _ = <-p.NodeIsUpChan:
 			if p.Parent() != nil {
-				p.SendTo(p.Parent(), &NodeIsUp{})
+				err := p.SendTo(p.Parent(), &NodeIsUp{})
+				if err != nil {
+					dbg.Error(p.Info(), "couldn't send to parent",
+						p.Parent().Name(), err)
+				}
 			} else {
 				p.Replies++
 			}
@@ -125,13 +134,21 @@ func (p *ProtocolCount) Dispatch() error {
 // every node that receives one will reply with a 'NodeIsUp'-message
 func (p *ProtocolCount) FuncPC() {
 	if !p.IsRoot() {
-		p.SendTo(p.Parent(), &NodeIsUp{})
+		err := p.SendTo(p.Parent(), &NodeIsUp{})
+		if err != nil {
+			dbg.Error(p.Info(), "couldn't send to parent",
+				p.Parent().Name(), err)
+		}
 	}
 	if !p.IsLeaf() {
 		for _, child := range p.Children() {
 			go func(c *sda.TreeNode) {
 				dbg.Lvl3(p.Info(), "sending to", c.Entity.Addresses, c.Id, p.timeout)
-				p.SendTo(c, &PrepareCount{Timeout: p.timeout})
+				err := p.SendTo(c, &PrepareCount{Timeout: p.timeout})
+				if err != nil {
+					dbg.Error(p.Info(), "couldn't send to child",
+						c.Name())
+				}
 			}(child)
 		}
 	} else {
@@ -148,7 +165,10 @@ func (p *ProtocolCount) FuncC(cc []CountMsg) {
 	}
 	if !p.IsRoot() {
 		dbg.Lvl3(p.Info(), "Sends to", p.Parent().Id, p.Parent().Entity.Addresses)
-		p.SendTo(p.Parent(), &Count{count})
+		if err := p.SendTo(p.Parent(), &Count{count}); err != nil {
+			dbg.Error(p.Name(), "coouldn't send to parent",
+				p.Parent().Name())
+		}
 	} else {
 		p.Count <- count
 	}

--- a/protocols/randhound/simulation.go
+++ b/protocols/randhound/simulation.go
@@ -1,10 +1,10 @@
 package randhound
 
 import (
-	"log"
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/dedis/cothority/lib/dbg"
 	"github.com/dedis/cothority/lib/sda"
 )
 
@@ -53,13 +53,15 @@ func (rhs *RHSimulation) Run(config *sda.SimulationConfig) error {
 	if err != nil {
 		return err
 	}
-	log.Printf("RandHound - group config: %d %d %d %d %d %d\n", rh.Group.N, rh.Group.F, rh.Group.L, rh.Group.K, rh.Group.R, rh.Group.T)
-	log.Printf("RandHound - shards: %d\n", rhs.Shards)
-	rh.StartProtocol()
+	dbg.Printf("RandHound - group config: %d %d %d %d %d %d\n", rh.Group.N, rh.Group.F, rh.Group.L, rh.Group.K, rh.Group.R, rh.Group.T)
+	dbg.Printf("RandHound - shards: %d\n", rhs.Shards)
+	if err := rh.StartProtocol(); err != nil {
+		dbg.Error("Error while starting protcol:", err)
+	}
 
 	select {
 	case <-rh.Leader.Done:
-		log.Printf("RandHound - done")
+		dbg.Print("RandHound - done")
 		rnd, err := rh.Random()
 		if err != nil {
 			panic(err)
@@ -68,10 +70,10 @@ func (rhs *RHSimulation) Run(config *sda.SimulationConfig) error {
 		if err != nil {
 			panic(err)
 		}
-		log.Printf("RandHound - random bytes: %v\n", rnd)
-		log.Printf("RandHound - sharding: %v\n", sharding)
+		dbg.Printf("RandHound - random bytes: %v\n", rnd)
+		dbg.Printf("RandHound - sharding: %v\n", sharding)
 	case <-time.After(time.Second * 60):
-		log.Printf("RandHound - time out")
+		dbg.Print("RandHound - time out")
 	}
 
 	return nil

--- a/simul/cothority/cothority.go
+++ b/simul/cothority/cothority.go
@@ -52,7 +52,9 @@ func main() {
 		return
 	}
 	if monitorAddress != "" {
-		monitor.ConnectSink(monitorAddress)
+		if err := monitor.ConnectSink(monitorAddress); err != nil {
+			dbg.Error("Couldn't connect monitor to sink:", err)
+		}
 	}
 	sims := make([]sda.Simulation, len(scs))
 	var rootSC *sda.SimulationConfig
@@ -96,7 +98,9 @@ func main() {
 				dbg.Fatal(err)
 			}
 			node.ProtocolInstance().(*manage.ProtocolCount).SetTimeout(timeout)
-			node.StartProtocol()
+			if err := node.StartProtocol(); err != nil {
+				dbg.Error("Couldn't start protcol:", err)
+			}
 			dbg.Lvl1("Started counting children with timeout of", timeout)
 			select {
 			case count := <-node.ProtocolInstance().(*manage.ProtocolCount).Count:

--- a/simul/platform/cliutils.go
+++ b/simul/platform/cliutils.go
@@ -97,5 +97,7 @@ func Build(path, out, goarch, goos string, buildArgs ...string) (string, error) 
 // KillGo kills all go-instances
 func KillGo() {
 	cmd := exec.Command("killall", "go")
-	cmd.Run()
+	if err := cmd.Run(); err != nil {
+		dbg.Lvl3("Couldn't kill all go instances:", err)
+	}
 }

--- a/simul/platform/deterlab/users/users.go
+++ b/simul/platform/deterlab/users/users.go
@@ -51,17 +51,26 @@ func main() {
 			defer wg.Done()
 			if kill {
 				dbg.Lvl3("Cleaning up host", h, ".")
-				platform.SSHRun("", h, "sudo killall -9 cothority scp 2>/dev/null >/dev/null")
+				if _, err := platform.SSHRun("", h, "sudo killall -9 cothority scp 2>/dev/null >/dev/null"); err != nil {
+					dbg.Error("Couldn't run [sudo killall -9 cothority scp 2>/dev/null >/dev/null]",
+						err)
+				}
 				time.Sleep(1 * time.Second)
-				platform.SSHRun("", h, "sudo killall -9 cothority 2>/dev/null >/dev/null")
+				if _, err := platform.SSHRun("", h, "sudo killall -9 cothority 2>/dev/null >/dev/null"); err != nil {
+					dbg.Error("Couldn't run [sudo killall -9 cothority 2>/dev/null >/dev/null]",
+						err)
+				}
 				time.Sleep(1 * time.Second)
 				// Also kill all other process that start with "./" and are probably
 				// locally started processes
-				platform.SSHRun("", h, "sudo pkill -9 -f '\\./'")
+				_, err := platform.SSHRun("", h, "sudo pkill -9 -f '\\./'")
+				if err != nil {
+					dbg.Error("Couldn't run [sudo pkill -9 -f '\\./']", err)
+				}
 				time.Sleep(1 * time.Second)
 				if dbg.DebugVisible() > 3 {
 					dbg.Lvl4("Cleaning report:")
-					platform.SSHRunStdout("", h, "ps aux")
+					_ = platform.SSHRunStdout("", h, "ps aux")
 				}
 			} else {
 				dbg.Lvl3("Setting the file-limit higher on", h)

--- a/simul/platform/localhost.go
+++ b/simul/platform/localhost.go
@@ -146,7 +146,9 @@ func (d *Localhost) Deploy(rc RunConfig) error {
 		return err
 	}
 	d.sc.Config = string(rc.Toml())
-	d.sc.Save(d.runDir)
+	if err := d.sc.Save(d.runDir); err != nil {
+		return err
+	}
 	dbg.Lvl2("Localhost: Done deploying")
 	return nil
 
@@ -155,7 +157,9 @@ func (d *Localhost) Deploy(rc RunConfig) error {
 // Start will execute one cothority-binary for each server
 // configured
 func (d *Localhost) Start(args ...string) error {
-	os.Chdir(d.runDir)
+	if err := os.Chdir(d.runDir); err != nil {
+		return err
+	}
 	dbg.Lvl4("Localhost: chdir into", d.runDir)
 	ex := d.runDir + "/" + d.Simulation
 	d.running = true
@@ -205,7 +209,10 @@ func (d *Localhost) Wait() error {
 	case e := <-d.errChan:
 		dbg.Lvl3("Finished waiting for hosts:", e)
 		if e != nil {
-			d.Cleanup()
+			if err := d.Cleanup(); err != nil {
+				dbg.Error("Couldn't cleanup running instances",
+					err)
+			}
 			err = e
 		}
 	}

--- a/simul/platform/platform.go
+++ b/simul/platform/platform.go
@@ -76,7 +76,11 @@ func ReadRunFile(p Platform, filename string) []RunConfig {
 	dbg.Lvl3("Reading file", filename)
 
 	file, err := os.Open(filename)
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			dbg.Error("Couldn' close", file.Name())
+		}
+	}()
 	if err != nil {
 		dbg.Fatal("Couldn't open file", file, err)
 	}
@@ -103,7 +107,9 @@ func ReadRunFile(p Platform, filename string) []RunConfig {
 		// fill in the general config
 		masterConfig.Put(strings.TrimSpace(vals[0]), strings.TrimSpace(vals[1]))
 		// also put it in platform
-		toml.Decode(text, p)
+		if _, err := toml.Decode(text, p); err != nil {
+			dbg.Error("Error decoding", text)
+		}
 		dbg.Lvlf5("Platform is now %+v", p)
 	}
 


### PR DESCRIPTION
If errors occur do not simply ignore them (only in rare cases or tests). I tried to change the underlying logic of a function as little as possible. Most of the time I just print out the error message using `dbg.Error`. Only where it was obvious I changed the execution logic (for instance if the the function creates a directory using `od.MkDir` and the rest of the code depends on the successful creation of this directory, I just return the error and do not continue the execution of this function) 