### PR TITLE
Skipchain goroutines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     secure: Qu8PbKlf0Q5LoVeiut3+vEgghyLdZmvgrLsW/wI4XKSOL49K2LetELsZA6298OCoCaXm2BbESsoMApLglDx4h4PAOUwm/Sf28kJKRzmA0WidTR3XnIvBDnQrW7bm/9KV+de4uW6HUi7j4jp93E4y3LhBjBiq4ayVxlTHMKgQFBD02QFA7namD3LF5xjGnU99y7RNw0QNBv7BJfuOllIBJaetXQsHAcGX2pQmyZK5uQy52hXe6lVivWPdRrtDUVJQ3Yb7ez80fnLw3+5cBU21Om3L8P88QfbPZu7BCbUb6uwqruHX8a+ZqeDXVe9zpzqhvW+FckQz8MCHkLVXM6BucAS1y//s7VtYOiw6uhU4vsmP6dPbh90yS325n310P43mZ+7JX4XOV41/33CCK/zG4HxsTlsLeH0MTWjDpIBHR+UVJGySYrLD4hj1/WLTFPcycbTb9RwatUFao80KksaLG1TEH7zp14hav8M6cgZcJooabmNlqvj6UvkAOU88ZdUnjt3Bu64dhZpd/9cXQ65NRLFaQAyt3gufFUtT31azrPhomAP+JcK77CqcGDGye/Nhl2BEeio/dqeoACwwZHDPbhveCDqWEtumtV0LVUKuIyj0/EFkXByZBcnpzecIl5F4BB3ihgckQP5cS/OLKAsCztNOoIwewm+5/aCjIKh+T2M=
 
 script:
-  - make test
+  - make test_playground
 
 after_success:
   - goveralls -coverprofile=profile.cov -service=travis-ci -repotoken $COVERALLS_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     secure: Qu8PbKlf0Q5LoVeiut3+vEgghyLdZmvgrLsW/wI4XKSOL49K2LetELsZA6298OCoCaXm2BbESsoMApLglDx4h4PAOUwm/Sf28kJKRzmA0WidTR3XnIvBDnQrW7bm/9KV+de4uW6HUi7j4jp93E4y3LhBjBiq4ayVxlTHMKgQFBD02QFA7namD3LF5xjGnU99y7RNw0QNBv7BJfuOllIBJaetXQsHAcGX2pQmyZK5uQy52hXe6lVivWPdRrtDUVJQ3Yb7ez80fnLw3+5cBU21Om3L8P88QfbPZu7BCbUb6uwqruHX8a+ZqeDXVe9zpzqhvW+FckQz8MCHkLVXM6BucAS1y//s7VtYOiw6uhU4vsmP6dPbh90yS325n310P43mZ+7JX4XOV41/33CCK/zG4HxsTlsLeH0MTWjDpIBHR+UVJGySYrLD4hj1/WLTFPcycbTb9RwatUFao80KksaLG1TEH7zp14hav8M6cgZcJooabmNlqvj6UvkAOU88ZdUnjt3Bu64dhZpd/9cXQ65NRLFaQAyt3gufFUtT31azrPhomAP+JcK77CqcGDGye/Nhl2BEeio/dqeoACwwZHDPbhveCDqWEtumtV0LVUKuIyj0/EFkXByZBcnpzecIl5F4BB3ihgckQP5cS/OLKAsCztNOoIwewm+5/aCjIKh+T2M=
 
 script:
-  - make test_playground
+  - make test
 
 after_success:
   - goveralls -coverprofile=profile.cov -service=travis-ci -repotoken $COVERALLS_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test_lint:
 # for more than once in Travis. Change `make test` in .travis.yml
 # to `make test_playground`.
 test_playground:
-	cd services/skipchain; \
+	cd skipchain; \
 	for a in $$( seq 10 ); do \
 	  go test -v -race -short || exit 1 ; \
 	done;

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -244,6 +244,13 @@ func (s *Service) GetAllSkipchains(id *GetAllSkipchains) (*GetAllSkipchainsReply
 	return reply, nil
 }
 
+// IsPropagating returns true if there is at least one propagation running.
+func (s *Service) IsPropagating() bool {
+	s.propagatingMutex.Lock()
+	defer s.propagatingMutex.Unlock()
+	return s.propagating > 0
+}
+
 func (s *Service) getUpdateBlock(known *SkipBlock, unknown SkipBlockID) (*SkipBlock, error) {
 	s.blockRequests[string(unknown)] = make(chan *SkipBlock)
 	node := known.Roster.RandomServerIdentity()
@@ -591,12 +598,6 @@ func (s *Service) startPropagation(blocks []*SkipBlock) error {
 		log.Warn("Did only get", replies, "out of", len(roster.List))
 	}
 	return nil
-}
-
-func (s *Service) IsPropagating() bool {
-	s.propagatingMutex.Lock()
-	defer s.propagatingMutex.Unlock()
-	return s.propagating > 0
 }
 
 // saves all skipblocks.

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -588,7 +588,9 @@ func (s *Service) startPropagation(blocks []*SkipBlock) error {
 
 	s.propagatingMutex.Lock()
 	s.propagating++
+	s.propagatingMutex.Unlock()
 	replies, err := s.propagate(roster, &PropagateSkipBlocks{blocks}, propagateTimeout)
+	s.propagatingMutex.Lock()
 	s.propagating--
 	s.propagatingMutex.Unlock()
 	if err != nil {

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -236,8 +236,31 @@ func TestService_MultiLevel(t *testing.T) {
 			log.ErrFatal(checkMLUpdate(service, sbRoot, latest, base, height))
 		}
 	}
-	// Setting up two chains and linking one to the other
-	//time.Sleep(time.Second)
+	waitPropagationFinished(local)
+}
+
+func waitPropagationFinished(local *onet.LocalTest) {
+	var servers []*onet.Server
+	for _, s := range local.Servers {
+		servers = append(servers, s)
+	}
+	services := make([]*Service, len(servers))
+	for i, s := range local.GetServices(servers, skipchainSID) {
+		services[i] = s.(*Service)
+	}
+	propagating := true
+	for propagating {
+		propagating = false
+		for _, s := range services {
+			if s.IsPropagating() {
+				log.Print("Service", s, "is still propagating")
+				propagating = true
+			}
+		}
+		if propagating {
+			time.Sleep(time.Millisecond * 100)
+		}
+	}
 }
 
 func checkBacklinks(services []*Service, sb *SkipBlock) {
@@ -286,6 +309,7 @@ func TestService_Verification(t *testing.T) {
 	elSub := onet.NewRoster(el.List[0:2])
 	sbInter, err = makeGenesisRosterArgs(service, elSub, sbRoot.Hash, sb.VerifierIDs, 1, 1)
 	log.ErrFatal(err)
+	waitPropagationFinished(local)
 }
 
 func TestService_SignBlock(t *testing.T) {
@@ -307,6 +331,7 @@ func TestService_SignBlock(t *testing.T) {
 	log.Lvl1("Verifying signatures")
 	log.ErrFatal(sbRoot.VerifyForwardSignatures())
 	log.ErrFatal(sbSecond.VerifyForwardSignatures())
+	waitPropagationFinished(local)
 }
 
 func TestService_ProtocolVerification(t *testing.T) {
@@ -338,6 +363,7 @@ func TestService_ProtocolVerification(t *testing.T) {
 			t.Fatal("Timeout while waiting for reply", i)
 		}
 	}
+	waitPropagationFinished(local)
 }
 
 func TestService_ForwardSignature(t *testing.T) {
@@ -368,6 +394,7 @@ func TestService_RegisterVerification(t *testing.T) {
 	log.ErrFatal(err)
 	require.NotNil(t, sb.Data)
 	require.Equal(t, 0, len(ServiceVerifierChan))
+	waitPropagationFinished(local)
 }
 
 func TestService_StoreSkipBlock2(t *testing.T) {
@@ -415,6 +442,7 @@ func TestService_StoreSkipBlock2(t *testing.T) {
 	sbErr = ssbr.Latest.Copy()
 	_, cerr = s3.StoreSkipBlock(&StoreSkipBlock{ssbr.Latest.Hash, sbErr})
 	require.NotNil(t, cerr)
+	waitPropagationFinished(local)
 }
 
 func TestService_StoreSkipBlockSpeed(t *testing.T) {

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -24,6 +24,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestService_StoreSkipBlock(t *testing.T) {
+	defer log.AfterTest(t)
 	// First create a roster to attach the data to it
 	local := onet.NewLocalTest()
 	defer local.CloseAll()
@@ -81,6 +82,7 @@ func TestService_StoreSkipBlock(t *testing.T) {
 }
 
 func TestService_GetUpdateChain(t *testing.T) {
+	defer log.AfterTest(t)
 	// Create a small chain and test whether we can get from one element
 	// of the chain to the last element with a valid slice of SkipBlocks
 	local := onet.NewLocalTest()
@@ -143,6 +145,7 @@ func TestService_GetUpdateChain(t *testing.T) {
 }
 
 func TestService_SetChildrenSkipBlock(t *testing.T) {
+	defer log.AfterTest(t)
 	// How many nodes in Root
 	nodesRoot := 3
 
@@ -202,6 +205,7 @@ func TestService_SetChildrenSkipBlock(t *testing.T) {
 }
 
 func TestService_MultiLevel(t *testing.T) {
+	defer log.AfterTest(t)
 	local := onet.NewLocalTest()
 	defer local.CloseAll()
 	servers, el, genService := local.MakeHELS(3, skipchainSID)
@@ -281,6 +285,7 @@ func checkBacklinks(services []*Service, sb *SkipBlock) {
 }
 
 func TestService_Verification(t *testing.T) {
+	defer log.AfterTest(t)
 	local := onet.NewLocalTest()
 	defer local.CloseAll()
 	sbLength := 4
@@ -313,6 +318,7 @@ func TestService_Verification(t *testing.T) {
 }
 
 func TestService_SignBlock(t *testing.T) {
+	defer log.AfterTest(t)
 	// Testing whether we sign correctly the SkipBlocks
 	local := onet.NewLocalTest()
 	defer local.CloseAll()
@@ -335,6 +341,7 @@ func TestService_SignBlock(t *testing.T) {
 }
 
 func TestService_ProtocolVerification(t *testing.T) {
+	defer log.AfterTest(t)
 	// Testing whether we sign correctly the SkipBlocks
 	local := onet.NewLocalTest()
 	defer local.CloseAll()
@@ -370,6 +377,7 @@ func TestService_ForwardSignature(t *testing.T) {
 }
 
 func TestService_RegisterVerification(t *testing.T) {
+	defer log.AfterTest(t)
 	// Testing whether we sign correctly the SkipBlocks
 	onet.RegisterNewService("ServiceVerify", newServiceVerify)
 	local := onet.NewLocalTest()
@@ -398,6 +406,7 @@ func TestService_RegisterVerification(t *testing.T) {
 }
 
 func TestService_StoreSkipBlock2(t *testing.T) {
+	defer log.AfterTest(t)
 	nbrHosts := 3
 	local := onet.NewLocalTest()
 	defer local.CloseAll()
@@ -446,6 +455,7 @@ func TestService_StoreSkipBlock2(t *testing.T) {
 }
 
 func TestService_StoreSkipBlockSpeed(t *testing.T) {
+	defer log.AfterTest(t)
 	t.Skip("This is a hidden benchmark")
 	nbrHosts := 3
 	local := onet.NewLocalTest()


### PR DESCRIPTION
The skipchains to asynchronous updating of the forward-links and propagation of the new blocks. This is handy and good for performance (you don't have to wait for all forward-signatures and propagation before being able to go on), but in the tests it's a nuisance, as the go-routines are still active.

This patch adds a counter to the skipchain-service, so that we can test if it's done propagating.