### PR TITLE
including small protocol changes

### DIFF
--- a/protocols/bftcosi/bftcosi_test.go
+++ b/protocols/bftcosi/bftcosi_test.go
@@ -237,7 +237,6 @@ func runProtocolOnceGo(nbrHosts int, name string, refuseCount int,
 			return fmt.Errorf("%s Verification of the signature refused: %s - %+v", root.Name(), err.Error(), sig.Sig)
 		}
 		if !succeed && err == nil {
-			log.Print("Fail")
 			return fmt.Errorf("%s: Shouldn't have succeeded for %d hosts, but signed for count: %d",
 				root.Name(), nbrHosts, refuseCount)
 		}

--- a/protocols/manage/propagate.go
+++ b/protocols/manage/propagate.go
@@ -121,7 +121,8 @@ func (p *Propagate) Dispatch() error {
 		p.Unlock()
 		select {
 		case msg := <-p.ChannelSD:
-			log.Lvl3(p.ServerIdentity(), "Got data from", msg.ServerIdentity)
+			log.Lvl3(p.ServerIdentity(), "Got data from", msg.ServerIdentity, "and setting timeout to", msg.Msec)
+			p.sd.Msec = msg.Msec
 			if p.onData != nil {
 				_, netMsg, err := network.UnmarshalRegistered(msg.Data)
 				if err == nil {
@@ -148,7 +149,8 @@ func (p *Propagate) Dispatch() error {
 				process = false
 			}
 		case <-time.After(timeout):
-			log.Fatal("Timeout")
+			_, a, err := network.UnmarshalRegistered(p.sd.Data)
+			log.Fatalf("Timeout of %s reached. %v %s", timeout, a, err)
 			process = false
 		}
 	}

--- a/protocols/ntree/doc.go
+++ b/protocols/ntree/doc.go
@@ -1,0 +1,9 @@
+// Package ntree implements a simple protocol where each node signs a message
+// and the parent node verifies it.
+// The leader (the root node) collects N standard individual signatures
+// from the N witnesses using a tree.
+// It is very similar to the "naive" scheme where the leader directly sends the
+// message to be signed directly to its children. Th naive scheme is the the
+// same protocol but with a 1-level tree.
+// It can be used to compare both naive and ntree with CoSi.
+package ntree


### PR DESCRIPTION
Changes include:
- less verbosity in bftcosi-test
- propagate timeout in manage-protocol and more debug if the timeout is reached
- add some documentation to the ntree-protocol