### PR TITLE
PR: Adapt RandHound to New Protobuf

### DIFF
--- a/randhound/randhound.go
+++ b/randhound/randhound.go
@@ -333,8 +333,8 @@ func (rh *RandHound) Verify(suite abstract.Suite, random []byte, t *Transcript) 
 	for server, msg := range t.I2s {
 		c := 0
 		for i := 0; i < len(t.ChosenSecret); i++ {
-			for j := 0; j < len(t.ChosenSecret[i]); j++ {
-				if int(msg.ChosenSecret[c]) != t.ChosenSecret[i][j] {
+			for _, cs := range t.ChosenSecret[i] {
+				if int(msg.ChosenSecret[c]) != cs {
 					return fmt.Errorf("Server %v received wrong client commitment", server)
 				}
 				c++
@@ -643,9 +643,9 @@ func (rh *RandHound) handleR1(r1 WR1) error {
 
 		// Transformation of commitments from [][]int to []uint32 to avoid protobuf errors
 		var chosenSecret = make([]uint32, 0)
-		for i := range rh.chosenSecret {
-			for j := range rh.chosenSecret[i] {
-				chosenSecret = append(chosenSecret, uint32(rh.chosenSecret[i][j]))
+		for i := 0; i < len(rh.chosenSecret); i++ {
+			for _, cs := range rh.chosenSecret[i] {
+				chosenSecret = append(chosenSecret, uint32(cs))
 			}
 		}
 

--- a/randhound/randhound.go
+++ b/randhound/randhound.go
@@ -332,6 +332,7 @@ func (rh *RandHound) Verify(suite abstract.Suite, random []byte, t *Transcript) 
 	// Verify that all servers received the same client commitment
 	for server, msg := range t.I2s {
 		c := 0
+		// Deterministically iterate over map[int][]int
 		for i := 0; i < len(t.ChosenSecret); i++ {
 			for _, cs := range t.ChosenSecret[i] {
 				if int(msg.ChosenSecret[c]) != cs {
@@ -641,7 +642,7 @@ func (rh *RandHound) handleR1(r1 WR1) error {
 		log.Lvlf3("Grouping: %v", rh.group)
 		log.Lvlf3("ChosenSecret: %v", rh.chosenSecret)
 
-		// Transformation of commitments from [][]int to []uint32 to avoid protobuf errors
+		// Transformation of commitments from map[int][]int to []uint32 to avoid protobuf errors
 		var chosenSecret = make([]uint32, 0)
 		for i := 0; i < len(rh.chosenSecret); i++ {
 			for _, cs := range rh.chosenSecret[i] {

--- a/randhound/randhound.go
+++ b/randhound/randhound.go
@@ -919,7 +919,7 @@ func signSchnorr(suite abstract.Suite, key abstract.Scalar, m interface{}) error
 	reflect.ValueOf(m).Elem().FieldByName("Sig").Set(reflect.ValueOf(crypto.SchnorrSig{})) // XXX: hack
 
 	// Marshal message
-	mb, err := network.Marshal(m)
+	mb, err := network.Marshal(m) // TODO: change m to interface with hash to make it compatible to other languages (network.Marshal() adds struct-identifiers)
 	if err != nil {
 		return err
 	}
@@ -947,7 +947,7 @@ func verifySchnorr(suite abstract.Suite, key abstract.Point, m interface{}) erro
 	reflect.ValueOf(m).Elem().FieldByName("Sig").Set(reflect.ValueOf(crypto.SchnorrSig{})) // XXX: hack
 
 	// Marshal message
-	mb, err := network.Marshal(m)
+	mb, err := network.Marshal(m) // TODO: change m to interface with hash to make it compatible to other languages (network.Marshal() adds struct-identifiers)
 	if err != nil {
 		return err
 	}
@@ -969,7 +969,7 @@ func verifyMessage(suite abstract.Suite, m interface{}, hash1 []byte) error {
 	reflect.ValueOf(m).Elem().FieldByName("Sig").Set(reflect.ValueOf(crypto.SchnorrSig{})) // XXX: hack
 
 	// Marshal ...
-	mb, err := network.Marshal(m)
+	mb, err := network.Marshal(m) // TODO: change m to interface with hash to make it compatible to other languages (network.Marshal() adds struct-identifiers)
 	if err != nil {
 		return err
 	}

--- a/randhound/randhound.go
+++ b/randhound/randhound.go
@@ -337,7 +337,7 @@ func (rh *RandHound) Verify(suite abstract.Suite, random []byte, t *Transcript) 
 				if int(msg.ChosenSecret[c]) != t.ChosenSecret[i][j] {
 					return fmt.Errorf("Server %v received wrong client commitment", server)
 				}
-				c += 1
+				c++
 			}
 		}
 	}

--- a/randhound/struct.go
+++ b/randhound/struct.go
@@ -108,7 +108,7 @@ type R1 struct {
 type I2 struct {
 	Sig          crypto.SchnorrSig // Schnorr signature
 	SID          []byte            // Session identifier
-	ChosenSecret [][]uint32        // Chosen secrets
+	ChosenSecret []uint32          // Chosen secrets (flattened)
 	EncShare     []Share           // Encrypted shares
 	PolyCommit   []abstract.Point  // Polynomial commitments
 }


### PR DESCRIPTION
Seems like the only thing necessary to resolve #791 was the flattening of `ChosenSecrets` (old: `[][]uint32` new: `[]uint32`) in the `I2` message struct.

