### PR TITLE
skipchain_auth_kyber_3_949

### DIFF
--- a/identity/service.go
+++ b/identity/service.go
@@ -44,8 +44,10 @@ const defaultNumberSkipchains = 5
 var identityService onet.ServiceID
 
 // VerificationIdentity gives a combined VerifyBase + verifyIdentity.
-var VerificationIdentity = []skipchain.VerifierID{skipchain.VerifyBase, verifyIdentity}
-var verifyIdentity = skipchain.VerifierID(uuid.NewV5(uuid.NamespaceURL, "Identity"))
+var VerificationIdentity = []skipchain.VerifierID{skipchain.VerifyBase, VerifyIdentity}
+
+// VerifyIdentity makes sure that each new block is signed by a threshold of devices.
+var VerifyIdentity = skipchain.VerifierID(uuid.NewV5(uuid.NamespaceURL, "Identity"))
 
 func init() {
 	identityService, _ = onet.RegisterNewService(ServiceName, newIdentityService)
@@ -751,7 +753,7 @@ func newIdentityService(c *onet.Context) (onet.Service, error) {
 		log.Error("Registration error:", err)
 		return nil, err
 	}
-	skipchain.RegisterVerification(c, verifyIdentity, s.VerifyBlock)
+	skipchain.RegisterVerification(c, VerifyIdentity, s.VerifyBlock)
 	s.auth.pins = make(map[string]struct{})
 	s.auth.nonces = make(map[string]struct{})
 	s.auth.sets = make([]anon.Set, 0)

--- a/scmgr/README.md
+++ b/scmgr/README.md
@@ -4,9 +4,14 @@ Using the skipchain-manager, you can set up, modify and query skipchains.
 For an actual application using the skipchains, refer
 to [https://github.com/dedis/cothority/cisc].
 
-For it to work, you need the `public.toml` of a running cothority where
-you have the right to create a skipchain or add new blocks. If you want only
-to test how it works, the simplest way to get up and started is:
+The `scmgr` will be running on your local machine and it will communicate with
+one or more remote conodes. For it to work, you need the `public.toml` of a
+running cothority where you have the right to create a skipchain or add new
+blocks.
+
+If you want only to test how it works, you can have the conodes and the `scmgr`
+on your local mmachine for testing. Then the simplest way to get up and
+running is:
 
 ```bash
 cd cothority/conode
@@ -15,8 +20,8 @@ cd cothority/conode
 
 This will start three conodes locally and create a new `public.toml` that
 you can use with scmgr. In the following examples, we suppose that the
-`public.toml` file is in the current directory and that you installed `scmgr`
-using
+`public.toml` file and the `co1`, `co2`, and `co3` directories are in the current
+directory and that you installed `scmgr` using
 
 ```bash
 go get github.com/dedis/cothority/scmgr
@@ -32,14 +37,74 @@ then remove the possibility for 3rd parties to create a new skipchain on your
 conode. In a later step we'll let them access your conode for a restricted set
 of tasks.
 
-There are two ways to link with your conode: either you have access to the
-`private.toml` file of your conode, or you can read its log-files and recover
-a PIN.
+To link your conode and your client, you need to have access to the
+`private.toml` file of your conode.
 
 ### Link using private.toml
 
-The `private.toml`-file is in 
+The `private.toml`-file is in `~/.config/conode` for Linux-systems and in
+`~/Library/Conode` for MacOSX-systems. If you started a local cothority for testing,
+you should have three directories, `co1`, `co2` and `co3` where you run the
+`run_conode.sh`-command.
+
+So for the testing system, the command is:
+
+```bash
+scmgr admin link co1/private.toml
+```
+
+That command will create a new private/public keypair for your client and register
+it with one of your conodes.
 
 ## Creating a new skipchain
 
-To create a new
+Now that you linked to your conode, you can create a new skipchain on it, with its
+only participant being _co1_:
+
+```bash
+scmgr skipchain create -b 10 -he 10 co1/public.toml
+```
+
+This will ask the first node in the `public.toml` file to be the leader and to
+create a new skipchain with `baseheight = 10` and `maximumheight = 10`.
+Refer to the Chainiac-paper on description of those heights. TLDR: the bigger
+the _baseheight_, the longer the links between the blocks get. The bigger the
+_maximumheight_, the longer the longest link gets.
+
+Once the skipchain is created, `scmgr` will print out the ID of the new
+skipchain. For the _following_ examples, you can also create a skipchain using
+`cisc` and enter its ID.
+
+## Following a skipchain
+
+Now that the skipchain is created, you can open up your security a bit and decide
+that this skipchain is trustworthy and that all nodes participating in it are
+also trustworthy. There are three different levels of trust that you can chose:
+
+* ID - only this very skipchain is allowed to use your node to store new blocks
+* Restricted - your block will also accept new skipchains, as long as no other
+than a subset of nodes of the given skipchain participate in it
+* Any - your block will also accept new skipchains, as long as _any_ node of the
+given skipchain participates
+
+For our example, we will tell _co2_ and _co3_ to follow the skipchain created
+above and to accept any new block added to that skipchain:
+
+```bash
+scmgr admin link co2/private.toml
+scmgr admin link co3/private.toml
+scmgr admin follow -id SKIPCHAIN_ID 127.0.0.1:2004
+scmgr admin follow -id SKIPCHAIN_ID 127.0.0.1:2006
+```
+
+Where _SKIPCHAIN_ID_ has to be replaced by the ID of the skipchain returned from
+the `scmgr skipchain create` command above.
+
+Now you can ask your first node to extend the nodes that participate in the
+skipchain to all nodes:
+
+```bash
+scmgr skipchain add SKIPCHAIN_ID public.toml
+```
+
+Now you have a skipchain that includes all testing-nodes.

--- a/scmgr/README.md
+++ b/scmgr/README.md
@@ -50,7 +50,7 @@ you should have three directories, `co1`, `co2` and `co3` where you run the
 So for the testing system, the command is:
 
 ```bash
-scmgr admin link co1/private.toml
+scmgr link add co1/private.toml
 ```
 
 That command will create a new private/public keypair for your client and register
@@ -91,10 +91,10 @@ For our example, we will tell _co2_ and _co3_ to follow the skipchain created
 above and to accept any new block added to that skipchain:
 
 ```bash
-scmgr admin link co2/private.toml
-scmgr admin link co3/private.toml
-scmgr admin follow -id SKIPCHAIN_ID 127.0.0.1:2004
-scmgr admin follow -id SKIPCHAIN_ID 127.0.0.1:2006
+scmgr link add co2/private.toml
+scmgr link add co3/private.toml
+scmgr follow add single SKIPCHAIN_ID 127.0.0.1:7004
+scmgr follow add single SKIPCHAIN_ID 127.0.0.1:7006
 ```
 
 Where _SKIPCHAIN_ID_ has to be replaced by the ID of the skipchain returned from
@@ -104,7 +104,12 @@ Now you can ask your first node to extend the nodes that participate in the
 skipchain to all nodes:
 
 ```bash
-scmgr skipchain add SKIPCHAIN_ID public.toml
+scmgr skipchain block add -roster public.toml SKIPCHAIN_ID
 ```
 
-Now you have a skipchain that includes all testing-nodes.
+Now you have a skipchain that includes all testing-nodes. To see the block that
+you just created, you can use
+
+```bash
+scmgr skipchain block print SKIPBLOCK_ID
+```

--- a/scmgr/README.md
+++ b/scmgr/README.md
@@ -1,3 +1,45 @@
 # SkipChain Manager - scmgr
 
 Using the skipchain-manager, you can set up, modify and query skipchains.
+For an actual application using the skipchains, refer
+to [https://github.com/dedis/cothority/cisc].
+
+For it to work, you need the `public.toml` of a running cothority where
+you have the right to create a skipchain or add new blocks. If you want only
+to test how it works, the simplest way to get up and started is:
+
+```bash
+cd cothority/conode
+./run_conode.sh local 3
+```
+
+This will start three conodes locally and create a new `public.toml` that
+you can use with scmgr. In the following examples, we suppose that the
+`public.toml` file is in the current directory and that you installed `scmgr`
+using
+
+```bash
+go get github.com/dedis/cothority/scmgr
+```
+
+## Securing node by creating a link
+
+Per default, everybody is allowed to use your conode to create new skipchains.
+This is good for testing setups where your conode is in your private network
+and cannot be accessed from the outside. However, if you put your conode on the
+internet (and you should), you need to create a link with it first, which will
+then remove the possibility for 3rd parties to create a new skipchain on your
+conode. In a later step we'll let them access your conode for a restricted set
+of tasks.
+
+There are two ways to link with your conode: either you have access to the
+`private.toml` file of your conode, or you can read its log-files and recover
+a PIN.
+
+### Link using private.toml
+
+The `private.toml`-file is in 
+
+## Creating a new skipchain
+
+To create a new

--- a/scmgr/app.go
+++ b/scmgr/app.go
@@ -161,7 +161,7 @@ func linkQuery(c *cli.Context) error {
 	return errors.New("not yet implemented")
 }
 
-func followAddId(c *cli.Context) error {
+func followAddID(c *cli.Context) error {
 	cfg := getConfigOrFail(c)
 	if c.NArg() != 2 {
 		return errors.New("please give: skipchain_id ip:port")

--- a/scmgr/app.go
+++ b/scmgr/app.go
@@ -439,7 +439,7 @@ func dnsList(c *cli.Context) error {
 	return nil
 }
 
-// lsIndex writes one index-file for every known skipchain and an index.html
+// lsIndex writes one index-file for every known skipchain and an index.js
 // for all skiplchains.
 func dnsIndex(c *cli.Context) error {
 	output := c.Args().First()
@@ -447,7 +447,7 @@ func dnsIndex(c *cli.Context) error {
 		return errors.New("Missing output path")
 	}
 
-	cleanHTMLFiles(output)
+	cleanJSFiles(output)
 
 	cfg, err := loadConfig(c)
 	if err != nil {
@@ -473,8 +473,8 @@ func dnsIndex(c *cli.Context) error {
 
 		// Write the genesis block file
 		content, _ := json.Marshal(block)
-		log.Infof("Writing %s.html", block.GenesisID)
-		err := ioutil.WriteFile(filepath.Join(output, block.GenesisID+".html"), content, 0644)
+		log.Infof("Writing %s.js", block.GenesisID)
+		err := ioutil.WriteFile(filepath.Join(output, block.GenesisID+".js"), content, 0644)
 
 		if err != nil {
 			log.Info("Cannot write block-specific file")
@@ -486,9 +486,9 @@ func dnsIndex(c *cli.Context) error {
 		log.Info("Cannot convert to json")
 	}
 
-	// Write the json into the index.html
-	log.Infof("Storing an index of all blocks to index.html")
-	err = ioutil.WriteFile(filepath.Join(output, "index.html"), content, 0644)
+	// Write the json into the index.js
+	log.Infof("Storing an index of all blocks to index.js")
+	err = ioutil.WriteFile(filepath.Join(output, "index.js"), content, 0644)
 	if err != nil {
 		log.Info("Cannot write in the file")
 	}
@@ -553,15 +553,15 @@ func dnsUpdate(c *cli.Context) error {
 	return cfg.save(c)
 }
 
-// Remove every file matching *.html in the given directory
-func cleanHTMLFiles(dir string) error {
+// Remove every file matching *.js in the given directory
+func cleanJSFiles(dir string) error {
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
 		return err
 	}
 
 	for _, f := range files {
-		if strings.HasSuffix(f.Name(), ".html") {
+		if strings.HasSuffix(f.Name(), ".js") {
 			err := os.Remove(filepath.Join(dir, f.Name()))
 			if err != nil {
 				return err
@@ -572,14 +572,14 @@ func cleanHTMLFiles(dir string) error {
 	return nil
 }
 
-// JSON skipblock element to be written in the index.html file
+// JSON skipblock element to be written in the index.js file
 type jsonBlock struct {
 	GenesisID string
 	Servers   []string
 	Data      []byte
 }
 
-// JSON list of skipblocks element to be written in the index.html file
+// JSON list of skipblocks element to be written in the index.js file
 type jsonBlockList struct {
 	Blocks []jsonBlock
 }

--- a/scmgr/app.go
+++ b/scmgr/app.go
@@ -20,6 +20,7 @@ import (
 	"github.com/BurntSushi/toml"
 	bolt "github.com/coreos/bbolt"
 	"github.com/dedis/cothority"
+	"github.com/dedis/cothority/identity"
 	"github.com/dedis/cothority/skipchain"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/util/encoding"
@@ -358,10 +359,23 @@ func scPrint(c *cli.Context) error {
 	}
 	log.Infof("Data: %x", sb.Data)
 	for i, vf := range sb.VerifierIDs {
-		log.Infof("Verification[%d] = %x", i, vf)
+		vfStr := vf.String()
+		switch vf {
+		case skipchain.VerifyBase:
+			vfStr = "skipchain.VerifyBase"
+		case skipchain.VerifyRoot:
+			vfStr = "skipchain.VerifyRoot"
+		case skipchain.VerifyControl:
+			vfStr = "skipchain.VerifyControl"
+		case skipchain.VerifyData:
+			vfStr = "skipchain.VerifyData"
+		case identity.VerifyIdentity:
+			vfStr = "identity.VerifyIdentity"
+		}
+		log.Infof("Verification[%d] = %s", i, vfStr)
 	}
 	log.Infof("SkipchainID: %x", sb.SkipChainID())
-	log.Infof("Hash: %x", sb.Hash)
+	log.Infof("Hash/SkipblockID: %x", sb.Hash)
 	return nil
 }
 

--- a/scmgr/commands.go
+++ b/scmgr/commands.go
@@ -55,7 +55,7 @@ func getCommands() cli.Commands {
 							Name:      "single",
 							Usage:     "only allow inclusion in this specific chain",
 							ArgsUsage: "skipchain-id ip:port",
-							Action:    followAddId,
+							Action:    followAddID,
 						},
 						{
 							Name:      "roster",

--- a/scmgr/commands.go
+++ b/scmgr/commands.go
@@ -1,0 +1,160 @@
+package main
+
+import cli "gopkg.in/urfave/cli.v1"
+
+func getCommands() []cli.Command {
+	groupsDef := "[group-definition]"
+	return []cli.Command{
+		{
+			Name:  "admin",
+			Usage: "administer the skipchain-service",
+			Subcommands: []cli.Command{
+				{
+					Name:    "link",
+					Usage:   "link with a skipchain-service",
+					Aliases: []string{"l"},
+					Action:  adminLink,
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "pin, p",
+							Value: "",
+							Usage: "give ip:port:pin of skipchain-service",
+						},
+						cli.StringFlag{
+							Name:  "private, priv",
+							Value: "",
+							Usage: "give private.toml of skipchain-service",
+						},
+					},
+				},
+				{
+					Name:    "unlink",
+					Usage:   "unlink ip:port - unlink with a skipchain service",
+					Aliases: []string{"ul"},
+					Action:  adminUnlink,
+				},
+				{
+					Name:      "follow",
+					Usage:     "follow a skipchain and allow its conodes to set up new skipchains",
+					Aliases:   []string{"f"},
+					ArgsUsage: "skipchain-id",
+					Action:    adminFollow,
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "id",
+							Usage: "ID - only allow that chain to add blocks",
+						},
+						cli.StringFlag{
+							Name:  "search, s",
+							Usage: "ID - search for that chain in known rosters",
+						},
+						cli.StringFlag{
+							Name:  "lookup, l",
+							Usage: "IP:Port:ID - where to find the chain",
+						},
+						cli.BoolFlag{
+							Name:  "any, a",
+							Usage: "Allow new chain if any of the nodes is present",
+						},
+					},
+				},
+				{
+					Name:      "delfollow",
+					Usage:     "delete a skipchain from the list of followed skipchains",
+					Aliases:   []string{"d"},
+					ArgsUsage: "skipchain-id",
+					Action:    adminDelfollow,
+				},
+				{
+					Name:    "list",
+					Usage:   "list all skipchains we follow",
+					Aliases: []string{"ls"},
+					Action:  adminList,
+				},
+			},
+		},
+		{
+			Name:    "skipchain",
+			Usage:   "handle skipchains",
+			Aliases: []string{"sc"},
+			Subcommands: cli.Commands{
+				{
+					Name:      "create",
+					Usage:     "make a new skipchain",
+					Aliases:   []string{"c"},
+					ArgsUsage: groupsDef,
+					Action:    scCreate,
+					Flags: []cli.Flag{
+						cli.IntFlag{
+							Name:  "base, b",
+							Value: 2,
+							Usage: "base for skipchains",
+						},
+						cli.IntFlag{
+							Name:  "height, he",
+							Value: 2,
+							Usage: "maximum height of skipchain",
+						},
+					},
+				},
+				{
+					Name:      "add",
+					Usage:     "add a new roster to a skipchain",
+					Aliases:   []string{"a"},
+					ArgsUsage: "skipchain-id " + groupsDef,
+					Action:    scAdd,
+				},
+				{
+					Name:      "update",
+					Usage:     "get latest valid block",
+					Aliases:   []string{"u"},
+					ArgsUsage: "skipchain-id",
+					Action:    scUpdate,
+				},
+			},
+		},
+		{
+			Name:  "list",
+			Usage: "handle list of skipblocks",
+			Subcommands: []cli.Command{
+				{
+					Name:      "join",
+					Usage:     "join a skipchain and store it locally",
+					Aliases:   []string{"j"},
+					ArgsUsage: groupsDef + " skipchain-id",
+					Action:    lsJoin,
+				},
+				{
+					Name:    "known",
+					Aliases: []string{"k"},
+					Usage:   "lists all known skipblocks",
+					Flags: []cli.Flag{
+						cli.BoolFlag{
+							Name:  "long, l",
+							Usage: "give long id of blocks",
+						},
+					},
+					Action: lsKnown,
+				},
+				{
+					Name:      "index",
+					Usage:     "create index-files for all known skipchains",
+					ArgsUsage: "output path",
+					Action:    lsIndex,
+				},
+				{
+					Name:      "fetch",
+					Usage:     "ask all known conodes for skipchains",
+					ArgsUsage: "[group-file]",
+					Flags: []cli.Flag{
+						cli.BoolFlag{
+							Name:  "recursive, r",
+							Usage: "recurse into other conodes",
+						},
+					},
+					Action: lsFetch,
+				},
+			},
+		},
+	}
+}

--- a/scmgr/test.sh
+++ b/scmgr/test.sh
@@ -28,7 +28,7 @@ main(){
 testNewChain(){
 	for t in none strict any; do
 	  setupThree
-		testOut "Starting testFollow_$t"
+		testOut "Starting testNewChain_$t"
 		testNewChain_$t
 		cleanup
 	done
@@ -38,23 +38,23 @@ testNewChain_none(){
 	testFollow_id
 
 	setupGenesis group1.toml
-	testFail runSc skipchain add $ID group12.toml
+	testFail runSc skipchain block add -roster group12.toml $ID
 }
 
 testNewChain_strict(){
 	setupGenesis group1.toml
-	testOK runSc admin follow -lookup ${host[1]}:$ID ${host[2]}
+	testOK runSc follow add roster -lookup ${host[1]} $ID ${host[2]}
 
 	setupGenesis group1.toml
-	testFail runSc skipchain add $ID group123.toml
+	testFail runSc skipchain block add -roster group123.toml $ID
 }
 
 testNewChain_any(){
 	setupGenesis group1.toml
-	testOK runSc admin follow -lookup ${host[1]}:$ID -any ${host[2]}
+	testOK runSc follow add roster -lookup ${host[1]} -any $ID ${host[2]}
 
 	setupGenesis group1.toml
-	testOK runSc skipchain add $ID group123.toml
+	testOK runSc skipchain block add -roster group123.toml $ID
 }
 
 testFollow(){
@@ -75,45 +75,45 @@ setupThree(){
 	hosts=()
 	for h in 1 2 3; do
 		host[$h]="localhost:$(( 2000 + 2 * h ))"
-		runSc admin link -priv co$h/private.toml
+		runSc link add co$h/private.toml
 	done
 }
 
 testFollow_id(){
 	setupGenesis group1.toml
-	runSc admin follow -id 00 ${host[2]}
-	testFail runSc skipchain add $ID group12.toml
-	testOK runSc admin follow -id $ID ${host[2]}
-	testOK runSc skipchain add $ID group12.toml
+	runSc follow add single 00 ${host[2]}
+	testFail runSc skipchain block add -roster group12.toml $ID
+	testOK runSc follow add single $ID ${host[2]}
+	testOK runSc skipchain block add -roster group12.toml $ID
 }
 
 testFollow_search(){
 	setupGenesis group1.toml
-	runSc admin follow -id $ID ${host[2]}
-	runSc skipchain add $ID group12.toml
+	runSc follow add single $ID ${host[2]}
+	runSc skipchain block add -roster group12.toml $ID
 
 	setupGenesis group1.toml
-	testOK runSc admin follow -search $ID ${host[2]}
-	testOK runSc skipchain add $ID group12.toml
+	testOK runSc follow add roster $ID ${host[2]}
+	testOK runSc skipchain block add -roster group12.toml $ID
 }
 
 testFollow_lookup(){
 	setupGenesis group1.toml
-	testOK runSc admin follow -lookup ${host[1]}:$ID ${host[2]}
-	testOK runSc skipchain add $ID group12.toml
+	testOK runSc follow add roster -lookup ${host[1]} $ID ${host[2]}
+	testOK runSc skipchain block add -roster group12.toml $ID
 }
 
 testFollow_list(){
 	setupGenesis group1.toml
-	runSc admin follow -lookup ${host[1]}:$ID ${host[2]}
-	testGrep $ID runSc admin list ${host[2]}
+	runSc follow add roster -lookup ${host[1]} $ID ${host[2]}
+	testGrep $ID runSc follow list ${host[2]}
 }
 
 testFollow_delete(){
 	testFollow_list
-	testFail runSc admin delfollow 00 ${host[2]}
-	testOK runSc admin delfollow $ID ${host[2]}
-	testNGrep $ID runSc admin list ${host[2]}
+	testFail runSc follow delete 00 ${host[2]}
+	testOK runSc follow delete $ID ${host[2]}
+	testNGrep $ID runSc follow list ${host[2]}
 }
 
 testLink(){
@@ -122,29 +122,29 @@ testLink(){
 	testOK [ -n "$ID" ]
 	ID=""
 	testFail [ -n "$ID" ]
-	testOK runSc admin link -priv co1/private.toml
-	testOK runSc admin follow -id 00 127.0.0.1:2002
-	testFail runSc admin follow -id 00 127.0.0.1:2004
+	testOK runSc link add co1/private.toml
+	testOK runSc follow add single 00 127.0.0.1:2002
+	testFail runSc follow add single 00 127.0.0.1:2004
 	setupGenesis
 	testOK [ -n "$ID" ]
 }
 
 testUnlink(){
 	startCl
-	testOK runSc admin link -priv co1/private.toml
-	testFail runSc admin unlink localhost:2004
-	testOK runSc admin unlink localhost:2002
-	testFail runSc admin unlink localhost:2002
+	testOK runSc link add co1/private.toml
+	testFail runSc link del localhost:2004
+	testOK runSc link del localhost:2002
+	testFail runSc link del localhost:2002
 }
 
 testFetch(){
 	startCl
 	setupGenesis
 	rm -f $CFG
-	testFail runSc list fetch
-	testOK runSc list fetch public.toml
-	testGrep 2002 runSc list known
-	testGrep 2004 runSc list known
+	testFail runSc scdns fetch
+	testOK runSc scdns fetch public.toml $ID
+	testGrep 2002 runSc scdns list
+	testGrep 2004 runSc scdns list
 }
 
 testRestart(){
@@ -152,43 +152,41 @@ testRestart(){
 	setupGenesis
 	pkill -9 conode 2> /dev/null
 	runCoBG 1 2
-	testOK runSc sc add $ID public.toml
+	testOK runSc skipchain block add -roster public.toml $ID
 }
 
 testAdd(){
 	startCl
 	setupGenesis
-	testFail runSc sc add 1234 public.toml
-	testOK runSc sc add $ID public.toml
+	testFail runSc skipchain block add -roster public.toml 1234
+	testOK runSc skipchain block add -roster public.toml $ID
 	runCoBG 3
-	runGrepSed "Latest block of" "s/.* //" runSc sc update $ID
-	LATEST=$SED
-	testOK runSc sc add $LATEST public.toml
+	testOK runSc skipchain block add -roster public.toml $ID
 }
 
 setupGenesis(){
-	runGrepSed "Created new" "s/.* //" runSc sc create ${1:-public.toml}
+	runGrepSed "Created new" "s/.* //" runSc skipchain create ${1:-public.toml}
 	ID=$SED
 }
 
 testJoin(){
 	startCl
-	runGrepSed "Created new" "s/.* //" runSc sc create public.toml
+	runGrepSed "Created new" "s/.* //" runSc skipchain create public.toml
 	ID=$SED
 	rm -f $CFG
-	testGrep "Didn't find any" runSc list known
-	testFail runSc list join public.toml 1234
-	testGrep "Didn't find any" runSc list known
-	testOK runSc list join public.toml $ID
-	testGrep $ID runSc list known -l
+	testGrep "Didn't find any" runSc scdns list
+	testFail runSc scdns fetch public.toml 1234
+	testGrep "Didn't find any" runSc scdns list
+	testOK runSc scdns fetch public.toml $ID
+	testGrep $ID runSc scdns list -l
 }
 
 testCreate(){
 	startCl
-	testGrep "Didn't find any" runSc list known -l
-	testFail runSc sc create
-	testOK runSc sc create public.toml
-	testGrep "Genesis-block" runSc list known -l
+	testGrep "Didn't find any" runSc scdns list -l
+	testFail runSc skipchain create
+	testOK runSc skipchain create public.toml
+	testGrep "Genesis-block" runSc scdns list -l
 }
 
 testIndex(){
@@ -196,13 +194,14 @@ testIndex(){
 	setupGenesis
 	touch random.html
 
-	testFail runSc list index
-	testOK runSc list index $PWD
+	testFail runSc scdns index
+	testOK runSc scdns index $PWD
 	testGrep "$ID" cat index.html
 	testGrep "127.0.0.1" cat index.html
 	testGrep "$ID" cat "$ID.html"
 	testGrep "127.0.0.1" cat "$ID.html"
 	testNFile random.html
+	dbgOut ""
 }
 
 testConfig(){
@@ -212,8 +211,8 @@ testConfig(){
 	CFG=$CFGDIR/config.bin
 	rmdir $CFGDIR
 	head -n 4 public.toml > one.toml
-	testOK runSc sc create one.toml
-	testOK runSc sc create public.toml
+	testOK runSc skipchain create one.toml
+	testOK runSc skipchain create public.toml
 	rm -rf $CFGDIR
 	CFG=$OLDCFG
 }

--- a/skipchain/README.md
+++ b/skipchain/README.md
@@ -1,0 +1,31 @@
+# Skipchain implementation
+
+This skipchain implementation is based upon the Chainiac-paper (*LINK*) and offers
+a very simple, extendable voting-based permissioned blockchain. Instead of having
+one global blockchain, the skipchain implementation allows users to use a personal
+blockchain where they can store data. In the cothority, the following data
+types are implemented:
+
+* CISC [github.com/dedis/cothority/cisc] - offers a key/value storage where
+a threshold of devices need to sign off on changes. Currently supported
+key/values are:
+  * SSH-keys - storing public ssh-keys that will be followed by a ssh-server for
+  passwordless logins
+  * Web-pages - store your webpage on your personal blockchain and only allow
+  changes if a threshold of administrators sign off
+  * Free values - add any key/value pair to your personal skipchain
+* RandHound [github.com/dedis/cothority/randhound] - produce verifiable random numbers
+and store them on a blockchain for later proofs
+
+## Overview of implementation
+
+The skipchain itself is held by one or more conodes. Clients can connect to the leader and propose new blocks. Every time a new
+block is received, the leader runs a BFT-protocol with the other
+nodes. All nodes keep a copy of the skipchain-blocks.
+
+## Usage
+
+A simple first step on how to use skipchains is described in the skipchain-manager
+readme: [github.com/dedis/cothority/scmgr/README.md].
+
+Another usage example is in CISC: [github.com/dedis/cothority/cisc/README.md]

--- a/skipchain/api.go
+++ b/skipchain/api.go
@@ -1,12 +1,16 @@
 package skipchain
 
 import (
-	"github.com/dedis/cothority"
 	"github.com/dedis/kyber"
+	"github.com/dedis/kyber/group/edwards25519"
+	"github.com/dedis/kyber/sign/schnorr"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
 )
+
+// Suite is defined locally until we have a better way to give it per-service.
+var Suite = edwards25519.NewBlakeSHA256Ed25519()
 
 const (
 	// ErrorBlockNotFound indicates that for any number of operations the
@@ -37,27 +41,29 @@ type Client struct {
 
 // NewClient instantiates a new client with name 'n'
 func NewClient() *Client {
-	return &Client{Client: onet.NewClient("Skipchain", cothority.Suite)}
+	return &Client{Client: onet.NewClient("Skipchain", Suite)}
 }
 
-// StoreSkipBlock asks the cothority to store the new skipblock, and eventually
+// StoreSkipBlockSignature asks the cothority to store the new skipblock, and eventually
 // attach it to the 'latest' skipblock.
-//  - latest is the skipblock where the new skipblock is appended. If el and d
+//  - latest is the skipblock where the new skipblock is appended. If ro and d
 //   are nil, a new skipchain will be created with 'latest' as genesis-block.
-//  - el is the new roster for that block. If el is nil, the previous roster
+//  - ro is the new roster for that block. If ro is nil, the previous roster
 //   will be used.
 //  - d is the data for the new block. It can be nil. If it is not of type
 //   []byte, it will be marshalled using `network.Marshal`.
-func (c *Client) StoreSkipBlock(latest *SkipBlock, el *onet.Roster, d network.Message) (reply *StoreSkipBlockReply, cerr onet.ClientError) {
+//  - priv is the private key that will be used to sign the skipblock. If priv
+//   is nil, the skipblock will not be signed.
+func (c *Client) StoreSkipBlockSignature(latest *SkipBlock, ro *onet.Roster, d network.Message, priv kyber.Scalar) (reply *StoreSkipBlockReply, cerr onet.ClientError) {
 	log.Lvlf3("%#v", latest)
 	var newBlock *SkipBlock
 	var latestID SkipBlockID
-	if el == nil && d == nil {
+	if ro == nil && d == nil {
 		newBlock = latest
 	} else {
 		newBlock = latest.Copy()
-		if el != nil {
-			newBlock.Roster = el
+		if ro != nil {
+			newBlock.Roster = ro
 		}
 		if d != nil {
 			var ok bool
@@ -75,16 +81,37 @@ func (c *Client) StoreSkipBlock(latest *SkipBlock, el *onet.Roster, d network.Me
 	}
 	host := latest.Roster.Get(0)
 	reply = &StoreSkipBlockReply{}
-	cerr = c.SendProtobuf(host, &StoreSkipBlock{latestID, newBlock}, reply)
+	var sig *[]byte
+	if priv != nil {
+		signature, err := schnorr.Sign(Suite, priv, newBlock.CalculateHash())
+		if err != nil {
+			return nil, onet.NewClientErrorCode(ErrorParameterWrong, "couldn't sign block: "+err.Error())
+		}
+		sig = &signature
+	}
+	cerr = c.SendProtobuf(host, &StoreSkipBlock{LatestID: latestID, NewBlock: newBlock,
+		Signature: sig}, reply)
 	if cerr != nil {
 		return nil, cerr
 	}
 	return reply, nil
 }
 
-// CreateGenesis is a convenience function to create a new SkipChain with the
+// StoreSkipBlock asks the cothority to store the new skipblock, and eventually
+// attach it to the 'latest' skipblock.
+//  - latest is the skipblock where the new skipblock is appended. If ro and d
+//   are nil, a new skipchain will be created with 'latest' as genesis-block.
+//  - ro is the new roster for that block. If ro is nil, the previous roster
+//   will be used.
+//  - d is the data for the new block. It can be nil. If it is not of type
+//   []byte, it will be marshalled using `network.Marshal`.
+func (c *Client) StoreSkipBlock(latest *SkipBlock, ro *onet.Roster, d network.Message) (reply *StoreSkipBlockReply, cerr onet.ClientError) {
+	return c.StoreSkipBlockSignature(latest, ro, d, nil)
+}
+
+// CreateGenesisSignature is a convenience function to create a new SkipChain with the
 // given parameters.
-//  - el is the responsible roster
+//  - ro is the responsible roster
 //  - baseH is the base-height - the distance between two non-height-1 skipblocks
 //  - maxH is the maximum height, which must be <= baseH
 //  - ver is a slice of verifications to apply to that block
@@ -92,12 +119,13 @@ func (c *Client) StoreSkipBlock(latest *SkipBlock, el *onet.Roster, d network.Me
 //    except if the data is of type []byte, in which case it will be stored
 //    as-is on the skipchain.
 //  - parent is the responsible parent-block, can be 'nil'
+//  - priv is a private key that is allowed to sign for new skipblocks
 //
 // This function returns the created skipblock or nil and an error.
-func (c *Client) CreateGenesis(el *onet.Roster, baseH, maxH int, ver []VerifierID,
-	data interface{}, parent SkipBlockID) (*SkipBlock, onet.ClientError) {
+func (c *Client) CreateGenesisSignature(ro *onet.Roster, baseH, maxH int, ver []VerifierID,
+	data interface{}, parent SkipBlockID, priv kyber.Scalar) (*SkipBlock, onet.ClientError) {
 	genesis := NewSkipBlock()
-	genesis.Roster = el
+	genesis.Roster = ro
 	genesis.VerifierIDs = ver
 	genesis.MaximumHeight = maxH
 	genesis.BaseHeight = baseH
@@ -114,11 +142,28 @@ func (c *Client) CreateGenesis(el *onet.Roster, baseH, maxH int, ver []VerifierI
 			genesis.Data = buf
 		}
 	}
-	sb, cerr := c.StoreSkipBlock(genesis, nil, nil)
+	sb, cerr := c.StoreSkipBlockSignature(genesis, nil, nil, priv)
 	if cerr != nil {
 		return nil, cerr
 	}
 	return sb.Latest, nil
+}
+
+// CreateGenesis is a convenience function to create a new SkipChain with the
+// given parameters.
+//  - ro is the responsible roster
+//  - baseH is the base-height - the distance between two non-height-1 skipblocks
+//  - maxH is the maximum height, which must be <= baseH
+//  - ver is a slice of verifications to apply to that block
+//  - data can be nil or any data that will be network.Marshaled to the skipblock,
+//    except if the data is of type []byte, in which case it will be stored
+//    as-is on the skipchain.
+//  - parent is the responsible parent-block, can be 'nil'
+//
+// This function returns the created skipblock or nil and an error.
+func (c *Client) CreateGenesis(ro *onet.Roster, baseH, maxH int, ver []VerifierID,
+	data interface{}, parent SkipBlockID) (*SkipBlock, onet.ClientError) {
+	return c.CreateGenesisSignature(ro, baseH, maxH, ver, data, parent, nil)
 }
 
 // CreateRootControl is a convenience function and creates two Skipchains:
@@ -183,4 +228,100 @@ func (c *Client) GetSingleBlockByIndex(roster *onet.Roster, genesis SkipBlockID,
 	cerr = c.SendProtobuf(roster.RandomServerIdentity(),
 		&GetSingleBlockByIndex{genesis, index}, reply)
 	return
+}
+
+// CreateLinkPrivate asks the conode to create a link by sending a public
+// key of the client, signed by the private key of the conode. The reasoning is
+// that an administrator should well be able to copy the private.toml-file from
+// the server and use that to authenticate and link to the conode.
+func (c *Client) CreateLinkPrivate(si *network.ServerIdentity, conodePriv kyber.Scalar,
+	pub kyber.Point) onet.ClientError {
+	reply := &EmptyReply{}
+	msg, err := pub.MarshalBinary()
+	if err != nil {
+		return onet.NewClientErrorCode(ErrorOnet, "couldn't marshal point: "+err.Error())
+	}
+	sig, err := schnorr.Sign(Suite, conodePriv, msg)
+	if err != nil {
+		return onet.NewClientErrorCode(ErrorOnet, "couldn't sign public key: "+err.Error())
+	}
+	return c.SendProtobuf(si, &CreateLinkPrivate{Public: pub, Signature: sig}, reply)
+}
+
+// Unlink removes a link on the remote service for our client. This might be
+// because we want to change the key. It's not possible to remove a lost key,
+// only if you have the private key can you request to remove the public
+// counterpart on the server.
+func (c *Client) Unlink(si *network.ServerIdentity, priv kyber.Scalar) onet.ClientError {
+	msg, err := si.Public.MarshalBinary()
+	if err != nil {
+		return onet.NewClientErrorCode(ErrorOnet, err.Error())
+	}
+	msg = append([]byte("unlink:"), msg...)
+	sig, err := schnorr.Sign(Suite, priv, msg)
+	if err != nil {
+		return onet.NewClientErrorCode(ErrorOnet, err.Error())
+	}
+	public := Suite.Point().Mul(priv, nil)
+	return c.SendProtobuf(si, &Unlink{
+		Public:    public,
+		Signature: sig,
+	}, &EmptyReply{})
+}
+
+// AddFollow gives a skipchain-id to the conode that should be used to allow/disallow
+// new blocks. Only if SettingAuthentication(true) has been called is this active.
+// The Follow is one of: 0 - only allow this skipchain to add new blocks.
+// 1 - search if it can find that skipchain-id and then add the whole roster to
+// the list of allowed nodes to request a new skipblock. 2 - lookup the skipchain-id
+// given the ip and port of the conode where it is available.
+func (c *Client) AddFollow(si *network.ServerIdentity, clientPriv kyber.Scalar,
+	scid SkipBlockID, Follow FollowType, NewChain PolicyNewChain, conode string) onet.ClientError {
+	req := &AddFollow{
+		SkipchainID: scid,
+		Follow:      Follow,
+		NewChain:    NewChain,
+		Conode:      conode,
+	}
+	msg := []byte{byte(Follow)}
+	msg = append(scid, msg...)
+	msg = append(msg, []byte(conode)...)
+	sig, err := schnorr.Sign(Suite, clientPriv, msg)
+	if err != nil {
+		return onet.NewClientErrorCode(ErrorParameterWrong, "couldn't sign message:"+err.Error())
+	}
+	req.Signature = sig
+	return c.SendProtobuf(si, req, nil)
+}
+
+// DelFollow asks the conode to remove a skipchain-id from the list of skipchains that are
+// used to to allow/disallow new blocks. Only if SettingAuthentication(true) has
+// been called is this active.
+func (c *Client) DelFollow(si *network.ServerIdentity, clientPriv kyber.Scalar, scid SkipBlockID) onet.ClientError {
+	msg := append([]byte("delfollow:"), scid...)
+	sig, err := schnorr.Sign(Suite, clientPriv, msg)
+	if err != nil {
+		return onet.NewClientErrorCode(ErrorParameterWrong, err.Error())
+	}
+	return c.SendProtobuf(si, &DelFollow{SkipchainID: scid, Signature: sig}, nil)
+}
+
+// ListFollow returns the list of latest skipblock of all skipchains that are followed
+// for authentication purposes.
+func (c *Client) ListFollow(si *network.ServerIdentity, clientPriv kyber.Scalar) (*ListFollowReply, onet.ClientError) {
+	msg, err := si.Public.MarshalBinary()
+	if err != nil {
+		return nil, onet.NewClientErrorCode(ErrorParameterWrong, err.Error())
+	}
+	msg = append([]byte("listfollow:"), msg...)
+	sig, err := schnorr.Sign(Suite, clientPriv, msg)
+	if err != nil {
+		return nil, onet.NewClientErrorCode(ErrorParameterWrong, err.Error())
+	}
+	reply := &ListFollowReply{}
+	cerr := c.SendProtobuf(si, &ListFollow{Signature: sig}, reply)
+	if cerr != nil {
+		return nil, cerr
+	}
+	return reply, nil
 }

--- a/skipchain/api_test.go
+++ b/skipchain/api_test.go
@@ -9,6 +9,8 @@ import (
 
 	"sync"
 
+	"github.com/dedis/kyber"
+	"github.com/dedis/kyber/util/key"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
@@ -19,7 +21,7 @@ func init() {
 }
 
 func TestClient_CreateGenesis(t *testing.T) {
-	l := onet.NewTCPTest(tSuite)
+	l := onet.NewTCPTest(Suite)
 	_, roster, _ := l.GenTree(3, true)
 	defer l.CloseAll()
 	c := newTestClient(l)
@@ -37,7 +39,7 @@ func TestClient_CreateGenesis(t *testing.T) {
 }
 
 func TestClient_CreateRootControl(t *testing.T) {
-	l := onet.NewTCPTest(tSuite)
+	l := onet.NewTCPTest(Suite)
 	_, roster, _ := l.GenTree(3, true)
 	defer l.CloseAll()
 	c := newTestClient(l)
@@ -49,15 +51,15 @@ func TestClient_GetUpdateChain(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Long run not good for Travis")
 	}
-	l := onet.NewTCPTest(tSuite)
-	_, el, _ := l.GenTree(5, true)
+	l := onet.NewTCPTest(Suite)
+	_, ro, _ := l.GenTree(5, true)
 	defer l.CloseAll()
 
 	clients := make(map[int]*Client)
 	for i := range [8]byte{} {
 		clients[i] = newTestClient(l)
 	}
-	_, inter, cerr := clients[0].CreateRootControl(el, el, nil, 1, 1, 1)
+	_, inter, cerr := clients[0].CreateRootControl(ro, ro, nil, 1, 1, 1)
 	log.ErrFatal(cerr)
 
 	wg := sync.WaitGroup{}
@@ -73,12 +75,12 @@ func TestClient_GetUpdateChain(t *testing.T) {
 }
 
 func TestClient_CreateRootInter(t *testing.T) {
-	l := onet.NewTCPTest(tSuite)
-	_, el, _ := l.GenTree(5, true)
+	l := onet.NewTCPTest(Suite)
+	_, ro, _ := l.GenTree(5, true)
 	defer l.CloseAll()
 
 	c := newTestClient(l)
-	root, inter, cerr := c.CreateRootControl(el, el, nil, 1, 1, 1)
+	root, inter, cerr := c.CreateRootControl(ro, ro, nil, 1, 1, 1)
 	log.ErrFatal(cerr)
 	if root == nil || inter == nil {
 		t.Fatal("Pointers are nil")
@@ -98,28 +100,28 @@ func TestClient_CreateRootInter(t *testing.T) {
 
 func TestClient_StoreSkipBlock(t *testing.T) {
 	nbrHosts := 3
-	l := onet.NewTCPTest(tSuite)
-	_, el, _ := l.GenTree(nbrHosts, true)
+	l := onet.NewTCPTest(Suite)
+	_, ro, _ := l.GenTree(nbrHosts, true)
 	defer l.CloseAll()
 
 	c := newTestClient(l)
 	log.Lvl1("Creating root and control chain")
-	_, inter, cerr := c.CreateRootControl(el, el, nil, 1, 1, 1)
+	_, inter, cerr := c.CreateRootControl(ro, ro, nil, 1, 1, 1)
 	log.ErrFatal(cerr)
-	el2 := onet.NewRoster(el.List[:nbrHosts-1])
-	log.Lvl1("Proposing roster", el2)
+	ro2 := onet.NewRoster(ro.List[:nbrHosts-1])
+	log.Lvl1("Proposing roster", ro2)
 	var sb1 *StoreSkipBlockReply
-	sb1, cerr = c.StoreSkipBlock(inter, el2, nil)
+	sb1, cerr = c.StoreSkipBlock(inter, ro2, nil)
 	log.ErrFatal(cerr)
 	log.Lvl1("Proposing same roster again")
-	_, cerr = c.StoreSkipBlock(inter, el2, nil)
+	_, cerr = c.StoreSkipBlock(inter, ro2, nil)
 	require.NotNil(t, cerr,
 		"Appending two Blocks to the same last block should fail")
 	log.Lvl1("Proposing following roster")
-	sb1, cerr = c.StoreSkipBlock(sb1.Latest, el2, []byte{1, 2, 3})
+	sb1, cerr = c.StoreSkipBlock(sb1.Latest, ro2, []byte{1, 2, 3})
 	log.ErrFatal(cerr)
 	require.Equal(t, sb1.Latest.Data, []byte{1, 2, 3})
-	sb2, cerr := c.StoreSkipBlock(sb1.Latest, el2, &testData{})
+	sb2, cerr := c.StoreSkipBlock(sb1.Latest, ro2, &testData{})
 	log.ErrFatal(cerr)
 	require.True(t, sb2.Previous.Equal(sb1.Latest),
 		"New previous should be previous latest")
@@ -144,23 +146,24 @@ func TestClient_StoreSkipBlock(t *testing.T) {
 
 func TestClient_GetAllSkipchains(t *testing.T) {
 	nbrHosts := 3
-	l := onet.NewTCPTest(tSuite)
-	_, el, _ := l.GenTree(nbrHosts, true)
+	l := onet.NewTCPTest(Suite)
+	_, ro, _ := l.GenTree(nbrHosts, true)
 	defer l.CloseAll()
 
 	c := newTestClient(l)
 	log.Lvl1("Creating root and control chain")
-	sb1, cerr := c.CreateGenesis(el, 1, 1, VerificationNone, nil, nil)
+	sb1, cerr := c.CreateGenesis(ro, 1, 1, VerificationNone, nil, nil)
 	log.ErrFatal(cerr)
-	_, cerr = c.StoreSkipBlock(sb1, el, nil)
+	_, cerr = c.StoreSkipBlock(sb1, ro, nil)
 	log.ErrFatal(cerr)
-	sb2, cerr := c.CreateGenesis(el, 1, 1, VerificationNone, nil, nil)
+	sb2, cerr := c.CreateGenesis(ro, 1, 1, VerificationNone, nil, nil)
 	log.ErrFatal(cerr)
 	sb1id := sb1.SkipChainID()
 	sb2id := sb2.SkipChainID()
 
-	sbs, cerr := c.GetAllSkipchains(el.List[0])
-	require.Equal(t, 2, len(sbs.SkipChains))
+	sbs, cerr := c.GetAllSkipchains(ro.List[0])
+	log.ErrFatal(cerr)
+	require.Equal(t, 3, len(sbs.SkipChains))
 	sbs1id := sbs.SkipChains[0].SkipChainID()
 	sbs2id := sbs.SkipChains[1].SkipChainID()
 	require.True(t, sb1id.Equal(sbs1id) || sb1id.Equal(sbs2id))
@@ -170,7 +173,7 @@ func TestClient_GetAllSkipchains(t *testing.T) {
 
 func TestClient_GetSingleBlockByIndex(t *testing.T) {
 	nbrHosts := 3
-	l := onet.NewTCPTest(tSuite)
+	l := onet.NewTCPTest(Suite)
 	_, roster, _ := l.GenTree(nbrHosts, true)
 	defer l.CloseAll()
 
@@ -180,14 +183,164 @@ func TestClient_GetSingleBlockByIndex(t *testing.T) {
 	log.ErrFatal(cerr)
 	reply2, cerr := c.StoreSkipBlock(sb1, roster, nil)
 	log.ErrFatal(cerr)
-	search, cerr := c.GetSingleBlockByIndex(roster, sb1.Hash, -1)
+	_, cerr = c.GetSingleBlockByIndex(roster, sb1.Hash, -1)
 	require.NotNil(t, cerr)
-	search, cerr = c.GetSingleBlockByIndex(roster, sb1.Hash, 0)
+	search, cerr := c.GetSingleBlockByIndex(roster, sb1.Hash, 0)
+	log.ErrFatal(cerr)
 	require.True(t, sb1.Equal(search))
 	search, cerr = c.GetSingleBlockByIndex(roster, sb1.Hash, 1)
+	log.ErrFatal(cerr)
 	require.True(t, reply2.Latest.Equal(search))
-	search, cerr = c.GetSingleBlockByIndex(roster, sb1.Hash, 2)
+	_, cerr = c.GetSingleBlockByIndex(roster, sb1.Hash, 2)
 	require.NotNil(t, cerr)
+}
+
+func TestClient_CreateLinkPrivate(t *testing.T) {
+	ls := linked(1)
+	defer ls.local.CloseAll()
+	require.Equal(t, 0, len(ls.service.Storage.Clients))
+	cerr := ls.client.CreateLinkPrivate(ls.server.ServerIdentity, ls.servPriv, ls.pub)
+	require.Nil(t, cerr)
+}
+
+func TestClient_SettingAuthentication(t *testing.T) {
+	ls := linked(1)
+	defer ls.local.CloseAll()
+	require.Equal(t, 0, len(ls.service.Storage.Clients))
+	cerr := ls.client.CreateLinkPrivate(ls.si, ls.servPriv, ls.pub)
+	require.Nil(t, cerr)
+	require.Equal(t, 1, len(ls.service.Storage.Clients))
+}
+
+func TestClient_Follow(t *testing.T) {
+	ls := linked(3)
+	defer ls.local.CloseAll()
+	require.Equal(t, 0, len(ls.service.Storage.Clients))
+	priv0 := ls.servPriv
+	cerr := ls.client.CreateLinkPrivate(ls.si, priv0, ls.pub)
+	require.Nil(t, cerr)
+	priv1 := ls.local.GetPrivate(ls.servers[1])
+	cerr = ls.client.CreateLinkPrivate(ls.roster.List[1], priv1, ls.servers[1].ServerIdentity.Public)
+	require.Nil(t, cerr)
+	priv2 := ls.local.GetPrivate(ls.servers[2])
+	cerr = ls.client.CreateLinkPrivate(ls.roster.List[2], priv2, ls.servers[2].ServerIdentity.Public)
+	require.Nil(t, cerr)
+	log.Lvl1(ls.roster)
+
+	// Verify that server1 doesn't allow a new skipchain using server0 and server1
+	roster01 := onet.NewRoster(ls.roster.List[0:2])
+	_, cerr = ls.client.CreateGenesis(roster01, 1, 1, VerificationNone, nil, nil)
+	require.NotNil(t, cerr)
+
+	roster0 := onet.NewRoster([]*network.ServerIdentity{ls.si})
+	genesis, cerr := ls.client.CreateGenesisSignature(roster0, 1, 1, VerificationNone, nil, nil, priv0)
+	require.Nil(t, cerr)
+
+	// Now server1 follows skipchain from server0, so it should allow a new skipblock,
+	// but not a new skipchain
+	log.Lvl1("(0) Following skipchain-id only")
+	cerr = ls.client.AddFollow(ls.roster.List[1], priv1, genesis.SkipChainID(),
+		FollowID, NewChainStrictNodes, "")
+	require.Nil(t, cerr)
+	block1, cerr := ls.client.StoreSkipBlockSignature(genesis, roster01, nil, priv0)
+	require.Nil(t, cerr)
+	genesis1, cerr := ls.client.CreateGenesisSignature(roster01, 1, 1, VerificationNone, nil, nil, priv0)
+	require.Nil(t, cerr)
+	_, cerr = ls.client.StoreSkipBlockSignature(genesis1, roster01, nil, priv0)
+	require.NotNil(t, cerr)
+
+	// Now server1 follows the skipchain as a 'roster-inclusion' skipchain, so it
+	// should also allow creation of a new skipchain
+	log.Lvl1("(1) Following roster of skipchain")
+	cerr = ls.client.AddFollow(ls.roster.List[1], priv1, genesis.SkipChainID(),
+		FollowSearch, NewChainStrictNodes, "")
+	require.Nil(t, cerr)
+	block2, cerr := ls.client.StoreSkipBlockSignature(block1.Latest, roster01, nil, priv0)
+	require.Nil(t, cerr)
+	genesis2, cerr := ls.client.CreateGenesisSignature(roster01, 1, 1, VerificationNone, nil, nil, priv0)
+	require.Nil(t, cerr)
+	_, cerr = ls.client.StoreSkipBlockSignature(genesis2, roster01, nil, priv0)
+	require.Nil(t, cerr)
+
+	// Finally test with third server
+	log.Lvl1("(1) Following skipchain-id only on server2")
+	cerr = ls.client.AddFollow(ls.roster.List[2], priv2, genesis.SkipChainID(),
+		FollowSearch, NewChainStrictNodes, "")
+	require.NotNil(t, cerr)
+	log.Lvl1("(2) Following skipchain-id only on server2")
+	cerr = ls.client.AddFollow(ls.roster.List[2], priv2, genesis.SkipChainID(),
+		FollowLookup, NewChainStrictNodes, ls.server.Address().NetworkAddress())
+	require.Nil(t, cerr)
+	_, cerr = ls.client.StoreSkipBlockSignature(block2.Latest, ls.roster, nil, priv0)
+	require.Nil(t, cerr)
+	_, cerr = ls.client.CreateGenesisSignature(ls.roster, 1, 1, VerificationNone, nil, nil, priv0)
+	require.Nil(t, cerr)
+}
+
+func TestClient_DelFollow(t *testing.T) {
+	ls := linked(3)
+	defer ls.local.CloseAll()
+
+	sb, cerr := ls.client.CreateGenesis(ls.roster, 1, 1, VerificationNone, nil, nil)
+	require.Nil(t, cerr)
+	cerr = ls.client.AddFollow(ls.server.ServerIdentity, ls.priv, sb.SkipChainID(),
+		FollowID, NewChainNone, "")
+	require.Nil(t, cerr)
+	require.Equal(t, 1, len(ls.service.Storage.FollowIDs))
+
+	cerr = ls.client.DelFollow(ls.server.ServerIdentity, ls.priv, sb.SkipChainID())
+	require.Nil(t, cerr)
+	require.Equal(t, 0, len(ls.service.Storage.FollowIDs))
+}
+
+func TestClient_ListFollow(t *testing.T) {
+	ls := linked(3)
+	defer ls.local.CloseAll()
+
+	sb1, cerr := ls.client.CreateGenesis(ls.roster, 1, 1, VerificationNone, nil, nil)
+	require.Nil(t, cerr)
+	cerr = ls.client.AddFollow(ls.server.ServerIdentity, ls.priv, sb1.SkipChainID(),
+		FollowID, NewChainNone, "")
+	require.Nil(t, cerr)
+	sb2, cerr := ls.client.CreateGenesis(ls.roster, 1, 1, VerificationNone, nil, nil)
+	require.Nil(t, cerr)
+	cerr = ls.client.AddFollow(ls.server.ServerIdentity, ls.priv, sb2.SkipChainID(),
+		FollowLookup, NewChainNone, ls.server.ServerIdentity.Address.NetworkAddress())
+	require.Nil(t, cerr)
+
+	list, cerr := ls.client.ListFollow(ls.server.ServerIdentity, ls.priv)
+	require.Nil(t, cerr)
+	require.Equal(t, 1, len(*list.Follow))
+	require.Equal(t, 1, len(*list.FollowIDs))
+}
+
+type linkStruct struct {
+	local    *onet.LocalTest
+	roster   *onet.Roster
+	servers  []*onet.Server
+	server   *onet.Server
+	service  *Service
+	si       *network.ServerIdentity
+	servPriv kyber.Scalar
+	priv     kyber.Scalar
+	pub      kyber.Point
+	client   *Client
+}
+
+func linked(nbr int) *linkStruct {
+	kp := key.NewKeyPair(Suite)
+	ls := &linkStruct{
+		local: onet.NewTCPTest(Suite),
+		priv:  kp.Secret,
+		pub:   kp.Public,
+	}
+	ls.servers, ls.roster, _ = ls.local.GenTree(nbr, true)
+	ls.server = ls.servers[0]
+	ls.si = ls.server.ServerIdentity
+	ls.servPriv = ls.local.GetPrivate(ls.server)
+	ls.service = ls.local.GetServices(ls.servers, skipchainSID)[0].(*Service)
+	ls.client = newTestClient(ls.local)
+	return ls
 }
 
 func newTestClient(l *onet.LocalTest) *Client {

--- a/skipchain/msgs.go
+++ b/skipchain/msgs.go
@@ -1,9 +1,13 @@
 package skipchain
 
-import "github.com/dedis/onet/network"
+import (
+	"github.com/dedis/kyber"
+	"github.com/dedis/onet"
+	"github.com/dedis/onet/network"
+)
 
 func init() {
-	for _, m := range []interface{}{
+	network.RegisterMessages(
 		// - API calls
 		// Store new skipblock
 		&StoreSkipBlock{},
@@ -16,6 +20,22 @@ func init() {
 		// Fetch all skipchains
 		&GetAllSkipchains{},
 		&GetAllSkipchainsReply{},
+		// Create link with client
+		&CreateLinkPrivate{},
+		// Unlink a client
+		&Unlink{},
+		// Setting authentication
+		&SettingAuthentication{},
+		// Adding a skipchain to follow
+		&AddFollow{},
+		// Removing a skipchain from following
+		&DelFollow{},
+		// EmptyReply for calls that only return errors
+		&EmptyReply{},
+		// Lists all skipchains we follow
+		&ListFollow{},
+		// Returns the genesis-blocks of all skipchains we follow
+		&ListFollowReply{},
 		// - Internal calls
 		// Propagation
 		&PropagateSkipBlocks{},
@@ -23,16 +43,20 @@ func init() {
 		&ForwardSignature{},
 		// Request updated block
 		&GetBlock{},
-		// Reply with updated block
+		// Updated block reply
 		&GetBlockReply{},
 		// - Data structures
 		&SkipBlockFix{},
 		&SkipBlock{},
 		// Own service
 		&Service{},
-	} {
-		network.RegisterMessage(m)
-	}
+		// - Protocol messages
+		&ProtoExtendSignature{},
+		&ProtoExtendRoster{},
+		&ProtoExtendRosterReply{},
+		&ProtoGetUpdate{},
+		&ProtoBlockReply{},
+	)
 }
 
 // This file holds all messages that can be sent to the SkipChain,
@@ -43,9 +67,13 @@ func init() {
 // StoreSkipBlock - Requests a new skipblock to be appended to
 // the given SkipBlock. If the given SkipBlock has Index 0 (which
 // is invalid), a new SkipChain will be created.
+// if AuthSkipchain == true, then the signature has to be a valid
+// Schnorr signature on the hash of the NewBlock by either one of the
+// conodes in the roster or by one of the clients.
 type StoreSkipBlock struct {
-	LatestID SkipBlockID
-	NewBlock *SkipBlock
+	LatestID  SkipBlockID
+	NewBlock  *SkipBlock
+	Signature *[]byte
 }
 
 // StoreSkipBlockReply - returns the signed SkipBlock with updated backlinks
@@ -128,4 +156,130 @@ type PropagateSkipBlock struct {
 // GetBlockReply returns the requested block.
 type GetBlockReply struct {
 	SkipBlock *SkipBlock
+}
+
+// Protocol messages
+
+// ProtoExtendSignature can be used as proof that a node accepted to be included
+// in a new roster.
+type ProtoExtendSignature struct {
+	SI        network.ServerIdentityID
+	Signature []byte
+}
+
+// ProtoExtendRoster asks a conode whether it would be OK to accept a new block
+// with himself as part of the roster.
+type ProtoExtendRoster struct {
+	Block SkipBlock
+}
+
+// ProtoStructExtendRoster embeds the treenode
+type ProtoStructExtendRoster struct {
+	*onet.TreeNode
+	ProtoExtendRoster
+}
+
+// ProtoExtendRosterReply is a signature on the Genesis-id.
+type ProtoExtendRosterReply struct {
+	Signature *[]byte
+}
+
+// ProtoStructExtendRosterReply embeds the treenode
+type ProtoStructExtendRosterReply struct {
+	*onet.TreeNode
+	ProtoExtendRosterReply
+}
+
+// ProtoGetUpdate requests the latest block
+type ProtoGetUpdate struct {
+	SBID SkipBlockID
+}
+
+// ProtoStructGetUpdate embeds the treenode
+type ProtoStructGetUpdate struct {
+	*onet.TreeNode
+	ProtoGetUpdate
+}
+
+// ProtoBlockReply returns a block - either from update or from getblock
+type ProtoBlockReply struct {
+	SkipBlock *SkipBlock
+}
+
+// ProtoStructBlockReply embeds the treenode
+type ProtoStructBlockReply struct {
+	*onet.TreeNode
+	ProtoBlockReply
+}
+
+// CreateLinkPrivate asks to store the given public key in the list of administrative
+// clients.
+type CreateLinkPrivate struct {
+	Public    kyber.Point
+	Signature []byte
+}
+
+// Unlink requests the conode to remove the link from its Internal
+// table of links. The signature has to be on the message
+// "unlink:" + the byte-representation of the public key to remove.
+type Unlink struct {
+	Public    kyber.Point
+	Signature []byte
+}
+
+// EmptyReply is an empty reply. If there was an error in the
+// request, it will be returned
+type EmptyReply struct{}
+
+// SettingAuthentication sets the authentication bit that enables restriction
+// of the skipchains that are accepted. It needs to be signed by one of the
+// clients. The signature is on []byte{0} if Authentication is false and on
+// []byte{1} if the Authentication is true.
+// TODO: perhaps we need to protect this against replay-attacks by adding a
+// monotonically increasing nonce that is also stored on the conode.
+type SettingAuthentication struct {
+	Authentication int
+	Signature      []byte
+}
+
+// AddFollow adds a skipchain to follow. The Signature is on the SkipchainID concatenated
+// with the Follow as a byte and the Conode.
+// The Follow is one of the following:
+//   * FollowID will store this skipchain-id and only allow evolution of
+//   this skipchain. This implies NewChainNone.
+//   * FollowType asks all stored skipchains if it knows that skipchain. All
+//   PolicyNewChain are allowed.
+//   * FollowLookup takes a ip:port where the skipchain can be found. All
+//   PolicyNewChain are allowed.
+// The NewChain-policy is ignored for FollowID, but for the other policies
+// it is defined as follows:
+//   * NewChainNone doesn't allow any new chains from any node from this skipchain.
+//   * NewChainAnyNode allows new chains if any node from this skipchain is present.
+//   * NewChainStrictNodes allows new chains only one or more nodes from this skipchain
+//   are present in the new chain.
+type AddFollow struct {
+	SkipchainID SkipBlockID
+	Follow      FollowType
+	NewChain    PolicyNewChain
+	Conode      string
+	Signature   []byte
+}
+
+// DelFollow removes a skipchain from following. The Signature is on the SkipchainID.
+type DelFollow struct {
+	SkipchainID SkipBlockID
+	Signature   []byte
+}
+
+// ListFollow returns all followed lists all skipchains we follow.
+// The signature has to be on the following message:
+// "listfollow:" + the public key of the conode
+type ListFollow struct {
+	Signature []byte
+}
+
+// ListFollowReply returns the genesis-blocks of all skipchains we follow
+type ListFollowReply struct {
+	Follow    *[]FollowChainType
+	FollowIDs *[]SkipBlockID
 }

--- a/skipchain/msgs.go
+++ b/skipchain/msgs.go
@@ -24,6 +24,10 @@ func init() {
 		&CreateLinkPrivate{},
 		// Unlink a client
 		&Unlink{},
+		// List all client keys
+		&Listlink{},
+		// Returns a list of public keys
+		&ListlinkReply{},
 		// Setting authentication
 		&SettingAuthentication{},
 		// Adding a skipchain to follow
@@ -225,6 +229,17 @@ type CreateLinkPrivate struct {
 type Unlink struct {
 	Public    kyber.Point
 	Signature []byte
+}
+
+// Listlink requests a list of all public keys stored in this
+// conode and allowed to request administrative tasks.
+type Listlink struct{}
+
+// ListlinkReply returns the list of public keys allowed to
+// do administrative tasks on this conode. If the list is empty,
+// then this node is not secured.
+type ListlinkReply struct {
+	Publics []kyber.Point
 }
 
 // EmptyReply is an empty reply. If there was an error in the

--- a/skipchain/protocol.go
+++ b/skipchain/protocol.go
@@ -1,0 +1,193 @@
+package skipchain
+
+/*
+The `NewProtocol` method is used to define the protocol and to register
+the handlers that will be called if a certain type of message is received.
+The handlers will be treated according to their signature.
+
+The protocol-file defines the actions that the protocol needs to do in each
+step. The root-node will call the `Start`-method of the protocol. Each
+node will only use the `Handle`-methods, and not call `Start` again.
+*/
+
+import (
+	"github.com/dedis/kyber/sign/schnorr"
+	"github.com/dedis/onet"
+	"github.com/dedis/onet/log"
+	"github.com/dedis/onet/network"
+)
+
+// ProtocolExtendRoster asks a remote node if he would accept to participate
+// in a skipchain with a given id.
+const ProtocolExtendRoster = "scExtendRoster"
+
+// ProtocolGetUpdate asks a remote node to return the latest block of a
+// skipchain.
+const ProtocolGetUpdate = "scGetUpdate"
+
+func init() {
+	onet.GlobalProtocolRegister(ProtocolExtendRoster, NewProtocolExtendRoster)
+	onet.GlobalProtocolRegister(ProtocolGetUpdate, NewProtocolGetUpdate)
+}
+
+// ExtendRoster is used for different communications in the skipchain-service.
+type ExtendRoster struct {
+	*onet.TreeNodeInstance
+
+	ExtendRoster      *ProtoExtendRoster
+	ExtendRosterReply chan []ProtoExtendSignature
+	Followers         *[]FollowChainType
+	FollowerIDs       []SkipBlockID
+	DB                *SkipBlockDB
+	SaveCallback      func()
+}
+
+// GetUpdate needs to be configured by the service to hold the database
+// of all skipblocks.
+type GetUpdate struct {
+	*onet.TreeNodeInstance
+
+	GetUpdate      *ProtoGetUpdate
+	GetUpdateReply chan *SkipBlock
+	DB             *SkipBlockDB
+}
+
+// NewProtocolExtendRoster prepares for a protocol that checks if a roster can
+// be extended.
+func NewProtocolExtendRoster(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
+	t := &ExtendRoster{
+		TreeNodeInstance:  n,
+		ExtendRosterReply: make(chan []ProtoExtendSignature),
+	}
+	return t, t.RegisterHandlers(t.HandleExtendRoster, t.HandleExtendRosterReply)
+}
+
+// NewProtocolGetUpdate prepares for a protocol that fetches an update
+func NewProtocolGetUpdate(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
+	t := &GetUpdate{
+		TreeNodeInstance: n,
+		GetUpdateReply:   make(chan *SkipBlock),
+	}
+	return t, t.RegisterHandlers(t.HandleGetUpdate, t.HandleBlockReply)
+}
+
+// Start sends the Announce-message to all children
+func (p *ExtendRoster) Start() error {
+	log.Lvl3("Starting Protocol ExtendRoster")
+	return p.SendToChildren(p.ExtendRoster)
+}
+
+// Start sends the Announce-message to all children
+func (p *GetUpdate) Start() error {
+	log.Lvl3("Starting Protocol GetUpdate")
+	return p.SendToChildren(p.GetUpdate)
+}
+
+// HandleExtendRoster uses the stored followers to decide if we want to accept
+// to be part of the new roster.
+func (p *ExtendRoster) HandleExtendRoster(msg ProtoStructExtendRoster) error {
+	defer p.Done()
+
+	log.Lvlf3("%s: Check block with roster %s", p.ServerIdentity(), msg.Block.Roster.List)
+	if p.isBlockAccepted(msg.ServerIdentity, &msg.Block) {
+		sig, err := schnorr.Sign(Suite, p.Private(), msg.Block.SkipChainID())
+		if err != nil {
+			log.Error("couldn't sign genesis-block")
+			return p.SendToParent(&ProtoExtendRosterReply{})
+		}
+		return p.SendToParent(&ProtoExtendRosterReply{Signature: &sig})
+	}
+
+	return p.SendToParent(&ProtoExtendRosterReply{})
+}
+
+func (p *ExtendRoster) isBlockAccepted(sender *network.ServerIdentity, block *SkipBlock) bool {
+	// Search for matching skipchain-ids
+	log.Lvlf3("%s: checking block with skipchainid: %x", p.ServerIdentity(), block.SkipChainID())
+	for _, id := range p.FollowerIDs {
+		if block.SkipChainID().Equal(id) {
+			log.Lvlf3("%s: Found skipchain-id", p.ServerIdentity())
+			return true
+		}
+	}
+
+	// If followers are defined, first search the latest block, then verify if
+	// we're still OK to handle new blocks for that skipchain.
+	if p.Followers != nil && len(*p.Followers) > 0 {
+		for _, fct := range *p.Followers {
+			log.Lvlf3("%s: Checking skipchain %x", p.ServerIdentity(), fct.Block.SkipChainID())
+			// See if its in this skipchain
+			if fct.Block.SkipChainID().Equal(block.SkipChainID()) {
+				log.Lvlf3("%s: Accepted existing skipchain", p.ServerIdentity())
+				return true
+			}
+
+			// Get the latest skipblock available
+			err := fct.GetLatest(p.ServerIdentity(), p)
+			if err != nil {
+				log.Error(err)
+			}
+
+			// Verify if we still accept the new block, given the definition of this
+			// new skipchain.
+			if fct.AcceptNew(block, p.ServerIdentity()) {
+				log.Lvlf3("%s: accepted new block", p.ServerIdentity())
+				return true
+			}
+		}
+		log.Lvlf3("%s: refused new block", p.ServerIdentity())
+		return false
+	}
+
+	if p.SaveCallback != nil {
+		p.SaveCallback()
+	}
+
+	// If no followers are present, we accept everything.
+	log.Lvlf3("%s: will return %t", p.ServerIdentity(), len(p.FollowerIDs) == 0)
+	return len(p.FollowerIDs) == 0
+}
+
+// HandleExtendRosterReply checks if all nodes are OK to hold this new block.
+func (p *ExtendRoster) HandleExtendRosterReply(reply []ProtoStructExtendRosterReply) error {
+	defer p.Done()
+
+	var sigs []ProtoExtendSignature
+	for _, r := range reply {
+		if r.Signature == nil {
+			sigs = []ProtoExtendSignature{}
+			break
+		}
+		if schnorr.Verify(Suite, r.ServerIdentity.Public, p.ExtendRoster.Block.SkipChainID(), *r.Signature) != nil {
+			sigs = []ProtoExtendSignature{}
+			break
+		}
+		sigs = append(sigs, ProtoExtendSignature{SI: r.ServerIdentity.ID, Signature: *r.Signature})
+	}
+	p.ExtendRosterReply <- sigs
+	return nil
+}
+
+// HandleGetUpdate searches for a skipblock and returns it if it is found.
+func (p *GetUpdate) HandleGetUpdate(msg ProtoStructGetUpdate) error {
+	defer p.Done()
+
+	if p.DB == nil {
+		log.Lvl3(p.ServerIdentity(), "no block stored in Db")
+		return p.SendToParent(&ProtoBlockReply{})
+	}
+
+	sb, err := p.DB.GetLatest(p.DB.GetByID(msg.SBID))
+	if err != nil {
+		log.Error("couldn't get latest: " + err.Error())
+		return err
+	}
+	return p.SendToParent(&ProtoBlockReply{SkipBlock: sb})
+}
+
+// HandleBlockReply contacts the service that a new block has arrived
+func (p *GetUpdate) HandleBlockReply(msg ProtoStructBlockReply) error {
+	defer p.Done()
+	p.GetUpdateReply <- msg.SkipBlock
+	return nil
+}

--- a/skipchain/protocol_test.go
+++ b/skipchain/protocol_test.go
@@ -1,0 +1,175 @@
+package skipchain_test
+
+import (
+	"testing"
+
+	"github.com/dedis/cothority/skipchain"
+	"github.com/dedis/kyber/sign/schnorr"
+	"github.com/dedis/onet"
+	"github.com/dedis/onet/log"
+	"github.com/dedis/onet/network"
+	"github.com/stretchr/testify/require"
+)
+
+const tsName = "tsName"
+
+var tsID onet.ServiceID
+var tSuite = skipchain.Suite
+
+func init() {
+	var err error
+	tsID, err = onet.RegisterNewService(tsName, newTestService)
+	log.ErrFatal(err)
+}
+
+// TestGU tests the GetUpdate message
+func TestGU(t *testing.T) {
+	local := onet.NewLocalTest(tSuite)
+	defer local.CloseAll()
+	servers, ro, _ := local.GenTree(2, true)
+	tss := local.GetServices(servers, tsID)
+
+	ts0 := tss[0].(*testService)
+	ts1 := tss[1].(*testService)
+	sb0 := skipchain.NewSkipBlock()
+	sb0.Roster = ro
+	sb0.Hash = sb0.CalculateHash()
+	sb1 := skipchain.NewSkipBlock()
+	sb1.BackLinkIDs = []skipchain.SkipBlockID{sb0.Hash}
+	sb1.Hash = sb1.CalculateHash()
+	bl := &skipchain.BlockLink{Hash: sb1.Hash, Signature: []byte{}}
+	sb0.ForwardLink = []*skipchain.BlockLink{bl}
+	db, bucket := ts0.GetAdditionalBucket("skipblocks")
+	ts0.Db = skipchain.NewSkipBlockDB(db, bucket)
+	ts0.Db.Store(sb0)
+	ts0.Db.Store(sb1)
+	db, bucket = ts1.GetAdditionalBucket("skipblocks")
+	ts1.Db = skipchain.NewSkipBlockDB(db, bucket)
+	ts1.Db.Store(sb0)
+	ts1.Db.Store(sb1)
+	sb := ts1.CallGU(sb0)
+	require.NotNil(t, sb)
+	require.Equal(t, sb1.Hash, sb.Hash)
+}
+
+// TestER tests the ProtoExtendRoster message
+func TestER(t *testing.T) {
+	nodes := []int{2, 5, 13}
+	for _, nbrNodes := range nodes {
+		testER(t, tsID, nbrNodes)
+	}
+}
+
+func testER(t *testing.T, tsid onet.ServiceID, nbrNodes int) {
+	log.Lvl1("Testing", nbrNodes, "nodes")
+	local := onet.NewLocalTest(tSuite)
+	defer local.CloseAll()
+	servers, roster, tree := local.GenBigTree(nbrNodes, nbrNodes, nbrNodes, true)
+	tss := local.GetServices(servers, tsid)
+	log.Lvl3(tree.Dump())
+
+	sb := &skipchain.SkipBlock{SkipBlockFix: &skipchain.SkipBlockFix{Roster: roster,
+		Data: []byte{}}}
+
+	// Check refusing of new chains
+	for _, t := range tss {
+		t.(*testService).FollowerIDs = []skipchain.SkipBlockID{[]byte{0}}
+	}
+	ts := tss[0].(*testService)
+	sigs := ts.CallER(tree, sb)
+	require.Equal(t, 0, len(sigs))
+
+	// Check inclusion of new chains
+	for _, t := range tss {
+		t.(*testService).Followers = []skipchain.FollowChainType{{
+			Block:    sb,
+			NewChain: skipchain.NewChainAnyNode,
+		}}
+	}
+	sigs = ts.CallER(tree, sb)
+	require.Equal(t, nbrNodes-1, len(sigs))
+
+	for _, s := range sigs {
+		_, si := roster.Search(s.SI)
+		require.NotNil(t, si)
+		require.Nil(t, schnorr.Verify(tSuite, si.Public, sb.SkipChainID(), s.Signature))
+	}
+
+	// Have only one node refuse
+	if nbrNodes > 2 {
+		for i := 2; i < nbrNodes; i++ {
+			log.Lvl2("Checking failing signature at", i)
+			tss[i].(*testService).FollowerIDs = []skipchain.SkipBlockID{[]byte{0}}
+			tss[i].(*testService).Followers = []skipchain.FollowChainType{}
+			sigs = ts.CallER(tree, sb)
+			require.Equal(t, 0, len(sigs))
+			tss[i].(*testService).Followers = []skipchain.FollowChainType{{
+				Block:    sb,
+				NewChain: skipchain.NewChainAnyNode,
+			}}
+		}
+	}
+}
+
+type testService struct {
+	*onet.ServiceProcessor
+	Followers   []skipchain.FollowChainType
+	FollowerIDs []skipchain.SkipBlockID
+	Db          *skipchain.SkipBlockDB
+}
+
+func (ts *testService) CallER(t *onet.Tree, b *skipchain.SkipBlock) []skipchain.ProtoExtendSignature {
+	pi, err := ts.CreateProtocol(skipchain.ProtocolExtendRoster, t)
+	if err != nil {
+		return []skipchain.ProtoExtendSignature{}
+	}
+	pisc := pi.(*skipchain.ExtendRoster)
+	pisc.ExtendRoster = &skipchain.ProtoExtendRoster{Block: *b}
+	if err := pi.Start(); err != nil {
+		log.ErrFatal(err)
+	}
+	return <-pisc.ExtendRosterReply
+}
+
+func (ts *testService) CallGU(sb *skipchain.SkipBlock) *skipchain.SkipBlock {
+	t := onet.NewRoster([]*network.ServerIdentity{ts.ServerIdentity(), sb.Roster.List[0]}).GenerateBinaryTree()
+	pi, err := ts.CreateProtocol(skipchain.ProtocolGetUpdate, t)
+	if err != nil {
+		log.Error(err)
+		return &skipchain.SkipBlock{}
+	}
+	pisc := pi.(*skipchain.GetUpdate)
+	pisc.GetUpdate = &skipchain.ProtoGetUpdate{SBID: sb.Hash}
+	if err := pi.Start(); err != nil {
+		log.ErrFatal(err)
+	}
+	return <-pisc.GetUpdateReply
+}
+
+func (ts *testService) NewProtocol(ti *onet.TreeNodeInstance, conf *onet.GenericConfig) (pi onet.ProtocolInstance, err error) {
+	if ti.ProtocolName() == skipchain.ProtocolExtendRoster {
+		// Start by getting latest blocks of all followers
+		pi, err = skipchain.NewProtocolExtendRoster(ti)
+		if err == nil {
+			pier := pi.(*skipchain.ExtendRoster)
+			pier.Followers = &ts.Followers
+			pier.FollowerIDs = ts.FollowerIDs
+			pier.DB = ts.Db
+		}
+	}
+	if ti.ProtocolName() == skipchain.ProtocolGetUpdate {
+		pi, err = skipchain.NewProtocolGetUpdate(ti)
+		if err == nil {
+			pigu := pi.(*skipchain.GetUpdate)
+			pigu.DB = ts.Db
+		}
+	}
+	return
+}
+
+func newTestService(c *onet.Context) (onet.Service, error) {
+	s := &testService{
+		ServiceProcessor: onet.NewServiceProcessor(c),
+	}
+	return s, nil
+}

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -1,3 +1,11 @@
+// Package skipchain implements a service in the cothority that
+// keeps track of a skipchain. It offers API-calls to create
+// new skipchains, add blocks to existing skipchains, and
+// request updates to known skipchain.
+//
+// The basic strcture needed from a clients point of view is
+// Client, that has all the methods defined on it to interact
+// with a skipchain.
 package skipchain
 
 import (
@@ -8,7 +16,10 @@ import (
 	"time"
 
 	"github.com/dedis/cothority/bftcosi"
+	"github.com/dedis/cothority/cosi/crypto"
 	"github.com/dedis/cothority/messaging"
+	"github.com/dedis/kyber"
+	"github.com/dedis/kyber/sign/schnorr"
 	"github.com/dedis/kyber/util/random"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
@@ -20,10 +31,11 @@ import (
 const ServiceName = "Skipchain"
 const bftNewBlock = "SkipchainBFTNew"
 const bftFollowBlock = "SkipchainBFTFollow"
+const storageKey = "skipchainconfig"
 
 func init() {
 	skipchainSID, _ = onet.RegisterNewService(ServiceName, newSkipchainService)
-	network.RegisterMessage(&SkipBlockMap{})
+	network.RegisterMessages(&Storage{})
 }
 
 // Only used in tests
@@ -40,6 +52,22 @@ type Service struct {
 	lastSave           time.Time
 	newBlocksMutex     sync.Mutex
 	newBlocks          map[string]bool
+	storageMutex       sync.Mutex
+	Storage            *Storage
+}
+
+// Storage is saved to disk.
+type Storage struct {
+	// Follow is a slice of latest blocks that point to skipchains that are allowed
+	// to create new blocks
+	Follow []FollowChainType
+	// FollowIDs is a slice of IDs that are allowed to ask us to sign and store
+	// new blocks for their skipchain.
+	FollowIDs []SkipBlockID
+	// Clients is a list of public keys of clients that have successfully linked
+	// to this service. Once a client is linked to a service, only blocks signed
+	// by this client will be allowed.
+	Clients []kyber.Point
 }
 
 // StoreSkipBlock stores a new skipblock in the system. This can be either a
@@ -65,10 +93,21 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, on
 		return nil, onet.NewClientErrorCode(ErrorParameterWrong,
 			"only leader is allowed to add blocks")
 	}
+	if len(s.Storage.Clients) > 0 {
+		if psbd.Signature == nil {
+			return nil, onet.NewClientErrorCode(ErrorParameterWrong,
+				"cannot create new skipblock without authentication")
+		}
+		if !s.authenticate(psbd.NewBlock.CalculateHash(), *psbd.Signature) {
+			return nil, onet.NewClientErrorCode(ErrorParameterWrong,
+				"wrong signature for this skipchain")
+		}
+	}
 	var prev *SkipBlock
 	var changed []*SkipBlock
 
 	if psbd.LatestID.IsNull() {
+		log.Lvl3("Creating new skipchain with roster", psbd.NewBlock.Roster.List)
 		// A new chain is created
 		prop.Index = 0
 		prop.Height = prop.MaximumHeight
@@ -102,6 +141,7 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, on
 		changed = append(changed, prop)
 
 	} else {
+		log.Lvlf2("Adding block with roster %+v to %x", psbd.NewBlock.Roster.List, psbd.LatestID)
 		// We're appending a block to an existing chain
 		prev = s.db.GetByID(psbd.LatestID)
 		if prev == nil {
@@ -121,6 +161,7 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, on
 				"this skipchain-id is currently processing a block")
 		}
 		defer s.newBlockEnd(prev)
+
 		prop.MaximumHeight = prev.MaximumHeight
 		prop.BaseHeight = prev.BaseHeight
 		prop.ParentBlockID = nil
@@ -150,11 +191,23 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, on
 			prop.BackLinkIDs[h] = pointer.Hash
 		}
 		prop.updateHash()
+
+		// Only check changing roster, or if this is the block after the genesis-block,
+		// as we don't verify the roster for the genesis-block.
+		log.Lvl3("Checking if all nodes from roster accept block")
+		if !prev.Roster.ID.Equal(prop.Roster.ID) || prop.Index == 1 {
+			if !s.willNodesAcceptBlock(prop) {
+				return nil, onet.NewClientErrorCode(ErrorBlockContent,
+					"node refused to accept new roster")
+			}
+		}
+
 		if err := s.addForwardLink(prev, prop); err != nil {
 			return nil, onet.NewClientErrorCode(ErrorBlockContent,
 				"Couldn't get forward signature on block: "+err.Error())
 		}
 		changed = append(changed, prev, prop)
+		log.Lvl3("Asking forward-links from all linked blocks")
 		for i, bl := range prop.BackLinkIDs[1:] {
 			back := s.db.GetByID(bl)
 			if back == nil {
@@ -166,12 +219,13 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, on
 					prev.GetForward(0)}); err != nil {
 				// This is not a critical failure - we have at least
 				// one forward-link
-				log.Error("Couldn't get old block to sign")
+				log.Error("Couldn't get old block to sign: " + err.Error())
 			} else {
 				changed = append(changed, back)
 			}
 		}
 	}
+	log.Lvlf3("Propagate %d blocks", len(changed))
 	if err := s.startPropagation(changed); err != nil {
 		return nil, onet.NewClientErrorCode(ErrorVerification,
 			"Couldn't propagate new blocks: "+err.Error())
@@ -193,7 +247,7 @@ func (s *Service) GetUpdateChain(latestKnown *GetUpdateChain) (network.Message, 
 		return nil, onet.NewClientErrorCode(ErrorBlockNotFound, "Couldn't find latest skipblock")
 	}
 	// at least the latest know and the next block:
-	blocks := []*SkipBlock{block}
+	blocks := []*SkipBlock{block.Copy()}
 	log.Lvlf3("Starting to search chain at %x", s.Context.ServerIdentity().ID[0:8])
 	for block.GetForwardLen() > 0 {
 		link := block.ForwardLink[block.GetForwardLen()-1]
@@ -201,7 +255,7 @@ func (s *Service) GetUpdateChain(latestKnown *GetUpdateChain) (network.Message, 
 		if next == nil {
 			log.Lvl3("Didn't find next block, updating block")
 			var err error
-			next, err = s.getUpdateBlock(block, link.Hash)
+			next, err = s.callGetBlock(block, link.Hash)
 			if err != nil {
 				return nil, onet.NewClientErrorCode(ErrorBlockNotFound,
 					err.Error())
@@ -210,7 +264,7 @@ func (s *Service) GetUpdateChain(latestKnown *GetUpdateChain) (network.Message, 
 			if i, _ := next.Roster.Search(s.ServerIdentity().ID); i < 0 {
 				log.Lvl3("We're not responsible for", next, "- asking for update")
 				var err error
-				next, err = s.getUpdateBlock(next, link.Hash)
+				next, err = s.callGetBlock(next, link.Hash)
 				if err != nil {
 					return nil, onet.NewClientErrorCode(ErrorBlockNotFound,
 						err.Error())
@@ -218,7 +272,7 @@ func (s *Service) GetUpdateChain(latestKnown *GetUpdateChain) (network.Message, 
 			}
 		}
 		block = next
-		blocks = append(blocks, next)
+		blocks = append(blocks, next.Copy())
 	}
 	log.Lvl3("Found", len(blocks), "blocks")
 	reply := &GetUpdateChainReply{blocks}
@@ -275,6 +329,186 @@ func (s *Service) GetAllSkipchains(id *GetAllSkipchains) (*GetAllSkipchainsReply
 	return reply, nil
 }
 
+// CreateLinkPrivate checks if the given public key is signed with our private
+// key and stores it in the list of allowed clients if it is true.
+func (s *Service) CreateLinkPrivate(link *CreateLinkPrivate) (*EmptyReply, onet.ClientError) {
+	msg, err := link.Public.MarshalBinary()
+	if err != nil {
+		return nil, onet.NewClientErrorCode(ErrorOnet, "couldn't marshal public key: "+err.Error())
+	}
+	if err = schnorr.Verify(Suite, s.ServerIdentity().Public, msg, link.Signature); err != nil {
+		return nil, onet.NewClientErrorCode(ErrorParameterWrong, "wrong signature on public key: "+err.Error())
+	}
+	s.storageMutex.Lock()
+	s.Storage.Clients = append(s.Storage.Clients, link.Public)
+	s.storageMutex.Unlock()
+	s.save()
+	return &EmptyReply{}, nil
+}
+
+// Unlink removes a public key from the list of linked nodes.
+// Authentication to unlink is done by a signature on the
+// following message:
+// "unlink:" + byte representation of the public key to be
+// removed
+func (s *Service) Unlink(unlink *Unlink) (*EmptyReply, onet.ClientError) {
+	msg, err := unlink.Public.MarshalBinary()
+	if err != nil {
+		return &EmptyReply{}, onet.NewClientErrorCode(ErrorOnet, err.Error())
+	}
+	msg = append([]byte("unlink:"), msg...)
+	err = schnorr.Verify(s.Suite(), unlink.Public, msg, unlink.Signature)
+	if err != nil {
+		return &EmptyReply{}, onet.NewClientErrorCode(ErrorOnet, err.Error())
+	}
+	client := -1
+	for i, pub := range s.Storage.Clients {
+		if pub.Equal(unlink.Public) {
+			client = i
+			break
+		}
+	}
+	if client == -1 {
+		return &EmptyReply{}, onet.NewClientErrorCode(ErrorParameterWrong, "didn't find this clients public key")
+	}
+	s.Storage.Clients = append(s.Storage.Clients[:client], s.Storage.Clients[client+1:]...)
+	s.save()
+	return &EmptyReply{}, nil
+}
+
+// AddFollow adds a new skipchain to be followed
+func (s *Service) AddFollow(add *AddFollow) (*EmptyReply, onet.ClientError) {
+	msg := []byte{byte(add.Follow)}
+	msg = append(add.SkipchainID, msg...)
+	msg = append(msg, []byte(add.Conode)...)
+	if !s.verifySigs(msg, add.Signature) {
+		return &EmptyReply{}, onet.NewClientErrorCode(ErrorParameterWrong, "wrong signature of unknown signer")
+	}
+
+	s.storageMutex.Lock()
+	defer s.save()
+	defer s.storageMutex.Unlock()
+	switch add.Follow {
+	case FollowID:
+		log.Lvlf2("%s FollowChain %x", s.ServerIdentity(), add.SkipchainID)
+		s.Storage.FollowIDs = append(s.Storage.FollowIDs, add.SkipchainID)
+	case FollowSearch:
+		// First search if anybody knows that SkipBlockID
+		sis := map[string]*network.ServerIdentity{}
+		for _, fct := range s.Storage.Follow {
+			for _, si := range fct.Block.Roster.List {
+				sis[si.ID.String()] = si
+			}
+		}
+		// TODO: this is really not good and will fail if we have too many blocks.
+		sbs, err := s.db.getAll()
+		if err != nil {
+			return nil, onet.NewClientErrorCode(ErrorParameterWrong, "couldn't load db of all blocks")
+		}
+		for sc := range sbs {
+			for _, si := range s.db.GetByID(SkipBlockID(sc)).Roster.List {
+				sis[si.ID.String()] = si
+			}
+		}
+		found := false
+		for _, si := range sis {
+			roster := onet.NewRoster([]*network.ServerIdentity{si})
+			s.storageMutex.Unlock()
+			reply, cerr := NewClient().GetUpdateChain(roster, add.SkipchainID)
+			s.storageMutex.Lock()
+			if cerr == nil {
+				last := reply.Update[len(reply.Update)-1]
+				if last.SkipChainID().Equal(add.SkipchainID) {
+					s.Storage.Follow = append(s.Storage.Follow,
+						FollowChainType{
+							Block:    last,
+							NewChain: add.NewChain,
+						})
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			return nil, onet.NewClientErrorCode(ErrorParameterWrong, "didn't find that skipchain-id")
+		}
+		log.Lvlf2("%s FollowSearch %s %x", s.ServerIdentity(), add.Conode, add.SkipchainID)
+	case FollowLookup:
+		si := network.NewServerIdentity(Suite.Point(), network.NewTCPAddress(add.Conode))
+		roster := onet.NewRoster([]*network.ServerIdentity{si})
+		s.storageMutex.Unlock()
+		reply, cerr := NewClient().GetUpdateChain(roster, add.SkipchainID)
+		s.storageMutex.Lock()
+		if cerr != nil {
+			return nil, onet.NewClientErrorCode(ErrorBlockNotFound, "didn't find skipchain at given address")
+		}
+		last := reply.Update[len(reply.Update)-1]
+		if !last.SkipChainID().Equal(add.SkipchainID) {
+			return nil, onet.NewClientErrorCode(ErrorBlockNotFound, "returned block is not correct")
+		}
+		s.Storage.Follow = append(s.Storage.Follow,
+			FollowChainType{
+				Block:    last,
+				NewChain: add.NewChain,
+			})
+		log.Lvlf2("%s FollowLookup %x", s.ServerIdentity(), add.SkipchainID)
+	default:
+		return nil, onet.NewClientErrorCode(ErrorParameterWrong, "that Follow is not known.")
+	}
+	return &EmptyReply{}, nil
+}
+
+// DelFollow searches for that skipchain in the follower
+// list and deletes it if it is there.
+func (s *Service) DelFollow(del *DelFollow) (*EmptyReply, onet.ClientError) {
+	msg := append([]byte("delfollow:"), del.SkipchainID...)
+	if !s.verifySigs(msg, del.Signature) {
+		return &EmptyReply{}, onet.NewClientErrorCode(ErrorParameterWrong, "wrong signature of unknown signer")
+	}
+	deleted := false
+	for i, scid := range s.Storage.FollowIDs {
+		if scid.Equal(del.SkipchainID) {
+			s.Storage.FollowIDs = append(s.Storage.FollowIDs[:i],
+				s.Storage.FollowIDs[i+1:]...)
+			deleted = true
+			break
+		}
+	}
+	for i, fct := range s.Storage.Follow {
+		if fct.Block.SkipChainID().Equal(del.SkipchainID) {
+			s.Storage.Follow = append(s.Storage.Follow[:i],
+				s.Storage.Follow[i+1:]...)
+			deleted = true
+			break
+		}
+	}
+	if !deleted {
+		return &EmptyReply{}, onet.NewClientErrorCode(ErrorParameterWrong, "didn't find any block of that id")
+	}
+	s.save()
+	return &EmptyReply{}, nil
+}
+
+// ListFollow returns the skipchain-ids that are followed
+func (s *Service) ListFollow(list *ListFollow) (*ListFollowReply, onet.ClientError) {
+	reply := &ListFollowReply{}
+	msg, err := s.ServerIdentity().Public.MarshalBinary()
+	if err != nil {
+		return reply, onet.NewClientErrorCode(ErrorOnet, "couldn't marshal public key")
+	}
+	msg = append([]byte("listfollow:"), msg...)
+	if !s.verifySigs(msg, list.Signature) {
+		return reply, onet.NewClientErrorCode(ErrorParameterWrong, "wrong signature of unknown signer")
+	}
+	if len(s.Storage.Follow) > 0 {
+		reply.Follow = &s.Storage.Follow
+	}
+	if len(s.Storage.FollowIDs) > 0 {
+		reply.FollowIDs = &s.Storage.FollowIDs
+	}
+	return reply, nil
+}
+
 // IsPropagating returns true if there is at least one propagation running.
 func (s *Service) IsPropagating() bool {
 	s.newBlocksMutex.Lock()
@@ -282,7 +516,45 @@ func (s *Service) IsPropagating() bool {
 	return len(s.newBlocks) > 0
 }
 
-func (s *Service) getUpdateBlock(known *SkipBlock, unknown SkipBlockID) (*SkipBlock, error) {
+// NewProtocol intercepts the creation of the skipblock protocol and
+// initialises the necessary variables.
+func (s *Service) NewProtocol(ti *onet.TreeNodeInstance, conf *onet.GenericConfig) (pi onet.ProtocolInstance, err error) {
+	if ti.ProtocolName() == ProtocolExtendRoster {
+		// Start by getting latest blocks of all followers
+		pi, err = NewProtocolExtendRoster(ti)
+		if err == nil {
+			pier := pi.(*ExtendRoster)
+			pier.Followers = &s.Storage.Follow
+			pier.FollowerIDs = s.Storage.FollowIDs
+			pier.DB = s.db
+			pier.SaveCallback = s.save
+		}
+	}
+	if ti.ProtocolName() == ProtocolGetUpdate {
+		pi, err = NewProtocolGetUpdate(ti)
+		if err == nil {
+			pigu := pi.(*GetUpdate)
+			pigu.DB = s.db
+		}
+	}
+	return
+}
+
+func (s *Service) verifySigs(msg, sig []byte) bool {
+	// If there are no clients, all signatures verify.
+	if len(s.Storage.Clients) == 0 {
+		return true
+	}
+
+	for _, cl := range s.Storage.Clients {
+		if schnorr.Verify(Suite, cl, msg, sig) == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Service) callGetBlock(known *SkipBlock, unknown SkipBlockID) (*SkipBlock, error) {
 	s.blockRequestsMutex.Lock()
 	request := make(chan *SkipBlock)
 	s.blockRequests[string(unknown)] = request
@@ -324,7 +596,7 @@ func (s *Service) forwardSignature(fs *ForwardSignature) error {
 	// TODO: is this really signed by target.roster?
 	sig, err := s.startBFT(bftFollowBlock, target.Roster, fs.ForwardLink.Hash, data)
 	if err != nil {
-		return errors.New("Couldn't get signature")
+		return errors.New("Couldn't get signature: " + err.Error())
 	}
 	log.Lvl1("Adding forward-link to", target.Index)
 	target.AddForward(&BlockLink{fs.ForwardLink.Hash, sig.Sig})
@@ -346,7 +618,7 @@ func (s *Service) getBlock(env *network.Envelope) {
 	if i, _ := sb.Roster.Search(s.ServerIdentity().ID); i < 0 {
 		log.Lvl3("Not responsible for that block, recursing")
 		var err error
-		sb, err = s.getUpdateBlock(sb, sb.Hash)
+		sb, err = s.callGetBlock(sb, sb.Hash)
 		if err != nil {
 			log.Error(err)
 			sb = nil
@@ -377,7 +649,7 @@ func (s *Service) getBlockReply(env *network.Envelope) {
 // is valid.
 func (s *Service) bftVerifyFollowBlock(msg []byte, data []byte) bool {
 	err := func() error {
-		_, fsInt, err := network.Unmarshal(data, s.Suite())
+		_, fsInt, err := network.Unmarshal(data, Suite)
 		if err != nil {
 			return err
 		}
@@ -426,10 +698,10 @@ func (s *Service) bftVerifyNewBlock(msg []byte, data []byte) bool {
 	srcHash := data[0:32]
 	prevSB := s.db.GetByID(srcHash)
 	if prevSB == nil {
-		log.Error("Didn't find src-skipblock")
+		log.Error(s.ServerIdentity(), "Didn't find src-skipblock")
 		return false
 	}
-	_, newSBi, err := network.Unmarshal(data[32:], s.Suite())
+	_, newSBi, err := network.Unmarshal(data[32:], Suite)
 	if err != nil {
 		log.Error("Couldn't unmarshal SkipBlock", data)
 		return false
@@ -475,6 +747,10 @@ func (s *Service) propagateSkipBlock(msg network.Message) {
 	for _, sb := range sbs.SkipBlocks {
 		if err := sb.VerifyForwardSignatures(); err != nil {
 			log.Error(err)
+			return
+		}
+		if !s.blockIsFriendly(sb) {
+			log.Lvlf2("%s: block is not friendly: %x", s.ServerIdentity(), sb.Hash)
 			return
 		}
 		s.db.Store(sb)
@@ -549,7 +825,7 @@ func (s *Service) addForwardLink(src, dst *SkipBlock) error {
 	log.Lvlf3("%s adds forward-link to %s: %d->%d - fwlinks:%v", s.ServerIdentity(),
 		roster.List, src.Index, dst.Index, fwl)
 	if len(fwl) > 0 {
-		return errors.New("Forward-link got signed during our signing")
+		return errors.New("forward-link got signed during our signing")
 	}
 	src.ForwardLink = []*BlockLink{fwd}
 	if err = src.VerifyForwardSignatures(); err != nil {
@@ -560,22 +836,54 @@ func (s *Service) addForwardLink(src, dst *SkipBlock) error {
 
 // startBFT starts a BFT-protocol with the given parameters.
 func (s *Service) startBFT(proto string, roster *onet.Roster, msg, data []byte) (*bftcosi.BFTSignature, error) {
+	tree := roster.GenerateNaryTreeWithRoot(2, s.ServerIdentity())
+	if tree == nil {
+		return nil, errors.New("couldn't form tree")
+	}
+	node, err := s.CreateProtocol(proto, tree)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create new node: %s", err.Error())
+	}
+	root := node.(*bftcosi.ProtocolBFTCoSi)
+
 	switch len(roster.List) {
 	case 0:
-		return nil, errors.New("Found empty Roster")
+		return nil, errors.New("found empty Roster")
 	case 1:
-		return nil, errors.New("Need more than 1 entry for Roster")
+		pubs := []kyber.Point{s.ServerIdentity().Public}
+		co := crypto.NewCosi(Suite, root.Private(), pubs)
+		co.CreateCommitment(Suite.RandomStream())
+		co.CreateChallenge(msg)
+		co.CreateResponse()
+		// This is when using kyber-cosi
+		// r, c := cosi.Commit(Suite, random.Stream)
+		// ch, err := cosi.Challenge(Suite, c, s.ServerIdentity().Public, msg)
+		// if err != nil {
+		// 	return nil, errors.New("couldn't create cosi-signature: " + err.Error())
+		// }
+		// resp, err := cosi.Response(Suite, root.Private(), r, ch)
+		// if err != nil {
+		// 	return nil, errors.New("couldn't create cosi-signature: " + err.Error())
+		// }
+		// coSig, err := cosi.Sign(Suite, c, resp, nil)
+		// if err != nil {
+		// 	return nil, errors.New("couldn't create cosi-signature: " + err.Error())
+		// }
+		sig := &bftcosi.BFTSignature{
+			Msg:        msg,
+			Sig:        co.Signature(),
+			Exceptions: []bftcosi.Exception{},
+		}
+		if crypto.VerifySignature(Suite, pubs, msg, sig.Sig) != nil {
+			return nil, errors.New("failed in cosi")
+		}
+		return sig, nil
+		//return nil, errors.New("need more than 1 entry for Roster")
 	}
 
 	// Start the protocol
-	tree := roster.GenerateNaryTreeWithRoot(2, s.ServerIdentity())
-	node, err := s.CreateProtocol(proto, tree)
-	if err != nil {
-		return nil, fmt.Errorf("Couldn't create new node: %s", err.Error())
-	}
 
 	// Register the function generating the protocol instance
-	root := node.(*bftcosi.ProtocolBFTCoSi)
 	root.Msg = msg
 	root.Data = data
 
@@ -590,17 +898,17 @@ func (s *Service) startBFT(proto string, roster *onet.Roster, msg, data []byte) 
 	case <-done:
 		sig = root.Signature()
 		if sig.Sig == nil {
-			return nil, errors.New("Couldn't sign forward-link")
+			return nil, errors.New("couldn't sign forward-link")
 		}
 		return sig, nil
 	case <-time.After(time.Second * 60):
-		return nil, errors.New("Timed out while waiting for signature")
+		return nil, errors.New("timed out while waiting for signature")
 	}
 }
 
 // notify other services about new/updated skipblock
 func (s *Service) startPropagation(blocks []*SkipBlock) error {
-	log.Lvl3("Starting to propagate for service", s.ServerIdentity())
+	log.Lvl2("Starting to propagate for service", s.ServerIdentity())
 	siMap := map[string]*network.ServerIdentity{}
 	// Add all rosters of all blocks - everybody needs to be contacted
 	for _, block := range blocks {
@@ -647,33 +955,149 @@ func (s *Service) newBlockEnd(sb *SkipBlock) bool {
 	return true
 }
 
+// authenticate searches if this node or any follower-node can verify the
+// schnorr-signature.
+func (s *Service) authenticate(msg []byte, sig []byte) bool {
+	if err := schnorr.Verify(Suite, s.ServerIdentity().Public, msg, sig); err == nil {
+		return true
+	}
+	s.storageMutex.Lock()
+	defer s.storageMutex.Unlock()
+	for _, fct := range s.Storage.Follow {
+		for _, si := range fct.Block.Roster.List {
+			if err := schnorr.Verify(Suite, si.Public, msg, sig); err == nil {
+				return true
+			}
+		}
+	}
+	for _, cl := range s.Storage.Clients {
+		if err := schnorr.Verify(Suite, cl, msg, sig); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// blockIsFriendly searches if all members of the new block are followed
+// by this node.
+func (s *Service) blockIsFriendly(sb *SkipBlock) bool {
+	s.storageMutex.Lock()
+	defer s.storageMutex.Unlock()
+
+	// If no skipchains are stored, allow everything
+	if len(s.Storage.Follow) == 0 {
+		return true
+	}
+	// accept all blocks that are already stored with us.
+	if s.db.GetByID(sb.SkipChainID()) != nil {
+		return true
+	}
+	// Also accept blocks that are stored in the FollowIDs
+	for _, id := range s.Storage.FollowIDs {
+		if id.Equal(sb.SkipChainID()) {
+			return true
+		}
+	}
+	// Accept if there is only one node in the roster or if we're the
+	// root.
+	index, _ := sb.Roster.Search(s.ServerIdentity().ID)
+	if len(sb.Roster.List) == 1 || index == 0 {
+		return true
+	}
+	for _, fct := range s.Storage.Follow {
+		err := fct.GetLatest(s.ServerIdentity(), s)
+		if err != nil {
+			log.Error(err)
+		}
+		if fct.AcceptNew(sb, s.ServerIdentity()) {
+			return true
+		}
+	}
+	return false
+}
+
+// willNodesAcceptBlock returns true if all nodes in the block accept it.
+func (s *Service) willNodesAcceptBlock(block *SkipBlock) bool {
+	pi, err := s.CreateProtocol(ProtocolExtendRoster, block.Roster.GenerateNaryTree(len(block.Roster.List)))
+	if err != nil {
+		return false
+	}
+	pisc := pi.(*ExtendRoster)
+	pisc.ExtendRoster = &ProtoExtendRoster{Block: *block}
+	pisc.Start()
+	sigs := <-pisc.ExtendRosterReply
+	// TODO: store the sigs in the skipblock to prove the other node was OK
+	return len(sigs) == len(block.Roster.List)-1
+}
+
+// saves all skipblocks.
+func (s *Service) save() {
+	s.storageMutex.Lock()
+	defer s.storageMutex.Unlock()
+	log.Lvl3("Saving service")
+	err := s.Save(storageKey, s.Storage)
+	if err != nil {
+		log.Error("Couldn't save file:", err)
+	}
+}
+
+// Tries to load the configuration and updates the data in the service
+// if it finds a valid config-file.
+func (s *Service) tryLoad() error {
+	msg, err := s.Load(storageKey)
+	if err != nil {
+		return err
+	}
+	if msg == nil {
+		return nil
+	}
+	var ok bool
+	s.Storage, ok = msg.(*Storage)
+	if !ok {
+		return errors.New("data of wrong type")
+	}
+	return nil
+}
+
 func newSkipchainService(c *onet.Context) (onet.Service, error) {
 	db, bucket := c.GetAdditionalBucket("skipblocks")
 	s := &Service{
 		ServiceProcessor: onet.NewServiceProcessor(c),
-		db:               &SkipBlockDB{db, bucket},
+		db:               NewSkipBlockDB(db, bucket),
+		Storage:          &Storage{},
 		verifiers:        map[VerifierID]SkipBlockVerifier{},
 		blockRequests:    make(map[string]chan *SkipBlock),
 		newBlocks:        make(map[string]bool),
 	}
-
+	if err := s.tryLoad(); err != nil {
+		return nil, err
+	}
 	s.lastSave = time.Now()
 	log.ErrFatal(s.RegisterHandlers(s.StoreSkipBlock, s.GetUpdateChain,
-		s.GetSingleBlock, s.GetSingleBlockByIndex, s.GetAllSkipchains))
-	s.RegisterProcessorFunc(network.MessageType(GetBlock{}),
+		s.GetSingleBlock, s.GetSingleBlockByIndex, s.GetAllSkipchains,
+		s.CreateLinkPrivate, s.Unlink, s.AddFollow, s.ListFollow,
+		s.DelFollow))
+	s.ServiceProcessor.RegisterProcessorFunc(network.MessageType(GetBlock{}),
 		s.getBlock)
-	s.RegisterProcessorFunc(network.MessageType(GetBlockReply{}),
+	s.ServiceProcessor.RegisterProcessorFunc(network.MessageType(GetBlockReply{}),
 		s.getBlockReply)
 
-	log.ErrFatal(s.registerVerification(VerifyBase, s.verifyFuncBase))
-	log.ErrFatal(s.registerVerification(VerifyRoot, s.verifyFuncRoot))
-	log.ErrFatal(s.registerVerification(VerifyControl, s.verifyFuncControl))
-	log.ErrFatal(s.registerVerification(VerifyData, s.verifyFuncData))
+	if err := s.registerVerification(VerifyBase, s.verifyFuncBase); err != nil {
+		return nil, err
+	}
+	if err := s.registerVerification(VerifyRoot, s.verifyFuncRoot); err != nil {
+		return nil, err
+	}
+	if err := s.registerVerification(VerifyControl, s.verifyFuncControl); err != nil {
+		return nil, err
+	}
+	if err := s.registerVerification(VerifyData, s.verifyFuncData); err != nil {
+		return nil, err
+	}
 
 	var err error
 	s.propagate, err = messaging.NewPropagationFunc(c, "SkipchainPropagate", s.propagateSkipBlock)
 	if err != nil {
-		log.Error(err)
 		return nil, err
 	}
 	s.ProtocolRegister(bftNewBlock, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -622,7 +622,10 @@ func TestService_CreateLinkPrivate(t *testing.T) {
 	server := servers[0]
 	service := local.GetServices(servers, skipchainSID)[0].(*Service)
 	require.Equal(t, 0, len(service.Storage.Clients))
-	_, cerr := service.CreateLinkPrivate(&CreateLinkPrivate{Public: servers[0].ServerIdentity.Public, Signature: []byte{}})
+	links, cerr := service.Listlink(&Listlink{})
+	log.ErrFatal(cerr)
+	require.Equal(t, 0, len(links.Publics))
+	_, cerr = service.CreateLinkPrivate(&CreateLinkPrivate{Public: servers[0].ServerIdentity.Public, Signature: []byte{}})
 	require.NotNil(t, cerr)
 	msg, err := server.ServerIdentity.Public.MarshalBinary()
 	require.Nil(t, err)
@@ -630,6 +633,10 @@ func TestService_CreateLinkPrivate(t *testing.T) {
 	log.ErrFatal(err)
 	_, cerr = service.CreateLinkPrivate(&CreateLinkPrivate{Public: servers[0].ServerIdentity.Public, Signature: sig})
 	log.ErrFatal(cerr)
+
+	links, cerr = service.Listlink(&Listlink{})
+	log.ErrFatal(cerr)
+	require.Equal(t, 1, len(links.Publics))
 }
 
 func TestService_Unlink(t *testing.T) {

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -1,34 +1,40 @@
 package skipchain
 
 import (
+	"testing"
+
 	"bytes"
+
+	"strconv"
+
 	"errors"
 	"fmt"
-	"strconv"
-	"sync"
-	"testing"
+
 	"time"
 
-	"github.com/dedis/cothority"
+	"sync"
+
+	"github.com/dedis/kyber"
+	"github.com/dedis/kyber/sign/schnorr"
+	"github.com/dedis/kyber/util/key"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
+	"github.com/dedis/onet/network"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-var tSuite = cothority.Suite
-
 func TestMain(m *testing.M) {
-	log.MainTest(m)
+	log.MainTest(m, 2)
 }
 
 func TestService_StoreSkipBlock(t *testing.T) {
 	// First create a roster to attach the data to it
-	local := onet.NewLocalTest(tSuite)
+	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	_, el, genService := local.MakeHELS(5, skipchainSID, tSuite)
+	_, el, genService := local.MakeHELS(5, skipchainSID, Suite)
 	service := genService.(*Service)
 
 	// Setting up root roster
@@ -44,7 +50,7 @@ func TestService_StoreSkipBlock(t *testing.T) {
 	genesis.Roster = sbRoot.Roster
 	genesis.VerifierIDs = VerificationStandard
 	blockCount := 0
-	psbr, err := service.StoreSkipBlock(&StoreSkipBlock{nil, genesis})
+	psbr, err := service.StoreSkipBlock(&StoreSkipBlock{LatestID: nil, NewBlock: genesis})
 	assert.Nil(t, err)
 	latest := psbr.Latest
 	// verify creation of GenesisBlock:
@@ -61,7 +67,7 @@ func TestService_StoreSkipBlock(t *testing.T) {
 	next.ParentBlockID = sbRoot.Hash
 	next.Roster = sbRoot.Roster
 	id := psbr.Latest.Hash
-	psbr2, err := service.StoreSkipBlock(&StoreSkipBlock{id, next})
+	psbr2, err := service.StoreSkipBlock(&StoreSkipBlock{LatestID: id, NewBlock: next})
 	assert.Nil(t, err)
 	log.Lvl2(psbr2)
 	if psbr2 == nil {
@@ -83,12 +89,12 @@ func TestService_StoreSkipBlock(t *testing.T) {
 func TestService_GetUpdateChain(t *testing.T) {
 	// Create a small chain and test whether we can get from one element
 	// of the chain to the last element with a valid slice of SkipBlocks
-	local := onet.NewLocalTest(tSuite)
+	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	conodes := 10
 	sbCount := conodes - 1
-	servers, el, gs := local.MakeHELS(conodes, skipchainSID, tSuite)
+	servers, el, gs := local.MakeHELS(conodes, skipchainSID, Suite)
 	s := gs.(*Service)
 
 	sbs := make([]*SkipBlock, sbCount)
@@ -102,8 +108,8 @@ func TestService_GetUpdateChain(t *testing.T) {
 		newSB.Roster = onet.NewRoster(el.List[i : i+2])
 		service := local.Services[servers[i].ServerIdentity.ID][skipchainSID].(*Service)
 		log.Lvl2("Doing skipblock", i, servers[i].ServerIdentity, newSB.Roster.List)
-		reply, err := service.StoreSkipBlock(&StoreSkipBlock{sbs[i-1].Hash, newSB})
-		assert.Nil(t, err)
+		reply, err := service.StoreSkipBlock(&StoreSkipBlock{LatestID: sbs[i-1].Hash, NewBlock: newSB})
+		require.Nil(t, err)
 		require.NotNil(t, reply.Latest)
 		sbs[i] = reply.Latest
 	}
@@ -148,10 +154,10 @@ func TestService_SetChildrenSkipBlock(t *testing.T) {
 	// How many nodes in Root
 	nodesRoot := 3
 
-	local := onet.NewLocalTest(tSuite)
+	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	hosts, el, genService := local.MakeHELS(nodesRoot, skipchainSID, tSuite)
+	hosts, el, genService := local.MakeHELS(nodesRoot, skipchainSID, Suite)
 	service := genService.(*Service)
 
 	// Setting up two chains and linking one to the other
@@ -205,10 +211,10 @@ func TestService_SetChildrenSkipBlock(t *testing.T) {
 }
 
 func TestService_MultiLevel(t *testing.T) {
-	local := onet.NewLocalTest(tSuite)
+	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, el, genService := local.MakeHELS(3, skipchainSID, tSuite)
+	servers, el, genService := local.MakeHELS(3, skipchainSID, Suite)
 	services := make([]*Service, len(servers))
 	for i, s := range local.GetServices(servers, skipchainSID) {
 		services[i] = s.(*Service)
@@ -230,7 +236,7 @@ func TestService_MultiLevel(t *testing.T) {
 				log.Lvl3("Adding block", sbi)
 				sb := NewSkipBlock()
 				sb.Roster = el
-				psbr, err := service.StoreSkipBlock(&StoreSkipBlock{latest.Hash, sb})
+				psbr, err := service.StoreSkipBlock(&StoreSkipBlock{LatestID: latest.Hash, NewBlock: sb})
 				log.ErrFatal(err)
 				latest = psbr.Latest
 				for n, i := range sb.BackLinkIDs {
@@ -256,11 +262,11 @@ func TestService_MultiLevel(t *testing.T) {
 }
 
 func TestService_Verification(t *testing.T) {
-	local := onet.NewLocalTest(tSuite)
+	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	sbLength := 4
-	_, el, genService := local.MakeHELS(sbLength, skipchainSID, tSuite)
+	_, el, genService := local.MakeHELS(sbLength, skipchainSID, Suite)
 	service := genService.(*Service)
 
 	elRoot := onet.NewRoster(el.List[0:3])
@@ -283,16 +289,16 @@ func TestService_Verification(t *testing.T) {
 	require.NotNil(t, sbInter)
 	log.Lvl1("Creating skipblock with sub-Roster from root")
 	elSub := onet.NewRoster(el.List[0:2])
-	sbInter, err = makeGenesisRosterArgs(service, elSub, sbRoot.Hash, sb.VerifierIDs, 1, 1)
+	_, err = makeGenesisRosterArgs(service, elSub, sbRoot.Hash, sb.VerifierIDs, 1, 1)
 	log.ErrFatal(err)
 }
 
 func TestService_SignBlock(t *testing.T) {
 	// Testing whether we sign correctly the SkipBlocks
-	local := onet.NewLocalTest(tSuite)
+	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	_, el, genService := local.MakeHELS(3, skipchainSID, tSuite)
+	_, el, genService := local.MakeHELS(3, skipchainSID, Suite)
 	service := genService.(*Service)
 
 	sbRoot, err := makeGenesisRosterArgs(service, el, nil, VerificationNone, 1, 1)
@@ -300,7 +306,7 @@ func TestService_SignBlock(t *testing.T) {
 	el2 := onet.NewRoster(el.List[0:2])
 	sb := NewSkipBlock()
 	sb.Roster = el2
-	reply, err := service.StoreSkipBlock(&StoreSkipBlock{sbRoot.Hash, sb})
+	reply, err := service.StoreSkipBlock(&StoreSkipBlock{LatestID: sbRoot.Hash, NewBlock: sb})
 	log.ErrFatal(err)
 	sbRoot = reply.Previous
 	sbSecond := reply.Latest
@@ -311,10 +317,10 @@ func TestService_SignBlock(t *testing.T) {
 
 func TestService_ProtocolVerification(t *testing.T) {
 	// Testing whether we sign correctly the SkipBlocks
-	local := onet.NewLocalTest(tSuite)
+	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	_, el, s := local.MakeHELS(3, skipchainSID, tSuite)
+	_, el, s := local.MakeHELS(3, skipchainSID, Suite)
 	s1 := s.(*Service)
 	count := make(chan bool, 3)
 	verifyFunc := func(newID []byte, newSB *SkipBlock) bool {
@@ -330,7 +336,7 @@ func TestService_ProtocolVerification(t *testing.T) {
 	log.ErrFatal(err)
 	sbNext := sbRoot.Copy()
 	sbNext.BackLinkIDs = []SkipBlockID{sbRoot.Hash}
-	_, cerr := s1.StoreSkipBlock(&StoreSkipBlock{sbRoot.Hash, sbNext})
+	_, cerr := s1.StoreSkipBlock(&StoreSkipBlock{LatestID: sbRoot.Hash, NewBlock: sbNext})
 	log.ErrFatal(cerr)
 	for i := 0; i < 3; i++ {
 		select {
@@ -344,7 +350,7 @@ func TestService_ProtocolVerification(t *testing.T) {
 func TestService_RegisterVerification(t *testing.T) {
 	// Testing whether we sign correctly the SkipBlocks
 	onet.RegisterNewService("ServiceVerify", newServiceVerify)
-	local := onet.NewLocalTest(tSuite)
+	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	hosts, el, s1 := makeHELS(local, 3)
@@ -371,7 +377,7 @@ func TestService_RegisterVerification(t *testing.T) {
 
 func TestService_StoreSkipBlock2(t *testing.T) {
 	nbrHosts := 3
-	local := onet.NewLocalTest(tSuite)
+	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	hosts, roster, s1 := makeHELS(local, nbrHosts)
@@ -387,15 +393,15 @@ func TestService_StoreSkipBlock2(t *testing.T) {
 			Data:          []byte{},
 		},
 	}
-	ssbr, cerr := s1.StoreSkipBlock(&StoreSkipBlock{nil, sbRoot})
+	ssbr, cerr := s1.StoreSkipBlock(&StoreSkipBlock{LatestID: nil, NewBlock: sbRoot})
 	log.ErrFatal(cerr)
 	roster2 := onet.NewRoster(roster.List[:nbrHosts-1])
 	log.Lvl1("Proposing roster", roster2)
 	sb1 := ssbr.Latest.Copy()
 	sb1.Roster = roster2
-	ssbr, cerr = s2.StoreSkipBlock(&StoreSkipBlock{sbRoot.Hash, sb1})
+	ssbr, cerr = s2.StoreSkipBlock(&StoreSkipBlock{LatestID: sbRoot.Hash, NewBlock: sb1})
 	require.NotNil(t, cerr)
-	ssbr, cerr = s1.StoreSkipBlock(&StoreSkipBlock{sbRoot.Hash, sb1})
+	ssbr, cerr = s1.StoreSkipBlock(&StoreSkipBlock{LatestID: sbRoot.Hash, NewBlock: sb1})
 	log.ErrFatal(cerr)
 	require.NotNil(t, ssbr.Latest)
 
@@ -409,21 +415,21 @@ func TestService_StoreSkipBlock2(t *testing.T) {
 		},
 	}
 	sbErr.ParentBlockID = SkipBlockID([]byte{1, 2, 3})
-	_, cerr = s1.StoreSkipBlock(&StoreSkipBlock{nil, sbErr})
+	_, cerr = s1.StoreSkipBlock(&StoreSkipBlock{LatestID: nil, NewBlock: sbErr})
 	require.NotNil(t, cerr)
-	_, cerr = s1.StoreSkipBlock(&StoreSkipBlock{sbErr.ParentBlockID, sbErr})
+	_, cerr = s1.StoreSkipBlock(&StoreSkipBlock{LatestID: sbErr.ParentBlockID, NewBlock: sbErr})
 	// Last successful log...
 	require.NotNil(t, cerr)
 
 	sbErr = ssbr.Latest.Copy()
-	_, cerr = s3.StoreSkipBlock(&StoreSkipBlock{ssbr.Latest.Hash, sbErr})
+	_, cerr = s3.StoreSkipBlock(&StoreSkipBlock{LatestID: ssbr.Latest.Hash, NewBlock: sbErr})
 	require.NotNil(t, cerr)
 }
 
 func TestService_StoreSkipBlockSpeed(t *testing.T) {
 	t.Skip("This is a hidden benchmark")
 	nbrHosts := 3
-	local := onet.NewLocalTest(tSuite)
+	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	_, roster, s1 := makeHELS(local, nbrHosts)
@@ -437,7 +443,7 @@ func TestService_StoreSkipBlockSpeed(t *testing.T) {
 			Data:          []byte{},
 		},
 	}
-	ssbrep, cerr := s1.StoreSkipBlock(&StoreSkipBlock{nil, sbRoot})
+	ssbrep, cerr := s1.StoreSkipBlock(&StoreSkipBlock{LatestID: nil, NewBlock: sbRoot})
 	log.ErrFatal(cerr)
 
 	last := time.Now()
@@ -445,15 +451,15 @@ func TestService_StoreSkipBlockSpeed(t *testing.T) {
 		now := time.Now()
 		log.Lvl3(i, now.Sub(last))
 		last = now
-		ssbrep, cerr = s1.StoreSkipBlock(&StoreSkipBlock{ssbrep.Latest.Hash,
-			sbRoot})
+		ssbrep, cerr = s1.StoreSkipBlock(&StoreSkipBlock{LatestID: ssbrep.Latest.Hash,
+			NewBlock: sbRoot})
 		log.ErrFatal(cerr)
 	}
 }
 
 func TestService_ParallelStore(t *testing.T) {
 	nbrRoutines := 10
-	local := onet.NewLocalTest(tSuite)
+	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	_, roster, s1 := makeHELS(local, 3)
@@ -465,7 +471,7 @@ func TestService_ParallelStore(t *testing.T) {
 			Data:          []byte{},
 		},
 	}
-	ssbrep, cerr := s1.StoreSkipBlock(&StoreSkipBlock{nil, sbRoot})
+	ssbrep, cerr := s1.StoreSkipBlock(&StoreSkipBlock{LatestID: nil, NewBlock: sbRoot})
 	log.ErrFatal(cerr)
 
 	wg := &sync.WaitGroup{}
@@ -475,7 +481,7 @@ func TestService_ParallelStore(t *testing.T) {
 			cl := NewClient()
 			block := sbRoot.Copy()
 			for {
-				_, cerr := s1.StoreSkipBlock(&StoreSkipBlock{latest.Hash, block})
+				_, cerr := s1.StoreSkipBlock(&StoreSkipBlock{LatestID: latest.Hash, NewBlock: block})
 				if cerr == nil {
 					log.Lvl1("Done with", i)
 					wg.Done()
@@ -500,10 +506,10 @@ func TestService_ParallelStore(t *testing.T) {
 
 func TestService_Propagation(t *testing.T) {
 	nbrNodes := 100
-	local := onet.NewLocalTest(tSuite)
+	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, ro, genService := local.MakeHELS(nbrNodes, skipchainSID, tSuite)
+	servers, ro, genService := local.MakeHELS(nbrNodes, skipchainSID, Suite)
 	services := make([]*Service, len(servers))
 	for i, s := range local.GetServices(servers, skipchainSID) {
 		services[i] = s.(*Service)
@@ -514,17 +520,258 @@ func TestService_Propagation(t *testing.T) {
 		3, 3)
 	log.ErrFatal(err)
 	require.NotNil(t, sbRoot)
-	_, err = service.StoreSkipBlock(&StoreSkipBlock{sbRoot.Hash, sbRoot})
+	_, err = service.StoreSkipBlock(&StoreSkipBlock{LatestID: sbRoot.Hash, NewBlock: sbRoot})
 	log.ErrFatal(err)
+}
+
+func TestService_AddFollow(t *testing.T) {
+	local := onet.NewLocalTest(Suite)
+	defer waitPropagationFinished(t, local)
+	defer local.CloseAll()
+	servers, ro, _ := local.MakeHELS(3, skipchainSID, Suite)
+	services := make([]*Service, len(servers))
+	for i, s := range local.GetServices(servers, skipchainSID) {
+		services[i] = s.(*Service)
+		services[i].Storage.Clients = []kyber.Point{services[i].ServerIdentity().Public}
+	}
+	service := services[0]
+	sb := NewSkipBlock()
+	sb.Roster = onet.NewRoster([]*network.ServerIdentity{ro.List[0]})
+	sb.MaximumHeight = 2
+	sb.BaseHeight = 2
+	sb.Data = []byte{}
+	sb.VerifierIDs = []VerifierID{VerifyBase}
+	ssb := &StoreSkipBlock{LatestID: nil, NewBlock: sb, Signature: nil}
+
+	_, cerr := service.StoreSkipBlock(ssb)
+	require.NotNil(t, cerr)
+
+	// Wrong server signature
+	priv0 := local.GetPrivate(servers[0])
+	priv1 := local.GetPrivate(servers[1])
+	sig, err := schnorr.Sign(Suite, priv1, ssb.NewBlock.CalculateHash())
+	log.ErrFatal(err)
+	ssb.Signature = &sig
+	_, cerr = service.StoreSkipBlock(ssb)
+	require.NotNil(t, cerr)
+
+	// Correct server signature
+	log.Lvl2("correct server signature")
+	sig, err = schnorr.Sign(Suite, priv0, ssb.NewBlock.CalculateHash())
+	log.ErrFatal(err)
+	ssb.Signature = &sig
+	master0, cerr := service.StoreSkipBlock(ssb)
+	log.ErrFatal(cerr)
+
+	// Not fully authenticated roster
+	log.Lvl2("2nd roster is not registered")
+	services[1].Storage.FollowIDs = []SkipBlockID{[]byte{0}}
+	ssb.LatestID = master0.Latest.Hash
+	sb = sb.Copy()
+	ssb.NewBlock = sb
+	sb.Roster = onet.NewRoster([]*network.ServerIdentity{ro.List[0], ro.List[1]})
+	sig, err = schnorr.Sign(Suite, priv0, ssb.NewBlock.CalculateHash())
+	log.ErrFatal(err)
+	ssb.Signature = &sig
+	require.Equal(t, 0, services[1].db.Length())
+	_, cerr = service.StoreSkipBlock(ssb)
+	require.NotNil(t, cerr)
+	require.Equal(t, 0, services[1].db.Length())
+
+	// make other services follow skipchain
+	log.Lvl2("correct 2 node signing")
+	services[1].Storage.Follow = []FollowChainType{{
+		Block:    master0.Latest,
+		NewChain: NewChainAnyNode,
+	}}
+	sig, err = schnorr.Sign(Suite, priv0, ssb.NewBlock.CalculateHash())
+	log.ErrFatal(err)
+	ssb.Signature = &sig
+	master1, cerr := service.StoreSkipBlock(ssb)
+	log.ErrFatal(cerr)
+
+	// update skipblock and follow the skipblock
+	log.Lvl2("3 node signing with block update")
+	services[2].Storage.Follow = []FollowChainType{{
+		Block:    master0.Latest,
+		NewChain: NewChainAnyNode,
+	}}
+	sb = sb.Copy()
+	sb.Roster = onet.NewRoster([]*network.ServerIdentity{ro.List[1], ro.List[0], ro.List[2]})
+	sb.Hash = sb.CalculateHash()
+	ssb.NewBlock = sb
+	ssb.LatestID = master1.Latest.Hash
+	sig, err = schnorr.Sign(Suite, priv1, ssb.NewBlock.CalculateHash())
+	log.ErrFatal(err)
+	ssb.Signature = &sig
+	sbs, err := service.db.getAll()
+	log.ErrFatal(err)
+	for _, sb := range sbs {
+		services[1].db.Store(sb)
+	}
+	master2, cerr := services[1].StoreSkipBlock(ssb)
+	log.ErrFatal(cerr)
+	require.True(t, services[1].db.GetByID(master1.Latest.Hash).ForwardLink[0].Hash.Equal(master2.Latest.Hash))
+}
+
+func TestService_CreateLinkPrivate(t *testing.T) {
+	local := onet.NewLocalTest(Suite)
+	defer waitPropagationFinished(t, local)
+	defer local.CloseAll()
+	servers, _, _ := local.MakeHELS(3, skipchainSID, Suite)
+	server := servers[0]
+	service := local.GetServices(servers, skipchainSID)[0].(*Service)
+	require.Equal(t, 0, len(service.Storage.Clients))
+	_, cerr := service.CreateLinkPrivate(&CreateLinkPrivate{Public: servers[0].ServerIdentity.Public, Signature: []byte{}})
+	require.NotNil(t, cerr)
+	msg, err := server.ServerIdentity.Public.MarshalBinary()
+	require.Nil(t, err)
+	sig, err := schnorr.Sign(Suite, local.GetPrivate(servers[0]), msg)
+	log.ErrFatal(err)
+	_, cerr = service.CreateLinkPrivate(&CreateLinkPrivate{Public: servers[0].ServerIdentity.Public, Signature: sig})
+	log.ErrFatal(cerr)
+}
+
+func TestService_Unlink(t *testing.T) {
+	local := onet.NewLocalTest(Suite)
+	defer waitPropagationFinished(t, local)
+	defer local.CloseAll()
+	servers, _, _ := local.MakeHELS(3, skipchainSID, Suite)
+	server := servers[0]
+	service := local.GetServices(servers, skipchainSID)[0].(*Service)
+
+	kp := key.NewKeyPair(Suite)
+	msg, _ := kp.Public.MarshalBinary()
+	sig, err := schnorr.Sign(Suite, local.GetPrivate(servers[0]), msg)
+	log.ErrFatal(err)
+	_, cerr := service.CreateLinkPrivate(&CreateLinkPrivate{Public: kp.Public, Signature: sig})
+	log.ErrFatal(cerr)
+	require.Equal(t, 1, len(service.Storage.Clients))
+
+	// Wrong signature and wrong public key
+	_, cerr = service.Unlink(&Unlink{
+		Public:    servers[0].ServerIdentity.Public,
+		Signature: sig,
+	})
+	require.NotNil(t, cerr)
+	require.Equal(t, 1, len(service.Storage.Clients))
+
+	// Inexistant public key
+	msg, _ = server.ServerIdentity.Public.MarshalBinary()
+	msg = append([]byte("unlink:"), msg...)
+	sig, err = schnorr.Sign(Suite, local.GetPrivate(servers[0]), msg)
+	_, cerr = service.Unlink(&Unlink{
+		Public:    servers[0].ServerIdentity.Public,
+		Signature: sig,
+	})
+	require.NotNil(t, cerr)
+	require.Equal(t, 1, len(service.Storage.Clients))
+
+	// Wrong signature
+	msg, _ = kp.Public.MarshalBinary()
+	msg = append([]byte("unlink:"), msg...)
+	sig, err = schnorr.Sign(Suite, local.GetPrivate(servers[0]), msg)
+	_, cerr = service.Unlink(&Unlink{
+		Public:    kp.Public,
+		Signature: sig,
+	})
+	require.NotNil(t, cerr)
+	require.Equal(t, 1, len(service.Storage.Clients))
+
+	// Correct signautre and existing public key
+	msg, _ = kp.Public.MarshalBinary()
+	msg = append([]byte("unlink:"), msg...)
+	sig, err = schnorr.Sign(Suite, kp.Secret, msg)
+	_, cerr = service.Unlink(&Unlink{
+		Public:    kp.Public,
+		Signature: sig,
+	})
+	require.Nil(t, cerr)
+	require.Equal(t, 0, len(service.Storage.Clients))
+}
+
+func TestService_DelFollow(t *testing.T) {
+	local := onet.NewLocalTest(Suite)
+	defer waitPropagationFinished(t, local)
+	defer local.CloseAll()
+	servers, _, _ := local.MakeHELS(3, skipchainSID, Suite)
+	service := local.GetServices(servers, skipchainSID)[0].(*Service)
+
+	privWrong := key.NewKeyPair(Suite).Secret
+	priv := setupFollow(service)
+	iddel := []byte{0}
+	msg := append([]byte("delfollow:"), iddel...)
+
+	// Test wrong signature
+	sig, err := schnorr.Sign(Suite, privWrong, msg)
+	log.ErrFatal(err)
+	_, cerr := service.DelFollow(&DelFollow{SkipchainID: iddel, Signature: sig})
+	require.NotNil(t, cerr)
+	require.Equal(t, 2, len(service.Storage.FollowIDs))
+
+	sig, err = schnorr.Sign(Suite, priv, msg)
+	log.ErrFatal(err)
+	_, cerr = service.DelFollow(&DelFollow{SkipchainID: iddel, Signature: sig})
+	require.Nil(t, cerr)
+	require.Equal(t, 1, len(service.Storage.FollowIDs))
+
+	// Test removal of Follow
+	iddel = []byte{2}
+	msg = append([]byte("delfollow:"), iddel...)
+	sig, err = schnorr.Sign(Suite, priv, msg)
+	log.ErrFatal(err)
+	_, cerr = service.DelFollow(&DelFollow{SkipchainID: iddel, Signature: sig})
+	require.Nil(t, cerr)
+	require.Equal(t, 1, len(service.Storage.Follow))
+}
+
+func TestService_ListFollow(t *testing.T) {
+	local := onet.NewLocalTest(Suite)
+	defer waitPropagationFinished(t, local)
+	defer local.CloseAll()
+	servers, _, _ := local.MakeHELS(3, skipchainSID, Suite)
+	service := local.GetServices(servers, skipchainSID)[0].(*Service)
+
+	priv := setupFollow(service)
+
+	// Check wrong signature
+	msg, err := servers[1].ServerIdentity.Public.MarshalBinary()
+	log.ErrFatal(err)
+	msg = append([]byte("listfollow:"), msg...)
+	sig, err := schnorr.Sign(Suite, priv, msg)
+	log.ErrFatal(err)
+	lf, cerr := service.ListFollow(&ListFollow{Signature: sig})
+	require.NotNil(t, cerr)
+
+	msg, err = servers[0].ServerIdentity.Public.MarshalBinary()
+	log.ErrFatal(err)
+	msg = append([]byte("listfollow:"), msg...)
+	sig, err = schnorr.Sign(Suite, priv, msg)
+	log.ErrFatal(err)
+	lf, cerr = service.ListFollow(&ListFollow{Signature: sig})
+	require.Nil(t, cerr)
+	require.Equal(t, 2, len(*lf.Follow))
+	require.Equal(t, 2, len(*lf.FollowIDs))
+}
+
+func setupFollow(s *Service) kyber.Scalar {
+	kp := key.NewKeyPair(Suite)
+	s.Storage.Clients = []kyber.Point{kp.Public}
+	s.Storage.FollowIDs = []SkipBlockID{{0}, {1}}
+	s.Storage.Follow = []FollowChainType{
+		{Block: &SkipBlock{SkipBlockFix: &SkipBlockFix{Index: 0, Data: []byte{}}, Hash: []byte{2}}},
+		{Block: &SkipBlock{SkipBlockFix: &SkipBlockFix{Index: 0, Data: []byte{}}, Hash: []byte{3}}},
+	}
+	return kp.Secret
 }
 
 func checkMLForwardBackward(service *Service, root *SkipBlock, base, height int) error {
 	genesis := service.db.GetByID(root.Hash)
 	if genesis == nil {
-		return errors.New("Didn't find genesis-block in service")
+		return errors.New("didn't find genesis-block in service")
 	}
 	if len(genesis.ForwardLink) != height {
-		return errors.New("Genesis-block doesn't have forward-links of " +
+		return errors.New("genesis-block doesn't have forward-links of " +
 			strconv.Itoa(height))
 	}
 	return nil
@@ -539,7 +786,7 @@ func checkMLUpdate(service *Service, root, latest *SkipBlock, base, height int) 
 	updates := chain.(*GetUpdateChainReply).Update
 	genesis := updates[0]
 	if len(genesis.ForwardLink) != height {
-		return errors.New("Genesis-block doesn't have height " + strconv.Itoa(height))
+		return errors.New("genesis-block doesn't have height " + strconv.Itoa(height))
 	}
 	if len(updates[1].BackLinkIDs) != height {
 		return errors.New("Second block doesn't have correct number of backlinks")
@@ -577,11 +824,7 @@ func (sv *ServiceVerify) NewProtocol(tn *onet.TreeNodeInstance, c *onet.GenericC
 
 func newServiceVerify(c *onet.Context) (onet.Service, error) {
 	sv := &ServiceVerify{}
-	err := RegisterVerification(c, ServiceVerifier, sv.Verify)
-	if err != nil {
-		log.Error(err)
-		return nil, err
-	}
+	log.ErrFatal(RegisterVerification(c, ServiceVerifier, sv.Verify))
 	return sv, nil
 }
 
@@ -594,7 +837,7 @@ func makeGenesisRosterArgs(s *Service, el *onet.Roster, parent SkipBlockID,
 	sb.BaseHeight = base
 	sb.ParentBlockID = parent
 	sb.VerifierIDs = vid
-	psbr, err := s.StoreSkipBlock(&StoreSkipBlock{nil, sb})
+	psbr, err := s.StoreSkipBlock(&StoreSkipBlock{LatestID: nil, NewBlock: sb})
 	if err != nil {
 		return nil, err
 	}

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestSkipBlock_GetResponsible(t *testing.T) {
-	l := onet.NewTCPTest(tSuite)
+	l := onet.NewTCPTest(Suite)
 	_, roster, _ := l.GenTree(3, true)
 	defer l.CloseAll()
 
@@ -59,7 +59,7 @@ func TestSkipBlock_GetResponsible(t *testing.T) {
 }
 
 func TestSkipBlock_VerifySignatures(t *testing.T) {
-	l := onet.NewTCPTest(tSuite)
+	l := onet.NewTCPTest(Suite)
 	_, roster3, _ := l.GenTree(3, true)
 	defer l.CloseAll()
 	roster2 := onet.NewRoster(roster3.List[0:2])
@@ -99,7 +99,7 @@ func TestSkipBlock_Hash1(t *testing.T) {
 }
 
 func TestSkipBlock_Hash2(t *testing.T) {
-	local := onet.NewLocalTest(tSuite)
+	local := onet.NewLocalTest(Suite)
 	hosts, el, _ := local.GenTree(2, false)
 	defer local.CloseAll()
 	sbd1 := NewSkipBlock()
@@ -141,26 +141,26 @@ func TestBlockLink_Copy(t *testing.T) {
 }
 
 func TestSign(t *testing.T) {
-	l := onet.NewTCPTest(tSuite)
+	l := onet.NewTCPTest(Suite)
 	servers, roster, _ := l.GenTree(10, true)
 	msg := sha512.New().Sum(nil)
 	sig, err := sign(msg, servers, l)
 	log.ErrFatal(err)
-	log.ErrFatal(sig.Verify(tSuite, roster.Publics()))
+	log.ErrFatal(sig.Verify(Suite, roster.Publics()))
 	sig.Msg = sha512.New().Sum([]byte{1})
-	require.NotNil(t, sig.Verify(tSuite, roster.Publics()))
+	require.NotNil(t, sig.Verify(Suite, roster.Publics()))
 	defer l.CloseAll()
 }
 
 func sign(msg SkipBlockID, servers []*onet.Server, l *onet.LocalTest) (*bftcosi.BFTSignature, error) {
-	aggScalar := tSuite.Scalar().Zero()
-	aggPoint := tSuite.Point().Null()
+	aggScalar := Suite.Scalar().Zero()
+	aggPoint := Suite.Point().Null()
 	for _, s := range servers {
 		aggScalar.Add(aggScalar, l.GetPrivate(s))
 		aggPoint.Add(aggPoint, s.ServerIdentity.Public)
 	}
-	rand := tSuite.Scalar().Pick(tSuite.RandomStream())
-	comm := tSuite.Point().Mul(rand, nil)
+	rand := Suite.Scalar().Pick(Suite.RandomStream())
+	comm := Suite.Point().Mul(rand, nil)
 	sigC, err := comm.MarshalBinary()
 	if err != nil {
 		return nil, err
@@ -170,8 +170,8 @@ func sign(msg SkipBlockID, servers []*onet.Server, l *onet.LocalTest) (*bftcosi.
 	aggPoint.MarshalTo(hash)
 	hash.Write(msg)
 	challBuff := hash.Sum(nil)
-	chall := tSuite.Scalar().SetBytes(challBuff)
-	resp := tSuite.Scalar().Mul(aggScalar, chall)
+	chall := Suite.Scalar().SetBytes(challBuff)
+	resp := Suite.Scalar().Mul(aggScalar, chall)
 	resp = resp.Add(rand, resp)
 	sigR, err := resp.MarshalBinary()
 	if err != nil {


### PR DESCRIPTION
This is an implementation of #949 with the current skipchain. I'd like to take this as a base for the documentation and the new storage-system.

It also adds a `link` command to restrict who is allowed to communicate with the service:
`scmgr admin link` automatically setting up a private/public key pair and linking that to the skipchain-service

Closes #949
Closes #981 
