### PR TITLE
App flag order

### DIFF
--- a/conode/conode.go
+++ b/conode/conode.go
@@ -47,18 +47,6 @@ func main() {
 	cliApp.Name = "conode"
 	cliApp.Usage = "run a cothority server"
 	cliApp.Version = Version
-	serverFlags := []cli.Flag{
-		cli.StringFlag{
-			Name:  "config, c",
-			Value: app.GetDefaultConfigFile(DefaultName),
-			Usage: "configuration file of the server",
-		},
-		cli.IntFlag{
-			Name:  "debug, d",
-			Value: 0,
-			Usage: "debug-level: 1 for terse, 5 for maximal",
-		},
-	}
 
 	cliApp.Commands = []cli.Command{
 		{
@@ -82,7 +70,6 @@ func main() {
 			Action: func(c *cli.Context) {
 				runServer(c)
 			},
-			Flags: serverFlags,
 		},
 		{
 			Name:      "check",
@@ -107,7 +94,10 @@ func main() {
 			Action: convert64,
 		},
 	}
-	cliApp.Flags = serverFlags
+	cliApp.Flags = []cli.Flag{
+		app.FlagDebug,
+		app.FlagConfig,
+	}
 	cliApp.Before = func(c *cli.Context) error {
 		log.SetDebugVisible(c.Int("debug"))
 		return nil
@@ -119,7 +109,7 @@ func main() {
 
 func runServer(ctx *cli.Context) {
 	// first check the options
-	config := ctx.String("config")
+	config := ctx.GlobalString("config")
 
 	app.RunServer(config, cothority.Suite)
 }

--- a/conode/run_conode.sh
+++ b/conode/run_conode.sh
@@ -37,7 +37,7 @@ main(){
 		exit 1
 	fi
 	gopath="$(go env GOPATH)"
-	
+
 	if ! echo $PATH | grep -q $gopath/bin; then
 		echo "Please add '$gopath/bin' to your '$PATH'"
 		PATH=$PATH:$gopath/bin
@@ -135,7 +135,7 @@ runLocal(){
 		if [ ! -d $co ]; then
 			echo -e "127.0.0.1:$((7000 + 2 * $n))\nConode_$n\n$co" | $CONODE_BIN setup
 		fi
-		$CONODE_BIN -d $DEBUG server -c $co/private.toml &
+		$CONODE_BIN -d $DEBUG -c $co/private.toml server &
 		cat $co/public.toml >> public.toml
 	done
 	sleep 1

--- a/conode/run_conode.sh
+++ b/conode/run_conode.sh
@@ -219,7 +219,7 @@ runPublic(){
 	if [ "$MEMLIMIT" ]; then
 		ulimit -Sv $(( MEMLIMIT * 1024 ))
 	fi
-	$CONODE_BIN -d $DEBUG server $ARGS | tee $LOG
+	$CONODE_BIN -d $DEBUG $ARGS server | tee $LOG
 	if [ "$MAIL" ]; then
 		tail -n 200 $LOG | $MAILCMD -s "conode-log from $(hostname):$(date)" $MAILADDR
 		echo "Waiting one minute before launching conode again"

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -243,7 +243,7 @@ func TestService_MultiLevel(t *testing.T) {
 								bl.ForwardLink[n].Hash.Equal(sb.Hash) {
 								break
 							}
-							time.Sleep(10 * time.Millisecond)
+							time.Sleep(200 * time.Millisecond)
 						}
 					}
 				}


### PR DESCRIPTION
Putting the `-c` and `-d` in front of the command.

Also fixes skipchain-error by following onet.