### PR TITLE
Fix wireprotocol for simulation

### DIFF
--- a/network/encoding.go
+++ b/network/encoding.go
@@ -41,7 +41,7 @@ func (pId PacketTypeID) String() string {
 	if ok {
 		return t.String()
 	}
-	return fmt.Sprintf("%x", uuid.UUID(pId))
+	return uuid.UUID(pId).String()
 }
 
 // Equal returns true if pId is equal to t
@@ -77,7 +77,6 @@ func RegisterPacketUUID(mt PacketTypeID, rt reflect.Type) PacketTypeID {
 		return mt
 	}
 	registry.put(mt, rt)
-
 	return mt
 }
 
@@ -186,7 +185,7 @@ var marshalLock sync.Mutex
 
 // MarshalRegisteredType will marshal a struct with its respective type into a
 // slice of bytes. That slice of bytes can be then decoded in
-// UnmarshalRegisteredType.
+// UnmarshalRegisteredType. data MUST BE a pointer to the message.
 func MarshalRegisteredType(data Body) ([]byte, error) {
 	marshalLock.Lock()
 	defer marshalLock.Unlock()

--- a/network/encoding.go
+++ b/network/encoding.go
@@ -185,7 +185,7 @@ var marshalLock sync.Mutex
 
 // MarshalRegisteredType will marshal a struct with its respective type into a
 // slice of bytes. That slice of bytes can be then decoded in
-// UnmarshalRegisteredType. data MUST BE a pointer to the message.
+// UnmarshalRegisteredType. data must be a pointer to the message.
 func MarshalRegisteredType(data Body) ([]byte, error) {
 	marshalLock.Lock()
 	defer marshalLock.Unlock()

--- a/network/tcp.go
+++ b/network/tcp.go
@@ -3,7 +3,6 @@ package network
 import (
 	"bytes"
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -160,7 +159,6 @@ func (c *TCPConn) sendRaw(b []byte) error {
 	// Then send everything through the connection
 	// Send chunk by chunk
 	log.Lvl5("Sending from", c.conn.LocalAddr(), "to", c.conn.RemoteAddr())
-	log.Print("BUFFER: ", hex.EncodeToString(b))
 	var sent Size
 	for sent < packetSize {
 		n, err := c.conn.Write(b[sent:])

--- a/protocols/bftcosi/packets.go
+++ b/protocols/bftcosi/packets.go
@@ -4,9 +4,23 @@ import (
 	"crypto/sha512"
 	"errors"
 
+	"github.com/dedis/cothority/network"
 	"github.com/dedis/cothority/sda"
 	"github.com/dedis/crypto/abstract"
 )
+
+func init() {
+	for _, i := range []interface{}{
+		BFTSignature{},
+		Announce{},
+		Commitment{},
+		ChallengePrepare{},
+		ChallengeCommit{},
+		Response{},
+	} {
+		network.RegisterPacketType(i)
+	}
+}
 
 // RoundType is a type to know if we are in the "prepare" round or the "commit"
 // round

--- a/protocols/byzcoin/cosi/cosi.go
+++ b/protocols/byzcoin/cosi/cosi.go
@@ -36,9 +36,21 @@ import (
 	"errors"
 	"time"
 
+	"github.com/dedis/cothority/network"
 	"github.com/dedis/crypto/abstract"
 	"github.com/dedis/crypto/config"
 )
+
+func init() {
+	for _, r := range []interface{}{
+		Announcement{},
+		Commitment{},
+		Challenge{},
+		Response{},
+	} {
+		network.RegisterPacketType(r)
+	}
+}
 
 // Cosi is the struct that implements the basic cosi.
 type Cosi struct {

--- a/protocols/byzcoin/ntree/ntree.go
+++ b/protocols/byzcoin/ntree/ntree.go
@@ -6,11 +6,25 @@ import (
 
 	"github.com/dedis/cothority/crypto"
 	"github.com/dedis/cothority/log"
+	"github.com/dedis/cothority/network"
 	"github.com/dedis/cothority/protocols/byzcoin"
 	"github.com/dedis/cothority/protocols/byzcoin/blockchain"
 	"github.com/dedis/cothority/protocols/byzcoin/blockchain/blkparser"
 	"github.com/dedis/cothority/sda"
 )
+
+func init() {
+	for _, i := range []interface{}{
+		BlockAnnounce{},
+		NaiveBlockSignature{},
+		Exception{},
+		RoundSignatureRequest{},
+		RoundSignatureResponse{},
+		NtreeSignature{},
+	} {
+		network.RegisterPacketType(i)
+	}
+}
 
 // Ntree is a basic implementation of a byzcoin consensus protocol using a tree
 // and each verifiers will have independent signatures. The messages are then

--- a/protocols/byzcoin/packets.go
+++ b/protocols/byzcoin/packets.go
@@ -1,10 +1,24 @@
 package byzcoin
 
 import (
+	"github.com/dedis/cothority/network"
 	"github.com/dedis/cothority/protocols/byzcoin/blockchain"
 	"github.com/dedis/cothority/protocols/byzcoin/cosi"
 	"github.com/dedis/cothority/sda"
 )
+
+func init() {
+	for _, i := range []interface{}{
+		BlockSignature{},
+		Announce{},
+		Commitment{},
+		ChallengePrepare{},
+		ChallengeCommit{},
+		Response{},
+	} {
+		network.RegisterPacketType(i)
+	}
+}
 
 // RoundType is a type to know if we are in the "prepare" round or the "commit"
 // round

--- a/protocols/byzcoin/pbft/packets.go
+++ b/protocols/byzcoin/pbft/packets.go
@@ -1,9 +1,21 @@
 package pbft
 
 import (
+	"github.com/dedis/cothority/network"
 	"github.com/dedis/cothority/protocols/byzcoin/blockchain"
 	"github.com/dedis/cothority/sda"
 )
+
+func init() {
+	for _, i := range []interface{}{
+		PrePrepare{},
+		Prepare{},
+		Commit{},
+		Finish{},
+	} {
+		network.RegisterPacketType(i)
+	}
+}
 
 // Messages which will be sent around by the most naive PBFT simulation in
 // "byzcoin"

--- a/protocols/cosi/packets.go
+++ b/protocols/cosi/packets.go
@@ -12,6 +12,14 @@ func init() {
 	sda.RegisterMessageProxy(func() sda.MessageProxy {
 		return new(MessageProxy)
 	})
+	for _, r := range []interface{}{
+		Announcement{},
+		Commitment{},
+		Challenge{},
+		Response{},
+	} {
+		network.RegisterPacketType(r)
+	}
 }
 
 const (

--- a/protocols/jvss/handlers.go
+++ b/protocols/jvss/handlers.go
@@ -4,9 +4,21 @@ import (
 	"strings"
 
 	"github.com/dedis/cothority/log"
+	"github.com/dedis/cothority/network"
 	"github.com/dedis/cothority/sda"
 	"github.com/dedis/crypto/poly"
 )
+
+func init() {
+	for _, i := range []interface{}{
+		SecInitMsg{},
+		SecConfMsg{},
+		SigReqMsg{},
+		SigRespMsg{},
+	} {
+		network.RegisterPacketType(i)
+	}
+}
 
 // SecInitMsg are used to initialise new shared secrets both long- and
 // short-term.

--- a/protocols/manage/broadcast.go
+++ b/protocols/manage/broadcast.go
@@ -4,10 +4,13 @@ import (
 	"errors"
 
 	"github.com/dedis/cothority/log"
+	"github.com/dedis/cothority/network"
 	"github.com/dedis/cothority/sda"
 )
 
 func init() {
+	network.RegisterPacketType(ContactNodes{})
+	network.RegisterPacketType(Done{})
 	sda.GlobalProtocolRegister("Broadcast", NewBroadcastProtocol)
 }
 

--- a/protocols/manage/propagate.go
+++ b/protocols/manage/propagate.go
@@ -12,6 +12,11 @@ import (
 	"github.com/dedis/cothority/sda"
 )
 
+func init() {
+	network.RegisterPacketType(PropagateSendData{})
+	network.RegisterPacketType(PropagateReply{})
+}
+
 // Propagate is a protocol that sends some data to all attached nodes
 // and waits for confirmation before returning.
 type Propagate struct {

--- a/sda/overlay.go
+++ b/sda/overlay.go
@@ -730,7 +730,7 @@ func (d *defaultProtoIO) Unwrap(msg interface{}) (interface{}, *OverlayMessage, 
 	case ProtocolMsg:
 		sdaMsg := inner
 		var err error
-		_, unmar, err := network.UnmarshalRegistered(sdaMsg.MsgSlice)
+		_, protoMsg, err := network.UnmarshalRegistered(sdaMsg.MsgSlice)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -739,7 +739,7 @@ func (d *defaultProtoIO) Unwrap(msg interface{}) (interface{}, *OverlayMessage, 
 			To:   sdaMsg.To,
 			From: sdaMsg.From,
 		}
-		returnMsg = unmar
+		returnMsg = protoMsg
 	case RequestTree:
 		returnOverlay.RequestTree = &inner
 	case RequestRoster:

--- a/sda/overlay.go
+++ b/sda/overlay.go
@@ -730,7 +730,7 @@ func (d *defaultProtoIO) Unwrap(msg interface{}) (interface{}, *OverlayMessage, 
 	case ProtocolMsg:
 		sdaMsg := inner
 		var err error
-		_, msg, err := network.UnmarshalRegistered(sdaMsg.MsgSlice)
+		_, unmar, err := network.UnmarshalRegistered(sdaMsg.MsgSlice)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -739,7 +739,7 @@ func (d *defaultProtoIO) Unwrap(msg interface{}) (interface{}, *OverlayMessage, 
 			To:   sdaMsg.To,
 			From: sdaMsg.From,
 		}
-		returnMsg = msg
+		returnMsg = unmar
 	case RequestTree:
 		returnOverlay.RequestTree = &inner
 	case RequestRoster:


### PR DESCRIPTION
The new wire protocol design is not compatible for simulations because one simulation uses different "network" packages, one for each process, so there are packets which are non registered so it's not possible to Unmarshal them.

This PR fixes that by simply registering the packets a protocol use at init time.