### PR TITLE
Log print correct

### DIFF
--- a/log/lvl.go
+++ b/log/lvl.go
@@ -159,6 +159,9 @@ func lvl(lvl, skip int, args ...interface{}) {
 	case lvlPrint:
 		fg(ct.White, true)
 		lvlStr = "I"
+	case lvlInfo:
+		fg(ct.White, true)
+		lvlStr = "I"
 	case lvlWarning:
 		fg(ct.Green, true)
 		lvlStr = "W"
@@ -185,7 +188,7 @@ func lvl(lvl, skip int, args ...interface{}) {
 		str = fmt.Sprintf("%s.%09d%s", ti.Format("06/02/01 15:04:05"), ti.Nanosecond(), str)
 	}
 	str = fmt.Sprintf("%-2s%s", lvlStr, str)
-	if lvl < lvlPrint {
+	if lvl < lvlInfo {
 		fmt.Fprint(stdErr, str)
 	} else {
 		fmt.Fprint(stdOut, str)

--- a/log/lvl.go
+++ b/log/lvl.go
@@ -116,14 +116,14 @@ var outputLines = true
 
 var regexpPaths, _ = regexp.Compile(".*/")
 
-func lvl(lvl int, args ...interface{}) {
+func lvl(lvl, skip int, args ...interface{}) {
 	debugMut.Lock()
 	defer debugMut.Unlock()
 
 	if lvl > debugVisible {
 		return
 	}
-	pc, _, line, _ := runtime.Caller(3)
+	pc, _, line, _ := runtime.Caller(skip)
 	name := regexpPaths.ReplaceAllString(runtime.FuncForPC(pc).Name(), "")
 	lineStr := fmt.Sprintf("%d", line)
 
@@ -206,10 +206,10 @@ func fg(c ct.Color, bright bool) {
 // or
 // Lvl1 -> lvld -> lvl
 func lvlf(l int, f string, args ...interface{}) {
-	lvl(l, fmt.Sprintf(f, args...))
+	lvl(l, 3, fmt.Sprintf(f, args...))
 }
 func lvld(l int, args ...interface{}) {
-	lvl(l, args...)
+	lvl(l, 3, args...)
 }
 
 // Lvl1 debug output is informational and always displayed

--- a/log/ui.go
+++ b/log/ui.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-func lvlUI(lvl int, args ...interface{}) {
+func lvlUI(l int, args ...interface{}) {
 	if debugVisible > 0 {
-		lvld(lvl, args...)
+		lvl(l, 3, args...)
 	} else {
-		print(lvl, args...)
+		print(l, args...)
 	}
 }
 

--- a/log/ui_test.go
+++ b/log/ui_test.go
@@ -57,3 +57,16 @@ func TestInfo(t *testing.T) {
 	assert.Equal(t, "None Python\n", getStdOut())
 	SetDebugVisible(1)
 }
+
+func TestLvl(t *testing.T) {
+	SetDebugVisible(1)
+	Info("TestLvl")
+	assert.Equal(t, "I : (                             log.TestLvl:   0) - TestLvl\n",
+		getStdOut())
+	Print("TestLvl")
+	assert.Equal(t, "I : (                             log.TestLvl:   0) - TestLvl\n",
+		getStdOut())
+	Warn("TestLvl")
+	assert.Equal(t, "W : (                             log.TestLvl:   0) - TestLvl\n",
+		getStdErr())
+}


### PR DESCRIPTION
Print correct output for `Print` and others when in debug-output.