### PR TITLE
Adapt to change in onet for no base64 in toml files

### DIFF
--- a/cisc/cisc.go
+++ b/cisc/cisc.go
@@ -211,7 +211,7 @@ func adminAdd(c *cli.Context) error {
 	h := cothority.Suite.Hash()
 	pubs := make([]kyber.Point, len(keys))
 	for i, k := range keys {
-		pub, err := encoding.String64ToPoint(cothority.Suite, k)
+		pub, err := encoding.StringHexToPoint(cothority.Suite, k)
 		if err != nil {
 			log.Error("Couldn't parse public key:", k)
 			return err
@@ -250,11 +250,11 @@ func adminAdd(c *cli.Context) error {
 func idKeyPair(c *cli.Context) error {
 	kp := key.NewKeyPair(cothority.Suite)
 
-	secStr, err := encoding.ScalarToString64(nil, kp.Secret)
+	secStr, err := encoding.ScalarToStringHex(nil, kp.Secret)
 	if err != nil {
 		return err
 	}
-	pubStr, err := encoding.PointToString64(nil, kp.Public)
+	pubStr, err := encoding.PointToStringHex(nil, kp.Public)
 	if err != nil {
 		return err
 	}
@@ -291,7 +291,7 @@ func idCreate(c *cli.Context) error {
 		typ = identity.PublicAuth
 		priv := c.Args().Get(1)
 		var err error
-		kp.Secret, err = encoding.String64ToScalar(cothority.Suite, priv)
+		kp.Secret, err = encoding.StringHexToScalar(cothority.Suite, priv)
 		if err != nil {
 			log.Error("Couldn't parse private key")
 			return err

--- a/pop/app.go
+++ b/pop/app.go
@@ -215,7 +215,7 @@ func orgPublic(c *cli.Context) error {
 	party, err := cfg.getPartybyHash(c.Args().Get(1))
 	log.ErrFatal(err)
 	for _, k := range keys {
-		pub, err := encoding.String64ToPoint(cothority.Suite, k)
+		pub, err := encoding.StringHexToPoint(cothority.Suite, k)
 		if err != nil {
 			log.Fatal("Couldn't parse public key:", k, err)
 		}
@@ -311,11 +311,11 @@ func orgMerge(c *cli.Context) error {
 // creates a new private/public pair
 func attCreate(c *cli.Context) error {
 	kp := key.NewKeyPair(cothority.Suite)
-	secStr, err := encoding.ScalarToString64(nil, kp.Secret)
+	secStr, err := encoding.ScalarToStringHex(nil, kp.Secret)
 	if err != nil {
 		return err
 	}
-	pubStr, err := encoding.PointToString64(nil, kp.Public)
+	pubStr, err := encoding.PointToStringHex(nil, kp.Public)
 	if err != nil {
 		return err
 	}
@@ -638,7 +638,7 @@ func decodeGroups(buf string) ([]*service.ShortDesc, error) {
 // TODO: Needs to be public in app package!!!
 // toServerIdentity converts this ServerToml struct to a ServerIdentity.
 func toServerIdentity(s *app.ServerToml, suite kyber.Group) (*network.ServerIdentity, error) {
-	public, err := encoding.String64ToPoint(suite, s.Public)
+	public, err := encoding.StringHexToPoint(suite, s.Public)
 	if err != nil {
 		return nil, err
 	}

--- a/pop/service/api.go
+++ b/pop/service/api.go
@@ -165,7 +165,7 @@ func newFinalStatementFromTomlStruct(fsToml *finalStatementToml) (*FinalStatemen
 	}
 	atts := []kyber.Point{}
 	for _, p := range fsToml.Attendees {
-		pub, err := encoding.String64ToPoint(cothority.Suite, p)
+		pub, err := encoding.StringHexToPoint(cothority.Suite, p)
 		if err != nil {
 			return nil, err
 		}
@@ -267,7 +267,7 @@ func newPopDescFromTomlStruct(descToml *popDescToml) (*PopDesc, error) {
 		if err != nil {
 			return nil, err
 		}
-		pub, err := encoding.String64ToPoint(cothority.Suite, s[3])
+		pub, err := encoding.StringHexToPoint(cothority.Suite, s[3])
 		if err != nil {
 			return nil, err
 		}
@@ -290,7 +290,7 @@ func newPopDescFromTomlStruct(descToml *popDescToml) (*PopDesc, error) {
 			if err != nil {
 				return nil, err
 			}
-			pub, err := encoding.String64ToPoint(cothority.Suite, s[3])
+			pub, err := encoding.StringHexToPoint(cothority.Suite, s[3])
 			if err != nil {
 				return nil, err
 			}
@@ -334,7 +334,7 @@ func (fs *FinalStatement) toTomlStruct() (*finalStatementToml, error) {
 	}
 	atts := make([]string, len(fs.Attendees))
 	for i, p := range fs.Attendees {
-		str, err := encoding.PointToString64(nil, p)
+		str, err := encoding.PointToStringHex(nil, p)
 		if err != nil {
 			return nil, err
 		}
@@ -478,7 +478,7 @@ func Equal(r1, r2 *onet.Roster) bool {
 func toToml(r *onet.Roster) ([][]string, error) {
 	rostr := make([][]string, len(r.List))
 	for i, si := range r.List {
-		str, err := encoding.PointToString64(nil, si.Public)
+		str, err := encoding.PointToStringHex(nil, si.Public)
 		if err != nil {
 			return nil, err
 		}
@@ -509,11 +509,11 @@ func newPopTokenFromTomlStruct(t *popTokenToml) (*PopToken, error) {
 	if err != nil {
 		return nil, err
 	}
-	token.Private, err = encoding.String64ToScalar(cothority.Suite, t.Private)
+	token.Private, err = encoding.StringHexToScalar(cothority.Suite, t.Private)
 	if err != nil {
 		return nil, err
 	}
-	token.Public, err = encoding.String64ToPoint(cothority.Suite, t.Public)
+	token.Public, err = encoding.StringHexToPoint(cothority.Suite, t.Public)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Automatically convert public.toml files using the migrate
feature of run_conode.sh.