### PR TITLE
Fix Datarace in router.go #669

### DIFF
--- a/network/router.go
+++ b/network/router.go
@@ -70,14 +70,6 @@ func (r *Router) Start() {
 			}
 			return
 		}
-		/*r.mutex.Lock()*/
-		//if r.isClosed {
-		//if err := c.Close(); err != nil {
-		//log.Error("Could not close orphan connection to", c.Remote())
-		//}
-		//r.mutex.Unlock()
-		//return
-		/*}*/
 		if err := r.registerConnection(dst, c); err != nil {
 			log.Lvl3(r.address, "Do not accept incoming connection to", c.Remote(), "because it's closed")
 			return
@@ -88,7 +80,6 @@ func (r *Router) Start() {
 			log.Lvl3(r.address, "Do not accept incoming connection to", c.Remote(), "because it's closed")
 			return
 		}
-		//r.mutex.Unlock()
 	})
 	if err != nil {
 		log.Error("Error listening:", err)
@@ -122,9 +113,6 @@ func (r *Router) Stop() error {
 	// wait for all handleConn to finish
 	r.wg.Wait()
 
-	/*r.connsMut.Lock()*/
-	//r.isClosed = false
-	/*r.connsMut.Unlock()*/
 	if err != nil {
 		return err
 	}

--- a/network/router.go
+++ b/network/router.go
@@ -33,7 +33,7 @@ type Router struct {
 	// can be opened at the same time on both endpoints, there can be more
 	// than one connection per ServerIdentityID.
 	connections map[ServerIdentityID][]Conn
-	connsMut    sync.Mutex
+	mutex       sync.Mutex
 
 	// boolean flag indicating that the router is already clos{ing,ed}.
 	isClosed bool
@@ -70,9 +70,25 @@ func (r *Router) Start() {
 			}
 			return
 		}
-		// start handleConn that waits for incoming messages and
+		/*r.mutex.Lock()*/
+		//if r.isClosed {
+		//if err := c.Close(); err != nil {
+		//log.Error("Could not close orphan connection to", c.Remote())
+		//}
+		//r.mutex.Unlock()
+		//return
+		/*}*/
+		if err := r.registerConnection(dst, c); err != nil {
+			log.Lvl3(r.address, "Do not accept incoming connection to", c.Remote(), "because it's closed")
+			return
+		}
+		// start handleConn in a go routine that waits for incoming messages and
 		// dispatches them.
-		r.launchHandleRoutine(dst, c)
+		if err := r.launchHandleRoutine(dst, c); err != nil {
+			log.Lvl3(r.address, "Do not accept incoming connection to", c.Remote(), "because it's closed")
+			return
+		}
+		//r.mutex.Unlock()
 	})
 	if err != nil {
 		log.Error("Error listening:", err)
@@ -88,7 +104,7 @@ func (r *Router) Stop() error {
 	//if r.host.Listening() {
 	err = r.host.Stop()
 	//}
-	r.connsMut.Lock()
+	r.mutex.Lock()
 	// set the isClosed to true
 	r.isClosed = true
 
@@ -101,14 +117,14 @@ func (r *Router) Stop() error {
 			}
 		}
 	}
-	r.connsMut.Unlock()
+	r.mutex.Unlock()
 
 	// wait for all handleConn to finish
 	r.wg.Wait()
 
-	r.connsMut.Lock()
-	r.isClosed = false
-	r.connsMut.Unlock()
+	/*r.connsMut.Lock()*/
+	//r.isClosed = false
+	/*r.connsMut.Unlock()*/
 	if err != nil {
 		return err
 	}
@@ -162,9 +178,13 @@ func (r *Router) connect(si *ServerIdentity) (Conn, error) {
 		return nil, err
 	}
 
-	r.registerConnection(si, c)
+	if err := r.registerConnection(si, c); err != nil {
+		return nil, err
+	}
 
-	r.launchHandleRoutine(si, c)
+	if err := r.launchHandleRoutine(si, c); err != nil {
+		return nil, err
+	}
 	return c, nil
 
 }
@@ -215,8 +235,8 @@ func (r *Router) handleConn(remote *ServerIdentity, c Conn) {
 // connection returns the first connection associated with this ServerIdentity.
 // If no connection is found, it returns nil.
 func (r *Router) connection(sid ServerIdentityID) Conn {
-	r.connsMut.Lock()
-	defer r.connsMut.Unlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	arr := r.connections[sid]
 	if len(arr) == 0 {
 		return nil
@@ -227,35 +247,45 @@ func (r *Router) connection(sid ServerIdentityID) Conn {
 // registerConnection registers a ServerIdentity for a new connection, mapped with the
 // real physical address of the connection and the connection itself.
 // It uses the networkLock mutex.
-func (r *Router) registerConnection(remote *ServerIdentity, c Conn) {
+func (r *Router) registerConnection(remote *ServerIdentity, c Conn) error {
 	log.Lvl4(r.address, "Registers", remote.Address)
-	r.connsMut.Lock()
-	defer r.connsMut.Unlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if r.isClosed {
+		return ErrClosed
+	}
 	_, okc := r.connections[remote.ID]
 	if okc {
 		log.Lvl5("Connection already registered. Appending new connection to same identity.")
 	}
 	r.connections[remote.ID] = append(r.connections[remote.ID], c)
+	return nil
 }
 
-func (r *Router) launchHandleRoutine(dst *ServerIdentity, c Conn) {
+func (r *Router) launchHandleRoutine(dst *ServerIdentity, c Conn) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if r.isClosed {
+		return ErrClosed
+	}
 	r.wg.Add(1)
 	go r.handleConn(dst, c)
+	return nil
 }
 
 // Closed returns true if the router is closed (or is closing). For a router
 // to be closed means that a call to Stop() must have been made.
 func (r *Router) Closed() bool {
-	r.connsMut.Lock()
-	defer r.connsMut.Unlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	return r.isClosed
 }
 
 // Tx implements monitor/CounterIO
 // It returns the Tx for all connections managed by this router
 func (r *Router) Tx() uint64 {
-	r.connsMut.Lock()
-	defer r.connsMut.Unlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	var tx uint64
 	for _, arr := range r.connections {
 		for _, c := range arr {
@@ -268,8 +298,8 @@ func (r *Router) Tx() uint64 {
 // Rx implements monitor/CounterIO
 // It returns the Rx for all connections managed by this router
 func (r *Router) Rx() uint64 {
-	r.connsMut.Lock()
-	defer r.connsMut.Unlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	var rx uint64
 	for _, arr := range r.connections {
 		for _, c := range arr {
@@ -304,6 +334,5 @@ func (r *Router) receiveServerIdentity(c Conn) (*ServerIdentity, error) {
 		return nil, err
 	}
 	log.Lvl4(r.address, "Identity received from", dst.Address)
-	r.registerConnection(&dst, c)
 	return &dst, nil
 }

--- a/network/router.go
+++ b/network/router.go
@@ -71,13 +71,13 @@ func (r *Router) Start() {
 			return
 		}
 		if err := r.registerConnection(dst, c); err != nil {
-			log.Lvl3(r.address, "Do not accept incoming connection to", c.Remote(), "because it's closed")
+			log.Lvl3(r.address, "does not accept incoming connection to", c.Remote(), "because it's closed")
 			return
 		}
 		// start handleConn in a go routine that waits for incoming messages and
 		// dispatches them.
 		if err := r.launchHandleRoutine(dst, c); err != nil {
-			log.Lvl3(r.address, "Do not accept incoming connection to", c.Remote(), "because it's closed")
+			log.Lvl3(r.address, "does not accept incoming connection to", c.Remote(), "because it's closed")
 			return
 		}
 	})

--- a/network/router_test.go
+++ b/network/router_test.go
@@ -120,9 +120,9 @@ func testRouterAutoConnection(t *testing.T, fac routerFactory) {
 	if err := h2.Stop(); err != nil {
 		t.Fatal("Should be able to stop h2")
 	}
-	h2.mutex.Lock()
+	h2.Lock()
 	delete(h2.connections, h1.ServerIdentity.ID)
-	h2.mutex.Unlock()
+	h2.Unlock()
 	err = h1.Send(h2.ServerIdentity, &SimpleMessage{12})
 	require.NotNil(t, err)
 }

--- a/network/router_test.go
+++ b/network/router_test.go
@@ -120,9 +120,9 @@ func testRouterAutoConnection(t *testing.T, fac routerFactory) {
 	if err := h2.Stop(); err != nil {
 		t.Fatal("Should be able to stop h2")
 	}
-	h2.connsMut.Lock()
+	h2.mutex.Lock()
 	delete(h2.connections, h1.ServerIdentity.ID)
-	h2.connsMut.Unlock()
+	h2.mutex.Unlock()
 	err = h1.Send(h2.ServerIdentity, &SimpleMessage{12})
 	require.NotNil(t, err)
 }


### PR DESCRIPTION
Resolves #669 
It puts a lock inside the new connection function that is given to the listener, so if the router is stopping just before or just in the middle, the connection won't be launched,i.e. `wg.Add` won't be called during a call to `wg.Done`.