### PR TITLE
return correct IPv6 unspecified address in Address.Host

### DIFF
--- a/network/address.go
+++ b/network/address.go
@@ -152,7 +152,8 @@ func (a Address) Port() string {
 func (a Address) Public() bool {
 	private, err := regexp.MatchString("(^127\\.)|(^10\\.)|"+
 		"(^172\\.1[6-9]\\.)|(^172\\.2[0-9]\\.)|"+
-		"(^172\\.3[0-1]\\.)|(^192\\.168\\.)|(^169\\.254)", a.NetworkAddress())
+		"(^172\\.3[0-1]\\.)|(^192\\.168\\.)|(^169\\.254)|"+
+		"(^\\[::\\])", a.NetworkAddress())
 	if err != nil {
 		return false
 	}

--- a/network/address.go
+++ b/network/address.go
@@ -122,6 +122,10 @@ func (a Address) Host() string {
 	if e != nil {
 		return ""
 	}
+	// IPv6 global address has to be in brackets.
+	if h == "::" {
+		h = "[::]"
+	}
 	return h
 }
 

--- a/network/address.go
+++ b/network/address.go
@@ -122,7 +122,7 @@ func (a Address) Host() string {
 	if e != nil {
 		return ""
 	}
-	// IPv6 global address has to be in brackets.
+	// IPv6 unspecified address has to be in brackets.
 	if h == "::" {
 		h = "[::]"
 	}

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -3,7 +3,8 @@ package network
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/dedis/cothority/log"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConnType(t *testing.T) {
@@ -52,12 +53,13 @@ func TestAddress(t *testing.T) {
 	}
 
 	for i, str := range tests {
+		log.Lvl1("Testing", str)
 		add := Address(str.Value)
-		assert.Equal(t, str.Valid, add.Valid(), "Address (%d) %s", i, str.Value)
-		assert.Equal(t, str.Type, add.ConnType(), "Address (%d) %s", i, str.Value)
-		assert.Equal(t, str.Address, add.NetworkAddress())
-		assert.Equal(t, str.Host, add.Host())
-		assert.Equal(t, str.Port, add.Port())
-		assert.Equal(t, str.Public, add.Public())
+		require.Equal(t, str.Valid, add.Valid(), "Address (%d) %s", i, str.Value)
+		require.Equal(t, str.Type, add.ConnType(), "Address (%d) %s", i, str.Value)
+		require.Equal(t, str.Address, add.NetworkAddress())
+		require.Equal(t, str.Host, add.Host())
+		require.Equal(t, str.Port, add.Port())
+		require.Equal(t, str.Public, add.Public())
 	}
 }

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/dedis/cothority/log"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConnType(t *testing.T) {
@@ -55,11 +55,11 @@ func TestAddress(t *testing.T) {
 	for i, str := range tests {
 		log.Lvl1("Testing", str)
 		add := Address(str.Value)
-		require.Equal(t, str.Valid, add.Valid(), "Address (%d) %s", i, str.Value)
-		require.Equal(t, str.Type, add.ConnType(), "Address (%d) %s", i, str.Value)
-		require.Equal(t, str.Address, add.NetworkAddress())
-		require.Equal(t, str.Host, add.Host())
-		require.Equal(t, str.Port, add.Port())
-		require.Equal(t, str.Public, add.Public())
+		assert.Equal(t, str.Valid, add.Valid(), "Address (%d) %s", i, str.Value)
+		assert.Equal(t, str.Type, add.ConnType(), "Address (%d) %s", i, str.Value)
+		assert.Equal(t, str.Address, add.NetworkAddress())
+		assert.Equal(t, str.Host, add.Host())
+		assert.Equal(t, str.Port, add.Port())
+		assert.Equal(t, str.Public, add.Public())
 	}
 }

--- a/network/address_test.go
+++ b/network/address_test.go
@@ -39,6 +39,7 @@ func TestAddress(t *testing.T) {
 		{"tcp://10.0.0.4:2000", true, PlainTCP, "10.0.0.4:2000", "10.0.0.4", "2000", false},
 		{"tcp://67.43.129.85:2000", true, PlainTCP, "67.43.129.85:2000", "67.43.129.85", "2000", true},
 		{"purb://10.0.0.4:2000", true, PURB, "10.0.0.4:2000", "10.0.0.4", "2000", false},
+		{"tls://[::]:1000", true, TLS, "[::]:1000", "[::]", "1000", false},
 		{"tls4://10.0.0.4:2000", false, InvalidConnType, "", "", "", false},
 		{"tls://1000.0.0.4:2000", false, InvalidConnType, "", "", "", false},
 		{"tls://10.0.0.4:20000000", false, InvalidConnType, "", "", "", false},


### PR DESCRIPTION
When using `SplitHostPort`, the IPv6 unspecified address is returned as "::", whereas other IPv6 addresses are returned in "[]". This patch unifies the behaviour, so that `Address.Host` can be used in all circumstances.