### PR TITLE
Add the network.Entity to the Context

### DIFF
--- a/lib/sda/context.go
+++ b/lib/sda/context.go
@@ -10,6 +10,7 @@ type Context interface {
 	RegisterProtocolInstance(ProtocolInstance) error
 	SendRaw(*network.Entity, interface{}) error
 	Address() string
+	Entity() *network.Entity
 }
 
 // defaultContext is the implementation of the Context interface. It is
@@ -26,6 +27,10 @@ func newDefaultContext(h *Host, o *Overlay, servID ServiceID) *defaultContext {
 		Host:    h,
 		servID:  servID,
 	}
+}
+
+func (dc *defaultContext) Entity() *network.Entity {
+	return dc.Host.Entity
 }
 
 // NewTreeNodeInstance implements the Context interface method


### PR DESCRIPTION
It would be very useful  to have the Service's `network.Entity` as part of the `Context` so we can access it from the Services.