### PR TITLE
[1/7] Network refactoring - Address

### DIFF
--- a/app/lib/config/config_test.go
+++ b/app/lib/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/dedis/cothority/log"
+	"github.com/dedis/cothority/network"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,12 +23,12 @@ func TestMain(m *testing.M) {
 var serverGroup string = `Description = "Default Dedis Cosi servers"
 
 [[servers]]
-Addresses = ["5.135.161.91:2000"]
+Address = "tcp://5.135.161.91:2000"
 Public = "lLglU3nhHfUWe4p647hffn618TiUq+6FvTGzJw8eTGU="
 Description = "Nikkolasg's server: spreading the love of signing"
 
 [[servers]]
-Addresses = ["185.26.156.40:61117"]
+Address = "tcp://185.26.156.40:61117"
 Public = "apIWOKSt6JcOvNnjcVcPCNcaJJh/kPEjkbn2xSW+W+Q="
 Description = "Ismail's server"`
 
@@ -37,6 +38,10 @@ func TestReadGroupDescToml(t *testing.T) {
 
 	if len(group.Roster.List) != 2 {
 		t.Fatal("Should have 2 ServerIdentities")
+	}
+	nikkoAddr := group.Roster.List[0].Address
+	if !nikkoAddr.Valid() || nikkoAddr != network.NewTCPAddress("5.135.161.91:2000") {
+		t.Fatal("Address not valid " + group.Roster.List[0].Address.String())
 	}
 	if len(group.description) != 2 {
 		t.Fatal("Should have 2 descriptions")

--- a/app/lib/server/server.go
+++ b/app/lib/server/server.go
@@ -65,7 +65,7 @@ func InteractiveConfig(binaryName string) {
 	var hostStr string
 	var ipProvided = true
 	var portStr string
-	var serverBinding string
+	var serverBinding network.Address
 	if !strings.Contains(str, ":") {
 		str = ":" + str
 	}
@@ -87,16 +87,17 @@ func InteractiveConfig(binaryName string) {
 		portStr = port
 	}
 
-	serverBinding = hostStr + ":" + portStr
-	if net.ParseIP(hostStr) == nil {
-		log.Fatal("Invalid connection  information for", serverBinding)
+	serverBinding = network.NewTCPAddress(hostStr + ":" + portStr)
+	if !serverBinding.Valid() {
+		log.Error("Unable to validate address given", serverBinding)
+		return
 	}
 
 	log.Info("We now need to get a reachable address for other CoSi servers")
 	log.Info("and clients to contact you. This address will be put in a group definition")
 	log.Info("file that you can share and combine with others to form a Cothority roster.")
 
-	var publicAddress string
+	var publicAddress network.Address
 	var failedPublic bool
 	// if IP was not provided then let's get the public IP address
 	if !ipProvided {
@@ -112,7 +113,7 @@ func InteractiveConfig(binaryName string) {
 				log.Error("Could not parse your public IP address", err)
 				failedPublic = true
 			} else {
-				publicAddress = strings.TrimSpace(string(buff)) + ":" + portStr
+				publicAddress = network.NewTCPAddress(strings.TrimSpace(string(buff)) + ":" + portStr)
 			}
 		}
 	} else {
@@ -137,12 +138,16 @@ func InteractiveConfig(binaryName string) {
 		}
 	}
 
+	if !publicAddress.Valid() {
+		log.Fatal("Could not validate public ip address:", publicAddress)
+	}
+
 	// create the keys
 	privStr, pubStr := createKeyPair()
 	conf := &config.CothoritydConfig{
-		Public:    pubStr,
-		Private:   privStr,
-		Addresses: []string{serverBinding},
+		Public:  pubStr,
+		Private: privStr,
+		Address: serverBinding,
 	}
 
 	var configDone bool
@@ -238,7 +243,7 @@ func checkList(list *sda.Roster, descs []string) error {
 	serverStr := ""
 	for i, s := range list.List {
 		name := strings.Split(descs[i], " ")[0]
-		serverStr += fmt.Sprintf("%s_%s ", s.Addresses[0], name)
+		serverStr += fmt.Sprintf("%s_%s ", s.Address, name)
 	}
 	log.Lvl3("Sending message to: " + serverStr)
 	msg := "verification"
@@ -319,10 +324,10 @@ func entityListToPublics(el *sda.Roster) []abstract.Point {
 	return publics
 }
 
-func isPublicIP(ip string) bool {
+func isPublicIP(ip network.Address) bool {
 	public, err := regexp.MatchString("(^127\\.)|(^10\\.)|"+
 		"(^172\\.1[6-9]\\.)|(^172\\.2[0-9]\\.)|"+
-		"(^172\\.3[0-1]\\.)|(^192\\.168\\.)", ip)
+		"(^172\\.3[0-1]\\.)|(^192\\.168\\.)", ip.NetworkAddress())
 	if err != nil {
 		log.Error(err)
 	}
@@ -396,7 +401,7 @@ func getDefaultConfigFile(binaryName string) string {
 	}
 }
 
-func askReachableAddress(port string) string {
+func askReachableAddress(port string) network.Address {
 	ipStr := config.Input(DefaultAddress, "IP-address where your server can be reached")
 
 	splitted := strings.Split(ipStr, ":")
@@ -414,19 +419,19 @@ func askReachableAddress(port string) string {
 		// add the port
 		ipStr = ipStr + ":" + port
 	}
-	return ipStr
+	return network.NewTCPAddress(ipStr)
 }
 
 // tryConnect will bind to the ip address and ask a internet service to try to
 // connect to it. binding is the address where we must listen (needed because
 // the reachable address might not be the same as the binding address => NAT, ip
 // rules etc).
-func tryConnect(ip string, binding string) error {
+func tryConnect(ip, binding network.Address) error {
 
 	stopCh := make(chan bool, 1)
 	// let's bind
 	go func() {
-		ln, err := net.Listen("tcp", binding)
+		ln, err := net.Listen("tcp", binding.NetworkAddress())
 		if err != nil {
 			log.Error("Trouble with binding to the address:", err)
 			return
@@ -437,7 +442,7 @@ func tryConnect(ip string, binding string) error {
 	}()
 	defer func() { stopCh <- true }()
 
-	_, port, err := net.SplitHostPort(ip)
+	_, port, err := net.SplitHostPort(ip.NetworkAddress())
 	if err != nil {
 		return err
 	}

--- a/app/lib/server/server.go
+++ b/app/lib/server/server.go
@@ -23,8 +23,6 @@ import (
 	"github.com/dedis/cothority/network"
 	"github.com/dedis/cothority/sda"
 
-	"regexp"
-
 	// Empty imports to have the init-functions called which should
 	// register the protocol
 	"github.com/dedis/crypto/cosi"
@@ -124,7 +122,7 @@ func InteractiveConfig(binaryName string) {
 	if failedPublic {
 		publicAddress = askReachableAddress(portStr)
 	} else {
-		if isPublicIP(publicAddress) {
+		if publicAddress.Public() {
 			// try  to connect to ipfound:portgiven
 			tryIP := publicAddress
 			log.Info("Check if the address", tryIP, "is reachable from Internet...")
@@ -322,16 +320,6 @@ func entityListToPublics(el *sda.Roster) []abstract.Point {
 		publics[i] = e.Public
 	}
 	return publics
-}
-
-func isPublicIP(ip network.Address) bool {
-	public, err := regexp.MatchString("(^127\\.)|(^10\\.)|"+
-		"(^172\\.1[6-9]\\.)|(^172\\.2[0-9]\\.)|"+
-		"(^172\\.3[0-1]\\.)|(^192\\.168\\.)", ip.NetworkAddress())
-	if err != nil {
-		log.Error(err)
-	}
-	return !public
 }
 
 // Returns true if file exists and user is OK to overwrite, or file dont exists

--- a/network/address.go
+++ b/network/address.go
@@ -1,0 +1,136 @@
+package network
+
+import (
+	"net"
+	"strings"
+)
+
+// ConnType is a type to represent what is the type of a Conn
+// It can be of different types such as TCP, TLS etc.
+type ConnType string
+
+// Address contains the ConnType and the actual network address. It is used to connect
+// to a remote host with a Conn and to listen by a Listener.
+// A network address is comprised of the IP address and the port number joined
+// by a colon.
+// For the moment, there is no IPv6 support.
+type Address string
+
+const (
+	// PlainTCP represents a vanilla TCP connection
+	PlainTCP ConnType = "tcp"
+	// TLS represents a TLS encrypted connection over TCP
+	TLS = "tls"
+	// PURB represents a PURB encryption connection over TCP
+	PURB = "purb"
+	// Local represents a channel based connection type
+	Local = "local"
+	// UnvalidConnType represents a non valid connection type
+	UnvalidConnType = "wrong"
+)
+
+// typeAddressSep is the separator between the type of connection and the actual
+// ip address.
+const typeAddressSep = "://"
+
+func connType(t string) ConnType {
+	ct := ConnType(t)
+	types := []ConnType{PlainTCP, TLS, PURB, Local}
+	for _, t := range types {
+		if t == ct {
+			return ct
+		}
+	}
+	return UnvalidConnType
+}
+
+// ConnType return the connection type from this address
+// It returns an unvalid connection type if the address is not valid or if the
+// connection type is not known.
+func (a Address) ConnType() ConnType {
+	if !a.Valid() {
+		return UnvalidConnType
+	}
+	vals := strings.Split(string(a), typeAddressSep)
+	if len(vals) == 0 {
+		return UnvalidConnType
+	}
+	return connType(vals[0])
+}
+
+// NetworkAddress returns the network address part of an Address. That includes
+// the IP address and the port joined by a colon.
+// It returns an empty string if the a.Valid() returns false.
+func (a Address) NetworkAddress() string {
+	if !a.Valid() {
+		return ""
+	}
+	vals := strings.Split(string(a), typeAddressSep)
+	if len(vals) != 2 {
+		return ""
+	}
+	return vals[1]
+}
+
+// Valid returns true if the address is well formed or false otherwise.
+// An address is well formed if it is of the form: ConnType:NetworkAddress.
+// ConnType must be one of the constants defined in this file,
+// NetworkAddress must contain the IP address + Port number.
+// Ex. tls:192.168.1.10:5678
+func (a Address) Valid() bool {
+	vals := strings.Split(string(a), typeAddressSep)
+	if len(vals) != 2 {
+		return false
+	}
+	if connType(vals[0]) == UnvalidConnType {
+		return false
+	}
+
+	if ip, _, e := net.SplitHostPort(vals[1]); e != nil {
+		return false
+	} else if ip == "localhost" {
+		// localhost is not recognized by net.ParseIP ?
+		return true
+	} else if net.ParseIP(ip) == nil {
+		return false
+	}
+	return true
+}
+
+func (a Address) String() string {
+	return string(a)
+}
+
+// Host returns the host part of the address.
+// ex: "tcp://127.0.0.1:2000" => "127.0.0.1"
+func (a Address) Host() string {
+	na := a.NetworkAddress()
+	if na == "" {
+		return ""
+	}
+	h, _, e := net.SplitHostPort(a.NetworkAddress())
+	if e != nil {
+		return ""
+	}
+	return h
+}
+
+// Port will return the port part of the Address
+func (a Address) Port() string {
+	na := a.NetworkAddress()
+	if na == "" {
+		return ""
+	}
+	_, p, e := net.SplitHostPort(na)
+	if e != nil {
+		return ""
+	}
+	return p
+
+}
+
+// NewAddress takes a connection type and the raw address. It returns a
+// correctly formatted address, which will be of type t.
+func NewAddress(t ConnType, network string) Address {
+	return Address(string(t) + typeAddressSep + network)
+}

--- a/network/address.go
+++ b/network/address.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -132,6 +133,20 @@ func (a Address) Port() string {
 	}
 	return p
 
+}
+
+// Public returns true if the address is a public and valid one
+// or false otherwise.
+// Specifically it checks if it is a private address by checking
+// 192.168.**,10.***,127.***,172.**,169.254.**
+func (a Address) Public() bool {
+	private, err := regexp.MatchString("(^127\\.)|(^10\\.)|"+
+		"(^172\\.1[6-9]\\.)|(^172\\.2[0-9]\\.)|"+
+		"(^172\\.3[0-1]\\.)|(^192\\.168\\.)|(^169\\.254)", a.NetworkAddress())
+	if err != nil {
+		return false
+	}
+	return !private && a.Valid()
 }
 
 // NewAddress takes a connection type and the raw address. It returns a

--- a/network/address.go
+++ b/network/address.go
@@ -52,9 +52,6 @@ func (a Address) ConnType() ConnType {
 		return UnvalidConnType
 	}
 	vals := strings.Split(string(a), typeAddressSep)
-	if len(vals) == 0 {
-		return UnvalidConnType
-	}
 	return connType(vals[0])
 }
 
@@ -66,9 +63,6 @@ func (a Address) NetworkAddress() string {
 		return ""
 	}
 	vals := strings.Split(string(a), typeAddressSep)
-	if len(vals) != 2 {
-		return ""
-	}
 	return vals[1]
 }
 

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -42,6 +42,8 @@ func TestAddress(t *testing.T) {
 		{"tlsx10.0.0.4:2000", false, UnvalidConnType, "", "", ""},
 		{"tls:10.0.0.4x2000", false, UnvalidConnType, "", "", ""},
 		{"tlsx10.0.0.4x2000", false, UnvalidConnType, "", "", ""},
+		{"tlxblurdie", false, UnvalidConnType, "", "", ""},
+		{"tls://blublublu", false, UnvalidConnType, "", "", ""},
 	}
 
 	for i, str := range tests {

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -14,8 +14,8 @@ func TestConnType(t *testing.T) {
 		{"tcp", PlainTCP},
 		{"tls", TLS},
 		{"purb", PURB},
-		{"tcp4", UnvalidConnType},
-		{"_tls", UnvalidConnType},
+		{"tcp4", InvalidConnType},
+		{"_tls", InvalidConnType},
 	}
 
 	for _, str := range tests {
@@ -37,13 +37,15 @@ func TestAddress(t *testing.T) {
 		{"tls://10.0.0.4:2000", true, TLS, "10.0.0.4:2000", "10.0.0.4", "2000"},
 		{"tcp://10.0.0.4:2000", true, PlainTCP, "10.0.0.4:2000", "10.0.0.4", "2000"},
 		{"purb://10.0.0.4:2000", true, PURB, "10.0.0.4:2000", "10.0.0.4", "2000"},
-		{"tls4://10.0.0.4:2000", false, UnvalidConnType, "", "", ""},
-		{"tls://1000.0.0.4:2000", false, UnvalidConnType, "", "", ""},
-		{"tlsx10.0.0.4:2000", false, UnvalidConnType, "", "", ""},
-		{"tls:10.0.0.4x2000", false, UnvalidConnType, "", "", ""},
-		{"tlsx10.0.0.4x2000", false, UnvalidConnType, "", "", ""},
-		{"tlxblurdie", false, UnvalidConnType, "", "", ""},
-		{"tls://blublublu", false, UnvalidConnType, "", "", ""},
+		{"tls4://10.0.0.4:2000", false, InvalidConnType, "", "", ""},
+		{"tls://1000.0.0.4:2000", false, InvalidConnType, "", "", ""},
+		{"tls://10.0.0.4:20000000", false, InvalidConnType, "", "", ""},
+		{"tls://10.0.0.4:-10", false, InvalidConnType, "", "", ""},
+		{"tlsx10.0.0.4:2000", false, InvalidConnType, "", "", ""},
+		{"tls:10.0.0.4x2000", false, InvalidConnType, "", "", ""},
+		{"tlsx10.0.0.4x2000", false, InvalidConnType, "", "", ""},
+		{"tlxblurdie", false, InvalidConnType, "", "", ""},
+		{"tls://blublublu", false, InvalidConnType, "", "", ""},
 	}
 
 	for i, str := range tests {

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -37,7 +37,7 @@ func TestAddress(t *testing.T) {
 	}{
 		{"tls://10.0.0.4:2000", true, TLS, "10.0.0.4:2000", "10.0.0.4", "2000", false},
 		{"tcp://10.0.0.4:2000", true, PlainTCP, "10.0.0.4:2000", "10.0.0.4", "2000", false},
-		{"tcp://67.43.129.85:2000", true, PlainTCP, "10.0.0.4:2000", "10.0.0.4", "2000", true},
+		{"tcp://67.43.129.85:2000", true, PlainTCP, "67.43.129.85:2000", "67.43.129.85", "2000", true},
 		{"purb://10.0.0.4:2000", true, PURB, "10.0.0.4:2000", "10.0.0.4", "2000", false},
 		{"tls4://10.0.0.4:2000", false, InvalidConnType, "", "", "", false},
 		{"tls://1000.0.0.4:2000", false, InvalidConnType, "", "", "", false},
@@ -57,5 +57,6 @@ func TestAddress(t *testing.T) {
 		assert.Equal(t, str.Address, add.NetworkAddress())
 		assert.Equal(t, str.Host, add.Host())
 		assert.Equal(t, str.Port, add.Port())
+		assert.Equal(t, str.Public, add.Public())
 	}
 }

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -1,0 +1,55 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnType(t *testing.T) {
+	var tests = []struct {
+		Value    string
+		Expected ConnType
+	}{
+		{"tcp", PlainTCP},
+		{"tls", TLS},
+		{"purb", PURB},
+		{"tcp4", UnvalidConnType},
+		{"_tls", UnvalidConnType},
+	}
+
+	for _, str := range tests {
+		if connType(str.Value) != str.Expected {
+			t.Error("Wrong ConnType for " + str.Value)
+		}
+	}
+}
+
+func TestAddress(t *testing.T) {
+	var tests = []struct {
+		Value   string
+		Valid   bool
+		Type    ConnType
+		Address string
+		Host    string
+		Port    string
+	}{
+		{"tls://10.0.0.4:2000", true, TLS, "10.0.0.4:2000", "10.0.0.4", "2000"},
+		{"tcp://10.0.0.4:2000", true, PlainTCP, "10.0.0.4:2000", "10.0.0.4", "2000"},
+		{"purb://10.0.0.4:2000", true, PURB, "10.0.0.4:2000", "10.0.0.4", "2000"},
+		{"tls4://10.0.0.4:2000", false, UnvalidConnType, "", "", ""},
+		{"tls://1000.0.0.4:2000", false, UnvalidConnType, "", "", ""},
+		{"tlsx10.0.0.4:2000", false, UnvalidConnType, "", "", ""},
+		{"tls:10.0.0.4x2000", false, UnvalidConnType, "", "", ""},
+		{"tlsx10.0.0.4x2000", false, UnvalidConnType, "", "", ""},
+	}
+
+	for i, str := range tests {
+		add := Address(str.Value)
+		assert.Equal(t, str.Valid, add.Valid(), "Address (%d) %s", i, str.Value)
+		assert.Equal(t, str.Type, add.ConnType(), "Address (%d) %s", i, str.Value)
+		assert.Equal(t, str.Address, add.NetworkAddress())
+		assert.Equal(t, str.Host, add.Host())
+		assert.Equal(t, str.Port, add.Port())
+	}
+}

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -33,19 +33,21 @@ func TestAddress(t *testing.T) {
 		Address string
 		Host    string
 		Port    string
+		Public  bool
 	}{
-		{"tls://10.0.0.4:2000", true, TLS, "10.0.0.4:2000", "10.0.0.4", "2000"},
-		{"tcp://10.0.0.4:2000", true, PlainTCP, "10.0.0.4:2000", "10.0.0.4", "2000"},
-		{"purb://10.0.0.4:2000", true, PURB, "10.0.0.4:2000", "10.0.0.4", "2000"},
-		{"tls4://10.0.0.4:2000", false, InvalidConnType, "", "", ""},
-		{"tls://1000.0.0.4:2000", false, InvalidConnType, "", "", ""},
-		{"tls://10.0.0.4:20000000", false, InvalidConnType, "", "", ""},
-		{"tls://10.0.0.4:-10", false, InvalidConnType, "", "", ""},
-		{"tlsx10.0.0.4:2000", false, InvalidConnType, "", "", ""},
-		{"tls:10.0.0.4x2000", false, InvalidConnType, "", "", ""},
-		{"tlsx10.0.0.4x2000", false, InvalidConnType, "", "", ""},
-		{"tlxblurdie", false, InvalidConnType, "", "", ""},
-		{"tls://blublublu", false, InvalidConnType, "", "", ""},
+		{"tls://10.0.0.4:2000", true, TLS, "10.0.0.4:2000", "10.0.0.4", "2000", false},
+		{"tcp://10.0.0.4:2000", true, PlainTCP, "10.0.0.4:2000", "10.0.0.4", "2000", false},
+		{"tcp://67.43.129.85:2000", true, PlainTCP, "10.0.0.4:2000", "10.0.0.4", "2000", true},
+		{"purb://10.0.0.4:2000", true, PURB, "10.0.0.4:2000", "10.0.0.4", "2000", false},
+		{"tls4://10.0.0.4:2000", false, InvalidConnType, "", "", "", false},
+		{"tls://1000.0.0.4:2000", false, InvalidConnType, "", "", "", false},
+		{"tls://10.0.0.4:20000000", false, InvalidConnType, "", "", "", false},
+		{"tls://10.0.0.4:-10", false, InvalidConnType, "", "", "", false},
+		{"tlsx10.0.0.4:2000", false, InvalidConnType, "", "", "", false},
+		{"tls:10.0.0.4x2000", false, InvalidConnType, "", "", "", false},
+		{"tlsx10.0.0.4x2000", false, InvalidConnType, "", "", "", false},
+		{"tlxblurdie", false, InvalidConnType, "", "", "", false},
+		{"tls://blublublu", false, InvalidConnType, "", "", "", false},
 	}
 
 	for i, str := range tests {


### PR DESCRIPTION
This PR shows the first part of the big #499 PR regarding the use of an Address type which contains also the type of the connection.