### PR TITLE
[crypto] move to v0

### DIFF
--- a/bftcosi/bftcosi.go
+++ b/bftcosi/bftcosi.go
@@ -13,8 +13,8 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/cosi"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/cosi"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/log"
 )

--- a/bftcosi/packets.go
+++ b/bftcosi/packets.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha512"
 	"errors"
 
-	"github.com/dedis/crypto/abstract"
+	"gopkg.in/dedis/crypto.v0/abstract"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/network"
 )

--- a/byzcoin/blockchain/messg.go
+++ b/byzcoin/blockchain/messg.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 
 	"github.com/dedis/cothority/byzcoin/blockchain/blkparser"
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/suites"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/suites"
 	"gopkg.in/dedis/onet.v1/log"
 )
 

--- a/byzcoin/blockchain/proof.go
+++ b/byzcoin/blockchain/proof.go
@@ -8,7 +8,7 @@ import (
 	gohash "hash"
 	"strconv"
 
-	"github.com/dedis/crypto/abstract"
+	"gopkg.in/dedis/crypto.v0/abstract"
 	"gopkg.in/dedis/onet.v1/log"
 )
 

--- a/byzcoin/byzcoin.go
+++ b/byzcoin/byzcoin.go
@@ -13,7 +13,7 @@ import (
 	"github.com/dedis/cothority/byzcoin/blockchain"
 	"github.com/dedis/cothority/byzcoin/blockchain/blkparser"
 	"github.com/dedis/cothority/byzcoin/cosi"
-	"github.com/dedis/crypto/abstract"
+	"gopkg.in/dedis/crypto.v0/abstract"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/log"
 	"gopkg.in/dedis/onet.v1/simul/monitor"

--- a/byzcoin/cosi/cosi.go
+++ b/byzcoin/cosi/cosi.go
@@ -36,8 +36,8 @@ import (
 	"errors"
 	"time"
 
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/config"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/config"
 	"gopkg.in/dedis/onet.v1/network"
 )
 

--- a/byzcoin/cosi/cosi_test.go
+++ b/byzcoin/cosi/cosi_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/dedis/crypto/config"
-	"github.com/dedis/crypto/ed25519"
+	"gopkg.in/dedis/crypto.v0/config"
+	"gopkg.in/dedis/crypto.v0/ed25519"
 )
 
 var testSuite = ed25519.NewAES128SHA256Ed25519(false)

--- a/byzcoin/pbft/pbft.go
+++ b/byzcoin/pbft/pbft.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/dedis/cothority/byzcoin/blockchain"
-	"github.com/dedis/crypto/abstract"
+	"gopkg.in/dedis/crypto.v0/abstract"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/log"
 )

--- a/byzcoin/simulation/byzcoin.go
+++ b/byzcoin/simulation/byzcoin.go
@@ -9,7 +9,7 @@ import (
 	"github.com/dedis/cothority/byzcoin/blockchain"
 	"github.com/dedis/cothority/byzcoin/cosi"
 	"github.com/dedis/cothority/messaging"
-	"github.com/dedis/crypto/abstract"
+	"gopkg.in/dedis/crypto.v0/abstract"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/log"
 	"gopkg.in/dedis/onet.v1/simul/monitor"

--- a/cosi/check/check.go
+++ b/cosi/check/check.go
@@ -21,7 +21,7 @@ import (
 	"math"
 
 	"github.com/dedis/cothority/cosi/service"
-	"github.com/dedis/crypto/cosi"
+	"gopkg.in/dedis/crypto.v0/cosi"
 )
 
 // RequestTimeOut is how long we're willing to wait for a signature.

--- a/cosi/client.go
+++ b/cosi/client.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/dedis/cothority/cosi/check"
 	s "github.com/dedis/cothority/cosi/service"
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/cosi"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/cosi"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/app"
 	"gopkg.in/dedis/onet.v1/crypto"

--- a/cosi/protocol/cosi.go
+++ b/cosi/protocol/cosi.go
@@ -4,8 +4,8 @@ package cosi
 import (
 	"sync"
 
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/cosi"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/cosi"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/log"
 )

--- a/cosi/protocol/cosi_test.go
+++ b/cosi/protocol/cosi_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dedis/crypto/abstract"
+	"gopkg.in/dedis/crypto.v0/abstract"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/log"
 	"gopkg.in/dedis/onet.v1/network"

--- a/cosi/protocol/packets.go
+++ b/cosi/protocol/packets.go
@@ -3,7 +3,7 @@ package cosi
 import (
 	"errors"
 
-	"github.com/dedis/crypto/abstract"
+	"gopkg.in/dedis/crypto.v0/abstract"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/network"
 )

--- a/cosi/service/cosi_test.go
+++ b/cosi/service/cosi_test.go
@@ -3,8 +3,8 @@ package service
 import (
 	"testing"
 
-	"github.com/dedis/crypto/cosi"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/dedis/crypto.v0/cosi"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/log"
 )

--- a/cosi/simulation/cosi_test.go
+++ b/cosi/simulation/cosi_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dedis/crypto/cosi"
+	"gopkg.in/dedis/crypto.v0/cosi"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/log"
 )

--- a/cosi/simulation/protocol.go
+++ b/cosi/simulation/protocol.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	p "github.com/dedis/cothority/cosi/protocol"
-	"github.com/dedis/crypto/abstract"
+	"gopkg.in/dedis/crypto.v0/abstract"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/log"
 )

--- a/cosi/simulation/simulation.go
+++ b/cosi/simulation/simulation.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/BurntSushi/toml"
-	"github.com/dedis/crypto/cosi"
+	"gopkg.in/dedis/crypto.v0/cosi"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/log"
 	"gopkg.in/dedis/onet.v1/network"

--- a/guard/guard.go
+++ b/guard/guard.go
@@ -15,7 +15,7 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 
-	"github.com/dedis/crypto/abstract"
+	"gopkg.in/dedis/crypto.v0/abstract"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/app"
 	"gopkg.in/dedis/onet.v1/log"

--- a/guard/service/api.go
+++ b/guard/service/api.go
@@ -1,7 +1,7 @@
 package guard
 
 import (
-	"github.com/dedis/crypto/abstract"
+	"gopkg.in/dedis/crypto.v0/abstract"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/log"
 	"gopkg.in/dedis/onet.v1/network"

--- a/guard/service/guard.go
+++ b/guard/service/guard.go
@@ -3,7 +3,7 @@ package guard
 import (
 	"crypto/rand"
 
-	"github.com/dedis/crypto/abstract"
+	"gopkg.in/dedis/crypto.v0/abstract"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/log"
 	"gopkg.in/dedis/onet.v1/network"

--- a/identity/api.go
+++ b/identity/api.go
@@ -5,8 +5,8 @@ import (
 
 	"io/ioutil"
 
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/config"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/config"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/crypto"
 	"gopkg.in/dedis/onet.v1/log"

--- a/identity/api_test.go
+++ b/identity/api_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dedis/crypto/config"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/dedis/crypto.v0/config"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/log"
 	"gopkg.in/dedis/onet.v1/network"

--- a/identity/service_test.go
+++ b/identity/service_test.go
@@ -3,8 +3,8 @@ package identity
 import (
 	"testing"
 
-	"github.com/dedis/crypto/config"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/dedis/crypto.v0/config"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/log"
 	"gopkg.in/dedis/onet.v1/network"

--- a/identity/struct.go
+++ b/identity/struct.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/dedis/cothority/skipchain"
-	"github.com/dedis/crypto/abstract"
+	"gopkg.in/dedis/crypto.v0/abstract"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/crypto"
 	"gopkg.in/dedis/onet.v1/log"

--- a/jvss/handlers.go
+++ b/jvss/handlers.go
@@ -3,7 +3,7 @@ package jvss
 import (
 	"strings"
 
-	"github.com/dedis/crypto/poly"
+	"gopkg.in/dedis/crypto.v0/poly"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/log"
 	"gopkg.in/dedis/onet.v1/network"

--- a/jvss/jvss.go
+++ b/jvss/jvss.go
@@ -17,9 +17,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/config"
-	"github.com/dedis/crypto/poly"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/config"
+	"gopkg.in/dedis/crypto.v0/poly"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/log"
 )

--- a/randhound/proof.go
+++ b/randhound/proof.go
@@ -3,9 +3,9 @@ package randhound
 import (
 	"errors"
 
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/poly"
-	"github.com/dedis/crypto/random"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/poly"
+	"gopkg.in/dedis/crypto.v0/random"
 	"gopkg.in/dedis/onet.v1/crypto"
 )
 

--- a/randhound/proof_test.go
+++ b/randhound/proof_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/dedis/cothority/randhound"
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/edwards"
-	"github.com/dedis/crypto/random"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/edwards"
+	"gopkg.in/dedis/crypto.v0/random"
 	"gopkg.in/dedis/onet.v1/log"
 )
 

--- a/randhound/randhound.go
+++ b/randhound/randhound.go
@@ -12,8 +12,8 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/random"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/random"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/crypto"
 	"gopkg.in/dedis/onet.v1/log"

--- a/randhound/struct.go
+++ b/randhound/struct.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dedis/crypto/abstract"
+	"gopkg.in/dedis/crypto.v0/abstract"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/crypto"
 	"gopkg.in/dedis/onet.v1/network"

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 
 	"github.com/dedis/cothority/bftcosi"
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/cosi"
+	"gopkg.in/dedis/crypto.v0/abstract"
+	"gopkg.in/dedis/crypto.v0/cosi"
 	"gopkg.in/dedis/onet.v1"
 	"gopkg.in/dedis/onet.v1/crypto"
 	"gopkg.in/dedis/onet.v1/log"


### PR DESCRIPTION
This PR fixes #814 : it moves all dependencies from `github.com/dedis/crypto` to `gopkg.in/dedis/crypto.v0`