### PR TITLE
Add coveralls reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
 
 script:
   - make test
-  - ./coveralls.sh
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,16 @@ go:
 
 install:
   - ./install.sh
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/mattn/goveralls
+
+env:
+  global:
+    secure: Qu8PbKlf0Q5LoVeiut3+vEgghyLdZmvgrLsW/wI4XKSOL49K2LetELsZA6298OCoCaXm2BbESsoMApLglDx4h4PAOUwm/Sf28kJKRzmA0WidTR3XnIvBDnQrW7bm/9KV+de4uW6HUi7j4jp93E4y3LhBjBiq4ayVxlTHMKgQFBD02QFA7namD3LF5xjGnU99y7RNw0QNBv7BJfuOllIBJaetXQsHAcGX2pQmyZK5uQy52hXe6lVivWPdRrtDUVJQ3Yb7ez80fnLw3+5cBU21Om3L8P88QfbPZu7BCbUb6uwqruHX8a+ZqeDXVe9zpzqhvW+FckQz8MCHkLVXM6BucAS1y//s7VtYOiw6uhU4vsmP6dPbh90yS325n310P43mZ+7JX4XOV41/33CCK/zG4HxsTlsLeH0MTWjDpIBHR+UVJGySYrLD4hj1/WLTFPcycbTb9RwatUFao80KksaLG1TEH7zp14hav8M6cgZcJooabmNlqvj6UvkAOU88ZdUnjt3Bu64dhZpd/9cXQ65NRLFaQAyt3gufFUtT31azrPhomAP+JcK77CqcGDGye/Nhl2BEeio/dqeoACwwZHDPbhveCDqWEtumtV0LVUKuIyj0/EFkXByZBcnpzecIl5F4BB3ihgckQP5cS/OLKAsCztNOoIwewm+5/aCjIKh+T2M=
 
 script:
   - make test
+  - ./coveralls.sh
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,9 @@ test_playground:
 test_verbose:
 	go test -v -race -short ./...
 
+# use test_verbose instead if you want to use this Makefile locally
 test_go:
-	go test -race -short ./...
+	./coveralls.sh
 
 test: test_fmt test_lint test_go
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/dedis/cothority.svg?branch=master)](https://travis-ci.org/dedis/cothority)
+[![Coverage Status](https://coveralls.io/repos/github/dedis/cothority/badge.svg)](https://coveralls.io/github/dedis/cothority)
 
 # Cothority
 

--- a/coveralls.sh
+++ b/coveralls.sh
@@ -5,11 +5,11 @@ DIR_SOURCE="$(find . -maxdepth 10 -type f -not -path '*/vendor*' -name '*.go' | 
 
 # Run test coverage on each subdirectories and merge the coverage profile.
 
-echo "mode: count" > profile.cov
+echo "mode: atomic" > profile.cov
 
 for dir in ${DIR_SOURCE};
 do
-    go test -short -race -covermode=count -coverprofile=$dir/profile.tmp $dir
+    go test -short -race -covermode=atomic -coverprofile=$dir/profile.tmp $dir
     if [ -f $dir/profile.tmp ]
     then
         cat $dir/profile.tmp | tail -n +2 >> profile.cov

--- a/coveralls.sh
+++ b/coveralls.sh
@@ -17,9 +17,9 @@ do
     fi
 done
 
-go tool cover -func profile.cov
+# If you want to print the coverage of each file individually uncomment:
+# go tool cover -func profile.cov
 
 # To submit the test coverage result to coveralls.io,
 # use goveralls (https://github.com/mattn/goveralls)
-
 goveralls -coverprofile=profile.cov -service=travis-ci -repotoken $COVERALLS_TOKEN

--- a/coveralls.sh
+++ b/coveralls.sh
@@ -9,7 +9,7 @@ echo "mode: count" > profile.cov
 
 for dir in ${DIR_SOURCE};
 do
-    go test -short -covermode=count -coverprofile=$dir/profile.tmp $dir
+    go test -short -race -covermode=count -coverprofile=$dir/profile.tmp $dir
     if [ -f $dir/profile.tmp ]
     then
         cat $dir/profile.tmp | tail -n +2 >> profile.cov

--- a/coveralls.sh
+++ b/coveralls.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Source: https://github.com/h12w/gosweep/blob/master/gosweep.sh
+
+DIR_SOURCE="$(find . -maxdepth 10 -type f -not -path '*/vendor*' -name '*.go' | xargs -I {} dirname {} | sort | uniq)"
+
+# Run test coverage on each subdirectories and merge the coverage profile.
+
+echo "mode: count" > profile.cov
+
+for dir in ${DIR_SOURCE};
+do
+    go test -short -covermode=count -coverprofile=$dir/profile.tmp $dir
+    if [ -f $dir/profile.tmp ]
+    then
+        cat $dir/profile.tmp | tail -n +2 >> profile.cov
+        rm $dir/profile.tmp
+    fi
+done
+
+go tool cover -func profile.cov
+
+# To submit the test coverage result to coveralls.io,
+# use goveralls (https://github.com/mattn/goveralls)
+
+goveralls -coverprofile=profile.cov -service=travis-ci -repotoken $COVERALLS_TOKEN

--- a/simul/runfiles/byzcoin.toml
+++ b/simul/runfiles/byzcoin.toml
@@ -1,5 +1,5 @@
 Servers = 36
-Simulation = "SimulationByzCoin"
+Simulation = "ByzCoin"
 NumClientTxs = 100000
 Rounds = 5
 BF = 5


### PR DESCRIPTION
Add goveralls/coveralls reporting (to keep track of test code coverage).
Resolves issue #549  