### PR TITLE
Two ways of taking control over ProtocolInstance creation

### DIFF
--- a/lib/sda/host.go
+++ b/lib/sda/host.go
@@ -65,7 +65,7 @@ type Host struct {
 	serviceStore *serviceStore
 
 	// factory overriding protocol instance creation
-	newProtocol func(*TreeNodeInstance)(ProtocolInstance, error)
+	newProtocol func(*TreeNodeInstance) (ProtocolInstance, error)
 }
 
 // NewHost starts a new Host that will listen on the network for incoming
@@ -250,7 +250,7 @@ func (h *Host) StartProcessMessages() {
 
 // RegisterNewProtocolFactory registers a new constructor function for the overlay to use for creating new
 // ProtocolInstance's
-func (h *Host) RegisterNewProtocol(fn func(*TreeNodeInstance)(ProtocolInstance, error)) {
+func (h *Host) RegisterNewProtocol(fn func(*TreeNodeInstance) (ProtocolInstance, error)) {
 	h.newProtocol = fn
 }
 

--- a/lib/sda/host.go
+++ b/lib/sda/host.go
@@ -49,22 +49,23 @@ type Host struct {
 	// lock associated to access trees
 	treesLock sync.Mutex
 	// lock associated with pending TreeMarshal
-	pendingTreeLock sync.Mutex
+	pendingTreeLock        sync.Mutex
 	// lock associated with pending SDAdata
-	pendingSDAsLock sync.Mutex
+	pendingSDAsLock        sync.Mutex
 	// working address is mostly for debugging purposes so we know what address
 	// is known as right now
-	workingAddress string
+	workingAddress         string
 	// listening is a flag to tell whether this host is listening or not
-	listening bool
+	listening              bool
 	// whether processMessages has started
 	processMessagesStarted bool
 	// tell processMessages to quit
-	ProcessMessagesQuit chan bool
+	ProcessMessagesQuit    chan bool
 
-	serviceStore *serviceStore
+	serviceStore           *serviceStore
 
-	newProtocolCallback func(*TreeNodeInstance)
+	// factory overriding protocol instance creation
+	newProtocol            func(*TreeNodeInstance)(ProtocolInstance, error)
 }
 
 // NewHost starts a new Host that will listen on the network for incoming
@@ -245,6 +246,12 @@ func (h *Host) StartProcessMessages() {
 	h.networkLock.Lock()
 	h.processMessagesStarted = true
 	go h.processMessages()
+}
+
+// RegisterNewProtocolFactory registers a new constructor function for the overlay to use for creating new
+// ProtocolInstance's
+func (h *Host) RegisterNewProtocol(fn func(*TreeNodeInstance)(ProtocolInstance, error)) {
+	h.newProtocol = fn
 }
 
 // ProcessMessages checks if it is one of the messages for us or dispatch it

--- a/lib/sda/host.go
+++ b/lib/sda/host.go
@@ -63,6 +63,8 @@ type Host struct {
 	ProcessMessagesQuit chan bool
 
 	serviceStore *serviceStore
+
+	newProtocolCallback func(*TreeNodeInstance)
 }
 
 // NewHost starts a new Host that will listen on the network for incoming

--- a/lib/sda/host.go
+++ b/lib/sda/host.go
@@ -49,23 +49,23 @@ type Host struct {
 	// lock associated to access trees
 	treesLock sync.Mutex
 	// lock associated with pending TreeMarshal
-	pendingTreeLock        sync.Mutex
+	pendingTreeLock sync.Mutex
 	// lock associated with pending SDAdata
-	pendingSDAsLock        sync.Mutex
+	pendingSDAsLock sync.Mutex
 	// working address is mostly for debugging purposes so we know what address
 	// is known as right now
-	workingAddress         string
+	workingAddress string
 	// listening is a flag to tell whether this host is listening or not
-	listening              bool
+	listening bool
 	// whether processMessages has started
 	processMessagesStarted bool
 	// tell processMessages to quit
-	ProcessMessagesQuit    chan bool
+	ProcessMessagesQuit chan bool
 
-	serviceStore           *serviceStore
+	serviceStore *serviceStore
 
 	// factory overriding protocol instance creation
-	newProtocol            func(*TreeNodeInstance)(ProtocolInstance, error)
+	newProtocol func(*TreeNodeInstance)(ProtocolInstance, error)
 }
 
 // NewHost starts a new Host that will listen on the network for incoming

--- a/lib/sda/local.go
+++ b/lib/sda/local.go
@@ -27,11 +27,13 @@ type LocalTest struct {
 	Trees map[TreeID]*Tree
 	// All single nodes
 	Nodes []*TreeNodeInstance
+	// A Callback to be called at protocol instantiation
+	NewProtocolCallback func(*TreeNodeInstance)
 }
 
 // NewLocalTest creates a new Local handler that can be used to test protocols
 // locally
-func NewLocalTest() *LocalTest {
+func NewLocalTest(newProtocolCallback func(*TreeNodeInstance)) *LocalTest {
 	return &LocalTest{
 		Hosts:       make(map[network.EntityID]*Host),
 		Overlays:    make(map[network.EntityID]*Overlay),
@@ -39,6 +41,7 @@ func NewLocalTest() *LocalTest {
 		EntityLists: make(map[EntityListID]*EntityList),
 		Trees:       make(map[TreeID]*Tree),
 		Nodes:       make([]*TreeNodeInstance, 0, 1),
+		NewProtocolCallback: newProtocolCallback,
 	}
 }
 
@@ -73,12 +76,13 @@ func (l *LocalTest) CreateProtocol(t *Tree, name string) (ProtocolInstance, erro
 // GenLocalHost returns a slice of 'n' Hosts. If 'connect' is true, the
 // hosts will be connected between each other. If 'processMsg' is true,
 // the ProcessMsg-method will be called.
-func (l *LocalTest) GenLocalHosts(n int, connect, processMsg bool) []*Host {
+func (l *LocalTest) GenLocalHosts(n int, connect, processMsg bool, newProtocolCallback func(*TreeNodeInstance)) []*Host {
 	hosts := GenLocalHosts(n, connect, processMsg)
 	for _, host := range hosts {
 		l.Hosts[host.Entity.ID] = host
 		l.Overlays[host.Entity.ID] = host.overlay
 		l.Services[host.Entity.ID] = host.serviceStore.services
+		host.newProtocolCallback = newProtocolCallback
 	}
 	return hosts
 }
@@ -87,7 +91,7 @@ func (l *LocalTest) GenLocalHosts(n int, connect, processMsg bool) []*Host {
 // be connected to the root host. If register is true, the EntityList and Tree
 // will be registered with the overlay.
 func (l *LocalTest) GenTree(n int, connect, processMsg, register bool) ([]*Host, *EntityList, *Tree) {
-	hosts := l.GenLocalHosts(n, connect, processMsg)
+	hosts := l.GenLocalHosts(n, connect, processMsg, l.NewProtocolCallback)
 
 	list := l.GenEntityListFromHost(hosts...)
 	tree := list.GenerateBinaryTree()
@@ -107,7 +111,7 @@ func (l *LocalTest) GenTree(n int, connect, processMsg, register bool) ([]*Host,
 // nbrHosts can be smaller than nbrTreeNodes, in which case a given host will
 // be used more than once in the tree.
 func (l *LocalTest) GenBigTree(nbrTreeNodes, nbrHosts, bf int, connect bool, register bool) ([]*Host, *EntityList, *Tree) {
-	hosts := l.GenLocalHosts(nbrHosts, connect, true)
+	hosts := l.GenLocalHosts(nbrHosts, connect, true, l.NewProtocolCallback)
 
 	list := l.GenEntityListFromHost(hosts...)
 	tree := list.GenerateBigNaryTree(bf, nbrTreeNodes)
@@ -242,7 +246,7 @@ func (l *LocalTest) GetServices(hosts []*Host, sid ServiceID) []Service {
 // MakeHELS is an abbreviation to make a Host, an EntityList, and a service.
 // It returns the service of the first host in the slice.
 func (l *LocalTest) MakeHELS(nbr int, sid ServiceID) ([]*Host, *EntityList, Service) {
-	hosts := l.GenLocalHosts(nbr, false, true)
+	hosts := l.GenLocalHosts(nbr, false, true, l.NewProtocolCallback)
 	el := l.GenEntityListFromHost(hosts...)
 	return hosts, el, l.Services[hosts[0].Entity.ID][sid]
 }

--- a/lib/sda/overlay.go
+++ b/lib/sda/overlay.go
@@ -90,6 +90,7 @@ func (o *Overlay) TransmitMsg(sdaMsg *Data) error {
 		// created
 		if !ok {
 			pi, err = ProtocolInstantiate(sdaMsg.To.ProtoID, tni)
+			o.host.newProtocolCallback(tni)
 			if err != nil {
 				return err
 			}

--- a/lib/sda/overlay.go
+++ b/lib/sda/overlay.go
@@ -89,8 +89,13 @@ func (o *Overlay) TransmitMsg(sdaMsg *Data) error {
 		// no servies defined => check if there is a protocol that can be
 		// created
 		if !ok {
-			pi, err = ProtocolInstantiate(sdaMsg.To.ProtoID, tni)
-			o.host.newProtocolCallback(tni)
+
+			if o.host.newProtocol != nil {
+				pi, err = o.host.newProtocol(tni) // If constructor registered at host, use it
+			} else {
+				pi, err = ProtocolInstantiate(sdaMsg.To.ProtoID, tni)
+			}
+
 			if err != nil {
 				return err
 			}

--- a/protocols/example/channels/example.go
+++ b/protocols/example/channels/example.go
@@ -71,7 +71,7 @@ func (p *ProtocolExampleChannels) Dispatch() error {
 				}
 			} else {
 				// If we're the leaf, start to reply
-				err := p.SendTo(p.Parent(), &Reply{1})
+				err := p.SendTo(p.Parent(), &Reply{1, p.Message})
 				if err != nil {
 					dbg.Error(p.Info(), "failed to send reply to",
 						p.Parent().Name(), err)
@@ -82,11 +82,12 @@ func (p *ProtocolExampleChannels) Dispatch() error {
 			children := 1
 			for _, c := range reply {
 				children += c.ChildrenCount
+				dbg.Lvl1("Child message was:", c.Message)
 			}
 			dbg.Lvl3(p.Entity().Addresses, "is done with total of", children)
 			if !p.IsRoot() {
 				dbg.Lvl3("Sending to parent")
-				err := p.SendTo(p.Parent(), &Reply{children})
+				err := p.SendTo(p.Parent(), &Reply{children, p.Message})
 				if err != nil {
 					dbg.Error(p.Info(), "failed to reply to",
 						p.Parent().Name(), err)

--- a/protocols/example/channels/example_test.go
+++ b/protocols/example/channels/example_test.go
@@ -25,7 +25,6 @@ func TestNode(t *testing.T) {
 		t.Fatal("Couldn't create protocol:", err)
 	}
 
-
 	protocol := p.(*example_channels.ProtocolExampleChannels)
 	protocol.Start()
 	timeout := network.WaitRetry * time.Duration(network.MaxRetry*nbrNodes*2) * time.Millisecond
@@ -49,12 +48,12 @@ func TestNode2(t *testing.T) {
 	_, _, tree := local.GenTree(nbrNodes, false, true, true)
 
 	// Register a constructor at host level
-	for _,h := range local.Hosts {
+	for _, h := range local.Hosts {
 		h.RegisterNewProtocol(NewProtocol)
 	}
 	defer local.CloseAll()
 
-	p, err := local.StartProtocol("ExampleChannels",tree)
+	p, err := local.StartProtocol("ExampleChannels", tree)
 	if err != nil {
 		t.Fatal("Couldn't create protocol:", err)
 	}
@@ -75,5 +74,5 @@ func TestNode2(t *testing.T) {
 func NewProtocol(tn *sda.TreeNodeInstance) (sda.ProtocolInstance, error) {
 	pi, err := example_channels.NewExampleChannels(tn)
 	pi.(*example_channels.ProtocolExampleChannels).Message = "This works."
-	return pi,err
+	return pi, err
 }

--- a/protocols/example/channels/example_test.go
+++ b/protocols/example/channels/example_test.go
@@ -13,16 +13,52 @@ import (
 // Tests a 2-node system
 func TestNode(t *testing.T) {
 	defer dbg.AfterTest(t)
-	dbg.TestOutput(testing.Verbose(), 4)
-	local := sda.NewLocalTest(Callback)
+	dbg.TestOutput(testing.Verbose(), 1)
+	local := sda.NewLocalTest()
 	nbrNodes := 2
 	_, _, tree := local.GenTree(nbrNodes, false, true, true)
+	sda.ProtocolRegisterName("ExampleChannels", NewProtocol) // change the constructor to local constructor
 	defer local.CloseAll()
 
-	p, err := local.StartProtocol("ExampleChannels", tree)
+	p, err := local.CreateProtocol(tree, "ExampleChannels")
 	if err != nil {
-		t.Fatal("Couldn't start protocol:", err)
+		t.Fatal("Couldn't create protocol:", err)
 	}
+
+
+	protocol := p.(*example_channels.ProtocolExampleChannels)
+	protocol.Start()
+	timeout := network.WaitRetry * time.Duration(network.MaxRetry*nbrNodes*2) * time.Millisecond
+	select {
+	case children := <-protocol.ChildCount:
+		dbg.Lvl2("Instance 1 is done")
+		if children != nbrNodes {
+			t.Fatal("Didn't get a child-cound of", nbrNodes)
+		}
+	case <-time.After(timeout):
+		t.Fatal("Didn't finish in time")
+	}
+}
+
+// Tests a 2-node system
+func TestNode2(t *testing.T) {
+	defer dbg.AfterTest(t)
+	dbg.TestOutput(testing.Verbose(), 1)
+	local := sda.NewLocalTest()
+	nbrNodes := 2
+	_, _, tree := local.GenTree(nbrNodes, false, true, true)
+
+	// Register a constructor at host level
+	for _,h := range local.Hosts {
+		h.RegisterNewProtocol(NewProtocol)
+	}
+	defer local.CloseAll()
+
+	p, err := local.StartProtocol("ExampleChannels",tree)
+	if err != nil {
+		t.Fatal("Couldn't create protocol:", err)
+	}
+
 	protocol := p.(*example_channels.ProtocolExampleChannels)
 	timeout := network.WaitRetry * time.Duration(network.MaxRetry*nbrNodes*2) * time.Millisecond
 	select {
@@ -36,7 +72,8 @@ func TestNode(t *testing.T) {
 	}
 }
 
-
-func Callback(tn *sda.TreeNodeInstance) {
-	dbg.Lvl1("Calllelddd")
+func NewProtocol(tn *sda.TreeNodeInstance) (sda.ProtocolInstance, error) {
+	pi, err := example_channels.NewExampleChannels(tn)
+	pi.(*example_channels.ProtocolExampleChannels).Message = "This works."
+	return pi,err
 }

--- a/protocols/example/channels/example_test.go
+++ b/protocols/example/channels/example_test.go
@@ -14,7 +14,7 @@ import (
 func TestNode(t *testing.T) {
 	defer dbg.AfterTest(t)
 	dbg.TestOutput(testing.Verbose(), 4)
-	local := sda.NewLocalTest()
+	local := sda.NewLocalTest(Callback)
 	nbrNodes := 2
 	_, _, tree := local.GenTree(nbrNodes, false, true, true)
 	defer local.CloseAll()
@@ -34,4 +34,9 @@ func TestNode(t *testing.T) {
 	case <-time.After(timeout):
 		t.Fatal("Didn't finish in time")
 	}
+}
+
+
+func Callback(tn *sda.TreeNodeInstance) {
+	dbg.Lvl1("Calllelddd")
 }

--- a/protocols/example/channels/struct.go
+++ b/protocols/example/channels/struct.go
@@ -17,6 +17,7 @@ type StructAnnounce struct {
 // Reply returns the count of all children.
 type Reply struct {
 	ChildrenCount int
+	Message string
 }
 
 // StructReply contains Reply and the data necessary to identify the

--- a/protocols/example/channels/struct.go
+++ b/protocols/example/channels/struct.go
@@ -17,7 +17,7 @@ type StructAnnounce struct {
 // Reply returns the count of all children.
 type Reply struct {
 	ChildrenCount int
-	Message string
+	Message       string
 }
 
 // StructReply contains Reply and the data necessary to identify the


### PR DESCRIPTION
When testing protocols that operate on the presence of data on `TreeNode` that are not the root, we need to have access to their `ProtocolInstance` in order to set a pointer to these data.

These are two ways of doing it, with a modified version of example_test.go as use case:

1. Call sda.ProtocolRegisterName for the test. You can actually override SDA's `ProtocolInstace` creation function with a locally provided function. This is nice because it doesn't change anything in SDA. This isn't nice because this survives the test (you need to set the old `NewProtocol` function back).
2. Adding some logic at the host level so that you can register your own `ProtocolInstace` constructor, like the services are doing. This is nice because you don't manipulate global state in SDA. This isn't nice because you change SDA lib.

So the question is, is it worth giving local tests their own way of creating `ProtocolInstance`, or is the little "hack" in a) already good enough ?