### PR TITLE
Make chain synchronisation fault tolerant

### DIFF
--- a/bftcosi/bftcosi.go
+++ b/bftcosi/bftcosi.go
@@ -21,7 +21,7 @@ import (
 	"github.com/dedis/onet/log"
 )
 
-const timeout = 1
+const defaultTimeout = 1 * time.Second
 
 // VerificationFunction can be passes to each protocol node. It will be called
 // (in a go routine) during the (start/handle) challenge prepare phase of the
@@ -42,6 +42,8 @@ type ProtocolBFTCoSi struct {
 	Msg []byte
 	// Data going along the msg to the verification
 	Data []byte
+	// Timeout is how long to wait while gathering commits.
+	Timeout time.Duration
 	// last block computed
 	lastBlock string
 	// refusal to sign for the commit phase or not. This flag is set during the
@@ -134,6 +136,7 @@ func NewBFTCoSiProtocol(n *onet.TreeNodeInstance, verify VerificationFunction) (
 		allowedExceptions:    nodes - (nodes+1)*2/3,
 		Msg:                  make([]byte, 0),
 		Data:                 make([]byte, 0),
+		Timeout:              defaultTimeout,
 	}
 
 	idx, _ := n.Roster().Search(bft.ServerIdentity().ID)
@@ -160,7 +163,6 @@ func (bft *ProtocolBFTCoSi) Start() error {
 		return err
 	}
 	go func() {
-		//time.Sleep(time.Second)
 		bft.startAnnouncement(RoundCommit)
 	}()
 	return nil
@@ -299,6 +301,7 @@ func (bft *ProtocolBFTCoSi) handleAnnouncement(msg announceChan) error {
 		return nil
 	}
 	if bft.IsLeaf() {
+		bft.Timeout = ann.Timeout
 		return bft.startCommitment(ann.TYPE)
 	}
 	return bft.sendToChildren(&ann)
@@ -582,7 +585,7 @@ func (bft *ProtocolBFTCoSi) readCommitChan(c chan commitChan, t RoundType) error
 					return nil
 				}
 			}
-		case <-time.After(time.Second * timeout):
+		case <-time.After(bft.Timeout):
 			// in some cases this might be ok because we accept a certain number of faults
 			// the caller is responsible for checking if enough messages are received
 			log.Error("timeout while trying to read commit messages")
@@ -621,7 +624,7 @@ func (bft *ProtocolBFTCoSi) readResponseChan(c chan responseChan, t RoundType) e
 					return nil
 				}
 			}
-		case <-time.After(time.Second * timeout):
+		case <-time.After(bft.Timeout):
 			log.Error("timeout while trying to read response messages")
 			return nil
 		}
@@ -631,7 +634,7 @@ func (bft *ProtocolBFTCoSi) readResponseChan(c chan responseChan, t RoundType) e
 // startAnnouncementPrepare create its announcement for the prepare round and
 // sends it down the tree.
 func (bft *ProtocolBFTCoSi) startAnnouncement(t RoundType) error {
-	bft.announceChan <- announceChan{Announce: Announce{TYPE: t}}
+	bft.announceChan <- announceChan{Announce: Announce{TYPE: t, Timeout: bft.Timeout}}
 	return nil
 }
 

--- a/bftcosi/bftcosi_test.go
+++ b/bftcosi/bftcosi_test.go
@@ -168,7 +168,6 @@ func TestCheckRefuseParallel(t *testing.T) {
 			log.Lvl3("Done with", n, fc)
 			wg.Done()
 		}(fc)
-		//wg.Wait()
 	}
 	wg.Wait()
 }

--- a/bftcosi/packets.go
+++ b/bftcosi/packets.go
@@ -3,6 +3,7 @@ package bftcosi
 import (
 	"crypto/sha512"
 	"errors"
+	"time"
 
 	"github.com/dedis/kyber"
 	"github.com/dedis/onet"
@@ -107,7 +108,7 @@ func (bs *BFTSignature) Verify(s network.Suite, publics []kyber.Point) error {
 // rounds)
 type Announce struct {
 	TYPE    RoundType
-	Timeout uint64
+	Timeout time.Duration
 }
 
 // announceChan is the type of the channel that will be used to catch

--- a/identity/struct.go
+++ b/identity/struct.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/pop/service"
@@ -16,7 +17,7 @@ import (
 )
 
 // How many msec to wait before a timeout is generated in the propagation
-const propagateTimeout = 10000
+const propagateTimeout = 10000 * time.Millisecond
 
 // ID represents one skipblock and corresponds to its Hash.
 type ID skipchain.SkipBlockID

--- a/messaging/propagate_test.go
+++ b/messaging/propagate_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
@@ -61,7 +62,7 @@ func propagate(t *testing.T, nbrNodes []int, nbrFailures []int) {
 
 		// start the propagation
 		log.Lvl2("Starting to propagate", reflect.TypeOf(msg))
-		children, err := propFuncs[0](el, msg, 1000)
+		children, err := propFuncs[0](el, msg, 1*time.Second)
 		log.ErrFatal(err)
 		if recvCount+nbrFailures[i] != n {
 			t.Fatal("Didn't get data-request")

--- a/pop/service/service.go
+++ b/pop/service/service.go
@@ -742,7 +742,7 @@ func (s *Service) signAndPropagate(final *FinalStatement, protoName string,
 			"Signing failed")
 	}
 
-	replies, err := s.PropagateFinalize(final.Desc.Roster, final, 10000)
+	replies, err := s.PropagateFinalize(final.Desc.Roster, final, 10000*time.Millisecond)
 	if err != nil {
 		return onet.NewClientError(err)
 	}

--- a/scmgr/test.sh
+++ b/scmgr/test.sh
@@ -193,6 +193,7 @@ testFailure() {
 	setupGenesis
 	testOK runSc skipchain block add --roster public.toml $ID
 
+	# -n: newest, so #4 is the one that is dead now
 	pkill -n conode
 	sleep .1
 	testOK runSc skipchain block add --roster public.toml $ID

--- a/skipchain/msgs.go
+++ b/skipchain/msgs.go
@@ -58,8 +58,8 @@ func init() {
 		&ProtoExtendSignature{},
 		&ProtoExtendRoster{},
 		&ProtoExtendRosterReply{},
-		&ProtoGetUpdate{},
-		&ProtoBlockReply{},
+		&ProtoGetBlocks{},
+		&ProtoGetBlocksReply{},
 	)
 }
 
@@ -194,26 +194,28 @@ type ProtoStructExtendRosterReply struct {
 	ProtoExtendRosterReply
 }
 
-// ProtoGetUpdate requests the latest block
-type ProtoGetUpdate struct {
-	SBID SkipBlockID
+// ProtoGetBlocks requests from another conode up to Count blocks,
+// traversing the skiplist forward from SBID.
+type ProtoGetBlocks struct {
+	SBID  SkipBlockID
+	Count int
 }
 
-// ProtoStructGetUpdate embeds the treenode
-type ProtoStructGetUpdate struct {
+// ProtoStructGetBlocks embeds the treenode
+type ProtoStructGetBlocks struct {
 	*onet.TreeNode
-	ProtoGetUpdate
+	ProtoGetBlocks
 }
 
-// ProtoBlockReply returns a block - either from update or from getblock
-type ProtoBlockReply struct {
-	SkipBlock *SkipBlock
+// ProtoGetiBlocksReply returns a slice of blocks - either from update or from getblock
+type ProtoGetBlocksReply struct {
+	SkipBlocks []*SkipBlock
 }
 
-// ProtoStructBlockReply embeds the treenode
-type ProtoStructBlockReply struct {
+// ProtoStructGetBlocksReply embeds the treenode
+type ProtoStructGetBlocksReply struct {
 	*onet.TreeNode
-	ProtoBlockReply
+	ProtoGetBlocksReply
 }
 
 // CreateLinkPrivate asks to store the given public key in the list of administrative

--- a/skipchain/msgs.go
+++ b/skipchain/msgs.go
@@ -199,6 +199,9 @@ type ProtoStructExtendRosterReply struct {
 type ProtoGetBlocks struct {
 	SBID  SkipBlockID
 	Count int
+	// Do the returned blocks skip forward in the chain, or
+	// are direct neighbors (not Skipping).
+	Skipping bool
 }
 
 // ProtoStructGetBlocks embeds the treenode
@@ -207,7 +210,7 @@ type ProtoStructGetBlocks struct {
 	ProtoGetBlocks
 }
 
-// ProtoGetiBlocksReply returns a slice of blocks - either from update or from getblock
+// ProtoGetBlocksReply returns a slice of blocks - either from update or from getblock
 type ProtoGetBlocksReply struct {
 	SkipBlocks []*SkipBlock
 }

--- a/skipchain/protocol.go
+++ b/skipchain/protocol.go
@@ -11,6 +11,7 @@ node will only use the `Handle`-methods, and not call `Start` again.
 */
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -25,13 +26,12 @@ import (
 // in a skipchain with a given id.
 const ProtocolExtendRoster = "scExtendRoster"
 
-// ProtocolGetUpdate asks a remote node to return the latest block of a
-// skipchain.
-const ProtocolGetUpdate = "scGetUpdate"
+// ProtocolGetBlocks asks a remote node for some blocks.
+const ProtocolGetBlocks = "scGetBlocks"
 
 func init() {
 	onet.GlobalProtocolRegister(ProtocolExtendRoster, NewProtocolExtendRoster)
-	onet.GlobalProtocolRegister(ProtocolGetUpdate, NewProtocolGetUpdate)
+	onet.GlobalProtocolRegister(ProtocolGetBlocks, NewProtocolGetBlocks)
 }
 
 // ExtendRoster is used for different communications in the skipchain-service.
@@ -53,13 +53,12 @@ type ExtendRoster struct {
 	doneChan        chan int
 }
 
-// GetUpdate needs to be configured by the service to hold the database
-// of all skipblocks.
-type GetUpdate struct {
+// GetBlocks is used for conodes to get blocks from each other.
+type GetBlocks struct {
 	*onet.TreeNodeInstance
 
-	GetUpdate      *ProtoGetUpdate
-	GetUpdateReply chan *SkipBlock
+	GetBlocks      *ProtoGetBlocks
+	GetBlocksReply chan []*SkipBlock
 	DB             *SkipBlockDB
 }
 
@@ -76,16 +75,16 @@ func NewProtocolExtendRoster(n *onet.TreeNodeInstance) (onet.ProtocolInstance, e
 	return t, t.RegisterHandlers(t.HandleExtendRoster, t.HandleExtendRosterReply)
 }
 
-// NewProtocolGetUpdate prepares for a protocol that fetches an update
-func NewProtocolGetUpdate(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-	t := &GetUpdate{
+// NewProtocolGetBlocks prepares for a protocol that fetches blocks.
+func NewProtocolGetBlocks(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
+	t := &GetBlocks{
 		TreeNodeInstance: n,
-		GetUpdateReply:   make(chan *SkipBlock),
+		GetBlocksReply:   make(chan []*SkipBlock),
 	}
-	return t, t.RegisterHandlers(t.HandleGetUpdate, t.HandleBlockReply)
+	return t, t.RegisterHandlers(t.HandleGetBlocks, t.HandleGetBlocksReply)
 }
 
-// Start sends the Announce-message to all children
+// Start sends the extend roster request to all of the children.
 func (p *ExtendRoster) Start() error {
 	log.Lvl3("Starting Protocol ExtendRoster")
 	errs := p.SendToChildrenInParallel(p.ExtendRoster)
@@ -95,10 +94,10 @@ func (p *ExtendRoster) Start() error {
 	return nil
 }
 
-// Start sends the Announce-message to all children
-func (p *GetUpdate) Start() error {
-	log.Lvl3("Starting Protocol GetUpdate")
-	return p.SendToChildren(p.GetUpdate)
+// Start sends the block request to all of the children.
+func (p *GetBlocks) Start() error {
+	log.Lvl3("Starting Protocol GetBlocks")
+	return p.SendToChildren(p.GetBlocks)
 }
 
 // HandleExtendRoster uses the stored followers to decide if we want to accept
@@ -219,26 +218,49 @@ func (p *ExtendRoster) HandleExtendRosterReply(r ProtoStructExtendRosterReply) e
 	return nil
 }
 
-// HandleGetUpdate searches for a skipblock and returns it if it is found.
-func (p *GetUpdate) HandleGetUpdate(msg ProtoStructGetUpdate) error {
+// HandleGetBlocks searches for a skipblock and returns it if it is found.
+func (p *GetBlocks) HandleGetBlocks(msg ProtoStructGetBlocks) error {
 	defer p.Done()
 
 	if p.DB == nil {
-		log.Lvl3(p.ServerIdentity(), "no block stored in Db")
-		return p.SendToParent(&ProtoBlockReply{})
+		return errors.New("no DB available")
 	}
 
-	sb, err := p.DB.GetLatest(p.DB.GetByID(msg.SBID))
-	if err != nil {
-		log.Error("couldn't get latest: " + err.Error())
-		return err
+	n := msg.Count
+	result := make([]*SkipBlock, 0, n)
+	next := msg.SBID
+	for n > 0 {
+		// TODO: see if this could be optimised by using multiple bucket.Get in a
+		// single transaction.
+		s := p.DB.GetByID(next)
+		if s == nil {
+			break
+		}
+		result = append(result, s)
+		n--
+
+		// Find the next one (or exit if we are at the latest)
+		if len(s.ForwardLink) == 0 {
+			break
+		}
+		next = s.ForwardLink[0].Hash()
 	}
-	return p.SendToParent(&ProtoBlockReply{SkipBlock: sb})
+	if len(result) == 0 {
+		// Not found, so send no reply. Another conode will
+		// hopefully find it and send it.
+		return nil
+	}
+
+	return p.SendToParent(&ProtoGetBlocksReply{SkipBlocks: result})
 }
 
-// HandleBlockReply contacts the service that a new block has arrived
-func (p *GetUpdate) HandleBlockReply(msg ProtoStructBlockReply) error {
-	defer p.Done()
-	p.GetUpdateReply <- msg.SkipBlock
+// HandleGetBlocksReply contacts the service that a new block has arrived
+func (p *GetBlocks) HandleGetBlocksReply(msg ProtoStructGetBlocksReply) error {
+
+	// Take the first answer we get and then terminate the protocol,
+	// other answers will be discarded by onet.
+	p.GetBlocksReply <- msg.SkipBlocks
+	p.Done()
+
 	return nil
 }

--- a/skipchain/protocol.go
+++ b/skipchain/protocol.go
@@ -219,8 +219,8 @@ func (p *ExtendRoster) HandleExtendRosterReply(r ProtoStructExtendRosterReply) e
 }
 
 // HandleGetBlocks returns a given number of blocks from the skipchain,
-// starting from a given block. If requested, it will return neighbor blocks,
-// otherwise it will skip forward as far as possible.
+// starting from a given block. If skipping is true, it will skip forward
+// as far as possible, otherwise it will advance one block at a time.
 func (p *GetBlocks) HandleGetBlocks(msg ProtoStructGetBlocks) error {
 	defer p.Done()
 

--- a/skipchain/protocol.go
+++ b/skipchain/protocol.go
@@ -218,7 +218,9 @@ func (p *ExtendRoster) HandleExtendRosterReply(r ProtoStructExtendRosterReply) e
 	return nil
 }
 
-// HandleGetBlocks searches for a skipblock and returns it if it is found.
+// HandleGetBlocks returns a given number of blocks from the skipchain,
+// starting from a given block. If requested, it will return neighbor blocks,
+// otherwise it will skip forward as far as possible.
 func (p *GetBlocks) HandleGetBlocks(msg ProtoStructGetBlocks) error {
 	defer p.Done()
 
@@ -243,7 +245,12 @@ func (p *GetBlocks) HandleGetBlocks(msg ProtoStructGetBlocks) error {
 		if len(s.ForwardLink) == 0 {
 			break
 		}
-		next = s.ForwardLink[0].Hash()
+
+		linkNum := 0
+		if msg.Skipping {
+			linkNum = len(s.ForwardLink) - 1
+		}
+		next = s.ForwardLink[linkNum].Hash()
 	}
 	if len(result) == 0 {
 		// Not found, so send no reply. Another conode will

--- a/skipchain/protocol_test.go
+++ b/skipchain/protocol_test.go
@@ -31,25 +31,61 @@ func TestGB(t *testing.T) {
 
 	ts0 := tss[0].(*testService)
 	ts1 := tss[1].(*testService)
+	ts2 := tss[2].(*testService)
+
 	sb0 := skipchain.NewSkipBlock()
 	sb0.Roster = ro
 	sb0.Hash = sb0.CalculateHash()
 	sb1 := skipchain.NewSkipBlock()
+	sb1.Roster = ro
 	sb1.BackLinkIDs = []skipchain.SkipBlockID{sb0.Hash}
 	sb1.Hash = sb1.CalculateHash()
-	bl := &skipchain.BlockLink{BFTSignature: bftcosi.BFTSignature{Msg: sb1.Hash, Sig: []byte{}}}
-	sb0.ForwardLink = []*skipchain.BlockLink{bl}
+	sb0.ForwardLink = []*skipchain.BlockLink{
+		&skipchain.BlockLink{
+			BFTSignature: bftcosi.BFTSignature{Msg: sb1.Hash, Sig: []byte{}},
+		},
+	}
+
+	sb2 := skipchain.NewSkipBlock()
+	sb2.BackLinkIDs = []skipchain.SkipBlockID{sb1.Hash}
+	sb2.Hash = sb2.CalculateHash()
+
+	sb3 := skipchain.NewSkipBlock()
+	sb3.BackLinkIDs = []skipchain.SkipBlockID{sb2.Hash}
+	sb3.Hash = sb3.CalculateHash()
+	sb2.ForwardLink = []*skipchain.BlockLink{
+		&skipchain.BlockLink{
+			BFTSignature: bftcosi.BFTSignature{Msg: sb3.Hash, Sig: []byte{}},
+		},
+	}
+	// and make sb1 forward[1] point to sb3 as well.
+	sb1.ForwardLink = []*skipchain.BlockLink{
+		&skipchain.BlockLink{
+			BFTSignature: bftcosi.BFTSignature{Msg: sb2.Hash, Sig: []byte{}},
+		},
+		&skipchain.BlockLink{
+			BFTSignature: bftcosi.BFTSignature{Msg: sb3.Hash, Sig: []byte{}},
+		},
+	}
+
 	db, bucket := ts0.GetAdditionalBucket("skipblocks")
 	ts0.Db = skipchain.NewSkipBlockDB(db, bucket)
 	ts0.Db.Store(sb0)
 	ts0.Db.Store(sb1)
+	ts0.Db.Store(sb2)
+	ts0.Db.Store(sb3)
 	db, bucket = ts1.GetAdditionalBucket("skipblocks")
 	ts1.Db = skipchain.NewSkipBlockDB(db, bucket)
 	ts1.Db.Store(sb0)
 	ts1.Db.Store(sb1)
+	ts1.Db.Store(sb2)
+	ts1.Db.Store(sb3)
+	ts2.Db = skipchain.NewSkipBlockDB(db, bucket)
+	// do not save anything into ts2 so that
+	// it is totally out of date, and cannot answer anything
 
 	// ask for only one
-	sb := ts1.CallGB(sb0, 1)
+	sb := ts1.CallGB(sb0, false, 1)
 	require.NotNil(t, sb)
 	require.Equal(t, 1, len(sb))
 	require.Equal(t, sb0.Hash, sb[0].Hash)
@@ -57,23 +93,44 @@ func TestGB(t *testing.T) {
 	// In order to test GetUpdate in the face of failures, pause one
 	servers[2].Pause()
 
-	// ask for 10, expect to get the 2 be put in above.
-	sb = ts1.CallGB(sb0, 10)
+	// ask for 10, expect to get the 4 of them
+	sb = ts1.CallGB(sb0, false, 10)
 	require.NotNil(t, sb)
-	require.Equal(t, 2, len(sb))
+	require.Equal(t, 4, len(sb))
 	require.Equal(t, sb0.Hash, sb[0].Hash)
 	require.Equal(t, sb1.Hash, sb[1].Hash)
+	require.Equal(t, sb2.Hash, sb[2].Hash)
+	require.Equal(t, sb3.Hash, sb[3].Hash)
+
+	// ask for 3
+	sb = ts1.CallGB(sb1, false, 3)
+	require.NotNil(t, sb)
+	require.Equal(t, 3, len(sb))
+	require.Equal(t, sb1.Hash, sb[0].Hash)
+	require.Equal(t, sb2.Hash, sb[1].Hash)
+	require.Equal(t, sb3.Hash, sb[2].Hash)
 
 	// And what about getupdate with all servers replying?
 	// server[2] does not have the correct block in it, so we expect it
 	// to get the request, but send no reply back. One of the others
 	// will find the blocks.
 	servers[2].Unpause()
-	sb = ts1.CallGB(sb0, 10)
+	sb = ts1.CallGB(sb0, false, 10)
 	require.NotNil(t, sb)
-	require.Equal(t, 2, len(sb))
+	require.Equal(t, 4, len(sb))
 	require.Equal(t, sb0.Hash, sb[0].Hash)
 	require.Equal(t, sb1.Hash, sb[1].Hash)
+	require.Equal(t, sb2.Hash, sb[2].Hash)
+	require.Equal(t, sb3.Hash, sb[3].Hash)
+
+	// with skipping, we expect to get sb0, sb1 and sb3.
+	sb = ts1.CallGB(sb0, true, 10)
+	require.NotNil(t, sb)
+	require.Equal(t, 3, len(sb))
+	require.Equal(t, sb0.Hash, sb[0].Hash)
+	require.Equal(t, sb1.Hash, sb[1].Hash)
+	require.Equal(t, sb3.Hash, sb[2].Hash)
+
 }
 
 // TestER tests the ProtoExtendRoster message
@@ -159,7 +216,7 @@ func (ts *testService) CallER(t *onet.Tree, b *skipchain.SkipBlock) []skipchain.
 	return <-pisc.ExtendRosterReply
 }
 
-func (ts *testService) CallGB(sb *skipchain.SkipBlock, n int) []*skipchain.SkipBlock {
+func (ts *testService) CallGB(sb *skipchain.SkipBlock, sk bool, n int) []*skipchain.SkipBlock {
 	t := sb.Roster.RandomSubset(ts.ServerIdentity(), 3).GenerateStar()
 	log.Lvl3("running on this tree", t.Dump())
 
@@ -170,8 +227,9 @@ func (ts *testService) CallGB(sb *skipchain.SkipBlock, n int) []*skipchain.SkipB
 	}
 	pisc := pi.(*skipchain.GetBlocks)
 	pisc.GetBlocks = &skipchain.ProtoGetBlocks{
-		Count: n,
-		SBID:  sb.Hash,
+		Count:    n,
+		SBID:     sb.Hash,
+		Skipping: sk,
 	}
 	if err := pi.Start(); err != nil {
 		log.ErrFatal(err)

--- a/skipchain/protocol_test.go
+++ b/skipchain/protocol_test.go
@@ -135,9 +135,6 @@ func TestGB(t *testing.T) {
 
 // TestER tests the ProtoExtendRoster message
 func TestER(t *testing.T) {
-	if testing.Short() {
-		t.Skip("this test does not pass on travis, see #1000")
-	}
 	nodes := []int{2, 5, 13}
 	for _, nbrNodes := range nodes {
 		testER(t, tsID, nbrNodes)

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -306,11 +306,12 @@ func (s *Service) syncChain(roster *onet.Roster, latest SkipBlockID) error {
 }
 
 // getBlocks uses ProtocolGetBlocks to return up to n blocks, traversing the
-// skiplist forward from id. It contacts a random subgroup of 3 of the nodes
+// skiplist forward from id. It contacts a random subgroup of some of the nodes
 // in the roster, in order to find an answer, even in the case that a few
 // nodes in the network are down.
 func (s *Service) getBlocks(roster *onet.Roster, id SkipBlockID, n int) ([]*SkipBlock, error) {
-	t := roster.RandomSubset(s.ServerIdentity(), 3).GenerateStar()
+	subCount := (len(roster.List)-1)/3 + 1
+	t := roster.RandomSubset(s.ServerIdentity(), subCount).GenerateStar()
 	pi, err := s.CreateProtocol(ProtocolGetBlocks, t)
 	if err != nil {
 		return nil, err

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -718,7 +718,7 @@ func (s *Service) deprecatedProcessorGetBlock(env *network.Envelope) {
 	}
 	sb := s.db.GetByID(gb.ID)
 	if sb == nil {
-		log.Error("Did not find block")
+		log.Errorf("Did not find block %v", gb.ID)
 		return
 	}
 	if i, _ := sb.Roster.Search(s.ServerIdentity().ID); i < 0 {

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -238,9 +238,8 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, on
 }
 
 // GetUpdateChain returns a slice of SkipBlocks which describe the part of the
-// skipchain from the latest block the caller knows of to the actual latest
-// SkipBlock.
-// Somehow comparable to search in SkipLists.
+// skipchain from the latest block the caller knows to the latest
+// SkipBlock we know.
 func (s *Service) GetUpdateChain(latestKnown *GetUpdateChain) (network.Message, onet.ClientError) {
 	block := s.db.GetByID(latestKnown.LatestID)
 	if block == nil {
@@ -280,58 +279,35 @@ func (s *Service) GetUpdateChain(latestKnown *GetUpdateChain) (network.Message, 
 	return reply, nil
 }
 
+// syncChain communicates with conodes in the Roster via getBlocks
+// in order to find the latest block.
 func (s *Service) syncChain(roster *onet.Roster, latest SkipBlockID) error {
-	// TODO: what if GetUpdateChain happened to choose US? Why doesn't it so far?
-	// TODO: maybe it is missing us because Go stdlib math/rand is never seeded? (in tests maybe
-	// that's correct, but in prod not so much)
-	// TODO: if GetUpdateChain happens to choose a server that's down,
-	// we need to retry (up to a limit)
-	reply, cerr := NewClient().GetUpdateChain(roster, latest)
-	if cerr != nil {
-		return cerr
-	}
-	for _, sb := range reply.Update {
-		for _, bid := range sb.BackLinkIDs {
-			// for every back link of block sb, do the following
-			// 1, find the block identified by the back link, call it back-block
-			// 2, ask for the same back-block from other nodes
-			//    the new new-block should have forward links
-			// 3, check the forward links are signed correctly
-			// 4, check the forward links are at the right height
-			back := s.db.GetByID(bid)
-			if back == nil {
-				continue
-			}
-
-			// get the one block with hash == back.Hash
-			result, cerr := s.getBlocks(roster, back.Hash, 1)
-			if cerr != nil {
-				return cerr
-			}
-			if len(result) != 1 {
-				return fmt.Errorf("expected to find 1 block, got %v", len(result))
-			}
-			newBack := result[0]
-
-			for _, fl := range newBack.ForwardLink {
-				if err := fl.Verify(Suite, roster.Publics()); err != nil {
-					return err
-				}
-			}
-			s.db.Store(newBack)
-		}
-		if err := sb.VerifyForwardSignatures(); err != nil {
+	// loop on getBlocks, fetching 10 at a time
+	for {
+		blocks, err := s.getBlocks(roster, latest, 10)
+		if err != nil {
 			return err
 		}
-		if !s.blockIsFriendly(sb) {
-			return fmt.Errorf("%s: block is not friendly: %x", s.ServerIdentity(), sb.Hash)
+
+		for _, sb := range blocks {
+			log.Lvl3("syncChain block", string(sb.Data))
+
+			if err := sb.VerifyForwardSignatures(); err != nil {
+				return err
+			}
+			if !s.blockIsFriendly(sb) {
+				return fmt.Errorf("%s: block is not friendly: %x", s.ServerIdentity(), sb.Hash)
+			}
+			s.db.Store(sb)
+			if len(sb.ForwardLink) == 0 {
+				return nil
+			}
+			latest = sb.Hash
 		}
-		s.db.Store(sb)
 	}
-	return nil
 }
 
-// getBlocks uses ProtocolGetUpdate to return up to n blocks, traversing the
+// getBlocks uses ProtocolGetBlocks to return up to n blocks, traversing the
 // skiplist forward from id. It contacts a random subgroup of 3 of the nodes
 // in the roster, in order to find an answer, even in the case that a few
 // nodes in the network are down.
@@ -344,17 +320,41 @@ func (s *Service) getBlocks(roster *onet.Roster, id SkipBlockID, n int) ([]*Skip
 
 	pisc := pi.(*GetBlocks)
 	pisc.GetBlocks = &ProtoGetBlocks{
-		SBID:  id,
-		Count: n,
+		SBID:     id,
+		Count:    n,
+		Skipping: true,
 	}
 	if err := pi.Start(); err != nil {
 		log.ErrFatal(err)
 	}
 	select {
 	case result := <-pisc.GetBlocksReply:
+		log.Lvl3("getBlocks result count: ", len(result))
 		return result, nil
 	case <-time.After(s.propTimeout):
-		return nil, errors.New("timeout waiting for GetUpdate reply")
+		return nil, errors.New("timeout waiting for GetBlocks reply")
+	}
+}
+
+// getLastBlock talks one of the servers in roster in order to find the latest
+// block that it knows about.
+func (s *Service) getLastBlock(roster *onet.Roster, latest SkipBlockID) (*SkipBlock, error) {
+	// loop on getBlocks, fetching 10 at a time
+	for {
+		blocks, err := s.getBlocks(roster, latest, 10)
+		if err != nil {
+			return nil, err
+		}
+		if len(blocks) == 0 {
+			return nil, errors.New("getLastBlock got unexpected empty list")
+		}
+		// last block of this batch
+		lb := blocks[len(blocks)-1]
+
+		if len(lb.ForwardLink) == 0 {
+			return lb, nil
+		}
+		latest = lb.Hash
 	}
 }
 
@@ -509,14 +509,14 @@ func (s *Service) AddFollow(add *AddFollow) (*EmptyReply, onet.ClientError) {
 				sis[si.ID.String()] = si
 			}
 		}
+
 		found := false
 		for _, si := range sis {
 			roster := onet.NewRoster([]*network.ServerIdentity{si})
-			s.storageMutex.Unlock()
-			reply, cerr := NewClient().GetUpdateChain(roster, add.SkipchainID)
-			s.storageMutex.Lock()
-			if cerr == nil {
-				last := reply.Update[len(reply.Update)-1]
+			last, err := s.getLastBlock(roster, add.SkipchainID)
+			if err != nil {
+				log.Error("could not get last block: ", err)
+			} else {
 				if last.SkipChainID().Equal(add.SkipchainID) {
 					s.Storage.Follow = append(s.Storage.Follow,
 						FollowChainType{
@@ -535,13 +535,10 @@ func (s *Service) AddFollow(add *AddFollow) (*EmptyReply, onet.ClientError) {
 	case FollowLookup:
 		si := network.NewServerIdentity(Suite.Point(), network.NewTCPAddress(add.Conode))
 		roster := onet.NewRoster([]*network.ServerIdentity{si})
-		s.storageMutex.Unlock()
-		reply, cerr := NewClient().GetUpdateChain(roster, add.SkipchainID)
-		s.storageMutex.Lock()
-		if cerr != nil {
+		last, err := s.getLastBlock(roster, add.SkipchainID)
+		if err != nil {
 			return nil, onet.NewClientErrorCode(ErrorBlockNotFound, "didn't find skipchain at given address")
 		}
-		last := reply.Update[len(reply.Update)-1]
 		if !last.SkipChainID().Equal(add.SkipchainID) {
 			return nil, onet.NewClientErrorCode(ErrorBlockNotFound, "returned block is not correct")
 		}

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -290,8 +290,6 @@ func (s *Service) syncChain(roster *onet.Roster, latest SkipBlockID) error {
 		}
 
 		for _, sb := range blocks {
-			log.Lvl3("syncChain block", string(sb.Data))
-
 			if err := sb.VerifyForwardSignatures(); err != nil {
 				return err
 			}
@@ -329,7 +327,6 @@ func (s *Service) getBlocks(roster *onet.Roster, id SkipBlockID, n int) ([]*Skip
 	}
 	select {
 	case result := <-pisc.GetBlocksReply:
-		log.Lvl3("getBlocks result count: ", len(result))
 		return result, nil
 	case <-time.After(s.propTimeout):
 		return nil, errors.New("timeout waiting for GetBlocks reply")

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -34,12 +34,9 @@ const bftFollowBlock = "SkipchainBFTFollow"
 const storageKey = "skipchainconfig"
 
 func init() {
-	skipchainSID, _ = onet.RegisterNewService(ServiceName, newSkipchainService)
+	onet.RegisterNewService(ServiceName, newSkipchainService)
 	network.RegisterMessages(&Storage{})
 }
-
-// Only used in tests
-var skipchainSID onet.ServiceID
 
 // Service handles adding new SkipBlocks
 type Service struct {
@@ -54,6 +51,8 @@ type Service struct {
 	newBlocks          map[string]bool
 	storageMutex       sync.Mutex
 	Storage            *Storage
+	bftTimeout         time.Duration
+	propTimeout        time.Duration
 }
 
 // Storage is saved to disk.
@@ -282,6 +281,11 @@ func (s *Service) GetUpdateChain(latestKnown *GetUpdateChain) (network.Message, 
 }
 
 func (s *Service) syncChain(roster *onet.Roster, latest SkipBlockID) error {
+	// TODO: what if GetUpdateChain happened to choose US? Why doesn't it so far?
+	// TODO: maybe it is missing us because Go stdlib math/rand is never seeded? (in tests maybe
+	// that's correct, but in prod not so much)
+	// TODO: if GetUpdateChain happens to choose a server that's down,
+	// we need to retry (up to a limit)
 	reply, cerr := NewClient().GetUpdateChain(roster, latest)
 	if cerr != nil {
 		return cerr
@@ -635,11 +639,17 @@ func (s *Service) callGetBlock(known *SkipBlock, unknown SkipBlockID) (*SkipBloc
 		&GetBlock{unknown}); err != nil {
 		return nil, errors.New("Couldn't get updated block: " + known.Short())
 	}
+
+	to := s.propTimeout
+	if to == 0 {
+		to = defaultPropagateTimeout
+	}
+
 	var block *SkipBlock
 	select {
 	case block = <-request:
 		log.Lvl3("Got block", block)
-	case <-time.After(time.Millisecond * time.Duration(propagateTimeout)):
+	case <-time.After(to):
 		return nil, errors.New("Couldn't get updated block in time: " + unknown.Short())
 	}
 	return block, nil
@@ -766,13 +776,19 @@ func (s *Service) bftVerifyFollowBlock(msg []byte, data []byte) bool {
 // verifyNewBlock makes sure that a signature-request for a forward-link
 // is valid.
 func (s *Service) bftVerifyNewBlock(msg []byte, data []byte) bool {
+	// TODO: check length of data before slicing it
+
 	log.Lvlf4("%s verifying block %x", s.ServerIdentity(), msg)
 	_, newSBi, err := network.Unmarshal(data[32:], Suite)
 	if err != nil {
 		log.Error("Couldn't unmarshal SkipBlock", data)
 		return false
 	}
-	newSB := newSBi.(*SkipBlock)
+	newSB, ok := newSBi.(*SkipBlock)
+	if !ok {
+		log.Errorf("Got unexpected type %T in bftVerifyNewBlock", newSBi)
+		return false
+	}
 	if !newSB.Hash.Equal(SkipBlockID(msg)) {
 		log.Lvlf2("Dest skipBlock different from msg %x %x", msg, []byte(newSB.Hash))
 		return false
@@ -801,7 +817,7 @@ func (s *Service) bftVerifyNewBlock(msg []byte, data []byte) bool {
 		return false
 	}
 
-	ok := func() bool {
+	ok = func() bool {
 		for _, ver := range newSB.VerifierIDs {
 			f, ok := s.verifiers[ver]
 			if !ok {
@@ -965,7 +981,6 @@ func (s *Service) startBFT(proto string, roster *onet.Roster, msg, data []byte) 
 			return nil, errors.New("failed in cosi")
 		}
 		return sig, nil
-		//return nil, errors.New("need more than 1 entry for Roster")
 	}
 
 	// Start the protocol
@@ -973,6 +988,10 @@ func (s *Service) startBFT(proto string, roster *onet.Roster, msg, data []byte) 
 	// Register the function generating the protocol instance
 	root.Msg = msg
 	root.Data = data
+
+	if s.bftTimeout != 0 {
+		root.Timeout = s.bftTimeout
+	}
 
 	// function that will be called when protocol is finished by the root
 	done := make(chan bool)
@@ -1009,12 +1028,16 @@ func (s *Service) startPropagation(blocks []*SkipBlock) error {
 	}
 	roster := onet.NewRoster(siList)
 
-	replies, err := s.propagate(roster, &PropagateSkipBlocks{blocks}, propagateTimeout)
+	to := s.propTimeout
+	if to == 0 {
+		to = defaultPropagateTimeout
+	}
+	replies, err := s.propagate(roster, &PropagateSkipBlocks{blocks}, to)
 	if err != nil {
 		return err
 	}
 	if replies != len(roster.List) {
-		log.Warn("Did only get", replies, "out of", len(roster.List))
+		log.Warn("Only got", replies, "out of", len(roster.List))
 	}
 	return nil
 }

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -20,6 +20,12 @@ import (
 	"gopkg.in/satori/go.uuid.v1"
 )
 
+func init() {
+	skipchainSID = onet.ServiceFactory.ServiceID(ServiceName)
+}
+
+var skipchainSID onet.ServiceID
+
 func TestMain(m *testing.M) {
 	log.MainTest(m, 2)
 }
@@ -42,6 +48,18 @@ func storeSkipBlock(t *testing.T, fail bool) {
 	defer local.CloseAll()
 	servers, el, genService := local.MakeHELS(4, skipchainSID, Suite)
 	service := genService.(*Service)
+	// This is the poor server who will play the part of the dead server
+	// for us.
+	deadServer := servers[len(servers)-1]
+
+	if fail {
+		// Set low timeout to make the test finish quickly.
+		service.bftTimeout = 50 * time.Millisecond
+		// WATCH OUT: log levels higher than 3 require a timeout of 500 ms.
+		// service.bftTimeout = 500 * time.Millisecond
+
+		service.propTimeout = 5 * service.bftTimeout
+	}
 
 	// Setting up root roster
 	sbRoot, err := makeGenesisRoster(service, el)
@@ -57,19 +75,21 @@ func storeSkipBlock(t *testing.T, fail bool) {
 	genesis.VerifierIDs = VerificationStandard
 	blockCount := 0
 	psbr, err := service.StoreSkipBlock(&StoreSkipBlock{LatestID: nil, NewBlock: genesis})
-	assert.Nil(t, err)
+	if err != nil {
+		t.Fatal("StoreSkipBlock:", err)
+	}
 	latest := psbr.Latest
 	// verify creation of GenesisBlock:
-	assert.Equal(t, blockCount, latest.Index)
+	blockCount++
+	assert.Equal(t, blockCount-1, latest.Index)
 	// the genesis block has a random back-link:
 	assert.Equal(t, 1, len(latest.BackLinkIDs))
 	assert.NotEqual(t, 0, latest.BackLinkIDs)
 
 	// kill one node and it should still work
 	if fail {
-		log.Lvl3("Closing server", servers[len(servers)-1].Address())
-		err = servers[len(servers)-1].Close()
-		log.ErrFatal(err)
+		log.Lvl3("Pausing server", deadServer.Address())
+		deadServer.Pause()
 	}
 
 	next := NewSkipBlock()
@@ -80,20 +100,48 @@ func storeSkipBlock(t *testing.T, fail bool) {
 	next.ParentBlockID = sbRoot.Hash
 	next.Roster = sbRoot.Roster
 	id := psbr.Latest.Hash
+	if id == nil {
+		t.Fatal("second block last id is nil")
+	}
 	psbr2, err := service.StoreSkipBlock(&StoreSkipBlock{LatestID: id, NewBlock: next})
-	assert.Nil(t, err)
-	log.Lvl2(psbr2)
+	if err != nil {
+		t.Fatal("StoreSkipBlock:", err)
+	}
 	assert.NotNil(t, psbr2)
 	assert.NotNil(t, psbr2.Latest)
 	latest2 := psbr2.Latest
 	// verify creation of GenesisBlock:
 	blockCount++
-	assert.Equal(t, blockCount, latest2.Index)
+	assert.Equal(t, blockCount-1, latest2.Index)
 	assert.Equal(t, 1, len(latest2.BackLinkIDs))
 	assert.NotEqual(t, 0, latest2.BackLinkIDs)
 
-	// We've added 2 blocks, + root block = 3
-	assert.Equal(t, 3, service.db.Length())
+	// And add it again, with all nodes running
+	if fail {
+		log.Lvl3("Unpausing server ", deadServer.Address())
+		deadServer.Unpause()
+	}
+
+	next.ParentBlockID = next.Hash
+	psbr3, err := service.StoreSkipBlock(&StoreSkipBlock{LatestID: psbr2.Latest.Hash, NewBlock: next})
+	// Until the catch-up logic is implemented, sometimes this one fails, so skip the checking
+	// in that case.
+	if err == nil {
+		assert.NotNil(t, psbr3)
+		assert.NotNil(t, psbr3.Latest)
+		latest3 := psbr3.Latest
+
+		// verify creation of GenesisBlock:
+		blockCount++
+		assert.Equal(t, blockCount-1, latest3.Index)
+		assert.Equal(t, 2, len(latest3.BackLinkIDs))
+		assert.NotEqual(t, 0, latest3.BackLinkIDs)
+	} else {
+		t.Log("3rd block write err", err)
+	}
+
+	// +1 for the root block
+	assert.Equal(t, blockCount+1, service.db.Length())
 }
 
 func TestService_GetUpdateChain(t *testing.T) {

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -54,7 +54,7 @@ func storeSkipBlock(t *testing.T, fail bool) {
 
 	if fail {
 		// Set low timeout to make the test finish quickly.
-		service.bftTimeout = 50 * time.Millisecond
+		service.bftTimeout = 100 * time.Millisecond
 		// WATCH OUT: log levels higher than 3 require a timeout of 500 ms.
 		// service.bftTimeout = 500 * time.Millisecond
 
@@ -94,8 +94,7 @@ func storeSkipBlock(t *testing.T, fail bool) {
 
 	next := NewSkipBlock()
 	next.Data = []byte("And the earth was without form, and void; " +
-		"and darkness was upon the face of the deep. " +
-		"And the Spirit of God moved upon the face of the waters.")
+		"and darkness was upon the face of the deep. ")
 	next.MaximumHeight = 2
 	next.ParentBlockID = sbRoot.Hash
 	next.Roster = sbRoot.Roster
@@ -110,7 +109,7 @@ func storeSkipBlock(t *testing.T, fail bool) {
 	assert.NotNil(t, psbr2)
 	assert.NotNil(t, psbr2.Latest)
 	latest2 := psbr2.Latest
-	// verify creation of GenesisBlock:
+
 	blockCount++
 	assert.Equal(t, blockCount-1, latest2.Index)
 	assert.Equal(t, 1, len(latest2.BackLinkIDs))
@@ -123,22 +122,17 @@ func storeSkipBlock(t *testing.T, fail bool) {
 	}
 
 	next.ParentBlockID = next.Hash
+	next.Data = []byte("And the Spirit of God moved upon the face of the waters.")
 	psbr3, err := service.StoreSkipBlock(&StoreSkipBlock{LatestID: psbr2.Latest.Hash, NewBlock: next})
-	// Until the catch-up logic is implemented, sometimes this one fails, so skip the checking
-	// in that case.
-	if err == nil {
-		assert.NotNil(t, psbr3)
-		assert.NotNil(t, psbr3.Latest)
-		latest3 := psbr3.Latest
+	assert.NotNil(t, psbr3)
+	assert.NotNil(t, psbr3.Latest)
+	latest3 := psbr3.Latest
 
-		// verify creation of GenesisBlock:
-		blockCount++
-		assert.Equal(t, blockCount-1, latest3.Index)
-		assert.Equal(t, 2, len(latest3.BackLinkIDs))
-		assert.NotEqual(t, 0, latest3.BackLinkIDs)
-	} else {
-		t.Log("3rd block write err", err)
-	}
+	// verify creation of GenesisBlock:
+	blockCount++
+	assert.Equal(t, blockCount-1, latest3.Index)
+	assert.Equal(t, 2, len(latest3.BackLinkIDs))
+	assert.NotEqual(t, 0, latest3.BackLinkIDs)
 
 	// +1 for the root block
 	assert.Equal(t, blockCount+1, service.db.Length())

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -557,7 +557,7 @@ func TestService_ParallelStore(t *testing.T) {
 }
 
 func TestService_Propagation(t *testing.T) {
-	nbrNodes := 10
+	nbrNodes := 60
 	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -510,6 +510,9 @@ func TestService_StoreSkipBlockSpeed(t *testing.T) {
 }
 
 func TestService_ParallelStore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("parallel store does not run on travis, see #1000")
+	}
 	nbrRoutines := 10
 	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)
@@ -557,6 +560,9 @@ func TestService_ParallelStore(t *testing.T) {
 }
 
 func TestService_Propagation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("propagation does not run on travis, see #1000")
+	}
 	nbrNodes := 60
 	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -18,8 +18,8 @@ import (
 	"gopkg.in/satori/go.uuid.v1"
 )
 
-// How many msec to wait before a timeout is generated in the propagation.
-const propagateTimeout = 5000
+// How long to wait before a timeout is generated in the propagation.
+const defaultPropagateTimeout = 5 * time.Second
 
 // SkipBlockID represents the Hash of the SkipBlock
 type SkipBlockID []byte


### PR DESCRIPTION
Stop using the websockets to fetch blocks when we need them.
Use the GetBlocks protocol instead.

When instantiating the protocol, we talk to a subset of nodes now, and
take the first answer.

Also: clean up the implementation of timeouts to be typesafe, and adjustable.