### PR TITLE
running pop-test with DEBUG_COLOR=on

### DIFF
--- a/pop/app.go
+++ b/pop/app.go
@@ -101,7 +101,7 @@ func main() {
 		log.SetDebugVisible(c.Int("debug"))
 		return nil
 	}
-	appCli.Run(os.Args)
+	log.ErrFatal(appCli.Run(os.Args))
 }
 
 // links this pop to a cothority
@@ -127,10 +127,11 @@ func orgLink(c *cli.Context) error {
 			log.Info("Please read PIN in server-log")
 			return nil
 		}
+		log.Print()
 		return err
 	}
 	cfg.Address = addr
-	log.Lvl3("Successfully linked with", addr)
+	log.Info("Successfully linked with", addr)
 	cfg.write()
 	return nil
 }

--- a/pop/service/service.go
+++ b/pop/service/service.go
@@ -402,7 +402,7 @@ func (s Service) MergeConfigReply(req *network.Envelope) {
 				return nil
 			}
 			if mcrVal.PopStatus < PopStatusOK {
-				log.Error("Wrong pop-status:", mcrVal.PopStatus)
+				log.Lvl2("Wrong pop-status:", mcrVal.PopStatus)
 				return mcrVal
 			}
 			if mcrVal.Final == nil {
@@ -545,7 +545,7 @@ func (s *Service) bftVerifyFinal(Msg []byte, Data []byte) bool {
 	var ok bool
 
 	if fs, ok = s.data.Finals[string(final.Desc.Hash())]; !ok {
-		log.Error("final Statement not found")
+		log.Error(s.ServerIdentity(), "final Statement not found")
 		return false
 	}
 

--- a/pop/test.sh
+++ b/pop/test.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 DBG_TEST=1
-DBG_APP=3
+DBG_APP=2
+# DBG_SRV=2
+
 NBR_CLIENTS=4
 NBR_SERVERS=3
 NBR_SERVERS_GROUP=$NBR_SERVERS
@@ -226,7 +228,6 @@ testAtJoin(){
 	runDbgCl 2 3 org final  ${pop_hash[2]} | tail > final2.toml
 	runCl 3 org final  ${pop_hash[3]}
 	runDbgCl 2 1 org final  ${pop_hash[3]} | tail > final3.toml
-	cat final1.toml
 
 	testFail runCl 1 attendee join -y
 	testFail runCl 1 attendee join -y ${priv[1]}
@@ -388,7 +389,7 @@ mkPopConfig(){
 	local n
 	for (( n=1; n<=$1; n++ ))
 	do
-		rm pop_desc$n.toml
+		rm -f pop_desc$n.toml
 		cat << EOF > pop_desc$n.toml
 Name = "Proof-of-Personhood Party"
 DateTime = "2017-08-08 15:00 UTC"
@@ -404,7 +405,7 @@ EOF
 			sed -n "$((4*$m-3)),$((4*$m))p" public.toml >> pop_desc$n.toml
 		fi
 	done
-	rm pop_merge.toml
+	rm -f pop_merge.toml
 	for (( n=1; n<=$2; n++ ))
 	do
 		cat << EOF >> pop_merge.toml
@@ -474,8 +475,11 @@ runCl(){
 runDbgCl(){
 	local DBG=$1
 	local CFG=cl$2
+	local COLOR=$DEBUG_COLOR
+	export DEBUG_COLOR=""
 	shift 2
 	./$APP -d $DBG -c $CFG $@
+	export DEBUG_COLOR=$COLOR
 }
 
 main

--- a/pop/test.sh
+++ b/pop/test.sh
@@ -475,11 +475,8 @@ runCl(){
 runDbgCl(){
 	local DBG=$1
 	local CFG=cl$2
-	local COLOR=$DEBUG_COLOR
-	export DEBUG_COLOR=""
 	shift 2
-	./$APP -d $DBG -c $CFG $@
-	export DEBUG_COLOR=$COLOR
+	DEBUG_COLOR="" ./$APP -d $DBG -c $CFG $@
 }
 
 main


### PR DESCRIPTION
When running the pop-tests and having DEBUG_COLOR=on, it fails, because there are ESC-characters at the end of the output.