### PR TITLE
[Wire-Protocol 1/3 ] SDA Changes

### DIFF
--- a/network/encoding.go
+++ b/network/encoding.go
@@ -44,6 +44,10 @@ func (mId PacketTypeID) String() string {
 	return fmt.Sprintf("%x", uuid.UUID(mId))
 }
 
+func (pId PacketTypeID) Equal(t PacketTypeID) bool {
+	return bytes.Compare(uuid.UUID(pId).Bytes(), uuid.UUID(t).Bytes()) == 0
+}
+
 // NamespaceURL is the basic namespace used for uuid
 // XXX should move that to external of the library as not every
 // cothority/packages should be expected to use that.

--- a/network/encoding.go
+++ b/network/encoding.go
@@ -37,11 +37,11 @@ var ErrorType = PacketTypeID(uuid.Nil)
 // String returns the name of the structure if it is known, else it returns
 // the hexadecimal value of the Id.
 func (pId PacketTypeID) String() string {
-	t, ok := registry.get(mId)
+	t, ok := registry.get(pId)
 	if ok {
 		return t.String()
 	}
-	return fmt.Sprintf("%x", uuid.UUID(mId))
+	return fmt.Sprintf("%x", uuid.UUID(pId))
 }
 
 // Equal returns true if pId is equal to t

--- a/network/encoding.go
+++ b/network/encoding.go
@@ -36,7 +36,7 @@ var ErrorType = PacketTypeID(uuid.Nil)
 
 // String returns the name of the structure if it is known, else it returns
 // the hexadecimal value of the Id.
-func (mId PacketTypeID) String() string {
+func (pId PacketTypeID) String() string {
 	t, ok := registry.get(mId)
 	if ok {
 		return t.String()
@@ -44,6 +44,7 @@ func (mId PacketTypeID) String() string {
 	return fmt.Sprintf("%x", uuid.UUID(mId))
 }
 
+// Equal returns true if pId is equal to t
 func (pId PacketTypeID) Equal(t PacketTypeID) bool {
 	return bytes.Compare(uuid.UUID(pId).Bytes(), uuid.UUID(t).Bytes()) == 0
 }

--- a/sda/context.go
+++ b/sda/context.go
@@ -26,7 +26,8 @@ func newContext(c *Conode, o *Overlay, servID ServiceID, manager *serviceManager
 // NewTreeNodeInstance creates a TreeNodeInstance that is bound to a
 // service instead of the Overlay.
 func (c *Context) NewTreeNodeInstance(t *Tree, tn *TreeNode, protoName string) *TreeNodeInstance {
-	return c.overlay.NewTreeNodeInstanceFromService(t, tn, ProtocolNameToID(protoName), c.servID)
+	io := c.overlay.protoIO.getByName(protoName)
+	return c.overlay.NewTreeNodeInstanceFromService(t, tn, ProtocolNameToID(protoName), c.servID, io)
 }
 
 // SendRaw sends a message to the ServerIdentity.

--- a/sda/export_test.go
+++ b/sda/export_test.go
@@ -1,13 +1,5 @@
 package sda
 
-import "github.com/dedis/cothority/network"
-
-// Export some private functions of Host for testing
-
-func (c *Conode) SendSDAData(id *network.ServerIdentity, msg *ProtocolMsg) error {
-	return c.overlay.sendSDAData(id, msg)
-}
-
 func (c *Conode) CreateProtocol(name string, t *Tree) (ProtocolInstance, error) {
 	return c.overlay.CreateProtocolSDA(name, t)
 }
@@ -24,10 +16,6 @@ func (c *Conode) Roster(id RosterID) (*Roster, bool) {
 func (c *Conode) GetTree(id TreeID) (*Tree, bool) {
 	t := c.overlay.Tree(id)
 	return t, t != nil
-}
-
-func (c *Conode) SendToTreeNode(from *Token, to *TreeNode, msg network.Body) error {
-	return c.overlay.SendToTreeNode(from, to, msg)
 }
 
 func (c *Conode) Overlay() *Overlay {

--- a/sda/messages.go
+++ b/sda/messages.go
@@ -109,16 +109,14 @@ func (t *Token) ChangeTreeNodeID(newid TreeNodeID) *Token {
 	return &tOther
 }
 
-// TreeNodeInfo contains from whose node in which tree a message is coming from
-// and which node is the destination.
+// TreeNodeInfo holds the sender and the destination of the message.
 type TreeNodeInfo struct {
 	To   *Token
 	From *Token
 }
 
-// OverlayMessage contains *all* information needed by the Overlay to perform
-// its duties such as TreeNodeInfo and the message to request a Tree or a Roster
-// to other nodes.
+// OverlayMessage contains all routing-information about the tree and the
+// roster.
 type OverlayMessage struct {
 	TreeNodeInfo *TreeNodeInfo
 

--- a/sda/messages.go
+++ b/sda/messages.go
@@ -45,8 +45,7 @@ type ProtocolMsg struct {
 // RoundID uniquely identifies a round of a protocol run
 type RoundID uuid.UUID
 
-// String returns the canonical representation of the rounds ID (wrapper around
-// uuid.UUID.String())
+// String returns the canonical representation of the rounds ID (wrapper around // uuid.UUID.String())
 func (rId RoundID) String() string {
 	return uuid.UUID(rId).String()
 }
@@ -108,6 +107,19 @@ func (t *Token) ChangeTreeNodeID(newid TreeNodeID) *Token {
 	tOther.TreeNodeID = newid
 	tOther.cacheID = TokenID(uuid.Nil)
 	return &tOther
+}
+
+type TreeNodeInfo struct {
+	To   *Token
+	From *Token
+}
+type OverlayMessage struct {
+	TreeNodeInfo *TreeNodeInfo
+
+	RequestTree   *RequestTree
+	TreeMarshal   *TreeMarshal
+	RequestRoster *RequestRoster
+	Roster        *Roster
 }
 
 // RequestTree is used to ask the parent for a given Tree

--- a/sda/messages.go
+++ b/sda/messages.go
@@ -109,10 +109,16 @@ func (t *Token) ChangeTreeNodeID(newid TreeNodeID) *Token {
 	return &tOther
 }
 
+// TreeNodeInfo contains from whose node in which tree a message is coming from
+// and which node is the destination.
 type TreeNodeInfo struct {
 	To   *Token
 	From *Token
 }
+
+// OverlayMessage contains *all* information needed by the Overlay to perform
+// its duties such as TreeNodeInfo and the message to request a Tree or a Roster
+// to other nodes.
 type OverlayMessage struct {
 	TreeNodeInfo *TreeNodeInfo
 

--- a/sda/overlay.go
+++ b/sda/overlay.go
@@ -758,3 +758,8 @@ func (d *defaultProtoIO) Unwrap(msg interface{}) (interface{}, *OverlayMessage, 
 func (d *defaultProtoIO) PacketType() network.PacketTypeID {
 	return network.PacketTypeID([16]byte{})
 }
+
+// Name implements the ProtocolIO interface. It returns the value "default".
+func (d *defaultProtoIO) Name() string {
+	return "default"
+}

--- a/sda/overlay.go
+++ b/sda/overlay.go
@@ -40,11 +40,22 @@ type Overlay struct {
 	// pendingSDAData are a list of message we received that does not correspond
 	// to any local Tree or/and Roster. We first request theses so we can
 	// instantiate properly protocolInstance that will use these SDAData msg.
-	pendingSDAs []*ProtocolMsg
+	pendingMsg []pendingMsg
 	// lock associated with pending SDAdata
-	pendingSDAsLock sync.Mutex
+	pendingMsgLock sync.Mutex
 
 	transmitMux sync.Mutex
+
+	protoIO *protocolIOStore
+}
+
+// pendingMsg is used to store messages destined for ProtocolInstances but when
+// the tree designated is not known to the Overlay. When the tree is sent to the
+// overlay, then the pendingMsg that are relying on this tree will get
+// processed.
+type pendingMsg struct {
+	*ProtocolMsg
+	ProtocolIO
 }
 
 // NewOverlay creates a new overlay-structure
@@ -58,8 +69,8 @@ func NewOverlay(c *Conode) *Overlay {
 		instancesInfo:      make(map[TokenID]bool),
 		protocolInstances:  make(map[TokenID]ProtocolInstance),
 		pendingTreeMarshal: make(map[RosterID][]*TreeMarshal),
-		pendingSDAs:        make([]*ProtocolMsg, 0),
 	}
+	o.protoIO = newProtocolIOStore(c, o)
 	// messages going to protocol instances
 	c.RegisterProcessor(o,
 		SDADataMessageID,       // protocol instance's messages
@@ -73,87 +84,32 @@ func NewOverlay(c *Conode) *Overlay {
 // Process implements the Processor interface so it process the messages that it
 // wants.
 func (o *Overlay) Process(data *network.Packet) {
-	switch data.MsgType {
-	case SDADataMessageID:
-		sdaMsg := data.Msg.(ProtocolMsg)
-		sdaMsg.ServerIdentity = data.ServerIdentity
-		err := o.TransmitMsg(&sdaMsg)
-		if err != nil {
-			log.Error("ProcessSDAMessage returned:", err)
+	// get protocolIO or default one
+	io := o.protoIO.getByPacketType(data.MsgType)
+	inner, info, err := io.Unwrap(data.Msg)
+	if err != nil {
+		log.Error("unwrapping: ", err)
+		return
+	}
+	switch true {
+	case info.RequestTree != nil:
+		o.handleRequestTree(data.ServerIdentity, info.RequestTree, io)
+	case info.TreeMarshal != nil:
+		o.handleSendTree(data.ServerIdentity, info.TreeMarshal, io)
+	case info.RequestRoster != nil:
+		o.handleRequestRoster(data.ServerIdentity, info.RequestRoster, io)
+	case info.Roster != nil:
+		o.handleSendRoster(data.ServerIdentity, info.Roster)
+	default:
+		typ := network.TypeToPacketTypeID(inner)
+		sda := &ProtocolMsg{
+			From:           info.TreeNodeInfo.From,
+			To:             info.TreeNodeInfo.To,
+			ServerIdentity: data.ServerIdentity,
+			Msg:            inner,
+			MsgType:        typ,
 		}
-
-	case RequestTreeMessageID:
-		// A host has sent us a request to get a tree definition
-		tid := data.Msg.(RequestTree).TreeID
-		tree := o.Tree(tid)
-		var err error
-		if tree != nil {
-			err = o.conode.Send(data.ServerIdentity, tree.MakeTreeMarshal())
-		} else {
-			// XXX Take care here for we must verify at the other side that
-			// the tree is Nil. Should we think of a way of sending back an
-			// "error" ?
-			err = o.conode.Send(data.ServerIdentity, (&Tree{}).MakeTreeMarshal())
-		}
-		if err != nil {
-			log.Error("Couldn't send tree:", err)
-		}
-	case SendTreeMessageID:
-		// A Host has replied to our request of a tree
-		tm := data.Msg.(TreeMarshal)
-		if tm.TreeID == TreeID(uuid.Nil) {
-			log.Error("Received an empty Tree")
-			return
-		}
-		il := o.Roster(tm.RosterID)
-		// The entity list does not exists, we should request that, too
-		if il == nil {
-			msg := &RequestRoster{tm.RosterID}
-			if err := o.conode.Send(data.ServerIdentity, msg); err != nil {
-				log.Error("Requesting Roster in SendTree failed", err)
-			}
-
-			// put the tree marshal into pending queue so when we receive the
-			// entitylist we can create the real Tree.
-			o.addPendingTreeMarshal(&tm)
-			return
-		}
-
-		tree, err := tm.MakeTree(il)
-		if err != nil {
-			log.Error("Couldn't create tree:", err)
-			return
-		}
-		log.Lvl4("Received new tree")
-		o.RegisterTree(tree)
-	case RequestRosterMessageID:
-		// Some host requested an Roster
-		id := data.Msg.(RequestRoster).RosterID
-		el := o.Roster(id)
-		var err error
-		if el != nil {
-			err = o.conode.Send(data.ServerIdentity, el)
-		} else {
-			log.Lvl2("Requested entityList that we don't have")
-			err = o.conode.Send(data.ServerIdentity, &Roster{})
-		}
-		if err != nil {
-			log.Error("Couldn't send empty entity list from host:",
-				o.conode.ServerIdentity.String(),
-				err)
-			return
-		}
-	case SendRosterMessageID:
-		// Host replied to our request of entitylist
-		il := data.Msg.(Roster)
-		if il.ID == RosterID(uuid.Nil) {
-			log.Lvl2("Received an empty Roster")
-		} else {
-			o.RegisterRoster(&il)
-			// Check if some trees can be constructed from this entitylist
-			o.checkPendingTreeMarshal(&il)
-		}
-		log.Lvl4("Received new entityList")
+		o.TransmitMsg(sda, io)
 	}
 }
 
@@ -162,10 +118,12 @@ func (o *Overlay) Process(data *network.Packet) {
 // - ask for the Tree
 // - create a new protocolInstance
 // - pass it to a given protocolInstance
-func (o *Overlay) TransmitMsg(sdaMsg *ProtocolMsg) error {
+// io is the protocolIO to use if a specific wireformat protocol is used.
+// It can be nil: in that case it fall backs to default wire protocol.
+func (o *Overlay) TransmitMsg(sdaMsg *ProtocolMsg, io ProtocolIO) error {
 	tree := o.Tree(sdaMsg.To.TreeID)
 	if tree == nil {
-		return o.requestTree(sdaMsg.ServerIdentity, sdaMsg)
+		return o.requestTree(sdaMsg.ServerIdentity, sdaMsg, io)
 	}
 
 	o.transmitMux.Lock()
@@ -187,7 +145,7 @@ func (o *Overlay) TransmitMsg(sdaMsg *ProtocolMsg) error {
 		if err != nil {
 			return errors.New("No TreeNode defined in this tree here")
 		}
-		tni := o.newTreeNodeInstanceFromToken(tn, sdaMsg.To)
+		tni := o.newTreeNodeInstanceFromToken(tn, sdaMsg.To, io)
 		// see if we know the Service Recipient
 		s, ok := o.conode.serviceManager.serviceByID(sdaMsg.To.ServiceID)
 
@@ -226,22 +184,6 @@ func (o *Overlay) TransmitMsg(sdaMsg *ProtocolMsg) error {
 	return nil
 }
 
-// sendSDAData marshals the inner msg and then sends a Data msg
-// to the appropriate entity
-func (o *Overlay) sendSDAData(si *network.ServerIdentity, sdaMsg *ProtocolMsg) error {
-	b, err := network.MarshalRegisteredType(sdaMsg.Msg)
-	if err != nil {
-		return fmt.Errorf("Error marshaling message: %s (msg = %+v)", err.Error(), sdaMsg.Msg)
-	}
-	sdaMsg.MsgSlice = b
-	sdaMsg.MsgType = network.TypeFromData(sdaMsg.Msg)
-	// put to nil so protobuf won't encode it and there won't be any error on the
-	// other side (because it doesn't know how to decode it)
-	sdaMsg.Msg = nil
-	log.Lvl4(o.conode.Address(), "Sending to", si.Address)
-	return o.conode.Send(si, sdaMsg)
-}
-
 // addPendingTreeMarshal adds a treeMarshal to the list.
 // This list is checked each time we receive a new Roster
 // so trees using this Roster can be constructed.
@@ -260,28 +202,25 @@ func (o *Overlay) addPendingTreeMarshal(tm *TreeMarshal) {
 
 // checkPendingMessages is called each time we receive a new tree if there are some SDA
 // messages using this tree. If there are, we can make an instance of a protocolinstance
-// and give it the message!.
-// NOTE: put that as a go routine so the rest of the processing messages are not
-// slowed down, if there are many pending sda message at once (i.e. start many new
-// protocols at same time)
+// and give it the message.
 func (o *Overlay) checkPendingMessages(t *Tree) {
 	go func() {
-		o.pendingSDAsLock.Lock()
-		var newPending []*ProtocolMsg
-		for _, msg := range o.pendingSDAs {
-			if t.ID.Equals(msg.To.TreeID) {
+		o.pendingMsgLock.Lock()
+		var newPending []pendingMsg
+		for _, pending := range o.pendingMsg {
+			if t.ID.Equals(pending.ProtocolMsg.To.TreeID) {
 				// if this message references t, instantiate it and go
-				err := o.TransmitMsg(msg)
+				err := o.TransmitMsg(pending.ProtocolMsg, pending.ProtocolIO)
 				if err != nil {
 					log.Error("TransmitMsg failed:", err)
 					continue
 				}
 			} else {
-				newPending = append(newPending, msg)
+				newPending = append(newPending, pending)
 			}
 		}
-		o.pendingSDAs = newPending
-		o.pendingSDAsLock.Unlock()
+		o.pendingMsg = newPending
+		o.pendingMsgLock.Unlock()
 	}()
 }
 
@@ -307,17 +246,34 @@ func (o *Overlay) checkPendingTreeMarshal(el *Roster) {
 	o.pendingTreeLock.Unlock()
 }
 
+func (o *Overlay) savePendingMsg(sdaMsg *ProtocolMsg, io ProtocolIO) {
+	o.pendingMsgLock.Lock()
+	o.pendingMsg = append(o.pendingMsg, pendingMsg{
+		ProtocolMsg: sdaMsg,
+		ProtocolIO:  io,
+	})
+	o.pendingMsgLock.Unlock()
+
+}
+
 // requestTree will ask for the tree the sdadata is related to.
 // it will put the message inside the pending list of sda message waiting to
 // have their trees.
-func (o *Overlay) requestTree(si *network.ServerIdentity, sdaMsg *ProtocolMsg) error {
-	o.pendingSDAsLock.Lock()
-	o.pendingSDAs = append(o.pendingSDAs, sdaMsg)
-	o.pendingSDAsLock.Unlock()
+// io is the wrapper to use to send the message, it can be nil.
+func (o *Overlay) requestTree(si *network.ServerIdentity, sdaMsg *ProtocolMsg, io ProtocolIO) error {
+	o.savePendingMsg(sdaMsg, io)
 
-	treeRequest := &RequestTree{sdaMsg.To.TreeID}
+	var msg interface{}
+	om := &OverlayMessage{
+		RequestTree: &RequestTree{sdaMsg.To.TreeID},
+	}
+	msg, err := io.Wrap(nil, om)
+	if err != nil {
+		return err
+	}
 
-	return o.conode.Send(si, treeRequest)
+	err = o.conode.Send(si, msg)
+	return err
 }
 
 // RegisterTree takes a tree and puts it in the map
@@ -384,15 +340,121 @@ func (o *Overlay) TreeNodeFromToken(t *Token) (*TreeNode, error) {
 	return tn, nil
 }
 
-// SendToTreeNode sends a message to a treeNode
-func (o *Overlay) SendToTreeNode(from *Token, to *TreeNode, msg network.Body) error {
-	sda := &ProtocolMsg{
-		Msg:  msg,
-		From: from,
-		To:   from.ChangeTreeNodeID(to.ID),
+func (o *Overlay) handleRequestTree(si *network.ServerIdentity, req *RequestTree, io ProtocolIO) {
+	tid := req.TreeID
+	tree := o.Tree(tid)
+	var err error
+	var treeM *TreeMarshal
+	var msg interface{}
+	if tree != nil {
+		treeM = tree.MakeTreeMarshal()
+	} else {
+		// XXX Take care here for we must verify at the other side that
+		// the tree is Nil. Should we think of a way of sending back an
+		// "error" ?
+		treeM = (&Tree{}).MakeTreeMarshal()
 	}
-	log.Lvl4(o.conode.Address(), "Sending to entity", to.ServerIdentity.Address)
-	return o.sendSDAData(to.ServerIdentity, sda)
+	msg, err = io.Wrap(nil, &OverlayMessage{
+		TreeMarshal: treeM,
+	})
+
+	if err != nil {
+		log.Error("couldn't wrap TreeMarshal:", err)
+		return
+	}
+
+	err = o.conode.Send(si, msg)
+	if err != nil {
+		log.Error("Couldn't send tree:", err)
+	}
+}
+
+func (o *Overlay) handleSendTree(si *network.ServerIdentity, tm *TreeMarshal, io ProtocolIO) {
+	if tm.TreeID == TreeID(uuid.Nil) {
+		log.Error("Received an empty Tree")
+		return
+	}
+	roster := o.Roster(tm.RosterID)
+	// The roster does not exists, we should request that, too
+	if roster == nil {
+		msg, err := io.Wrap(nil, &OverlayMessage{
+			RequestRoster: &RequestRoster{tm.RosterID},
+		})
+		if err != nil {
+			log.Error("could not wrap RequestRoster:", err)
+		}
+		if err := o.conode.Send(si, msg); err != nil {
+			log.Error("Requesting Roster in SendTree failed", err)
+		}
+		// put the tree marshal into pending queue so when we receive the
+		// entitylist we can create the real Tree.
+		o.addPendingTreeMarshal(tm)
+		return
+	}
+
+	tree, err := tm.MakeTree(roster)
+	if err != nil {
+		log.Error("Couldn't create tree:", err)
+		return
+	}
+	log.Lvl4("Received new tree")
+	o.RegisterTree(tree)
+}
+
+func (o *Overlay) handleRequestRoster(si *network.ServerIdentity, req *RequestRoster, io ProtocolIO) {
+	id := req.RosterID
+	roster := o.Roster(id)
+	var err error
+	var msg interface{}
+	if roster == nil {
+		// XXX Bad reaction to request...
+		log.Lvl2("Requested entityList that we don't have")
+		roster = &Roster{}
+	}
+
+	msg, err = io.Wrap(nil, &OverlayMessage{
+		Roster: roster,
+	})
+
+	if err != nil {
+		log.Error("error wraping up roster:", err)
+		return
+	}
+
+	err = o.conode.Send(si, msg)
+	if err != nil {
+		log.Error("Couldn't send empty entity list from host:",
+			o.conode.ServerIdentity.String(),
+			err)
+		return
+	}
+}
+
+func (o *Overlay) handleSendRoster(si *network.ServerIdentity, roster *Roster) {
+	if roster.ID == RosterID(uuid.Nil) {
+		log.Lvl2("Received an empty Roster")
+	} else {
+		o.RegisterRoster(roster)
+		// Check if some trees can be constructed from this entitylist
+		o.checkPendingTreeMarshal(roster)
+	}
+	log.Lvl4("Received new entityList")
+}
+
+// SendToTreeNode sends a message to a treeNode
+func (o *Overlay) SendToTreeNode(from *Token, to *TreeNode, msg network.Body, io ProtocolIO) error {
+	var final interface{}
+	info := &OverlayMessage{
+		TreeNodeInfo: &TreeNodeInfo{
+			From: from,
+			To:   from.ChangeTreeNodeID(to.ID),
+		},
+	}
+	final, err := io.Wrap(msg, info)
+	if err != nil {
+		return err
+	}
+	return o.conode.Send(to.ServerIdentity, final)
 }
 
 // nodeDone is called by node to signify that its work is finished and its
@@ -445,7 +507,8 @@ func (o *Overlay) CreateProtocolSDA(name string, t *Tree) (ProtocolInstance, err
 // CreateProtocolService adds the service-id to the token so the protocol will
 // be picked up by the correct service and handled by its NewProtocol method.
 func (o *Overlay) CreateProtocolService(name string, t *Tree, sid ServiceID) (ProtocolInstance, error) {
-	tni := o.NewTreeNodeInstanceFromService(t, t.Root, ProtocolNameToID(name), sid)
+	io := o.protoIO.getByName(name)
+	tni := o.NewTreeNodeInstanceFromService(t, t.Root, ProtocolNameToID(name), sid, io)
 	pi, err := o.conode.ProtocolInstantiate(tni.token.ProtoID, tni)
 	if err != nil {
 		return nil, err
@@ -475,12 +538,13 @@ func (o *Overlay) StartProtocol(t *Tree, name string) (ProtocolInstance, error) 
 // NewTreeNodeInstanceFromProtoName takes a protocol name and a tree and
 // instantiate a TreeNodeInstance for this protocol.
 func (o *Overlay) NewTreeNodeInstanceFromProtoName(t *Tree, name string) *TreeNodeInstance {
-	return o.NewTreeNodeInstanceFromProtocol(t, t.Root, ProtocolNameToID(name))
+	io := o.protoIO.getByName(name)
+	return o.NewTreeNodeInstanceFromProtocol(t, t.Root, ProtocolNameToID(name), io)
 }
 
 // NewTreeNodeInstanceFromProtocol takes a tree and a treenode (normally the
 // root) and and protocolID and returns a fresh TreeNodeInstance.
-func (o *Overlay) NewTreeNodeInstanceFromProtocol(t *Tree, tn *TreeNode, protoID ProtocolID) *TreeNodeInstance {
+func (o *Overlay) NewTreeNodeInstanceFromProtocol(t *Tree, tn *TreeNode, protoID ProtocolID, io ProtocolIO) *TreeNodeInstance {
 	tok := &Token{
 		TreeNodeID: tn.ID,
 		TreeID:     t.ID,
@@ -488,7 +552,7 @@ func (o *Overlay) NewTreeNodeInstanceFromProtocol(t *Tree, tn *TreeNode, protoID
 		ProtoID:    protoID,
 		RoundID:    RoundID(uuid.NewV4()),
 	}
-	tni := o.newTreeNodeInstanceFromToken(tn, tok)
+	tni := o.newTreeNodeInstanceFromToken(tn, tok, io)
 	o.RegisterTree(t)
 	o.RegisterRoster(t.Roster)
 	return tni
@@ -496,7 +560,7 @@ func (o *Overlay) NewTreeNodeInstanceFromProtocol(t *Tree, tn *TreeNode, protoID
 
 // NewTreeNodeInstanceFromService takes a tree, a TreeNode and a service ID and
 // returns a TNI.
-func (o *Overlay) NewTreeNodeInstanceFromService(t *Tree, tn *TreeNode, protoID ProtocolID, servID ServiceID) *TreeNodeInstance {
+func (o *Overlay) NewTreeNodeInstanceFromService(t *Tree, tn *TreeNode, protoID ProtocolID, servID ServiceID, io ProtocolIO) *TreeNodeInstance {
 	tok := &Token{
 		TreeNodeID: tn.ID,
 		TreeID:     t.ID,
@@ -505,7 +569,7 @@ func (o *Overlay) NewTreeNodeInstanceFromService(t *Tree, tn *TreeNode, protoID 
 		ServiceID:  servID,
 		RoundID:    RoundID(uuid.NewV4()),
 	}
-	tni := o.newTreeNodeInstanceFromToken(tn, tok)
+	tni := o.newTreeNodeInstanceFromToken(tn, tok, io)
 	o.RegisterTree(t)
 	o.RegisterRoster(t.Roster)
 	return tni
@@ -519,8 +583,8 @@ func (o *Overlay) ServerIdentity() *network.ServerIdentity {
 // newTreeNodeInstanceFromToken is to be called by the Overlay when it receives
 // a message it does not have a treenodeinstance registered yet. The protocol is
 // already running so we should *not* generate a new RoundID.
-func (o *Overlay) newTreeNodeInstanceFromToken(tn *TreeNode, tok *Token) *TreeNodeInstance {
-	tni := newTreeNodeInstance(o, tok, tn)
+func (o *Overlay) newTreeNodeInstanceFromToken(tn *TreeNode, tok *Token, io ProtocolIO) *TreeNodeInstance {
+	tni := newTreeNodeInstance(o, tok, tn, io)
 	o.instancesLock.Lock()
 	defer o.instancesLock.Unlock()
 	o.instances[tok.ID()] = tni
@@ -618,4 +682,79 @@ func (tnc *TreeNodeCache) GetFromToken(tok *Token) *TreeNode {
 		return nil
 	}
 	return tn
+}
+
+// defaultProtoIO implements the ProtocoIO interface but using the "regular/old"
+// wire format protocol,i.e. it wraps a message into a ProtocolMessage
+type defaultProtoIO struct{}
+
+// Wrap implements the ProtocolIO interface for the Overlay.
+func (d *defaultProtoIO) Wrap(msg interface{}, info *OverlayMessage) (interface{}, error) {
+	if msg != nil {
+		buff, err := network.MarshalRegisteredType(msg)
+		if err != nil {
+			return nil, err
+		}
+		typ := network.TypeFromData(msg)
+		protoMsg := &ProtocolMsg{
+			From:     info.TreeNodeInfo.From,
+			To:       info.TreeNodeInfo.To,
+			MsgSlice: buff,
+			MsgType:  typ,
+		}
+		return protoMsg, nil
+	}
+	var returnMsg interface{}
+	switch true {
+	case info.RequestTree != nil:
+		returnMsg = info.RequestTree
+	case info.RequestRoster != nil:
+		returnMsg = info.RequestRoster
+	case info.TreeMarshal != nil:
+		returnMsg = info.TreeMarshal
+	case info.Roster != nil:
+		returnMsg = info.Roster
+	default:
+		panic("overlay: default wrapper has nothing to wrap")
+	}
+	return returnMsg, nil
+}
+
+// Unwrap implements the ProtocolIO interface for the Overlay.
+func (d *defaultProtoIO) Unwrap(msg interface{}) (interface{}, *OverlayMessage, error) {
+	var returnMsg interface{}
+	var returnOverlay = new(OverlayMessage)
+	var err error
+
+	switch inner := msg.(type) {
+	case ProtocolMsg:
+		sdaMsg := inner
+		var err error
+		_, msg, err := network.UnmarshalRegistered(sdaMsg.MsgSlice)
+		if err != nil {
+			return nil, nil, err
+		}
+		// Put the msg into SDAData
+		returnOverlay.TreeNodeInfo = &TreeNodeInfo{
+			To:   sdaMsg.To,
+			From: sdaMsg.From,
+		}
+		returnMsg = msg
+	case RequestTree:
+		returnOverlay.RequestTree = &inner
+	case RequestRoster:
+		returnOverlay.RequestRoster = &inner
+	case TreeMarshal:
+		returnOverlay.TreeMarshal = &inner
+	case Roster:
+		returnOverlay.Roster = &inner
+	default:
+		err = errors.New("default protoIO: unwraping an unknown message type")
+	}
+	return returnMsg, returnOverlay, err
+}
+
+// Unwrap implements the ProtocolIO interface for the Overlay.
+func (d *defaultProtoIO) PacketType() network.PacketTypeID {
+	return network.PacketTypeID([16]byte{})
 }

--- a/sda/protocol.go
+++ b/sda/protocol.go
@@ -128,11 +128,11 @@ type ProtocolIO interface {
 // NewProtocolIO is a function typedef to instantiate a new ProtocolIO
 type NewProtocolIO func() ProtocolIO
 
-type protocolIOFactory_ struct {
+type protocolIOFactoryStruct struct {
 	factories map[string]NewProtocolIO
 }
 
-var protocolIOFactory = protocolIOFactory_{
+var protocolIOFactory = protocolIOFactoryStruct{
 	factories: make(map[string]NewProtocolIO),
 }
 

--- a/sda/protocol.go
+++ b/sda/protocol.go
@@ -128,7 +128,6 @@ type ProtocolIO interface {
 	// network. This is needed in order for the Overlay to receive those
 	// messages and dispatch them to the correct ProtocolIO.
 	PacketType() network.PacketTypeID
-
 	// Name returns the name associated with this ProtocolIO. When creating a
 	// protocol, if one use a name used by a ProtocolIO, this ProtocolIO will be
 	// used to Wrap and Unwrap messages.

--- a/sda/protocol.go
+++ b/sda/protocol.go
@@ -2,6 +2,7 @@ package sda
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/dedis/cothority/log"
 	"github.com/dedis/cothority/network"
@@ -99,4 +100,100 @@ func ProtocolNameToID(name string) ProtocolID {
 // protocol is tied to a service, use `Conode.ProtocolRegisterName`
 func GlobalProtocolRegister(name string, protocol NewProtocol) (ProtocolID, error) {
 	return protocols.Register(name, protocol)
+}
+
+// ProtocolIO is an interface that allows one protocol to completely define its
+// wire protocol format while still using the Overlay. Implementations must
+// provide methods to read a packet coming from the network and also to write a
+// packet going to the network. A default one is provided with
+// defaultProtocolIO so the regular wire-format protocol can still be used.
+type ProtocolIO interface {
+	// Wrap takes a message and the overlay information and returns the message
+	// has to be sent directly to the network alongside with any error that
+	// happened.
+	// the bigger outer struct. Msg can be nil, that case it means the message
+	// is only an internal message of the Overlay.
+	Wrap(msg interface{}, info *OverlayMessage) (interface{}, error)
+	// Unwrap takes the message coming from the network and must returns the
+	// inner message that is going to be dispatched to the ProtocolInstance, the
+	// OverlayMessage needed by the Overlay to function correctly and then any
+	// error that might have occured.
+	Unwrap(msg interface{}) (interface{}, *OverlayMessage, error)
+	// PacketType returns the packet type ID that this Protocol expects from the
+	// network. This is needed in order for the Overlay to receive those
+	// messages and dispatch them to the correct ProtocolIO.
+	PacketType() network.PacketTypeID
+}
+
+// NewProtocolIO is a function typedef to instantiate a new ProtocolIO
+type NewProtocolIO func() ProtocolIO
+
+type protocolIOFactory_ struct {
+	factories map[string]NewProtocolIO
+}
+
+var protocolIOFactory = protocolIOFactory_{
+	factories: make(map[string]NewProtocolIO),
+}
+
+// RegisterProtocolIO takes a name and and NewProtocolIO and save both fields.
+// When a Conode is instantiated, all ProtocolIO will be generated and stored
+// for this Conode.
+func RegisterProtocolIO(name string, n NewProtocolIO) {
+	_, present := protocolIOFactory.factories[name]
+	if present {
+		log.Error("protocolIOStore already registered a ProtocolIO at this name", name)
+		return
+	}
+	protocolIOFactory.factories[name] = n
+}
+
+// protocolIOStore contains all created ProtocolIO and is generally used by the
+// Overlay. It contains the default ProtocolIO used by the Overlay in order to
+// still function properly in case the old wire-format protocol is used.
+type protocolIOStore struct {
+	sync.Mutex
+	protos []ProtocolIO
+	names  map[string]int
+	types  map[network.PacketTypeID]int
+	// the one that gets used in case no ProtocolIO is defined
+	defaultIO ProtocolIO
+}
+
+func (p *protocolIOStore) getByName(name string) ProtocolIO {
+	p.Lock()
+	defer p.Unlock()
+	idx, ok := p.names[name]
+	if !ok || idx >= len(p.protos) || p.protos[idx] == nil {
+		return p.defaultIO
+	}
+	return p.protos[idx]
+}
+
+func (p *protocolIOStore) getByPacketType(t network.PacketTypeID) ProtocolIO {
+	p.Lock()
+	defer p.Unlock()
+	idx, ok := p.types[t]
+	if !ok || idx >= len(p.protos) || p.protos[idx] == nil {
+		return p.defaultIO
+	}
+	return p.protos[idx]
+}
+
+func newProtocolIOStore(disp network.Dispatcher, proc network.Processor) *protocolIOStore {
+	pstore := &protocolIOStore{
+		names:     make(map[string]int),
+		types:     make(map[network.PacketTypeID]int),
+		defaultIO: new(defaultProtoIO),
+	}
+	for name, newIO := range protocolIOFactory.factories {
+		io := newIO()
+		pstore.protos = append(pstore.protos, io)
+		pstore.names[name] = len(pstore.protos) - 1
+		pstore.types[io.PacketType()] = len(pstore.protos) - 1
+		disp.RegisterProcessor(proc, io.PacketType())
+		log.Lvl2("Instantiating ProtocolIO", name, "at position", len(pstore.protos))
+	}
+	// also add the default one
+	return pstore
 }

--- a/sda/protocol_test.go
+++ b/sda/protocol_test.go
@@ -159,7 +159,7 @@ func TestProtocolIOStore(t *testing.T) {
 	go func() {
 		// first time to wrap
 		res := <-chanProtoIOFeedback
-		assert.Equal(t, "", res)
+		require.Equal(t, "", res)
 		// second time to unwrap
 		res = <-chanProtoIOFeedback
 		require.Equal(t, "", res)

--- a/sda/protocol_test.go
+++ b/sda/protocol_test.go
@@ -145,9 +145,6 @@ func TestProtocolIOFactory(t *testing.T) {
 	defer eraseAllProtocolIO()
 	RegisterProtocolIO(NewTestProtocolIOChan)
 	assert.True(t, len(protocolIOFactory.factories) == 1)
-	// register twice
-	RegisterProtocolIO(NewTestProtocolIOChan)
-	// TODO check log error output
 }
 
 func TestProtocolIOStore(t *testing.T) {
@@ -165,7 +162,7 @@ func TestProtocolIOStore(t *testing.T) {
 		assert.Equal(t, "", res)
 		// second time to unwrap
 		res = <-chanProtoIOFeedback
-		assert.Equal(t, "", res)
+		require.Equal(t, "", res)
 
 	}()
 	_, err := h[0].StartProtocol(testProtoIOName, tree)
@@ -246,8 +243,7 @@ type TestProtocolInstance struct {
 }
 
 func newTestProtocolInstance(n *TreeNodeInstance) (ProtocolInstance, error) {
-	pi := new(TestProtocolInstance)
-	pi.TreeNodeInstance = n
+	pi := &TestProtocolInstance{n}
 	n.RegisterHandler(pi.handleSimpleMessage)
 	return pi, nil
 }
@@ -263,10 +259,6 @@ type SimpleMessageHandler struct {
 }
 
 func (t TestProtocolInstance) handleSimpleMessage(h SimpleMessageHandler) error {
-	var ok = true
-	if h.SimpleMessage.I != 12 {
-		ok = false
-	}
-	chanTestProtoInstance <- ok
+	chanTestProtoInstance <- h.SimpleMessage.I == 12
 	return nil
 }

--- a/sda/protocol_test.go
+++ b/sda/protocol_test.go
@@ -143,12 +143,10 @@ func TestProtocolAutomaticInstantiation(t *testing.T) {
 
 func TestProtocolIOFactory(t *testing.T) {
 	defer eraseAllProtocolIO()
-	RegisterProtocolIO(testProtoIOName, NewTestProtocolIOChan)
-	fn, present := protocolIOFactory.factories[testProtoIOName]
-	assert.NotNil(t, fn)
-	assert.True(t, present)
+	RegisterProtocolIO(NewTestProtocolIOChan)
+	assert.True(t, len(protocolIOFactory.factories) == 1)
 	// register twice
-	RegisterProtocolIO("testIO", NewTestProtocolIOChan)
+	RegisterProtocolIO(NewTestProtocolIOChan)
 	// TODO check log error output
 }
 
@@ -157,7 +155,7 @@ func TestProtocolIOStore(t *testing.T) {
 	local := NewLocalTest()
 	defer local.CloseAll()
 
-	RegisterProtocolIO(testProtoIOName, NewTestProtocolIO)
+	RegisterProtocolIO(NewTestProtocolIO)
 	GlobalProtocolRegister(testProtoIOName, newTestProtocolInstance)
 	h, _, tree := local.GenTree(2, true)
 
@@ -202,7 +200,7 @@ func NewTestProtocolIO() ProtocolIO {
 }
 
 func eraseAllProtocolIO() {
-	protocolIOFactory.factories = make(map[string]NewProtocolIO)
+	protocolIOFactory.factories = nil
 }
 
 func (t *TestProtocolIO) Wrap(msg interface{}, info *OverlayMessage) (interface{}, error) {
@@ -234,6 +232,10 @@ func (t *TestProtocolIO) Unwrap(msg interface{}) (interface{}, *OverlayMessage, 
 
 func (t *TestProtocolIO) PacketType() network.PacketTypeID {
 	return OuterPacketType
+}
+
+func (t *TestProtocolIO) Name() string {
+	return testProtoIOName
 }
 
 var chanTestProtoInstance = make(chan bool)

--- a/sda/protocol_test.go
+++ b/sda/protocol_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/alecthomas/assert"
 	"github.com/dedis/cothority/log"
 	"github.com/dedis/cothority/network"
 	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -141,18 +141,18 @@ func TestProtocolAutomaticInstantiation(t *testing.T) {
 	<-chanH2
 }
 
-func TestProtocolIOFactory(t *testing.T) {
-	defer eraseAllProtocolIO()
-	RegisterProtocolIO(NewTestProtocolIOChan)
-	assert.True(t, len(protocolIOFactory.factories) == 1)
+func TestMessageProxyFactory(t *testing.T) {
+	defer eraseAllMessageProxy()
+	RegisterMessageProxy(NewTestMessageProxyChan)
+	assert.True(t, len(messageProxyFactory.factories) == 1)
 }
 
-func TestProtocolIOStore(t *testing.T) {
-	defer eraseAllProtocolIO()
+func TestMessageProxyStore(t *testing.T) {
+	defer eraseAllMessageProxy()
 	local := NewLocalTest()
 	defer local.CloseAll()
 
-	RegisterProtocolIO(NewTestProtocolIO)
+	RegisterMessageProxy(NewTestMessageProxy)
 	GlobalProtocolRegister(testProtoIOName, newTestProtocolInstance)
 	h, _, tree := local.GenTree(2, true)
 
@@ -172,7 +172,7 @@ func TestProtocolIOStore(t *testing.T) {
 	assert.True(t, res)
 }
 
-// ProtocolIO part
+// MessageProxy part
 var chanProtoIOCreation = make(chan bool)
 var chanProtoIOFeedback = make(chan string)
 
@@ -185,22 +185,22 @@ type OuterPacket struct {
 
 var OuterPacketType = network.RegisterPacketType(OuterPacket{})
 
-type TestProtocolIO struct{}
+type TestMessageProxy struct{}
 
-func NewTestProtocolIOChan() ProtocolIO {
+func NewTestMessageProxyChan() MessageProxy {
 	chanProtoIOCreation <- true
-	return &TestProtocolIO{}
+	return &TestMessageProxy{}
 }
 
-func NewTestProtocolIO() ProtocolIO {
-	return &TestProtocolIO{}
+func NewTestMessageProxy() MessageProxy {
+	return &TestMessageProxy{}
 }
 
-func eraseAllProtocolIO() {
-	protocolIOFactory.factories = nil
+func eraseAllMessageProxy() {
+	messageProxyFactory.factories = nil
 }
 
-func (t *TestProtocolIO) Wrap(msg interface{}, info *OverlayMessage) (interface{}, error) {
+func (t *TestMessageProxy) Wrap(msg interface{}, info *OverlayMessage) (interface{}, error) {
 	outer := &OuterPacket{}
 	inner, ok := msg.(*SimpleMessage)
 	if !ok {
@@ -212,7 +212,7 @@ func (t *TestProtocolIO) Wrap(msg interface{}, info *OverlayMessage) (interface{
 	return outer, nil
 }
 
-func (t *TestProtocolIO) Unwrap(msg interface{}) (interface{}, *OverlayMessage, error) {
+func (t *TestMessageProxy) Unwrap(msg interface{}) (interface{}, *OverlayMessage, error) {
 	if msg == nil {
 		chanProtoIOFeedback <- "message nil!"
 		return nil, nil, errors.New("message nil")
@@ -227,11 +227,11 @@ func (t *TestProtocolIO) Unwrap(msg interface{}) (interface{}, *OverlayMessage, 
 	return real.Inner, real.Info, nil
 }
 
-func (t *TestProtocolIO) PacketType() network.PacketTypeID {
+func (t *TestMessageProxy) PacketType() network.PacketTypeID {
 	return OuterPacketType
 }
 
-func (t *TestProtocolIO) Name() string {
+func (t *TestMessageProxy) Name() string {
 	return testProtoIOName
 }
 

--- a/sda/treenode.go
+++ b/sda/treenode.go
@@ -47,7 +47,7 @@ type TreeNodeInstance struct {
 	// whether this node is closing
 	closing bool
 
-	protoIO ProtocolIO
+	protoIO MessageProxy
 }
 
 // aggregateMessages (if set) tells to aggregate messages from all children
@@ -61,7 +61,7 @@ const (
 type MsgHandler func([]*interface{})
 
 // NewNode creates a new node
-func newTreeNodeInstance(o *Overlay, tok *Token, tn *TreeNode, io ProtocolIO) *TreeNodeInstance {
+func newTreeNodeInstance(o *Overlay, tok *Token, tn *TreeNode, io MessageProxy) *TreeNodeInstance {
 	n := &TreeNodeInstance{overlay: o,
 		token:                tok,
 		channels:             make(map[network.PacketTypeID]interface{}),


### PR DESCRIPTION
This first PR introduces a way for protocols to have a clean wire format protocol with the least amount of changes. Look for #287 issue.
First this PR introduces the notion `OverlayMessage` which contains everything the `Overlay` needs to know in order to function properly. Protocols that wants to have their full own packet going into the network must have a field of `OverlayMessage` in their packet.

Then there is the notion of `ProtocolIO` (Please suggest other names if you got any) which fulfill two purposes:
 -  `Wrap` a protocol *inner* message into the protocol's bigger message with the overlay information `OverlayMessage`
 - `Unwrap` a protocol bigger message to give back to the `Overlay` the inner protocol message as well as the `OverlayMessage`

Sorry as there are also some --cleaning-up-- changes that add a bit to the PR size.
