### PR TITLE
changed dbg.Error to dbg.Lvl3 for expected ssh-failures

### DIFF
--- a/simul/platform/deterlab.go
+++ b/simul/platform/deterlab.go
@@ -195,7 +195,7 @@ func (d *Deterlab) Cleanup() error {
 	go func() {
 		// Cleanup eventual residues of previous round - users and sshd
 		if _, err := SSHRun(d.Login, d.Host, "killall -9 users sshd"); err != nil {
-			dbg.Lvl1("Error while cleaning up:", err)
+			dbg.Lvl3("Error while cleaning up:", err)
 		}
 
 		err := SSHRunStdout(d.Login, d.Host, "test -f remote/users && ( cd remote; ./users -kill )")

--- a/simul/platform/deterlab/users/users.go
+++ b/simul/platform/deterlab/users/users.go
@@ -51,22 +51,13 @@ func main() {
 			defer wg.Done()
 			if kill {
 				dbg.Lvl3("Cleaning up host", h, ".")
-				if _, err := platform.SSHRun("", h, "sudo killall -9 cothority scp 2>/dev/null >/dev/null"); err != nil {
-					dbg.Error("Couldn't run [sudo killall -9 cothority scp 2>/dev/null >/dev/null]",
-						err)
-				}
+				runSSH(h, "sudo killall -9 cothority scp 2>/dev/null >/dev/null")
 				time.Sleep(1 * time.Second)
-				if _, err := platform.SSHRun("", h, "sudo killall -9 cothority 2>/dev/null >/dev/null"); err != nil {
-					dbg.Error("Couldn't run [sudo killall -9 cothority 2>/dev/null >/dev/null]",
-						err)
-				}
+				runSSH(h, "sudo killall -9 cothority 2>/dev/null >/dev/null")
 				time.Sleep(1 * time.Second)
 				// Also kill all other process that start with "./" and are probably
 				// locally started processes
-				_, err := platform.SSHRun("", h, "sudo pkill -9 -f '\\./'")
-				if err != nil {
-					dbg.Error("Couldn't run [sudo pkill -9 -f '\\./']", err)
-				}
+				runSSH(h, "sudo pkill -9 -f '\\./'")
 				time.Sleep(1 * time.Second)
 				if dbg.DebugVisible() > 3 {
 					dbg.Lvl4("Cleaning report:")
@@ -170,4 +161,11 @@ func deterFromConfig(name ...string) *platform.Deterlab {
 	}
 	dbg.SetDebugVisible(d.Debug)
 	return d
+}
+
+// Runs a command on the remote host and outputs eventual error
+func runSSH(host, cmd string) {
+	if _, err := platform.SSHRun("", host, cmd); err != nil {
+		dbg.Lvlf3("Host %s got error %s while running [%s]", host, err.Error(), cmd)
+	}
 }

--- a/simul/platform/deterlab/users/users.go
+++ b/simul/platform/deterlab/users/users.go
@@ -163,7 +163,7 @@ func deterFromConfig(name ...string) *platform.Deterlab {
 	return d
 }
 
-// Runs a command on the remote host and outputs eventual error
+// Runs a command on the remote host and outputs an eventual error if debug level >= 3
 func runSSH(host, cmd string) {
 	if _, err := platform.SSHRun("", host, cmd); err != nil {
 		dbg.Lvlf3("Host %s got error %s while running [%s]", host, err.Error(), cmd)


### PR DESCRIPTION
Some of the ssh-calls in the simulation fail normally, because the cleanup is not necessary. Only when the previous simulation failed the cleanup is needed. So the error should normally be ignored.