### PR TITLE
showing keypair even without debugging on

### DIFF
--- a/cisc/cisc.go
+++ b/cisc/cisc.go
@@ -262,7 +262,7 @@ func idKeyPair(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	log.Lvlf2("Private: %s\nPublic: %s", privStr, pubStr)
+	log.Printf2("Private: %s\nPublic: %s", privStr, pubStr)
 	return nil
 }
 

--- a/cisc/cisc.go
+++ b/cisc/cisc.go
@@ -262,7 +262,7 @@ func idKeyPair(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	log.Printf2("Private: %s\nPublic: %s", privStr, pubStr)
+	log.Printf("Private: %s\nPublic: %s", privStr, pubStr)
 	return nil
 }
 

--- a/pop/app.go
+++ b/pop/app.go
@@ -643,8 +643,7 @@ func decodeGroups(buf string) ([]*service.ShortDesc, error) {
 // TODO: Needs to be public in app package!!!
 // toServerIdentity converts this ServerToml struct to a ServerIdentity.
 func toServerIdentity(s *app.ServerToml, suite abstract.Suite) (*network.ServerIdentity, error) {
-	pubR := strings.NewReader(s.Public)
-	public, err := crypto.Read64Pub(suite, pubR)
+	public, err := crypto.String64ToPub(suite, s.Public)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Old ui error: when doing

```
cisc id keypair
```

without giving a debug-level, nothing is printed.