### PR TITLE
adjusting stable path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 all: test
 
-PKG_STABLE = gopkg.in/dedis/cothority.v1.1
+# gopkg fits all v1.1, v1.2, ... in v1
+PKG_STABLE = gopkg.in/dedis/cothority.v1
 include $(GOPATH)/src/github.com/dedis/Coding/bin/Makefile.base
 
 # You can use `test_playground` to run any test or part of cothority

--- a/stable/remove_files
+++ b/stable/remove_files
@@ -1,2 +1,1 @@
 conode/experimental.go
-Makefile


### PR DESCRIPTION
Oups - gopkg puts everything in `v1` - no `v1.2` if not specified as such.

Depends on onet#228