### PR TITLE
Fixed Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ and that `$GOPATH` and `$GOBIN` are set
 ```bash
 go get github.com/dedis/cothority
 cd $GOPATH/src/github.com/dedis/cothority/app
-go install cosi/cosi.go
-go install cothorityd/cothorityd.go
+go install ./cosi/
+go install ./cothorityd/
 ```
 
 The two binaries `cosi` and `cothorityd` will be added to `$GOBIN`. If you already


### PR DESCRIPTION
install on packages works (instead of single files `go install cosi/cosi.go` which fails) 