### PR TITLE
[2/7] Refactor network - interfaces + Local network

### DIFF
--- a/network/local.go
+++ b/network/local.go
@@ -360,7 +360,8 @@ func NewLocalListenerWithManager(ctx *LocalManager, addr Address) (*LocalListene
 	return l, nil
 }
 
-// Listen implements the Listener interface
+// Listen implements the Listener interface. This call blocks until Stop() is
+// called on the listener.
 func (ll *LocalListener) Listen(fn func(Conn)) error {
 	ll.Lock()
 	if ll.listening {

--- a/network/local.go
+++ b/network/local.go
@@ -469,14 +469,3 @@ func NewLocalClientWithManager(ctx *LocalManager) *Client {
 func NewLocalAddress(addr string) Address {
 	return NewAddress(Local, addr)
 }
-
-/*// GetStatus implements the Host interface*/
-//func (l *chanHost) GetStatus() Status {
-//m := make(map[string]string)
-//m["Connections"] = strings.Join(l.conns.Get(), "\n")
-//m["Host"] = l.Address()
-//m["Total"] = strconv.Itoa(l.conns.Len())
-//m["Packets_Received"] = strconv.FormatUint(0, 10)
-//m["Packets_Sent"] = strconv.FormatUint(0, 10)
-//return m
-//}

--- a/network/local.go
+++ b/network/local.go
@@ -3,10 +3,11 @@ package network
 import (
 	"errors"
 	"fmt"
-	"golang.org/x/net/context"
 	"reflect"
 	"sync"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 // NewLocalRouter returns a fresh router which uses local connections. It takes
@@ -157,7 +158,8 @@ func (ccc *LocalContext) Len() int {
 	return len(ccc.queues)
 }
 
-// LocalConn is a connection that send and receive messages through channels
+// LocalConn is a connection that send and receive messages to other
+// connections locally
 type LocalConn struct {
 	local  endpoint
 	remote endpoint

--- a/network/local.go
+++ b/network/local.go
@@ -202,7 +202,16 @@ func NewLocalConn(local, remote Address) (*LocalConn, error) {
 // NewLocalConnWithManager is similar to NewLocalConn but takes a specific
 // LocalManager.
 func NewLocalConnWithManager(lm *LocalManager, local, remote Address) (*LocalConn, error) {
-	return lm.connect(local, remote)
+	for i := 0; i < MaxRetryConnect; i++ {
+		c, err := lm.connect(local, remote)
+		if err == nil {
+			return c, nil
+		} else if i == MaxRetryConnect-1 {
+			return nil, fmt.Errorf("Could not connect %x", err)
+		}
+		time.Sleep(WaitRetry)
+	}
+	return nil, errors.New("Could not connect")
 }
 
 // Send takes a context (that is not used in any way) and a message that

--- a/network/local.go
+++ b/network/local.go
@@ -350,20 +350,14 @@ func NewLocalListenerWithManager(ctx *LocalManager, addr Address) (*LocalListene
 		quit:    make(chan bool),
 		manager: ctx,
 	}
-	return l, l.bind(addr)
-}
-
-func (ll *LocalListener) bind(addr Address) error {
-	ll.Lock()
-	defer ll.Unlock()
 	if addr.ConnType() != Local {
-		return errors.New("Wrong address type for local listener")
+		return nil, errors.New("Wrong address type for local listener")
 	}
-	if ll.manager.isListening(addr) {
-		return fmt.Errorf("%s is already listening: can't listen again", addr)
+	if l.manager.isListening(addr) {
+		return nil, fmt.Errorf("%s is already listening: can't listen again", addr)
 	}
-	ll.addr = addr
-	return nil
+	l.addr = addr
+	return l, nil
 }
 
 // Listen implements the Listener interface

--- a/network/local.go
+++ b/network/local.go
@@ -7,14 +7,17 @@ import (
 	"time"
 )
 
-// NewLocalRouter returns a fresh router which uses local connections. It takes
-// the default manager.
+// NewLocalRouter returns a fresh router which uses only local queues. It uses
+// the default local manager.
+// If you need multiple independent local-queues, use NewLocalRouterWithManager.
+// In case of an error it is returned together with a nil-Router.
 func NewLocalRouter(sid *ServerIdentity) (*Router, error) {
 	return NewLocalRouterWithManager(defaultLocalManager, sid)
 }
 
-// NewLocalRouterWithmanager is the same as NewLocalRouter but takes a specific
-// Localmanager. This is useful to run parallel different local overlays.
+// NewLocalRouterWithManager is the same as NewLocalRouter but takes a specific
+// LocalManager. This is useful to run parallel different local overlays.
+// In case of an error it is returned together with a nil-Router.
 func NewLocalRouterWithManager(lm *LocalManager, sid *ServerIdentity) (*Router, error) {
 	h, err := NewLocalHostWithManager(lm, sid.Address)
 	if err != nil {
@@ -23,17 +26,19 @@ func NewLocalRouterWithManager(lm *LocalManager, sid *ServerIdentity) (*Router, 
 	return NewRouter(sid, h), nil
 }
 
-// LocalManager keeps reference to all opened local connections
-// It also keeps tracks of who is "listening", so it's possible to mimics
+// LocalManager keeps a reference to all opened local connections.
+// It also keeps track of who is "listening", so it's possible to mimic
 // Conn & Listener.
 type LocalManager struct {
 	// queues maps a remote endpoint to its packet queue. It's the main
-	//stucture used to communicate.
+	// structure used to communicate.
 	queues map[endpoint]*connQueue
 	sync.Mutex
+	// The listening-functions used when a new connection-request arrives.
 	listening map[Address]func(Conn)
 
-	baseUID uint64
+	// connection-counter for giving unique IDs to each connection.
+	counter uint64
 }
 
 // NewLocalManager returns a fresh new manager that can be used by LocalConn,
@@ -45,10 +50,12 @@ func NewLocalManager() *LocalManager {
 	}
 }
 
+// defaultLocalManager can be used if you need only one LocalManager.
 var defaultLocalManager = NewLocalManager()
 
 // endpoint represents one endpoint of a connection.
 type endpoint struct {
+	// addr is the Address of this endpoint.
 	addr Address
 	// uid is a unique identifier of the remote endpoint
 	// it's unique  for each direction:
@@ -57,14 +64,13 @@ type endpoint struct {
 	uid uint64
 }
 
-// LocalReset reset the whole map of connections + listener so it is like
-// a fresh defaultLocalManager.
+// LocalReset resets the map of connections + listeners for the defaultLocalManager.
 func LocalReset() {
 	defaultLocalManager = NewLocalManager()
 
 }
 
-// isListening returns true if the remote address is listening "virtually"
+// isListening returns true if the remote address is listening for connections.
 func (lm *LocalManager) isListening(remote Address) bool {
 	lm.Lock()
 	defer lm.Unlock()
@@ -72,7 +78,7 @@ func (lm *LocalManager) isListening(remote Address) bool {
 	return ok
 }
 
-// setListening marks the address as being able to accept incoming connection.
+// setListening marks the address as being able to accept incoming connections.
 // For each incoming connection, fn will be called in a go routine.
 func (lm *LocalManager) setListening(addr Address, fn func(Conn)) {
 	lm.Lock()
@@ -88,9 +94,9 @@ func (lm *LocalManager) unsetListening(addr Address) {
 	delete(lm.listening, addr)
 }
 
-// connect will check if the remote address is listening, if yes it creates
-// the two connections, and launch the listening function in a go routine.
-// It returns the outgoing connection with any error.
+// connect checks if the remote address is listening. Then it creates
+// the two connections, and launches the listening function in a go routine.
+// It returns the outgoing connection, or nil followed by an error, if any.
 func (lm *LocalManager) connect(local, remote Address) (*LocalConn, error) {
 	lm.Lock()
 	defer lm.Unlock()
@@ -100,18 +106,18 @@ func (lm *LocalManager) connect(local, remote Address) (*LocalConn, error) {
 		return nil, fmt.Errorf("%s can't connect to %s: it's not listening", local, remote)
 	}
 
-	outEndpoint := endpoint{local, lm.baseUID}
-	lm.baseUID++
+	outEndpoint := endpoint{local, lm.counter}
+	lm.counter++
 
-	incEndpoint := endpoint{remote, lm.baseUID}
-	lm.baseUID++
+	incEndpoint := endpoint{remote, lm.counter}
+	lm.counter++
 
 	outgoing := newLocalConn(lm, outEndpoint, incEndpoint)
 	incoming := newLocalConn(lm, incEndpoint, outEndpoint)
 
-	// outgoing knows how to store packet into the incoming's queue
+	// outgoing knows how to store packets into the incoming's queue.
 	lm.queues[outEndpoint] = outgoing.connQueue
-	// incoming knows how to store packet into the outgoing's queue
+	// incoming knows how to store packets into the outgoing's queue.
 	lm.queues[incEndpoint] = incoming.connQueue
 
 	go fn(incoming)
@@ -119,9 +125,9 @@ func (lm *LocalManager) connect(local, remote Address) (*LocalConn, error) {
 }
 
 // send gets the connection denoted by this endpoint and calls queueMsg
-// with the given msg slice  as argument on it. It returns ErrClosed if it does not find
-// the connection's queue.
-func (lm *LocalManager) send(e endpoint, buff []byte) error {
+// with the packet as argument to it.
+// It returns ErrClosed if it does not find the connection.
+func (lm *LocalManager) send(e endpoint, buff Packet) error {
 	lm.Lock()
 	defer lm.Unlock()
 	q, ok := lm.queues[e]
@@ -133,8 +139,8 @@ func (lm *LocalManager) send(e endpoint, buff []byte) error {
 	return nil
 }
 
-// close will get the connection denoted by this endpoint and will Close it if
-// present.
+// close gets the connection denoted by this endpoint and closes it if
+// it is present.
 func (lm *LocalManager) close(conn *LocalConn) {
 	lm.Lock()
 	defer lm.Unlock()
@@ -149,32 +155,34 @@ func (lm *LocalManager) close(conn *LocalConn) {
 	remote.close()
 }
 
-// len returns how many local connections is there
+// len returns how many local connections are open.
 func (lm *LocalManager) len() int {
 	lm.Lock()
 	defer lm.Unlock()
 	return len(lm.queues)
 }
 
-// LocalConn is a connection that send and receive messages to other
-// connections locally
+// LocalConn is a connection that sends and receives messages to other
+// connections locally.
 type LocalConn struct {
 	local  endpoint
 	remote endpoint
 
-	// connQueue is the part that is accesible from the LocalManager (i.e. is
-	// shared). Reason why we can't directly share LocalConn is because go test
-	// -race detects as data race (while it's *protected*)
+	// connQueue is accessible from the LocalManager (i.e. is
+	// shared). We can't directly share LocalConn because go test
+	// -race detects it as data race (while it's *protected*).
 	*connQueue
 
 	// counter to keep track of how many bytes read / written this connection
 	// has seen.
 	counterSafe
+	// the localManager responsible for that connection.
 	manager *LocalManager
 }
 
-// newLocalConn simply init the fields of a LocalConn but do not try to
-// connect. It should not be used as-is, most user wants to call NewLocalConn.
+// newLocalConn initializes the fields of a LocalConn but does'nt
+// connect. It should not be used from the outside, most user want
+// to use NewLocalConn.
 func newLocalConn(lm *LocalManager, local, remote endpoint) *LocalConn {
 	return &LocalConn{
 		remote:    remote,
@@ -184,8 +192,8 @@ func newLocalConn(lm *LocalManager, local, remote endpoint) *LocalConn {
 	}
 }
 
-// NewLocalConn returns a new channel connection from local to remote
-// Mimics the behavior of NewTCPConn => tries connecting right away.
+// NewLocalConn returns a new channel connection from local to remote.
+// It mimics the behavior of NewTCPConn and tries to connect right away.
 // It uses the default local manager.
 func NewLocalConn(local, remote Address) (*LocalConn, error) {
 	return NewLocalConnWithManager(defaultLocalManager, local, remote)
@@ -197,7 +205,9 @@ func NewLocalConnWithManager(lm *LocalManager, local, remote Address) (*LocalCon
 	return lm.connect(local, remote)
 }
 
-// Send implements the Conn interface.
+// Send takes a context (that is not used in any way) and a message that
+// will be sent to the remote endpoint.
+// If there is an error in the connection, it will be returned.
 func (lc *LocalConn) Send(msg Body) error {
 	buff, err := MarshalRegisteredType(msg)
 	if err != nil {
@@ -207,7 +217,9 @@ func (lc *LocalConn) Send(msg Body) error {
 	return lc.manager.send(lc.remote, buff)
 }
 
-// Receive implements the Conn interface.
+// Receive takes a context (that is not used) and waits for a packet to
+// be ready. It returns the received packet.
+// In case of an error the packet is nil and the error is returned.
 func (lc *LocalConn) Receive() (Packet, error) {
 	buff, err := lc.pop()
 	if err != nil {
@@ -222,17 +234,19 @@ func (lc *LocalConn) Receive() (Packet, error) {
 	}, err
 }
 
-// Local implements the Conn interface
+// Local returns the local address.
 func (lc *LocalConn) Local() Address {
 	return lc.local.addr
 }
 
-// Remote implements the Conn interface
+// Remote returns the remote address.
 func (lc *LocalConn) Remote() Address {
 	return lc.remote.addr
 }
 
-// Close implements the Conn interface
+// Close shuts down the connection on the local and the remote
+// side.
+// If the connection is not open, it returns an error.
 func (lc *LocalConn) Close() error {
 	if lc.connQueue.isClosed() {
 		return ErrClosed
@@ -249,9 +263,10 @@ func (lc *LocalConn) Type() ConnType {
 	return Local
 }
 
-// connQueue is a struct that managers the message queue of a LocalConn.
-// Messages are pushed and retrieved FIFO style.
+// connQueue manages the message queue of a LocalConn.
+// Messages are pushed and retrieved in a FIFO-queue.
 // All operations are thread-safe.
+// The messages are marshalled and stored in the queue as a slice of bytes.
 type connQueue struct {
 	*sync.Cond
 	queue  [][]byte
@@ -264,8 +279,8 @@ func newConnQueue() *connQueue {
 	}
 }
 
-// push insert the buffer into the queue.
-// push won't work if the connQueue is already closed.
+// push inserts a packet in the queue.
+// push won't work if the connQueue is already closed and silently return.
 func (c *connQueue) push(buff []byte) {
 	c.L.Lock()
 	defer c.L.Unlock()
@@ -276,9 +291,11 @@ func (c *connQueue) push(buff []byte) {
 	c.Signal()
 }
 
-// pop retrieve a buffer out of the queue.
-// If there is no messages, then it blocks UNTIL there is a call to push() or
-// close(). pop also returns directly in case this queue is already closed.
+// pop retrieves a packet out of the queue.
+// If there is no message, then it blocks UNTIL there is a call to push() or
+// close().
+// pop returns with an error if the queue is closed or gets closed while waiting
+// for a packet.
 func (c *connQueue) pop() ([]byte, error) {
 	c.L.Lock()
 	defer c.L.Unlock()
@@ -296,8 +313,8 @@ func (c *connQueue) pop() ([]byte, error) {
 	return nm, nil
 }
 
-// close set that queue to be unusable and signal every current pop() operations
-// to return.
+// close sets the closed-field to true and signals to all ongoing pop()
+// operations to return.
 func (c *connQueue) close() {
 	c.L.Lock()
 	defer c.L.Unlock()
@@ -312,31 +329,33 @@ func (c *connQueue) isClosed() bool {
 	return c.closed
 }
 
-// LocalListener is a Listener that uses LocalConn to communicate. It tries to
-// behave as much as possible as a real golang net.Listener but using LocalConn
+// LocalListener implements Listener and uses LocalConn to communicate. It
+// behaves as much as possible as a real golang net.Listener but using LocalConn
 // as the underlying communication layer.
 type LocalListener struct {
-	// addr is the addr we're listening to
+	// addr is the addr we're listening to.
 	addr Address
-	// are we listening or not
+	// whether the listening started or not.
 	listening bool
 
 	sync.Mutex
 
-	// quit is used to stop the listening routine
+	// quit is used to stop the listening routine.
 	quit chan bool
 
+	// the LocalManager used.
 	manager *LocalManager
 }
 
-// NewLocalListener returns a fresh LocalListener which implements the Listener
-// interface.
+// NewLocalListener returns a fresh LocalListener using the defaultLocalManager.
+// In case of an error the LocalListener is nil and the error is returned.
 func NewLocalListener(addr Address) (*LocalListener, error) {
 	return NewLocalListenerWithManager(defaultLocalManager, addr)
 }
 
-// NewLocalListenerWithManager is similar to NewLocalListener but taking a
-// specific LocalManager to use to communicate.
+// In case of an error, the LocalListener is nil and the error is returned.
+// An error occurs in case the address is invalid or the manager is already
+// listening on that address.
 func NewLocalListenerWithManager(lm *LocalManager, addr Address) (*LocalListener, error) {
 	l := &LocalListener{
 		quit:    make(chan bool),
@@ -352,8 +371,9 @@ func NewLocalListenerWithManager(lm *LocalManager, addr Address) (*LocalListener
 	return l, nil
 }
 
-// Listen implements the Listener interface. This call blocks until Stop() is
+// Listen calls fn every time a connection-request is received. This call blocks until Stop() is
 // called on the listener.
+// It returns an error if the LocalListener is already listening.
 func (ll *LocalListener) Listen(fn func(Conn)) error {
 	ll.Lock()
 	if ll.listening {
@@ -369,7 +389,8 @@ func (ll *LocalListener) Listen(fn func(Conn)) error {
 	return nil
 }
 
-// Stop implements the Listener interface
+// Stop shuts down listening.
+// It returns an error if the LocalListener is not listening yet.
 func (ll *LocalListener) Stop() error {
 	ll.Lock()
 	defer ll.Unlock()
@@ -382,38 +403,38 @@ func (ll *LocalListener) Stop() error {
 	return nil
 }
 
-// Address returns the listening address used.
+// Address returns the address used to listen.
 func (ll *LocalListener) Address() Address {
 	ll.Lock()
 	defer ll.Unlock()
 	return ll.addr
 }
 
-// Listening returns true if this Listener is actually listening for any
-// incoming connections.
+// Listening returns true if this Listener is listening for incoming connections.
 func (ll *LocalListener) Listening() bool {
 	ll.Lock()
 	defer ll.Unlock()
 	return ll.listening
 }
 
-// LocalHost is a Host implementation using LocalConn and LocalListener as
-// the underlying means of communication. It is a implementation of the Host
-// interface.
+// LocalHost implements the Host interface. It uses LocalConn and LocalListener as
+// the underlying means of communication.
 type LocalHost struct {
 	addr Address
 	*LocalListener
 	lm *LocalManager
 }
 
-// NewLocalHost returns a fresh Host using Local communication that will listen
+// NewLocalHost returns a new Host using Local communication. It listens
 // on the given addr.
+// If an error happened during setup, it returns a nil LocalHost and the error.
 func NewLocalHost(addr Address) (*LocalHost, error) {
 	return NewLocalHostWithManager(defaultLocalManager, addr)
 }
 
-// NewLocalHostWithManager is similar to NewLocalHost but specify which
-// LocalManager to use for communicating.
+// NewLocalHostWithManager is similar to NewLocalHost but takes a
+// LocalManager used for communication.
+// If an error happened during setup, it returns a nil LocalHost and the error.
 func NewLocalHostWithManager(lm *LocalManager, addr Address) (*LocalHost, error) {
 	lh := &LocalHost{
 		addr: addr,
@@ -425,7 +446,9 @@ func NewLocalHostWithManager(lm *LocalManager, addr Address) (*LocalHost, error)
 
 }
 
-// Connect implements the Host interface.
+// Connect sets up a connection to addr. It retries up to
+// MaxRetryConnect while waiting between each try.
+// In case of an error, it will return a nil Conn.
 func (lh *LocalHost) Connect(addr Address) (Conn, error) {
 	if addr.ConnType() != Local {
 		return nil, errors.New("Can't connect to non-Local address")
@@ -443,7 +466,7 @@ func (lh *LocalHost) Connect(addr Address) (Conn, error) {
 
 }
 
-// NewLocalClient returns Client that uses the Local communication layer.
+// NewLocalClient returns a new Client that uses the global localManager.
 func NewLocalClient() *Client {
 	return NewLocalClientWithManager(defaultLocalManager)
 }

--- a/network/local.go
+++ b/network/local.go
@@ -17,8 +17,8 @@ func NewLocalRouter(sid *ServerIdentity) (*Router, error) {
 
 // NewLocalRouterWithmanager is the same as NewLocalRouter but takes a specific
 // Localmanager. This is useful to run parallel different local overlays.
-func NewLocalRouterWithManager(ctx *LocalManager, sid *ServerIdentity) (*Router, error) {
-	h, err := NewLocalHostWithManager(ctx, sid.Address)
+func NewLocalRouterWithManager(lm *LocalManager, sid *ServerIdentity) (*Router, error) {
+	h, err := NewLocalHostWithManager(lm, sid.Address)
 	if err != nil {
 		return nil, err
 	}
@@ -177,12 +177,12 @@ type LocalConn struct {
 
 // newLocalConn simply init the fields of a LocalConn but do not try to
 // connect. It should not be used as-is, most user wants to call NewLocalConn.
-func newLocalConn(ctx *LocalManager, local, remote endpoint) *LocalConn {
+func newLocalConn(lm *LocalManager, local, remote endpoint) *LocalConn {
 	return &LocalConn{
 		remote:    remote,
 		local:     local,
 		connQueue: newConnQueue(),
-		manager:   ctx,
+		manager:   lm,
 	}
 }
 
@@ -195,12 +195,12 @@ func NewLocalConn(local, remote Address) (*LocalConn, error) {
 
 // NewLocalConnWithManager is similar to NewLocalConn but takes a specific
 // LocalManager.
-func NewLocalConnWithManager(ctx *LocalManager, local, remote Address) (*LocalConn, error) {
-	return ctx.connect(local, remote)
+func NewLocalConnWithManager(lm *LocalManager, local, remote Address) (*LocalConn, error) {
+	return lm.connect(local, remote)
 }
 
 // Send implements the Conn interface.
-func (lc *LocalConn) Send(ctx context.Context, msg Body) error {
+func (lc *LocalConn) Send(lm context.Context, msg Body) error {
 	buff, err := MarshalRegisteredType(msg)
 	if err != nil {
 		return err
@@ -210,7 +210,7 @@ func (lc *LocalConn) Send(ctx context.Context, msg Body) error {
 }
 
 // Receive implements the Conn interface.
-func (lc *LocalConn) Receive(ctx context.Context) (Packet, error) {
+func (lc *LocalConn) Receive(lm context.Context) (Packet, error) {
 	buff, err := lc.pop()
 	if err != nil {
 		return EmptyApplicationPacket, err
@@ -339,10 +339,10 @@ func NewLocalListener(addr Address) (*LocalListener, error) {
 
 // NewLocalListenerWithManager is similar to NewLocalListener but taking a
 // specific LocalManager to use to communicate.
-func NewLocalListenerWithManager(ctx *LocalManager, addr Address) (*LocalListener, error) {
+func NewLocalListenerWithManager(lm *LocalManager, addr Address) (*LocalListener, error) {
 	l := &LocalListener{
 		quit:    make(chan bool),
-		manager: ctx,
+		manager: lm,
 	}
 	if addr.ConnType() != Local {
 		return nil, errors.New("Wrong address type for local listener")
@@ -405,7 +405,7 @@ func (ll *LocalListener) Listening() bool {
 type LocalHost struct {
 	addr Address
 	*LocalListener
-	ctx *LocalManager
+	lm *LocalManager
 }
 
 // NewLocalHost returns a fresh Host using Local communication that will listen
@@ -416,13 +416,13 @@ func NewLocalHost(addr Address) (*LocalHost, error) {
 
 // NewLocalHostWithManager is similar to NewLocalHost but specify which
 // LocalManager to use for communicating.
-func NewLocalHostWithManager(ctx *LocalManager, addr Address) (*LocalHost, error) {
+func NewLocalHostWithManager(lm *LocalManager, addr Address) (*LocalHost, error) {
 	lh := &LocalHost{
 		addr: addr,
-		ctx:  ctx,
+		lm:   lm,
 	}
 	var err error
-	lh.LocalListener, err = NewLocalListenerWithManager(ctx, addr)
+	lh.LocalListener, err = NewLocalListenerWithManager(lm, addr)
 	return lh, err
 
 }
@@ -434,7 +434,7 @@ func (lh *LocalHost) Connect(addr Address) (Conn, error) {
 	}
 	var finalErr error
 	for i := 0; i < MaxRetryConnect; i++ {
-		c, err := NewLocalConnWithManager(lh.ctx, lh.addr, addr)
+		c, err := NewLocalConnWithManager(lh.lm, lh.addr, addr)
 		if err == nil {
 			return c, nil
 		}
@@ -452,9 +452,9 @@ func NewLocalClient() *Client {
 
 // NewLocalClientWithManager is similar to NewLocalClient but takes a specific
 // LocalManager to communicate.
-func NewLocalClientWithManager(ctx *LocalManager) *Client {
+func NewLocalClientWithManager(lm *LocalManager) *Client {
 	fn := func(own, remote *ServerIdentity) (Conn, error) {
-		return NewLocalConnWithManager(ctx, own.Address, remote.Address)
+		return NewLocalConnWithManager(lm, own.Address, remote.Address)
 	}
 	return newClient(fn)
 

--- a/network/local.go
+++ b/network/local.go
@@ -1,0 +1,459 @@
+package network
+
+import (
+	"errors"
+	"fmt"
+	"golang.org/x/net/context"
+	"reflect"
+	"sync"
+	"time"
+)
+
+// NewLocalRouter returns a fresh router which uses local connections. It takes
+// the default context.
+func NewLocalRouter(sid *ServerIdentity) (*Router, error) {
+	return NewLocalRouterWithContext(defaultLocalContext, sid)
+}
+
+// NewLocalRouterWithContext is the same as NewLocalRouter but takes a specific
+// LocalContext. This is useful to run parallel different local overlays.
+func NewLocalRouterWithContext(ctx *LocalContext, sid *ServerIdentity) (*Router, error) {
+	h, err := NewLocalHostWithContext(ctx, sid.Address)
+	if err != nil {
+		return nil, err
+	}
+	return NewRouter(sid, h), nil
+}
+
+// LocalContext keeps reference to all opened local connections
+// It also keeps tracks of who is "listening", so it's possible to mimics
+// Conn & Listener.
+type LocalContext struct {
+	// queues maps a remote endpoint to its packet queue. It's the main
+	//stucture used to communicate.
+	queues map[endpoint]*connQueue
+	sync.Mutex
+	listening map[Address]func(Conn)
+
+	baseUID uint64
+}
+
+// NewLocalContext returns a fresh new context that can be used by LocalConn,
+// LocalListener & LocalHost.
+func NewLocalContext() *LocalContext {
+	return &LocalContext{
+		queues:    make(map[endpoint]*connQueue),
+		listening: make(map[Address]func(Conn)),
+	}
+}
+
+var defaultLocalContext = NewLocalContext()
+
+// endpoint represents one endpoint of a connection.
+type endpoint struct {
+	addr Address
+	// uid is a unique identifier of the remote endpoint
+	// it's unique  for each direction:
+	// 127.0.0.1:2000 -> 127.0.0.1:2000 => 14
+	// 127.0.0.1:2000 <- 127.0.0.1:2000 => 15
+	uid uint64
+}
+
+// LocalReset reset the whole map of connections + listener so it is like
+// a fresh defaultLocalContext.
+func LocalReset() {
+	defaultLocalContext = NewLocalContext()
+
+}
+
+// IsListening returns true if the remote address is listening "virtually"
+func (ccc *LocalContext) IsListening(remote Address) bool {
+	ccc.Lock()
+	defer ccc.Unlock()
+	_, ok := ccc.listening[remote]
+	return ok
+}
+
+// Listening put the address as "listening" mode. If a user connects to this
+// addr, this function will be called.
+func (ccc *LocalContext) Listening(addr Address, fn func(Conn)) {
+	ccc.Lock()
+	defer ccc.Unlock()
+	ccc.listening[addr] = fn
+}
+
+// StopListening remove the address from the "listening" mode
+func (ccc *LocalContext) StopListening(addr Address) {
+	ccc.Lock()
+	defer ccc.Unlock()
+	delete(ccc.listening, addr)
+}
+
+// Connect will check if the remote address is listening, if yes it creates
+// the two connections, and launch the listening function in a go routine.
+// It returns the outgoing connection with any error.
+func (ccc *LocalContext) Connect(local, remote Address) (*LocalConn, error) {
+	ccc.Lock()
+	defer ccc.Unlock()
+
+	fn, ok := ccc.listening[remote]
+	if !ok {
+		return nil, fmt.Errorf("%s can't connect to %s: it's not listening", local, remote)
+	}
+
+	outEndpoint := endpoint{local, ccc.baseUID}
+	ccc.baseUID++
+
+	incEndpoint := endpoint{remote, ccc.baseUID}
+	ccc.baseUID++
+
+	outgoing := newLocalConn(ccc, outEndpoint, incEndpoint)
+	incoming := newLocalConn(ccc, incEndpoint, outEndpoint)
+
+	// outgoing knows how to store packet into the incoming's queue
+	ccc.queues[outEndpoint] = outgoing.connQueue
+	// incoming knows how to store packet into the outgoing's queue
+	ccc.queues[incEndpoint] = incoming.connQueue
+
+	go fn(incoming)
+	return outgoing, nil
+}
+
+// Send will get the connection denoted by this endpoint and will call queueMsg
+// with the packet as argument on it. It returns ErrClosed if it does not find
+// the connection.
+func (ccc *LocalContext) Send(e endpoint, nm Packet) error {
+	ccc.Lock()
+	defer ccc.Unlock()
+	q, ok := ccc.queues[e]
+	if !ok {
+		return ErrClosed
+	}
+
+	q.Push(nm)
+	return nil
+}
+
+// Close will get the connection denoted by this endpoint and will Close it if
+// present.
+func (ccc *LocalContext) Close(conn *LocalConn) {
+	ccc.Lock()
+	defer ccc.Unlock()
+	// delete this conn
+	delete(ccc.queues, conn.local)
+	// and delete the remote one + close it
+	remote, ok := ccc.queues[conn.remote]
+	if !ok {
+		return
+	}
+	delete(ccc.queues, conn.remote)
+	remote.Close()
+}
+
+// Len returns how many local connections is there
+func (ccc *LocalContext) Len() int {
+	ccc.Lock()
+	defer ccc.Unlock()
+	return len(ccc.queues)
+}
+
+// LocalConn is a connection that send and receive messages through channels
+type LocalConn struct {
+	local  endpoint
+	remote endpoint
+
+	// connQueue is the part that is accesible from the LocalContext (i.e. is
+	// shared). Reason why we can't directly share LocalConn is because go test
+	// -race detects as data race (while it's *protected*)
+	*connQueue
+
+	ctx *LocalContext
+}
+
+// newLocalConn simply init the fields of a LocalConn but do not try to
+// connect. It should not be used as-is, most user wants to call NewLocalConn.
+func newLocalConn(ctx *LocalContext, local, remote endpoint) *LocalConn {
+	return &LocalConn{
+		remote:    remote,
+		local:     local,
+		connQueue: newConnQueue(),
+		ctx:       ctx,
+	}
+}
+
+// NewLocalConn returns a new channel connection from local to remote
+// Mimics the behavior of NewTCPConn => tries connecting right away.
+// It uses the default local context.
+func NewLocalConn(local, remote Address) (*LocalConn, error) {
+	return NewLocalConnWithContext(defaultLocalContext, local, remote)
+}
+
+// NewLocalConnWithContext is similar to NewLocalConn but takes a specific
+// LocalContext.
+func NewLocalConnWithContext(ctx *LocalContext, local, remote Address) (*LocalConn, error) {
+	return ctx.Connect(local, remote)
+}
+
+// Send implements the Conn interface.
+func (cc LocalConn) Send(ctx context.Context, msg Body) error {
+
+	var body Body
+	var val = reflect.ValueOf(msg)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+	body = val.Interface()
+
+	var typ = TypeFromData(body)
+	nm := Packet{
+		MsgType: typ,
+		Msg:     body,
+	}
+	return cc.ctx.Send(cc.remote, nm)
+}
+
+// Receive implements the Conn interface.
+func (cc *LocalConn) Receive(ctx context.Context) (Packet, error) {
+	return cc.Pop()
+}
+
+// Local implements the Conn interface
+func (cc *LocalConn) Local() Address {
+	return cc.local.addr
+}
+
+// Remote implements the Conn interface
+func (cc *LocalConn) Remote() Address {
+	return cc.remote.addr
+}
+
+// Close implements the Conn interface
+func (cc *LocalConn) Close() error {
+	cc.connQueue.Close()
+	// close the remote conn also
+	cc.ctx.Close(cc)
+	return nil
+}
+
+// Rx implements the Conn interface
+func (cc *LocalConn) Rx() uint64 {
+	return 0
+}
+
+// Tx implements the Conn interface
+func (cc *LocalConn) Tx() uint64 {
+	return 0
+}
+
+// Type implements the Conn interface
+func (cc *LocalConn) Type() ConnType {
+	return Local
+}
+
+type connQueue struct {
+	*sync.Cond
+	queue    []Packet
+	isClosed bool
+}
+
+func newConnQueue() *connQueue {
+	return &connQueue{
+		Cond: sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+func (c *connQueue) Push(p Packet) {
+	c.L.Lock()
+	defer c.L.Unlock()
+	if c.isClosed {
+		return
+	}
+	c.queue = append(c.queue, p)
+	c.Signal()
+}
+
+func (c *connQueue) Pop() (Packet, error) {
+	c.L.Lock()
+	defer c.L.Unlock()
+	for len(c.queue) == 0 {
+		if c.isClosed {
+			return EmptyApplicationPacket, ErrClosed
+		}
+		c.Wait()
+	}
+	if c.isClosed {
+		return EmptyApplicationPacket, ErrClosed
+	}
+	nm := c.queue[0]
+	c.queue = c.queue[1:]
+	return nm, nil
+}
+
+func (c *connQueue) Close() {
+	c.L.Lock()
+	defer c.L.Unlock()
+	c.isClosed = true
+	c.Signal()
+}
+
+// LocalListener is a Listener that uses LocalConn to communicate. It tries to
+// behave as much as possible as a real golang net.Listener but using LocalConn
+// as the underlying communication layer.
+type LocalListener struct {
+	// addr is the addr we're listening to + mut
+	addr Address
+	// are we listening or not
+	listening bool
+
+	sync.Mutex
+
+	// quit is used to stop the listening routine
+	quit chan bool
+
+	ctx *LocalContext
+}
+
+// NewLocalListener returns a fresh LocalListener which implements the Listener
+// interface.
+func NewLocalListener(addr Address) (*LocalListener, error) {
+	return NewLocalListenerWithContext(defaultLocalContext, addr)
+}
+
+// NewLocalListenerWithContext is similar to NewLocalListener but taking a
+// specific LocalContext to use to communicate.
+func NewLocalListenerWithContext(ctx *LocalContext, addr Address) (*LocalListener, error) {
+	l := &LocalListener{
+		quit: make(chan bool),
+		ctx:  ctx,
+	}
+	return l, l.bind(addr)
+}
+
+func (ll *LocalListener) bind(addr Address) error {
+	ll.Lock()
+	defer ll.Unlock()
+	if addr.ConnType() != Local {
+		return errors.New("Wrong address type for local listener")
+	}
+	if ll.ctx.IsListening(addr) {
+		return fmt.Errorf("%s is already listening: can't listen again", addr)
+	}
+	ll.addr = addr
+	return nil
+}
+
+// Listen implements the Listener interface
+func (ll *LocalListener) Listen(fn func(Conn)) error {
+	ll.Lock()
+	ll.quit = make(chan bool)
+	ll.ctx.Listening(ll.addr, fn)
+	ll.listening = true
+	ll.Unlock()
+
+	<-ll.quit
+	return nil
+}
+
+// Stop implements the Listener interface
+func (ll *LocalListener) Stop() error {
+	ll.Lock()
+	defer ll.Unlock()
+	ll.ctx.StopListening(ll.addr)
+	if ll.listening {
+		close(ll.quit)
+	}
+	ll.listening = false
+	return nil
+}
+
+// Address returns the listening address used.
+func (ll *LocalListener) Address() Address {
+	ll.Lock()
+	defer ll.Unlock()
+	return ll.addr
+}
+
+// Listening returns true if this Listener is actually listening for any
+// incoming connections.
+func (ll *LocalListener) Listening() bool {
+	ll.Lock()
+	defer ll.Unlock()
+	return ll.listening
+}
+
+// LocalHost is a Host implementation using LocalConn and LocalListener as
+// the underlying means of communication. It is a implementation of the Host
+// interface.
+type LocalHost struct {
+	addr Address
+	*LocalListener
+	ctx *LocalContext
+}
+
+// NewLocalHost returns a fresh Host using Local communication that will listen
+// on the given addr.
+func NewLocalHost(addr Address) (*LocalHost, error) {
+	return NewLocalHostWithContext(defaultLocalContext, addr)
+}
+
+// NewLocalHostWithContext is similar to NewLocalHost but specify which
+// LocalContext to use for communicating.
+func NewLocalHostWithContext(ctx *LocalContext, addr Address) (*LocalHost, error) {
+	lh := &LocalHost{
+		addr: addr,
+		ctx:  ctx,
+	}
+	var err error
+	lh.LocalListener, err = NewLocalListenerWithContext(ctx, addr)
+	return lh, err
+
+}
+
+// Connect implements the Host interface.
+func (lh *LocalHost) Connect(addr Address) (Conn, error) {
+	if addr.ConnType() != Local {
+		return nil, errors.New("Can't connect to non-Local address")
+	}
+	var finalErr error
+	for i := 0; i < MaxRetryConnect; i++ {
+		c, err := NewLocalConnWithContext(lh.ctx, lh.addr, addr)
+		if err == nil {
+			return c, nil
+		}
+		finalErr = err
+		time.Sleep(WaitRetry)
+	}
+	return nil, finalErr
+
+}
+
+// NewLocalClient returns Client that uses the Local communication layer.
+func NewLocalClient() *Client {
+	return NewLocalClientWithContext(defaultLocalContext)
+}
+
+// NewLocalClientWithContext is similar to NewLocalClient but takes a specific
+// LocalContext to communicate.
+func NewLocalClientWithContext(ctx *LocalContext) *Client {
+	fn := func(own, remote *ServerIdentity) (Conn, error) {
+		return NewLocalConnWithContext(ctx, own.Address, remote.Address)
+	}
+	return newClient(fn)
+
+}
+
+// NewLocalAddress returns an Address of type Local with the given raw addr.
+func NewLocalAddress(addr string) Address {
+	return NewAddress(Local, addr)
+}
+
+/*// GetStatus implements the Host interface*/
+//func (l *chanHost) GetStatus() Status {
+//m := make(map[string]string)
+//m["Connections"] = strings.Join(l.conns.Get(), "\n")
+//m["Host"] = l.Address()
+//m["Total"] = strconv.Itoa(l.conns.Len())
+//m["Packets_Received"] = strconv.FormatUint(0, 10)
+//m["Packets_Sent"] = strconv.FormatUint(0, 10)
+//return m
+//}

--- a/network/local.go
+++ b/network/local.go
@@ -59,8 +59,8 @@ type endpoint struct {
 	addr Address
 	// uid is a unique identifier of the remote endpoint
 	// it's unique  for each direction:
-	// 127.0.0.1:2000 -> 127.0.0.1:2000 => 14
-	// 127.0.0.1:2000 <- 127.0.0.1:2000 => 15
+	// 127.0.0.1:2000 -> 127.0.0.1:7869 => 14
+	// 127.0.0.1:7869 <- 127.0.0.1:2000 => 15
 	uid uint64
 }
 

--- a/network/local.go
+++ b/network/local.go
@@ -312,7 +312,7 @@ func (c *connQueue) close() {
 // behave as much as possible as a real golang net.Listener but using LocalConn
 // as the underlying communication layer.
 type LocalListener struct {
-	// addr is the addr we're listening to + mut
+	// addr is the addr we're listening to
 	addr Address
 	// are we listening or not
 	listening bool

--- a/network/local.go
+++ b/network/local.go
@@ -197,7 +197,7 @@ func NewLocalConnWithContext(ctx *LocalContext, local, remote Address) (*LocalCo
 }
 
 // Send implements the Conn interface.
-func (cc LocalConn) Send(ctx context.Context, msg Body) error {
+func (lc *LocalConn) Send(ctx context.Context, msg Body) error {
 
 	var body Body
 	var val = reflect.ValueOf(msg)
@@ -211,44 +211,44 @@ func (cc LocalConn) Send(ctx context.Context, msg Body) error {
 		MsgType: typ,
 		Msg:     body,
 	}
-	return cc.ctx.Send(cc.remote, nm)
+	return lc.ctx.Send(lc.remote, nm)
 }
 
 // Receive implements the Conn interface.
-func (cc *LocalConn) Receive(ctx context.Context) (Packet, error) {
-	return cc.Pop()
+func (lc *LocalConn) Receive(ctx context.Context) (Packet, error) {
+	return lc.Pop()
 }
 
 // Local implements the Conn interface
-func (cc *LocalConn) Local() Address {
-	return cc.local.addr
+func (lc *LocalConn) Local() Address {
+	return lc.local.addr
 }
 
 // Remote implements the Conn interface
-func (cc *LocalConn) Remote() Address {
-	return cc.remote.addr
+func (lc *LocalConn) Remote() Address {
+	return lc.remote.addr
 }
 
 // Close implements the Conn interface
-func (cc *LocalConn) Close() error {
-	cc.connQueue.Close()
+func (lc *LocalConn) Close() error {
+	lc.connQueue.Close()
 	// close the remote conn also
-	cc.ctx.Close(cc)
+	lc.ctx.Close(lc)
 	return nil
 }
 
 // Rx implements the Conn interface
-func (cc *LocalConn) Rx() uint64 {
+func (lc *LocalConn) Rx() uint64 {
 	return 0
 }
 
 // Tx implements the Conn interface
-func (cc *LocalConn) Tx() uint64 {
+func (lc *LocalConn) Tx() uint64 {
 	return 0
 }
 
 // Type implements the Conn interface
-func (cc *LocalConn) Type() ConnType {
+func (lc *LocalConn) Type() ConnType {
 	return Local
 }
 

--- a/network/local.go
+++ b/network/local.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 // NewLocalRouter returns a fresh router which uses local connections. It takes
@@ -200,7 +198,7 @@ func NewLocalConnWithManager(lm *LocalManager, local, remote Address) (*LocalCon
 }
 
 // Send implements the Conn interface.
-func (lc *LocalConn) Send(lm context.Context, msg Body) error {
+func (lc *LocalConn) Send(msg Body) error {
 	buff, err := MarshalRegisteredType(msg)
 	if err != nil {
 		return err
@@ -210,7 +208,7 @@ func (lc *LocalConn) Send(lm context.Context, msg Body) error {
 }
 
 // Receive implements the Conn interface.
-func (lc *LocalConn) Receive(lm context.Context) (Packet, error) {
+func (lc *LocalConn) Receive() (Packet, error) {
 	buff, err := lc.pop()
 	if err != nil {
 		return EmptyApplicationPacket, err

--- a/network/local_test.go
+++ b/network/local_test.go
@@ -1,0 +1,285 @@
+package network
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test whether a call to a conn.Close() will stop the remote Receive() call
+func TestLocalConnCloseReceive(t *testing.T) {
+	addr := NewLocalAddress("127.0.0.1:2000")
+	listener, err := NewLocalListener(addr)
+	if err != nil {
+		t.Fatal("Could not listen", err)
+	}
+
+	var ready = make(chan bool)
+	go func() {
+		ready <- true
+		listener.Listen(func(c Conn) {
+			ready <- true
+			assert.Nil(t, c.Close())
+		})
+	}()
+	<-ready
+
+	outgoing, err := NewLocalConn(addr, addr)
+	if err != nil {
+		t.Fatal("erro NewLocalConn:", err)
+	}
+	<-ready
+
+	_, err = outgoing.Receive(context.TODO())
+	assert.Equal(t, ErrClosed, err)
+	assert.Nil(t, listener.Stop())
+
+}
+
+// Test if we can run two parallel local network using two different contexts
+func TestLocalContext(t *testing.T) {
+	ctx1 := NewLocalContext()
+	ctx2 := NewLocalContext()
+
+	addrListener := NewLocalAddress("127.0.0.1:2000")
+	addrConn := NewLocalAddress("127.0.0.1:2001")
+
+	done1 := make(chan error)
+	done2 := make(chan error)
+
+	go testConnListener(ctx1, done1, addrListener, addrConn, 1)
+	go testConnListener(ctx2, done2, addrListener, addrConn, 2)
+
+	var confirmed int
+	for confirmed != 2 {
+		var err error
+		select {
+		case err = <-done1:
+		case err = <-done2:
+		}
+
+		if err != nil {
+			t.Fatal(err)
+		}
+		confirmed++
+	}
+}
+
+// launch a listener, then a Conn and communicate their own address + individual
+// val
+func testConnListener(ctx *LocalContext, done chan error, listenA, connA Address, secret int) {
+	listener, err := NewLocalListenerWithContext(ctx, listenA)
+	if err != nil {
+		done <- err
+		return
+	}
+
+	var ok = make(chan error)
+
+	// make the listener send and receive a struct that only they can know (this
+	// listener + conn
+	handshake := func(c Conn, sending, receiving Address) error {
+		err := c.Send(context.TODO(), &AddressTest{sending, secret})
+		if err != nil {
+			return err
+		}
+		p, err := c.Receive(context.TODO())
+		if err != nil {
+			return err
+		}
+
+		at := p.Msg.(AddressTest)
+		if at.Addr != receiving {
+			return fmt.Errorf("Receiveid wrong address")
+		}
+		if at.Val != secret {
+			return fmt.Errorf("Received wrong secret")
+		}
+		return nil
+	}
+
+	go func() {
+		ok <- nil
+		listener.Listen(func(c Conn) {
+			ok <- nil
+			err := handshake(c, listenA, connA)
+			ok <- err
+		})
+		ok <- nil
+	}()
+	// wait go routine to start
+	<-ok
+
+	// trick to use host because it already tries multiple times to connect if
+	// the listening routine is not up yet.
+	h, err := NewLocalHostWithContext(ctx, connA)
+	if err != nil {
+		done <- err
+		return
+	}
+	c, err := h.Connect(listenA)
+	if err != nil {
+		done <- err
+		return
+	}
+
+	// wait listening function to start for the incoming conn
+	<-ok
+	err = handshake(c, connA, listenA)
+	if err != nil {
+		done <- err
+		return
+	}
+	// wait for any err of the handshake from the listening PoV
+	err = <-ok
+	if err != nil {
+		done <- err
+		return
+	}
+	if err := c.Close(); err != nil {
+		done <- err
+		return
+	}
+
+	listener.Stop()
+	<-ok
+	done <- nil
+}
+
+func TestLocalConnDiffAddress(t *testing.T) {
+	testLocalConn(t, NewLocalAddress("127.0.0.1:2000"), NewLocalAddress("127.0.0.1:2001"))
+}
+
+func TestLocalConnSameAddress(t *testing.T) {
+	testLocalConn(t, NewLocalAddress("127.0.0.1:2000"), NewLocalAddress("127.0.0.1:2000"))
+}
+
+func testLocalConn(t *testing.T, a1, a2 Address) {
+	addr1 := a1
+	addr2 := a2
+
+	listener, err := NewLocalListener(addr1)
+	if err != nil {
+		t.Fatal("Could not listen", err)
+	}
+
+	var ready = make(chan bool)
+	var incomingConn = make(chan bool)
+	var outgoingConn = make(chan bool)
+	go func() {
+		ready <- true
+		listener.Listen(func(c Conn) {
+			incomingConn <- true
+			nm, err := c.Receive(context.TODO())
+			assert.Nil(t, err)
+			assert.Equal(t, 3, nm.Msg.(SimpleMessage).I)
+			// acknoledge the message
+			incomingConn <- true
+			err = c.Send(context.TODO(), &SimpleMessage{3})
+			assert.Nil(t, err)
+			//wait ack
+			<-outgoingConn
+			// close connection
+			assert.Nil(t, c.Close())
+		})
+		ready <- true
+	}()
+	<-ready
+
+	outgoing, err := NewLocalConn(addr2, addr1)
+	if err != nil {
+		t.Fatal("erro NewLocalConn:", err)
+	}
+
+	// check if connection is opened on the listener
+	<-incomingConn
+	// send stg and wait for ack
+	assert.Nil(t, outgoing.Send(context.TODO(), &SimpleMessage{3}))
+	<-incomingConn
+
+	// receive stg and send ack
+	nm, err := outgoing.Receive(context.TODO())
+	assert.Nil(t, err)
+	assert.Equal(t, 3, nm.Msg.(SimpleMessage).I)
+	outgoingConn <- true
+
+	// close the incoming conn, so Receive here should return an error
+	nm, err = outgoing.Receive(context.TODO())
+	if err != ErrClosed {
+		t.Error("Receive should have returned an error")
+	}
+	assert.Nil(t, outgoing.Close())
+
+	// close the listener
+	assert.Nil(t, listener.Stop())
+	<-ready
+}
+
+func TestLocalManyConn(t *testing.T) {
+	nbrConn := 3
+	addr := NewLocalAddress("127.0.0.1:2000")
+	listener, err := NewLocalListener(addr)
+	if err != nil {
+		t.Fatal("Could not setup listener:", err)
+	}
+	var wg sync.WaitGroup
+	go func() {
+		listener.Listen(func(c Conn) {
+			_, err := c.Receive(context.TODO())
+			assert.Nil(t, err)
+
+			assert.Nil(t, c.Send(context.TODO(), &SimpleMessage{3}))
+		})
+	}()
+
+	if !waitListeningUp(addr) {
+		t.Fatal("Can't get listener up")
+	}
+	wg.Add(nbrConn)
+	for i := 1; i <= nbrConn; i++ {
+		go func(j int) {
+			a := NewLocalAddress("127.0.0.1:" + strconv.Itoa(2000+j))
+			c, err := NewLocalConn(a, addr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Nil(t, c.Send(context.TODO(), &SimpleMessage{3}))
+			nm, err := c.Receive(context.TODO())
+			assert.Nil(t, err)
+			assert.Equal(t, 3, nm.Msg.(SimpleMessage).I)
+			assert.Nil(t, c.Close())
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
+	listener.Stop()
+}
+
+func waitListeningUp(addr Address) bool {
+	for i := 0; i < 5; i++ {
+		if defaultLocalContext.IsListening(addr) {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return false
+}
+
+func NewTestLocalHost(port int) (*LocalHost, error) {
+	addr := NewLocalAddress("127.0.0.1:" + strconv.Itoa(port))
+	return NewLocalHost(addr)
+}
+
+type AddressTest struct {
+	Addr Address
+	Val  int
+}
+
+var AddressTestType = RegisterPacketType(&AddressTest{})

--- a/network/local_test.go
+++ b/network/local_test.go
@@ -44,8 +44,8 @@ func TestLocalConnCloseReceive(t *testing.T) {
 
 // Test if we can run two parallel local network using two different contexts
 func TestLocalContext(t *testing.T) {
-	ctx1 := NewLocalContext()
-	ctx2 := NewLocalContext()
+	ctx1 := NewLocalManager()
+	ctx2 := NewLocalManager()
 
 	addrListener := NewLocalAddress("127.0.0.1:2000")
 	addrConn := NewLocalAddress("127.0.0.1:2001")
@@ -73,8 +73,8 @@ func TestLocalContext(t *testing.T) {
 
 // launch a listener, then a Conn and communicate their own address + individual
 // val
-func testConnListener(ctx *LocalContext, done chan error, listenA, connA Address, secret int) {
-	listener, err := NewLocalListenerWithContext(ctx, listenA)
+func testConnListener(ctx *LocalManager, done chan error, listenA, connA Address, secret int) {
+	listener, err := NewLocalListenerWithManager(ctx, listenA)
 	if err != nil {
 		done <- err
 		return
@@ -118,7 +118,7 @@ func testConnListener(ctx *LocalContext, done chan error, listenA, connA Address
 
 	// trick to use host because it already tries multiple times to connect if
 	// the listening routine is not up yet.
-	h, err := NewLocalHostWithContext(ctx, connA)
+	h, err := NewLocalHostWithManager(ctx, connA)
 	if err != nil {
 		done <- err
 		return
@@ -264,7 +264,7 @@ func TestLocalManyConn(t *testing.T) {
 
 func waitListeningUp(addr Address) bool {
 	for i := 0; i < 5; i++ {
-		if defaultLocalContext.isListening(addr) {
+		if defaultLocalManager.isListening(addr) {
 			return true
 		}
 		time.Sleep(50 * time.Millisecond)

--- a/network/local_test.go
+++ b/network/local_test.go
@@ -264,7 +264,7 @@ func TestLocalManyConn(t *testing.T) {
 
 func waitListeningUp(addr Address) bool {
 	for i := 0; i < 5; i++ {
-		if defaultLocalContext.IsListening(addr) {
+		if defaultLocalContext.isListening(addr) {
 			return true
 		}
 		time.Sleep(50 * time.Millisecond)

--- a/network/local_test.go
+++ b/network/local_test.go
@@ -12,9 +12,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestLocalRouter(t *testing.T) {
+	addr := &ServerIdentity{Address: NewLocalAddress("127.0.0.1:2000")}
+	wrongAddr1 := &ServerIdentity{Address: NewAddress(PlainTCP, addr.Address.NetworkAddress())}
+	_, err := NewLocalRouter(wrongAddr1)
+	if err == nil {
+		t.Error("Should have returned something..")
+	}
+	_, err = NewLocalRouter(addr)
+	if err != nil {
+		t.Error("Should not have returned something")
+	}
+
+}
+
 func TestLocalListener(t *testing.T) {
 	addr := NewLocalAddress("127.0.0.1:2000")
-	listener, err := NewLocalListener(addr)
+	wrongAddr1 := NewAddress(PlainTCP, addr.NetworkAddress())
+	listener, err := NewLocalListener(wrongAddr1)
+	if err == nil {
+		t.Error("Create listener with wrong address should fail")
+	}
+	defaultLocalManager.setListening(addr, func(c Conn) {})
+	listener, err = NewLocalListener(addr)
+	if err == nil {
+		t.Error("Create listener with already binded address should fail")
+	}
+	LocalReset()
+
+	listener, err = NewLocalListener(addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,6 +89,12 @@ func TestLocalConnCloseReceive(t *testing.T) {
 	outgoing, err := NewLocalConn(addr, addr)
 	if err != nil {
 		t.Fatal("erro NewLocalConn:", err)
+	}
+	if outgoing.Type() != Local {
+		t.Error("Wrong type for Conn?")
+	}
+	if outgoing.Local() != addr {
+		t.Error("Wrong local addr for Conn!?")
 	}
 	<-ready
 
@@ -216,6 +248,7 @@ func testLocalConn(t *testing.T, a1, a2 Address) {
 			assert.Nil(t, err)
 			//wait ack
 			<-outgoingConn
+			assert.Equal(t, 2, listener.manager.len())
 			// close connection
 			assert.Nil(t, c.Close())
 		})
@@ -291,6 +324,13 @@ func TestLocalManyConn(t *testing.T) {
 
 	wg.Wait()
 	listener.Stop()
+}
+
+func TestDefaultLocalManager(t *testing.T) {
+	defaultLocalManager.setListening(NewLocalAddress("127.0.0.1"), func(c Conn) {})
+	assert.Equal(t, 1, len(defaultLocalManager.listening))
+	LocalReset()
+	assert.Equal(t, 0, len(defaultLocalManager.listening))
 }
 
 func waitListeningUp(addr Address) bool {

--- a/network/network.go
+++ b/network/network.go
@@ -1,10 +1,6 @@
 package network
 
-import (
-	"golang.org/x/net/context"
-
-	"github.com/dedis/cothority/monitor"
-)
+import "golang.org/x/net/context"
 
 // Conn is the basic interface to represent any communication mean
 // between two host.
@@ -29,8 +25,10 @@ type Conn interface {
 	Remote() Address
 	// Returns the local address and port
 	Local() Address
-	// XXX Can we remove that ?
-	monitor.CounterIO
+	// Tx returns how many bytes this connection has written
+	Tx() uint64
+	// Rx returns how many bytes this connection has read
+	Rx() uint64
 }
 
 // Listener is responsible for listening for incoming Conn on a particular

--- a/network/network.go
+++ b/network/network.go
@@ -1,18 +1,16 @@
 package network
 
-import "golang.org/x/net/context"
-
 // Conn is the basic interface to represent any communication mean
 // between two host.
 type Conn interface {
 	// Send a message through the connection.
 	// obj should be a POINTER to the actual struct to send, or an interface.
 	// It should not be a Golang type.
-	Send(ctx context.Context, obj Body) error
+	Send(obj Body) error
 	// Receive any message through the connection. It is a blocking call that
 	// returns either when a message arrived or when Close() has been called, or
 	// when a network error occured.
-	Receive(ctx context.Context) (Packet, error)
+	Receive() (Packet, error)
 	// Close will close the connection. Implementations must take care that
 	// Close() makes Receive() returns with an error, and any subsequent Send()
 	// will return with an error. Calling Close() on a closed Conn will return

--- a/network/network.go
+++ b/network/network.go
@@ -19,7 +19,8 @@ type Conn interface {
 	Receive(ctx context.Context) (Packet, error)
 	// Close will close the connection. Implementations must take care that
 	// Close() makes Receive() returns with an error, and any subsequent Send()
-	// will return with an error.
+	// will return with an error. Calling Close() on a closed Conn will return
+	// ErrClosed.
 	Close() error
 
 	// Type returns the type of this connection
@@ -38,11 +39,13 @@ type Listener interface {
 	// Listen will start listening for incoming connections
 	// Each time there is an incoming Conn, it will call the given
 	// function in a go routine with the incoming Conn as parameter.
-	// The call is BLOCKING.
+	// The call is BLOCKING. If this listener is already Listening, Listen
+	// should return an error.
 	Listen(func(Conn)) error
 	// Stop will stop the listening. Implementations must take care of making
 	// Stop() a blocking call. Stop() should return when the Listener really
-	// has stopped listening,i.e. the call to Listen has returned.
+	// has stopped listening,i.e. the call to Listen has returned. Calling twice
+	// Stop() should return an error ErrClosed on the second call.
 	Stop() error
 
 	// what is the address this listener is listening to + what type of

--- a/network/network.go
+++ b/network/network.go
@@ -1,0 +1,65 @@
+package network
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/dedis/cothority/monitor"
+)
+
+// Conn is the basic interface to represent any communication mean
+// between two host.
+type Conn interface {
+	// Send a message through the connection.
+	// obj should be a POINTER to the actual struct to send, or an interface.
+	// It should not be a Golang type.
+	Send(ctx context.Context, obj Body) error
+	// Receive any message through the connection. It is a blocking call that
+	// returns either when a message arrived or when Close() has been called, or
+	// when a network error occured.
+	Receive(ctx context.Context) (Packet, error)
+	// Close will close the connection. Implementations must take care that
+	// Close() makes Receive() returns with an error, and any subsequent Send()
+	// will return with an error.
+	Close() error
+
+	// Type returns the type of this connection
+	Type() ConnType
+	// Gives the address of the remote endpoint
+	Remote() Address
+	// Returns the local address and port
+	Local() Address
+	// XXX Can we remove that ?
+	monitor.CounterIO
+}
+
+// Listener is responsible for listening for incoming Conn on a particular
+// address.It can only accept one type of incoming Conn.
+type Listener interface {
+	// Listen will start listening for incoming connections
+	// Each time there is an incoming Conn, it will call the given
+	// function in a go routine with the incoming Conn as parameter.
+	// The call is BLOCKING.
+	Listen(func(Conn)) error
+	// Stop will stop the listening. Implementations must take care of making
+	// Stop() a blocking call. Stop() should return when the Listener really
+	// has stopped listening,i.e. the call to Listen has returned.
+	Stop() error
+
+	// what is the address this listener is listening to + what type of
+	// connection does it accept (address.ConnType())
+	Address() Address
+
+	// Returns whether this listener is actually listening or not. Sadly this
+	// function is mainly useful for tests where we need to make sure the
+	// listening routine is started.
+	Listening() bool
+}
+
+// Host is an interface that can Listen for a specific type of Conn and can
+// Connect to specific types of Conn. It used by the Router so the router can
+// manage connections all being oblivious to which type of connections.
+type Host interface {
+	Listener
+
+	Connect(addr Address) (Conn, error)
+}

--- a/network/network.go
+++ b/network/network.go
@@ -1,7 +1,6 @@
 package network
 
-// Conn is the basic interface to represent any communication mean
-// between two host.
+// Conn represents any communication between two hosts.
 type Conn interface {
 	// Send a message through the connection.
 	// obj should be a POINTER to the actual struct to send, or an interface.
@@ -9,7 +8,7 @@ type Conn interface {
 	Send(obj Body) error
 	// Receive any message through the connection. It is a blocking call that
 	// returns either when a message arrived or when Close() has been called, or
-	// when a network error occured.
+	// when a network error occurred.
 	Receive() (Packet, error)
 	// Close will close the connection. Implementations must take care that
 	// Close() makes Receive() returns with an error, and any subsequent Send()
@@ -17,11 +16,11 @@ type Conn interface {
 	// ErrClosed.
 	Close() error
 
-	// Type returns the type of this connection
+	// Type returns the type of this connection.
 	Type() ConnType
-	// Gives the address of the remote endpoint
+	// Gives the address of the remote endpoint.
 	Remote() Address
-	// Returns the local address and port
+	// Returns the local address and port.
 	Local() Address
 	// Tx returns how many bytes this connection has written
 	Tx() uint64
@@ -29,34 +28,34 @@ type Conn interface {
 	Rx() uint64
 }
 
-// Listener is responsible for listening for incoming Conn on a particular
-// address.It can only accept one type of incoming Conn.
+// Listener is responsible for listening for incoming Conns on a particular
+// address. It can only accept one type of incoming Conn.
 type Listener interface {
-	// Listen will start listening for incoming connections
-	// Each time there is an incoming Conn, it will call the given
+	// Listen for incoming connections.
+	// Each time there is an incoming Conn, it calls the given
 	// function in a go routine with the incoming Conn as parameter.
-	// The call is BLOCKING. If this listener is already Listening, Listen
+	// The call is blocking. If this listener is already Listening, Listen
 	// should return an error.
 	Listen(func(Conn)) error
-	// Stop will stop the listening. Implementations must take care of making
+	// Stop the listening. Implementations must take care of making
 	// Stop() a blocking call. Stop() should return when the Listener really
-	// has stopped listening,i.e. the call to Listen has returned. Calling twice
+	// has stopped listening, i.e. the call to Listen has returned. Calling twice
 	// Stop() should return an error ErrClosed on the second call.
 	Stop() error
 
-	// what is the address this listener is listening to + what type of
-	// connection does it accept (address.ConnType())
+	// A complete address including the type this listener is listening
+	// to.
 	Address() Address
 
-	// Returns whether this listener is actually listening or not. Sadly this
+	// Returns whether this listener is actually listening or not. This
 	// function is mainly useful for tests where we need to make sure the
 	// listening routine is started.
 	Listening() bool
 }
 
-// Host is an interface that can Listen for a specific type of Conn and can
-// Connect to specific types of Conn. It used by the Router so the router can
-// manage connections all being oblivious to which type of connections.
+// Host listens for a specific type of Conn and can Connect to specific types
+// of Conn. It is used by the Router so the router can manage connections
+// while being oblivious to which type of connections it's handling.
 type Host interface {
 	Listener
 

--- a/network/struct.go
+++ b/network/struct.go
@@ -3,8 +3,6 @@ package network
 import (
 	"bytes"
 	"errors"
-	"fmt"
-	"io"
 	"net"
 	"strings"
 	"sync"
@@ -279,30 +277,6 @@ func GlobalBind(address string) (string, error) {
 	return "0.0.0.0:" + addr[1], nil
 }
 
-<<<<<<< HEAD
-// handleError produces the higher layer error depending on the type
-// so user of the package can know what is the cause of the problem
-func handleError(err error) error {
-
-	if strings.Contains(err.Error(), "use of closed") || strings.Contains(err.Error(), "broken pipe") {
-		return ErrClosed
-	} else if strings.Contains(err.Error(), "canceled") {
-		return ErrCanceled
-	} else if err == io.EOF || strings.Contains(err.Error(), "EOF") {
-		return ErrEOF
-	}
-
-	netErr, ok := err.(net.Error)
-	if !ok {
-		return ErrUnknown
-	}
-	if netErr.Temporary() {
-		return ErrTemp
-	} else if netErr.Timeout() {
-		return ErrTimeout
-	}
-	return ErrUnknown
-=======
 // counterSafe is a struct that enables to update two counters Rx & Tx
 // atomically that can be have increasing values.
 // It's main use is for Conn to update how many bytes they've
@@ -339,5 +313,4 @@ func (c *counterSafe) updateTx(delta uint64) {
 	c.Lock()
 	defer c.Unlock()
 	c.tx += delta
->>>>>>> 429e587... more coverage (>95%) + tx/rx impl
 }

--- a/network/struct.go
+++ b/network/struct.go
@@ -279,6 +279,7 @@ func GlobalBind(address string) (string, error) {
 	return "0.0.0.0:" + addr[1], nil
 }
 
+<<<<<<< HEAD
 // handleError produces the higher layer error depending on the type
 // so user of the package can know what is the cause of the problem
 func handleError(err error) error {
@@ -301,4 +302,42 @@ func handleError(err error) error {
 		return ErrTimeout
 	}
 	return ErrUnknown
+=======
+// counterSafe is a struct that enables to update two counters Rx & Tx
+// atomically that can be have increasing values.
+// It's main use is for Conn to update how many bytes they've
+// written / read. This struct implements the monitor.CounterIO interface.
+type counterSafe struct {
+	tx uint64
+	rx uint64
+	sync.Mutex
+}
+
+// Rx returns the rx counter
+func (c *counterSafe) Rx() uint64 {
+	c.Lock()
+	defer c.Unlock()
+	return c.rx
+}
+
+// Tx returns the tx counter
+func (c *counterSafe) Tx() uint64 {
+	c.Lock()
+	defer c.Unlock()
+	return c.tx
+}
+
+// UpdateRx adds delta to the rx counter
+func (c *counterSafe) updateRx(delta uint64) {
+	c.Lock()
+	defer c.Unlock()
+	c.rx += delta
+}
+
+// UpdateRx adds delta to the tx counter
+func (c *counterSafe) updateTx(delta uint64) {
+	c.Lock()
+	defer c.Unlock()
+	c.tx += delta
+>>>>>>> 429e587... more coverage (>95%) + tx/rx impl
 }

--- a/network/struct.go
+++ b/network/struct.go
@@ -301,14 +301,14 @@ func (c *counterSafe) Tx() uint64 {
 	return c.tx
 }
 
-// UpdateRx adds delta to the rx counter
+// updateRx adds delta to the rx counter
 func (c *counterSafe) updateRx(delta uint64) {
 	c.Lock()
 	defer c.Unlock()
 	c.rx += delta
 }
 
-// UpdateRx adds delta to the tx counter
+// updateTx adds delta to the tx counter
 func (c *counterSafe) updateTx(delta uint64) {
 	c.Lock()
 	defer c.Unlock()


### PR DESCRIPTION
This PR implements the local communication part using signaling and queues..
This PR comes with the basic interface definitions which are used throughout the network library such as `Conn`, `Listener`  & `Host`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dedis/cothority/568)
<!-- Reviewable:end -->
