### PR TITLE
Make vartime suites work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 install:
-  - go get githib.com/dedis/onet
+  - go get github.com/dedis/onet
   - ( cd $GOPATH/src/github.com/dedis/onet ; git checkout p256 )
   - go get -t ./...
   - go get github.com/dedis/Coding || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 install:
   - go get -t ./...
   - go get github.com/dedis/Coding || true
+  - ( cd $GOPATH/src/github.com/dedis/onet ; git checkout p256 )
 
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: go
 
 install:
+  - go get githib.com/dedis/onet
+  - ( cd $GOPATH/src/github.com/dedis/onet ; git checkout p256 )
   - go get -t ./...
   - go get github.com/dedis/Coding || true
-  - ( cd $GOPATH/src/github.com/dedis/onet ; git checkout p256 )
 
 script:
   - make test

--- a/bftcosi/bftcosi.go
+++ b/bftcosi/bftcosi.go
@@ -21,7 +21,7 @@ import (
 	"github.com/dedis/onet/log"
 )
 
-const timeout = 1
+const defaultTimeout = 1 * time.Second
 
 // VerificationFunction can be passes to each protocol node. It will be called
 // (in a go routine) during the (start/handle) challenge prepare phase of the
@@ -42,6 +42,8 @@ type ProtocolBFTCoSi struct {
 	Msg []byte
 	// Data going along the msg to the verification
 	Data []byte
+	// Timeout is how long to wait while gathering commits.
+	Timeout time.Duration
 	// last block computed
 	lastBlock string
 	// refusal to sign for the commit phase or not. This flag is set during the
@@ -134,6 +136,7 @@ func NewBFTCoSiProtocol(n *onet.TreeNodeInstance, verify VerificationFunction) (
 		allowedExceptions:    nodes - (nodes+1)*2/3,
 		Msg:                  make([]byte, 0),
 		Data:                 make([]byte, 0),
+		Timeout:              defaultTimeout,
 	}
 
 	idx, _ := n.Roster().Search(bft.ServerIdentity().ID)
@@ -160,7 +163,6 @@ func (bft *ProtocolBFTCoSi) Start() error {
 		return err
 	}
 	go func() {
-		//time.Sleep(time.Second)
 		bft.startAnnouncement(RoundCommit)
 	}()
 	return nil
@@ -299,6 +301,7 @@ func (bft *ProtocolBFTCoSi) handleAnnouncement(msg announceChan) error {
 		return nil
 	}
 	if bft.IsLeaf() {
+		bft.Timeout = ann.Timeout
 		return bft.startCommitment(ann.TYPE)
 	}
 	return bft.sendToChildren(&ann)
@@ -582,7 +585,7 @@ func (bft *ProtocolBFTCoSi) readCommitChan(c chan commitChan, t RoundType) error
 					return nil
 				}
 			}
-		case <-time.After(time.Second * timeout):
+		case <-time.After(bft.Timeout):
 			// in some cases this might be ok because we accept a certain number of faults
 			// the caller is responsible for checking if enough messages are received
 			log.Error("timeout while trying to read commit messages")
@@ -621,7 +624,7 @@ func (bft *ProtocolBFTCoSi) readResponseChan(c chan responseChan, t RoundType) e
 					return nil
 				}
 			}
-		case <-time.After(time.Second * timeout):
+		case <-time.After(bft.Timeout):
 			log.Error("timeout while trying to read response messages")
 			return nil
 		}
@@ -631,7 +634,7 @@ func (bft *ProtocolBFTCoSi) readResponseChan(c chan responseChan, t RoundType) e
 // startAnnouncementPrepare create its announcement for the prepare round and
 // sends it down the tree.
 func (bft *ProtocolBFTCoSi) startAnnouncement(t RoundType) error {
-	bft.announceChan <- announceChan{Announce: Announce{TYPE: t}}
+	bft.announceChan <- announceChan{Announce: Announce{TYPE: t, Timeout: bft.Timeout}}
 	return nil
 }
 

--- a/bftcosi/bftcosi_test.go
+++ b/bftcosi/bftcosi_test.go
@@ -168,7 +168,6 @@ func TestCheckRefuseParallel(t *testing.T) {
 			log.Lvl3("Done with", n, fc)
 			wg.Done()
 		}(fc)
-		//wg.Wait()
 	}
 	wg.Wait()
 }

--- a/bftcosi/packets.go
+++ b/bftcosi/packets.go
@@ -59,7 +59,7 @@ func (bs *BFTSignature) Verify(s network.Suite, publics []kyber.Point) error {
 		aggPublic.Add(aggPublic, publics[i])
 	}
 	// compute the reduced public aggregate key (all - exception)
-	aggReducedPublic := s.Point().Null().Add(s.Point().Null(), aggPublic)
+	aggReducedPublic := aggPublic.Clone()
 
 	// compute the aggregate commit of exception
 	aggExCommit := s.Point().Null()
@@ -71,6 +71,10 @@ func (bs *BFTSignature) Verify(s network.Suite, publics []kyber.Point) error {
 	origCommit := s.Point()
 	pointLen := s.PointLen()
 	sigLen := pointLen + s.ScalarLen()
+
+	if len(bs.Sig) < sigLen {
+		return errors.New("signature too short")
+	}
 	if err := origCommit.UnmarshalBinary(bs.Sig[0:pointLen]); err != nil {
 		return err
 	}

--- a/bftcosi/packets.go
+++ b/bftcosi/packets.go
@@ -3,6 +3,7 @@ package bftcosi
 import (
 	"crypto/sha512"
 	"errors"
+	"time"
 
 	"github.com/dedis/kyber"
 	"github.com/dedis/onet"
@@ -107,7 +108,7 @@ func (bs *BFTSignature) Verify(s network.Suite, publics []kyber.Point) error {
 // rounds)
 type Announce struct {
 	TYPE    RoundType
-	Timeout uint64
+	Timeout time.Duration
 }
 
 // announceChan is the type of the channel that will be used to catch

--- a/cisc/lib.go
+++ b/cisc/lib.go
@@ -208,7 +208,7 @@ func getGroup(c *cli.Context) *app.Group {
 	gr, err := os.Open(gfile)
 	log.ErrFatal(err)
 	defer gr.Close()
-	groups, err := app.ReadGroupDescToml(gr, cothority.Suite)
+	groups, err := app.ReadGroupDescToml(gr)
 	log.ErrFatal(err)
 	if groups == nil || groups.Roster == nil || len(groups.Roster.List) == 0 {
 		log.Fatal("No servers found in roster from", gfile)

--- a/conode/conode.go
+++ b/conode/conode.go
@@ -60,7 +60,7 @@ func main() {
 				if c.String("debug") != "" {
 					log.Fatal("[-] Debug option cannot be used for the 'setup' command")
 				}
-				app.InteractiveConfig("conode")
+				app.InteractiveConfig("conode", cothority.Suite)
 				return nil
 			},
 		},
@@ -102,7 +102,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "config, c",
-			Value: app.GetDefaultConfigFile("cothority"),
+			Value: app.GetDefaultConfigFile("conode"),
 			Usage: "Configuration file of the server",
 		},
 	}
@@ -118,8 +118,7 @@ func main() {
 func runServer(ctx *cli.Context) {
 	// first check the options
 	config := ctx.GlobalString("config")
-
-	app.RunServer(config, cothority.Suite)
+	app.RunServer(config)
 }
 
 // checkConfig contacts all servers and verifies if it receives a valid

--- a/conode/run_conode.sh
+++ b/conode/run_conode.sh
@@ -7,23 +7,25 @@ set -e
 
 MAILADDR=linus.gasser@epfl.ch
 MAILCMD=/usr/bin/mail
-CONODE_BIN=conode
-DEDIS_PATH="$(go env GOPATH)/src/github.com/dedis"
-COTHORITY_PATH=$DEDIS_PATH/cothority
-ONET_PATH="$(go env GOPATH)/src/github.com/dedis/onet"
-CONODE_PATH=$COTHORITY_PATH/conode
-CONODE_GO=github.com/dedis/cothority/conode
+
+# Find out which package this copy of run_conode.sh is checked into.
+dir=$(dirname $(realpath $0))
+pkg=`cd $dir && go list ..`
+all_args="$*"
+
 # increment version sub if there's something about cothority that changes
 # and requires a migration, but onet does not change.
 VERSION_SUB="1"
 # increment version in onet if there's something that changes that needs
 # migration.
+ONET_PATH="$(go env GOPATH)/src/github.com/dedis/onet"
 VERSION_ONET=$( grep "const Version" $ONET_PATH/onet.go | sed -e "s/.* \"\(.*\)\"/\1/g" )
 VERSION="$VERSION_ONET-$VERSION_SUB"
-RUN_CONODE=$0
-ALL_ARGS="$*"
-LOG=/tmp/conode-$$.log
-MEMLIMIT=""
+
+# TAGS should be passed in from the environment if you want to add extra
+# build tags to all calls to go. For example to turn on vartime algorithms:
+#   TAGS="-tags vartime" ./run_conode.sh
+# Note: TAGS is also used by the integration tests.
 
 main(){
 	if [ ! "$1" ]; then
@@ -114,8 +116,8 @@ runLocal(){
 		shift
 	done
 
-	killall -9 $CONODE_BIN || true
-	go install $CONODE_GO
+	killall -9 conode || true
+	go install $TAGS $pkg/conode
 
 	rm -f public.toml
 	for n in $( seq $NBR ); do
@@ -128,14 +130,14 @@ runLocal(){
 			if grep 'Public =' $co/public.toml|grep -q =\"; then
 				echo "Detected base64 public key for $co: converting"
 				mv $co/public.toml $co/public.toml.bak
-				$CONODE_BIN convert64 < $co/public.toml.bak > $co/public.toml
+				conode convert64 < $co/public.toml.bak > $co/public.toml
 			fi
 		fi
 
 		if [ ! -d $co ]; then
-			echo -e "127.0.0.1:$((7000 + 2 * $n))\nConode_$n\n$co" | $CONODE_BIN setup
+			echo -e "127.0.0.1:$((7000 + 2 * $n))\nConode_$n\n$co" | conode setup
 		fi
-		$CONODE_BIN -d $DEBUG -c $co/private.toml server &
+		conode -d $DEBUG -c $co/private.toml server &
 		cat $co/public.toml >> public.toml
 	done
 	sleep 1
@@ -184,9 +186,9 @@ runPublic(){
 			fi
 			;;
 		-memory)
-			MEMORY=$2
+			MEMLIMIT=$2
 			shift
-			if [ "$MEMORY" -lt 500 ]; then
+			if [ "$MEMLIMIT" -lt 500 ]; then
 				echo "It will not run with less than 500 MBytes of RAM."
 				exit 1
 			fi
@@ -200,12 +202,12 @@ runPublic(){
 	if [ "$UPDATE" ]; then
 		update
 	else
-		go install $CONODE_GO
+		go install $TAGS $pkg/conode
 	fi
 	migrate
 	if [ ! -f $PATH_CONODE/private.toml ]; then
 		echo "Didn't find private.toml in $PATH_CONODE - setting up conode"
-		if $CONODE_BIN setup; then
+		if conode setup; then
 			echo "Successfully setup conode."
 			exit 0
 		else
@@ -216,18 +218,21 @@ runPublic(){
 
 	echo "Running conode with args: $ARGS and debug: $DEBUG"
 	# Thanks to Pavel Shved from http://unix.stackexchange.com/questions/44985/limit-memory-usage-for-a-single-linux-process
-	if [ "$MEMLIMIT" ]; then
+	if [ -n "$MEMLIMIT" ]; then
 		ulimit -Sv $(( MEMLIMIT * 1024 ))
 	fi
-	$CONODE_BIN -d $DEBUG $ARGS server | tee $LOG
+
+	log=/tmp/conode-$$.log
+	conode -d $DEBUG $ARGS server 2>&1 | tee $log
 	if [ "$MAIL" ]; then
-		tail -n 200 $LOG | $MAILCMD -s "conode-log from $(hostname):$(date)" $MAILADDR
+		tail -n 200 $log | $MAILCMD -s "conode-log from $(hostname):$(date)" $MAILADDR
 		echo "Waiting one minute before launching conode again"
 		sleep 60
 	fi
-	rm $LOG
+	rm $log
 	echo "Conode exited at $(date) - restarting"
-	exec $RUN_CONODE "$ALL_ARGS"
+	sleep 5
+	exec $0 $all_args
 }
 
 migrate(){
@@ -269,7 +274,7 @@ migrate(){
 				co="$PATH_CONODE"
 			echo "Converting base64 public key in $co"
 				mv $co/public.toml $co/public.toml.bak
-			$CONODE_BIN convert64 < $co/public.toml.bak > $co/public.toml
+			conode convert64 < $co/public.toml.bak > $co/public.toml
 			echo $VERSION > $PATH_VERSION
 			echo "Migration to $VERSION complete"
 			;;
@@ -295,9 +300,9 @@ update(){
 	TEST=$1
 	cat - > $TMP << EOF
 if [ ! "$TEST" ]; then
-  go get -u $COTHORITY_PATH/...
+  go get -u $pkg/...
 fi
-exec $RUN_CONODE $ACTION -update_rec $TMP
+exec $0 $ACTION -update_rec $TMP
 EOF
 	chmod a+x $TMP
 	exec $TMP
@@ -317,7 +322,7 @@ test(){
 testPublic(){
 	runPublic &
 	sleep 5
-	testGrep $CONODE_BIN pgrep -lf $CONODE_BIN
+	testGrep conode pgrep -lf conode
 }
 
 testLocal(){
@@ -326,11 +331,11 @@ testLocal(){
 		sleep 1
 	done
 	sleep 2
-	local found=$( pgrep $CONODE_BIN | wc -l | sed -e "s/ *//g" )
+	local found=$( pgrep conode | wc -l | sed -e "s/ *//g" )
 	if [ "$found" != 3 ]; then
 		fail "Didn't find 3 servers, but $found"
 	fi
-	pkill -9 $CONODE_BIN
+	pkill -9 conode
 }
 
 testMigrate(){

--- a/conode/test.sh
+++ b/conode/test.sh
@@ -15,9 +15,9 @@ main(){
 testConode(){
     runCoBG 1 2
     cp co1/public.toml .
-    tail -n 4 co2/public.toml >> public.toml
+    cat co2/public.toml >> public.toml
     testOK runCo 1 check -g public.toml
-    tail -n 4 co3/public.toml >> public.toml
+    cat co3/public.toml >> public.toml
     testFail runCo 1 check -g public.toml
 }
 

--- a/cosi/check/check.go
+++ b/cosi/check/check.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dedis/cothority"
 	"github.com/dedis/kyber"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/app"
@@ -32,7 +31,7 @@ var RequestTimeOut = time.Second * 10
 func Config(tomlFileName string, detail bool) error {
 	f, err := os.Open(tomlFileName)
 	log.ErrFatal(err, "Couldn't open group definition file")
-	group, err := app.ReadGroupDescToml(f, cothority.Suite)
+	group, err := app.ReadGroupDescToml(f)
 	log.ErrFatal(err, "Error while reading group definition file", err)
 	if len(group.Roster.List) == 0 {
 		log.ErrFatalf(err, "Empty entity or invalid group defintion in: %s",

--- a/cosi/client.go
+++ b/cosi/client.go
@@ -96,16 +96,16 @@ func sign(r io.Reader, tomlFileName string) (*s.SignatureResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	el, err := app.ReadGroupToml(f, cothority.Suite)
+	g, err := app.ReadGroupDescToml(f)
 	if err != nil {
 		return nil, err
 	}
-	if len(el.List) <= 0 {
+	if len(g.Roster.List) <= 0 {
 		return nil, errors.New("Empty or invalid cosi group file:" +
 			tomlFileName)
 	}
-	log.Lvl2("Sending signature to", el)
-	res, err := signStatement(r, el)
+	log.Lvl2("Sending signature to", g.Roster)
+	res, err := signStatement(r, g.Roster)
 	if err != nil {
 		return nil, err
 	}
@@ -185,12 +185,12 @@ func verify(fileName, sigFileName, groupToml string) error {
 		return err
 	}
 	log.Lvl4("Reading group definition")
-	el, err := app.ReadGroupToml(fGroup, cothority.Suite)
+	g, err := app.ReadGroupDescToml(fGroup)
 	if err != nil {
 		return err
 	}
 	log.Lvl4("Verfifying signature")
-	err = verifySignatureHash(b, sig, el)
+	err = verifySignatureHash(b, sig, g.Roster)
 	return err
 }
 

--- a/cosi/cosi.go
+++ b/cosi/cosi.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/dedis/cothority"
 	"github.com/dedis/onet/app"
 	"github.com/dedis/onet/log"
 	"gopkg.in/urfave/cli.v1"
@@ -124,7 +125,7 @@ func main() {
 						if c.GlobalIsSet("debug") {
 							log.Fatal("[-] Debug option cannot be used for the 'setup' command")
 						}
-						app.InteractiveConfig(BinaryName)
+						app.InteractiveConfig(BinaryName, cothority.Suite)
 						return nil
 					},
 				},

--- a/cosi/server.go
+++ b/cosi/server.go
@@ -5,7 +5,7 @@ import (
 
 	// Empty imports to have the init-functions called which should
 	// register the protocol
-	"github.com/dedis/cothority"
+
 	_ "github.com/dedis/cothority/cosi/protocol"
 	_ "github.com/dedis/cothority/cosi/service"
 	"github.com/dedis/onet/app"
@@ -15,5 +15,5 @@ func runServer(ctx *cli.Context) {
 	// first check the options
 	config := ctx.String("config")
 
-	app.RunServer(config, cothority.Suite)
+	app.RunServer(config)
 }

--- a/cosi/simulation/cosi_test.go
+++ b/cosi/simulation/cosi_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/cosi/crypto"
-	"github.com/dedis/kyber/suites"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
 )
 
-var tSuite = suites.MustFind("Ed25519")
+var tSuite = cothority.Suite
 
 func TestMain(m *testing.M) {
 	raiseLimit()

--- a/identity/struct.go
+++ b/identity/struct.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/pop/service"
@@ -16,7 +17,7 @@ import (
 )
 
 // How many msec to wait before a timeout is generated in the propagation
-const propagateTimeout = 10000
+const propagateTimeout = 10000 * time.Millisecond
 
 // ID represents one skipblock and corresponds to its Hash.
 type ID skipchain.SkipBlockID

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-for t in $( find . -name test.sh ); do
+# Many integration tests are currently broken. When they are all fixed,
+# this is how to run them.
+#for t in $( find . -name test.sh ); do
+
+# For now, run the ones that are fixed.
+for t in conode/test.sh scmgr/test.sh status/test.sh cosi/test.sh
+do
 	echo "Running integration-test $t"
 	( cd $( dirname $t ); ./$( basename $t ) ) || exit 1
 done

--- a/messaging/propagate_test.go
+++ b/messaging/propagate_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
@@ -61,7 +62,7 @@ func propagate(t *testing.T, nbrNodes []int, nbrFailures []int) {
 
 		// start the propagation
 		log.Lvl2("Starting to propagate", reflect.TypeOf(msg))
-		children, err := propFuncs[0](el, msg, 1000)
+		children, err := propFuncs[0](el, msg, 1*time.Second)
 		log.ErrFatal(err)
 		if recvCount+nbrFailures[i] != n {
 			t.Fatal("Didn't get data-request")

--- a/pop/app.go
+++ b/pop/app.go
@@ -567,13 +567,12 @@ func (cfg *Config) getPartybyHash(hash string) (*PartyConfig, error) {
 func readGroup(name string) *onet.Roster {
 	f, err := os.Open(name)
 	log.ErrFatal(err, "Couldn't open group definition file")
-	roster, err := app.ReadGroupToml(f, cothority.Suite)
+	g, err := app.ReadGroupDescToml(f)
 	log.ErrFatal(err, "Error while reading group definition file", err)
-	if len(roster.List) == 0 {
-		log.ErrFatalf(err, "Empty entity or invalid group defintion in: %s",
-			name)
+	if len(g.Roster.List) == 0 {
+		log.ErrFatalf(err, "Empty entity or invalid group defintion in: %s", name)
 	}
-	return roster
+	return g.Roster
 }
 
 // PopDescGroupToml represents serializable party description

--- a/pop/service/service.go
+++ b/pop/service/service.go
@@ -34,10 +34,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/bftcosi"
 	"github.com/dedis/cothority/messaging"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/sign/schnorr"
+	"github.com/dedis/kyber/suites"
 	"github.com/dedis/kyber/util/random"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
@@ -45,12 +47,16 @@ import (
 )
 
 func init() {
-	onet.RegisterNewService(Name, newService)
-	network.RegisterMessage(&saveData{})
-	checkConfigID = network.RegisterMessage(checkConfig{})
-	checkConfigReplyID = network.RegisterMessage(checkConfigReply{})
-	mergeConfigID = network.RegisterMessage(mergeConfig{})
-	mergeConfigReplyID = network.RegisterMessage(mergeConfigReply{})
+	// This service depends on EDDSA signatures, so it must not
+	// be instantiated with other suites.
+	if cothority.Suite == suites.MustFind("Ed25519") {
+		onet.RegisterNewService(Name, newService)
+		network.RegisterMessage(&saveData{})
+		checkConfigID = network.RegisterMessage(checkConfig{})
+		checkConfigReplyID = network.RegisterMessage(checkConfigReply{})
+		mergeConfigID = network.RegisterMessage(mergeConfig{})
+		mergeConfigReplyID = network.RegisterMessage(mergeConfigReply{})
+	}
 }
 
 // Name is the name to refer to the Template service from another

--- a/pop/service/service.go
+++ b/pop/service/service.go
@@ -742,7 +742,7 @@ func (s *Service) signAndPropagate(final *FinalStatement, protoName string,
 			"Signing failed")
 	}
 
-	replies, err := s.PropagateFinalize(final.Desc.Roster, final, 10000)
+	replies, err := s.PropagateFinalize(final.Desc.Roster, final, 10000*time.Millisecond)
 	if err != nil {
 		return onet.NewClientError(err)
 	}

--- a/pop/test.sh
+++ b/pop/test.sh
@@ -47,7 +47,7 @@ main(){
 testMerge(){
 	MERGE_FILE="pop_merge.toml"
 	mkConfig 3 3 2 4
-
+	
 	# att1 - p1, p2; att2 - p2; att3 - p3;
 	runCl 1 org public ${pub[1]} ${pop_hash[1]}
 	runCl 2 org public ${pub[1]} ${pop_hash[1]}
@@ -398,13 +398,13 @@ EOF
 	done
 	for (( n=1; n<=$2; n++ ))
 	do
-		sed -n "$((4*$n-3)),$((4*$n))p" public.toml >> pop_desc$n.toml
+	        sed -n "$((5*$n-4)),$((5*$n))p" public.toml >> pop_desc$n.toml
 		if [[ $2 -gt 1 ]]
 		then
 			local m=$(($n%$2 + 1))
-			sed -n "$((4*$m-3)),$((4*$m))p" public.toml >> pop_desc$n.toml
+			sed -n "$((5*$m-4)),$((5*$m))p" public.toml >> pop_desc$n.toml
 		fi
-	done
+	done	
 	rm -f pop_merge.toml
 	for (( n=1; n<=$2; n++ ))
 	do
@@ -413,10 +413,10 @@ EOF
 Location = "Earth, City$n"
 EOF
 		echo "[[parties.servers]]" >> pop_merge.toml
-		sed -n "$((4*$n-2)),$((4*$n))p" public.toml >> pop_merge.toml
+		sed -n "$((5*$n-4)),$((5*$n))p" public.toml >> pop_merge.toml
 		local m=$(($n%$2 + 1))
 		echo "[[parties.servers]]" >> pop_merge.toml
-		sed -n "$((4*$m-2)),$((4*$m))p" public.toml >> pop_merge.toml
+		sed -n "$((5*$m-4)),$((5*$m))p" public.toml >> pop_merge.toml
 	done
 }
 
@@ -425,9 +425,11 @@ testSave(){
 	mkPopConfig 1 2
 
 	testFail runCl 1 org config pop_desc1.toml
-	pkill -9 -f conode
+	pkill conode
+	sleep .1
 	mkLink 2
-	pkill -9 -f conode
+	pkill conode
+	sleep .1
 	runCoBG 1 2
 	testOK runCl 1 org config pop_desc1.toml
 }

--- a/scmgr/app.go
+++ b/scmgr/app.go
@@ -93,16 +93,16 @@ func linkAdd(c *cli.Context) error {
 	if err != nil {
 		return errors.New("error while reading private.toml: " + err.Error())
 	}
-	conodePriv, err := encoding.StringHexToScalar(skipchain.Suite, remote.Private)
+	conodePriv, err := encoding.StringHexToScalar(cothority.Suite, remote.Private)
 	if err != nil {
 		return errors.New("couldn't decode private key: " + err.Error())
 	}
-	conodePub, err := encoding.StringHexToPoint(skipchain.Suite, remote.Public)
+	conodePub, err := encoding.StringHexToPoint(cothority.Suite, remote.Public)
 	if err != nil {
 		return errors.New("couldn't decode public key: " + err.Error())
 	}
 	cfg := getConfigOrFail(c)
-	kp := key.NewKeyPair(skipchain.Suite)
+	kp := key.NewKeyPair(cothority.Suite)
 	si := network.NewServerIdentity(conodePub, remote.Address)
 	cfg.Values.Link[si.Public.String()] = &link{
 		Private: kp.Private,
@@ -139,7 +139,7 @@ func linkList(c *cli.Context) error {
 	cfg := getConfigOrFail(c)
 	for _, link := range cfg.Values.Link {
 		log.Infof("Linked public key for conode %s: %s", link.Address,
-			skipchain.Suite.Point().Mul(link.Private, nil))
+			cothority.Suite.Point().Mul(link.Private, nil))
 	}
 	return nil
 }
@@ -625,7 +625,7 @@ func readGroupArgs(c *cli.Context, pos int) *app.Group {
 func readGroup(name string) *app.Group {
 	f, err := os.Open(name)
 	log.ErrFatal(err, "Couldn't open group definition file")
-	group, err := app.ReadGroupDescToml(f, cothority.Suite)
+	group, err := app.ReadGroupDescToml(f)
 	log.ErrFatal(err, "Error while reading group definition file", err)
 	if len(group.Roster.List) == 0 {
 		log.ErrFatalf(err, "Empty entity or invalid group defintion in: %s",

--- a/scmgr/test.sh
+++ b/scmgr/test.sh
@@ -193,6 +193,7 @@ testFailure() {
 	setupGenesis
 	testOK runSc skipchain block add --roster public.toml $ID
 
+	# -n: newest, so #4 is the one that is dead now
 	pkill -n conode
 	sleep .1
 	testOK runSc skipchain block add --roster public.toml $ID

--- a/scmgr/test.sh
+++ b/scmgr/test.sh
@@ -3,7 +3,7 @@
 DBG_TEST=1
 # Debug-level for app
 DBG_APP=2
-DBG_SRV=2
+# DBG_SRV=2
 
 . $(go env GOPATH)/src/github.com/dedis/onet/app/libtest.sh
 

--- a/skipchain/api_test.go
+++ b/skipchain/api_test.go
@@ -9,6 +9,7 @@ import (
 
 	"sync"
 
+	"github.com/dedis/cothority"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/util/key"
 	"github.com/dedis/onet"
@@ -21,7 +22,7 @@ func init() {
 }
 
 func TestClient_CreateGenesis(t *testing.T) {
-	l := onet.NewTCPTest(Suite)
+	l := onet.NewTCPTest(cothority.Suite)
 	_, roster, _ := l.GenTree(3, true)
 	defer l.CloseAll()
 	c := newTestClient(l)
@@ -39,7 +40,7 @@ func TestClient_CreateGenesis(t *testing.T) {
 }
 
 func TestClient_CreateRootControl(t *testing.T) {
-	l := onet.NewTCPTest(Suite)
+	l := onet.NewTCPTest(cothority.Suite)
 	_, roster, _ := l.GenTree(3, true)
 	defer l.CloseAll()
 	c := newTestClient(l)
@@ -51,7 +52,7 @@ func TestClient_GetUpdateChain(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Long run not good for Travis")
 	}
-	l := onet.NewTCPTest(Suite)
+	l := onet.NewTCPTest(cothority.Suite)
 	_, ro, _ := l.GenTree(5, true)
 	defer l.CloseAll()
 
@@ -75,7 +76,7 @@ func TestClient_GetUpdateChain(t *testing.T) {
 }
 
 func TestClient_CreateRootInter(t *testing.T) {
-	l := onet.NewTCPTest(Suite)
+	l := onet.NewTCPTest(cothority.Suite)
 	_, ro, _ := l.GenTree(5, true)
 	defer l.CloseAll()
 
@@ -100,7 +101,7 @@ func TestClient_CreateRootInter(t *testing.T) {
 
 func TestClient_StoreSkipBlock(t *testing.T) {
 	nbrHosts := 3
-	l := onet.NewTCPTest(Suite)
+	l := onet.NewTCPTest(cothority.Suite)
 	_, ro, _ := l.GenTree(nbrHosts, true)
 	defer l.CloseAll()
 
@@ -146,7 +147,7 @@ func TestClient_StoreSkipBlock(t *testing.T) {
 
 func TestClient_GetAllSkipchains(t *testing.T) {
 	nbrHosts := 3
-	l := onet.NewTCPTest(Suite)
+	l := onet.NewTCPTest(cothority.Suite)
 	_, ro, _ := l.GenTree(nbrHosts, true)
 	defer l.CloseAll()
 
@@ -173,7 +174,7 @@ func TestClient_GetAllSkipchains(t *testing.T) {
 
 func TestClient_GetSingleBlockByIndex(t *testing.T) {
 	nbrHosts := 3
-	l := onet.NewTCPTest(Suite)
+	l := onet.NewTCPTest(cothority.Suite)
 	_, roster, _ := l.GenTree(nbrHosts, true)
 	defer l.CloseAll()
 
@@ -328,9 +329,9 @@ type linkStruct struct {
 }
 
 func linked(nbr int) *linkStruct {
-	kp := key.NewKeyPair(Suite)
+	kp := key.NewKeyPair(cothority.Suite)
 	ls := &linkStruct{
-		local: onet.NewTCPTest(Suite),
+		local: onet.NewTCPTest(cothority.Suite),
 		priv:  kp.Private,
 		pub:   kp.Public,
 	}

--- a/skipchain/msgs.go
+++ b/skipchain/msgs.go
@@ -58,8 +58,8 @@ func init() {
 		&ProtoExtendSignature{},
 		&ProtoExtendRoster{},
 		&ProtoExtendRosterReply{},
-		&ProtoGetUpdate{},
-		&ProtoBlockReply{},
+		&ProtoGetBlocks{},
+		&ProtoGetBlocksReply{},
 	)
 }
 
@@ -194,26 +194,28 @@ type ProtoStructExtendRosterReply struct {
 	ProtoExtendRosterReply
 }
 
-// ProtoGetUpdate requests the latest block
-type ProtoGetUpdate struct {
-	SBID SkipBlockID
+// ProtoGetBlocks requests from another conode up to Count blocks,
+// traversing the skiplist forward from SBID.
+type ProtoGetBlocks struct {
+	SBID  SkipBlockID
+	Count int
 }
 
-// ProtoStructGetUpdate embeds the treenode
-type ProtoStructGetUpdate struct {
+// ProtoStructGetBlocks embeds the treenode
+type ProtoStructGetBlocks struct {
 	*onet.TreeNode
-	ProtoGetUpdate
+	ProtoGetBlocks
 }
 
-// ProtoBlockReply returns a block - either from update or from getblock
-type ProtoBlockReply struct {
-	SkipBlock *SkipBlock
+// ProtoGetiBlocksReply returns a slice of blocks - either from update or from getblock
+type ProtoGetBlocksReply struct {
+	SkipBlocks []*SkipBlock
 }
 
-// ProtoStructBlockReply embeds the treenode
-type ProtoStructBlockReply struct {
+// ProtoStructGetBlocksReply embeds the treenode
+type ProtoStructGetBlocksReply struct {
 	*onet.TreeNode
-	ProtoBlockReply
+	ProtoGetBlocksReply
 }
 
 // CreateLinkPrivate asks to store the given public key in the list of administrative

--- a/skipchain/msgs.go
+++ b/skipchain/msgs.go
@@ -199,6 +199,9 @@ type ProtoStructExtendRosterReply struct {
 type ProtoGetBlocks struct {
 	SBID  SkipBlockID
 	Count int
+	// Do the returned blocks skip forward in the chain, or
+	// are direct neighbors (not Skipping).
+	Skipping bool
 }
 
 // ProtoStructGetBlocks embeds the treenode
@@ -207,7 +210,7 @@ type ProtoStructGetBlocks struct {
 	ProtoGetBlocks
 }
 
-// ProtoGetiBlocksReply returns a slice of blocks - either from update or from getblock
+// ProtoGetBlocksReply returns a slice of blocks - either from update or from getblock
 type ProtoGetBlocksReply struct {
 	SkipBlocks []*SkipBlock
 }

--- a/skipchain/protocol.go
+++ b/skipchain/protocol.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dedis/cothority"
 	"github.com/dedis/kyber/sign/schnorr"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
@@ -107,7 +108,7 @@ func (p *ExtendRoster) HandleExtendRoster(msg ProtoStructExtendRoster) error {
 
 	log.Lvlf3("%s: Check block with roster %s", p.ServerIdentity(), msg.Block.Roster.List)
 	if p.isBlockAccepted(msg.ServerIdentity, &msg.Block) {
-		sig, err := schnorr.Sign(Suite, p.Private(), msg.Block.SkipChainID())
+		sig, err := schnorr.Sign(cothority.Suite, p.Private(), msg.Block.SkipChainID())
 		if err != nil {
 			log.Error("couldn't sign genesis-block")
 			return p.SendToParent(&ProtoExtendRosterReply{})
@@ -195,7 +196,7 @@ func (p *ExtendRoster) HandleExtendRosterReply(r ProtoStructExtendRosterReply) e
 		if r.Signature == nil {
 			return false
 		}
-		if schnorr.Verify(Suite, r.ServerIdentity.Public, p.ExtendRoster.Block.SkipChainID(), *r.Signature) != nil {
+		if schnorr.Verify(cothority.Suite, r.ServerIdentity.Public, p.ExtendRoster.Block.SkipChainID(), *r.Signature) != nil {
 			log.Lvl3("Signature verification failed")
 			return false
 		}

--- a/skipchain/protocol.go
+++ b/skipchain/protocol.go
@@ -11,6 +11,7 @@ node will only use the `Handle`-methods, and not call `Start` again.
 */
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -25,13 +26,12 @@ import (
 // in a skipchain with a given id.
 const ProtocolExtendRoster = "scExtendRoster"
 
-// ProtocolGetUpdate asks a remote node to return the latest block of a
-// skipchain.
-const ProtocolGetUpdate = "scGetUpdate"
+// ProtocolGetBlocks asks a remote node for some blocks.
+const ProtocolGetBlocks = "scGetBlocks"
 
 func init() {
 	onet.GlobalProtocolRegister(ProtocolExtendRoster, NewProtocolExtendRoster)
-	onet.GlobalProtocolRegister(ProtocolGetUpdate, NewProtocolGetUpdate)
+	onet.GlobalProtocolRegister(ProtocolGetBlocks, NewProtocolGetBlocks)
 }
 
 // ExtendRoster is used for different communications in the skipchain-service.
@@ -53,13 +53,12 @@ type ExtendRoster struct {
 	doneChan        chan int
 }
 
-// GetUpdate needs to be configured by the service to hold the database
-// of all skipblocks.
-type GetUpdate struct {
+// GetBlocks is used for conodes to get blocks from each other.
+type GetBlocks struct {
 	*onet.TreeNodeInstance
 
-	GetUpdate      *ProtoGetUpdate
-	GetUpdateReply chan *SkipBlock
+	GetBlocks      *ProtoGetBlocks
+	GetBlocksReply chan []*SkipBlock
 	DB             *SkipBlockDB
 }
 
@@ -76,16 +75,16 @@ func NewProtocolExtendRoster(n *onet.TreeNodeInstance) (onet.ProtocolInstance, e
 	return t, t.RegisterHandlers(t.HandleExtendRoster, t.HandleExtendRosterReply)
 }
 
-// NewProtocolGetUpdate prepares for a protocol that fetches an update
-func NewProtocolGetUpdate(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-	t := &GetUpdate{
+// NewProtocolGetBlocks prepares for a protocol that fetches blocks.
+func NewProtocolGetBlocks(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
+	t := &GetBlocks{
 		TreeNodeInstance: n,
-		GetUpdateReply:   make(chan *SkipBlock),
+		GetBlocksReply:   make(chan []*SkipBlock),
 	}
-	return t, t.RegisterHandlers(t.HandleGetUpdate, t.HandleBlockReply)
+	return t, t.RegisterHandlers(t.HandleGetBlocks, t.HandleGetBlocksReply)
 }
 
-// Start sends the Announce-message to all children
+// Start sends the extend roster request to all of the children.
 func (p *ExtendRoster) Start() error {
 	log.Lvl3("Starting Protocol ExtendRoster")
 	errs := p.SendToChildrenInParallel(p.ExtendRoster)
@@ -95,10 +94,10 @@ func (p *ExtendRoster) Start() error {
 	return nil
 }
 
-// Start sends the Announce-message to all children
-func (p *GetUpdate) Start() error {
-	log.Lvl3("Starting Protocol GetUpdate")
-	return p.SendToChildren(p.GetUpdate)
+// Start sends the block request to all of the children.
+func (p *GetBlocks) Start() error {
+	log.Lvl3("Starting Protocol GetBlocks")
+	return p.SendToChildren(p.GetBlocks)
 }
 
 // HandleExtendRoster uses the stored followers to decide if we want to accept
@@ -219,26 +218,49 @@ func (p *ExtendRoster) HandleExtendRosterReply(r ProtoStructExtendRosterReply) e
 	return nil
 }
 
-// HandleGetUpdate searches for a skipblock and returns it if it is found.
-func (p *GetUpdate) HandleGetUpdate(msg ProtoStructGetUpdate) error {
+// HandleGetBlocks searches for a skipblock and returns it if it is found.
+func (p *GetBlocks) HandleGetBlocks(msg ProtoStructGetBlocks) error {
 	defer p.Done()
 
 	if p.DB == nil {
-		log.Lvl3(p.ServerIdentity(), "no block stored in Db")
-		return p.SendToParent(&ProtoBlockReply{})
+		return errors.New("no DB available")
 	}
 
-	sb, err := p.DB.GetLatest(p.DB.GetByID(msg.SBID))
-	if err != nil {
-		log.Error("couldn't get latest: " + err.Error())
-		return err
+	n := msg.Count
+	result := make([]*SkipBlock, 0, n)
+	next := msg.SBID
+	for n > 0 {
+		// TODO: see if this could be optimised by using multiple bucket.Get in a
+		// single transaction.
+		s := p.DB.GetByID(next)
+		if s == nil {
+			break
+		}
+		result = append(result, s)
+		n--
+
+		// Find the next one (or exit if we are at the latest)
+		if len(s.ForwardLink) == 0 {
+			break
+		}
+		next = s.ForwardLink[0].Hash()
 	}
-	return p.SendToParent(&ProtoBlockReply{SkipBlock: sb})
+	if len(result) == 0 {
+		// Not found, so send no reply. Another conode will
+		// hopefully find it and send it.
+		return nil
+	}
+
+	return p.SendToParent(&ProtoGetBlocksReply{SkipBlocks: result})
 }
 
-// HandleBlockReply contacts the service that a new block has arrived
-func (p *GetUpdate) HandleBlockReply(msg ProtoStructBlockReply) error {
-	defer p.Done()
-	p.GetUpdateReply <- msg.SkipBlock
+// HandleGetBlocksReply contacts the service that a new block has arrived
+func (p *GetBlocks) HandleGetBlocksReply(msg ProtoStructGetBlocksReply) error {
+
+	// Take the first answer we get and then terminate the protocol,
+	// other answers will be discarded by onet.
+	p.GetBlocksReply <- msg.SkipBlocks
+	p.Done()
+
 	return nil
 }

--- a/skipchain/protocol.go
+++ b/skipchain/protocol.go
@@ -219,8 +219,8 @@ func (p *ExtendRoster) HandleExtendRosterReply(r ProtoStructExtendRosterReply) e
 }
 
 // HandleGetBlocks returns a given number of blocks from the skipchain,
-// starting from a given block. If requested, it will return neighbor blocks,
-// otherwise it will skip forward as far as possible.
+// starting from a given block. If skipping is true, it will skip forward
+// as far as possible, otherwise it will advance one block at a time.
 func (p *GetBlocks) HandleGetBlocks(msg ProtoStructGetBlocks) error {
 	defer p.Done()
 

--- a/skipchain/protocol.go
+++ b/skipchain/protocol.go
@@ -218,7 +218,9 @@ func (p *ExtendRoster) HandleExtendRosterReply(r ProtoStructExtendRosterReply) e
 	return nil
 }
 
-// HandleGetBlocks searches for a skipblock and returns it if it is found.
+// HandleGetBlocks returns a given number of blocks from the skipchain,
+// starting from a given block. If requested, it will return neighbor blocks,
+// otherwise it will skip forward as far as possible.
 func (p *GetBlocks) HandleGetBlocks(msg ProtoStructGetBlocks) error {
 	defer p.Done()
 
@@ -243,7 +245,12 @@ func (p *GetBlocks) HandleGetBlocks(msg ProtoStructGetBlocks) error {
 		if len(s.ForwardLink) == 0 {
 			break
 		}
-		next = s.ForwardLink[0].Hash()
+
+		linkNum := 0
+		if msg.Skipping {
+			linkNum = len(s.ForwardLink) - 1
+		}
+		next = s.ForwardLink[linkNum].Hash()
 	}
 	if len(result) == 0 {
 		// Not found, so send no reply. Another conode will

--- a/skipchain/protocol_test.go
+++ b/skipchain/protocol_test.go
@@ -3,6 +3,7 @@ package skipchain_test
 import (
 	"testing"
 
+	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/bftcosi"
 	"github.com/dedis/cothority/skipchain"
 	"github.com/dedis/kyber/sign/schnorr"
@@ -14,7 +15,6 @@ import (
 const tsName = "tsName"
 
 var tsID onet.ServiceID
-var tSuite = skipchain.Suite
 
 func init() {
 	var err error
@@ -24,7 +24,7 @@ func init() {
 
 // TestGB tests the GetBlocks protocol
 func TestGB(t *testing.T) {
-	local := onet.NewLocalTest(tSuite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer local.CloseAll()
 	servers, ro, _ := local.GenTree(3, true)
 	tss := local.GetServices(servers, tsID)
@@ -143,7 +143,7 @@ func TestER(t *testing.T) {
 
 func testER(t *testing.T, tsid onet.ServiceID, nbrNodes int) {
 	log.Lvl1("Testing", nbrNodes, "nodes")
-	local := onet.NewLocalTest(tSuite)
+	local := onet.NewLocalTest(cothority.Suite)
 	servers, roster, tree := local.GenBigTree(nbrNodes, nbrNodes, nbrNodes, true)
 	tss := local.GetServices(servers, tsid)
 
@@ -159,7 +159,7 @@ func testER(t *testing.T, tsid onet.ServiceID, nbrNodes int) {
 	local.CloseAll()
 
 	// Check inclusion of new chains
-	local = onet.NewLocalTest(tSuite)
+	local = onet.NewLocalTest(cothority.Suite)
 	servers, roster, tree = local.GenBigTree(nbrNodes, nbrNodes, nbrNodes, true)
 	tss = local.GetServices(servers, tsid)
 	for _, t := range tss {
@@ -174,14 +174,14 @@ func testER(t *testing.T, tsid onet.ServiceID, nbrNodes int) {
 	for _, s := range sigs {
 		_, si := roster.Search(s.SI)
 		require.NotNil(t, si)
-		require.Nil(t, schnorr.Verify(tSuite, si.Public, sb.SkipChainID(), s.Signature))
+		require.Nil(t, schnorr.Verify(cothority.Suite, si.Public, sb.SkipChainID(), s.Signature))
 	}
 	local.CloseAll()
 
 	// When only one node refuse,
 	// we should be able to proceed because skipchain is fault tolerant
 	if nbrNodes > 4 {
-		local = onet.NewLocalTest(tSuite)
+		local = onet.NewLocalTest(cothority.Suite)
 		servers, roster, tree = local.GenBigTree(nbrNodes, nbrNodes, nbrNodes, true)
 		tss = local.GetServices(servers, tsid)
 		for i := 3; i < nbrNodes; i++ {

--- a/skipchain/protocol_test.go
+++ b/skipchain/protocol_test.go
@@ -31,25 +31,61 @@ func TestGB(t *testing.T) {
 
 	ts0 := tss[0].(*testService)
 	ts1 := tss[1].(*testService)
+	ts2 := tss[2].(*testService)
+
 	sb0 := skipchain.NewSkipBlock()
 	sb0.Roster = ro
 	sb0.Hash = sb0.CalculateHash()
 	sb1 := skipchain.NewSkipBlock()
+	sb1.Roster = ro
 	sb1.BackLinkIDs = []skipchain.SkipBlockID{sb0.Hash}
 	sb1.Hash = sb1.CalculateHash()
-	bl := &skipchain.BlockLink{BFTSignature: bftcosi.BFTSignature{Msg: sb1.Hash, Sig: []byte{}}}
-	sb0.ForwardLink = []*skipchain.BlockLink{bl}
+	sb0.ForwardLink = []*skipchain.BlockLink{
+		&skipchain.BlockLink{
+			BFTSignature: bftcosi.BFTSignature{Msg: sb1.Hash, Sig: []byte{}},
+		},
+	}
+
+	sb2 := skipchain.NewSkipBlock()
+	sb2.BackLinkIDs = []skipchain.SkipBlockID{sb1.Hash}
+	sb2.Hash = sb2.CalculateHash()
+
+	sb3 := skipchain.NewSkipBlock()
+	sb3.BackLinkIDs = []skipchain.SkipBlockID{sb2.Hash}
+	sb3.Hash = sb3.CalculateHash()
+	sb2.ForwardLink = []*skipchain.BlockLink{
+		&skipchain.BlockLink{
+			BFTSignature: bftcosi.BFTSignature{Msg: sb3.Hash, Sig: []byte{}},
+		},
+	}
+	// and make sb1 forward[1] point to sb3 as well.
+	sb1.ForwardLink = []*skipchain.BlockLink{
+		&skipchain.BlockLink{
+			BFTSignature: bftcosi.BFTSignature{Msg: sb2.Hash, Sig: []byte{}},
+		},
+		&skipchain.BlockLink{
+			BFTSignature: bftcosi.BFTSignature{Msg: sb3.Hash, Sig: []byte{}},
+		},
+	}
+
 	db, bucket := ts0.GetAdditionalBucket("skipblocks")
 	ts0.Db = skipchain.NewSkipBlockDB(db, bucket)
 	ts0.Db.Store(sb0)
 	ts0.Db.Store(sb1)
+	ts0.Db.Store(sb2)
+	ts0.Db.Store(sb3)
 	db, bucket = ts1.GetAdditionalBucket("skipblocks")
 	ts1.Db = skipchain.NewSkipBlockDB(db, bucket)
 	ts1.Db.Store(sb0)
 	ts1.Db.Store(sb1)
+	ts1.Db.Store(sb2)
+	ts1.Db.Store(sb3)
+	ts2.Db = skipchain.NewSkipBlockDB(db, bucket)
+	// do not save anything into ts2 so that
+	// it is totally out of date, and cannot answer anything
 
 	// ask for only one
-	sb := ts1.CallGB(sb0, 1)
+	sb := ts1.CallGB(sb0, false, 1)
 	require.NotNil(t, sb)
 	require.Equal(t, 1, len(sb))
 	require.Equal(t, sb0.Hash, sb[0].Hash)
@@ -57,23 +93,44 @@ func TestGB(t *testing.T) {
 	// In order to test GetUpdate in the face of failures, pause one
 	servers[2].Pause()
 
-	// ask for 10, expect to get the 2 be put in above.
-	sb = ts1.CallGB(sb0, 10)
+	// ask for 10, expect to get the 4 of them
+	sb = ts1.CallGB(sb0, false, 10)
 	require.NotNil(t, sb)
-	require.Equal(t, 2, len(sb))
+	require.Equal(t, 4, len(sb))
 	require.Equal(t, sb0.Hash, sb[0].Hash)
 	require.Equal(t, sb1.Hash, sb[1].Hash)
+	require.Equal(t, sb2.Hash, sb[2].Hash)
+	require.Equal(t, sb3.Hash, sb[3].Hash)
+
+	// ask for 3
+	sb = ts1.CallGB(sb1, false, 3)
+	require.NotNil(t, sb)
+	require.Equal(t, 3, len(sb))
+	require.Equal(t, sb1.Hash, sb[0].Hash)
+	require.Equal(t, sb2.Hash, sb[1].Hash)
+	require.Equal(t, sb3.Hash, sb[2].Hash)
 
 	// And what about getupdate with all servers replying?
 	// server[2] does not have the correct block in it, so we expect it
 	// to get the request, but send no reply back. One of the others
 	// will find the blocks.
 	servers[2].Unpause()
-	sb = ts1.CallGB(sb0, 10)
+	sb = ts1.CallGB(sb0, false, 10)
 	require.NotNil(t, sb)
-	require.Equal(t, 2, len(sb))
+	require.Equal(t, 4, len(sb))
 	require.Equal(t, sb0.Hash, sb[0].Hash)
 	require.Equal(t, sb1.Hash, sb[1].Hash)
+	require.Equal(t, sb2.Hash, sb[2].Hash)
+	require.Equal(t, sb3.Hash, sb[3].Hash)
+
+	// with skipping, we expect to get sb0, sb1 and sb3.
+	sb = ts1.CallGB(sb0, true, 10)
+	require.NotNil(t, sb)
+	require.Equal(t, 3, len(sb))
+	require.Equal(t, sb0.Hash, sb[0].Hash)
+	require.Equal(t, sb1.Hash, sb[1].Hash)
+	require.Equal(t, sb3.Hash, sb[2].Hash)
+
 }
 
 // TestER tests the ProtoExtendRoster message
@@ -159,7 +216,7 @@ func (ts *testService) CallER(t *onet.Tree, b *skipchain.SkipBlock) []skipchain.
 	return <-pisc.ExtendRosterReply
 }
 
-func (ts *testService) CallGB(sb *skipchain.SkipBlock, n int) []*skipchain.SkipBlock {
+func (ts *testService) CallGB(sb *skipchain.SkipBlock, sk bool, n int) []*skipchain.SkipBlock {
 	t := sb.Roster.RandomSubset(ts.ServerIdentity(), 3).GenerateStar()
 	log.Lvl3("running on this tree", t.Dump())
 
@@ -170,8 +227,9 @@ func (ts *testService) CallGB(sb *skipchain.SkipBlock, n int) []*skipchain.SkipB
 	}
 	pisc := pi.(*skipchain.GetBlocks)
 	pisc.GetBlocks = &skipchain.ProtoGetBlocks{
-		Count: n,
-		SBID:  sb.Hash,
+		Count:    n,
+		SBID:     sb.Hash,
+		Skipping: sk,
 	}
 	if err := pi.Start(); err != nil {
 		log.ErrFatal(err)

--- a/skipchain/protocol_test.go
+++ b/skipchain/protocol_test.go
@@ -135,9 +135,6 @@ func TestGB(t *testing.T) {
 
 // TestER tests the ProtoExtendRoster message
 func TestER(t *testing.T) {
-	if testing.Short() {
-		t.Skip("this test does not pass on travis, see #1000")
-	}
 	nodes := []int{2, 5, 13}
 	for _, nbrNodes := range nodes {
 		testER(t, tsID, nbrNodes)

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -718,7 +718,7 @@ func (s *Service) deprecatedProcessorGetBlock(env *network.Envelope) {
 	}
 	sb := s.db.GetByID(gb.ID)
 	if sb == nil {
-		log.Error("Did not find block")
+		log.Errorf("Did not find block %v", gb.ID)
 		return
 	}
 	if i, _ := sb.Roster.Search(s.ServerIdentity().ID); i < 0 {

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -238,9 +238,8 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, on
 }
 
 // GetUpdateChain returns a slice of SkipBlocks which describe the part of the
-// skipchain from the latest block the caller knows of to the actual latest
-// SkipBlock.
-// Somehow comparable to search in SkipLists.
+// skipchain from the latest block the caller knows to the latest
+// SkipBlock we know.
 func (s *Service) GetUpdateChain(latestKnown *GetUpdateChain) (network.Message, onet.ClientError) {
 	block := s.db.GetByID(latestKnown.LatestID)
 	if block == nil {
@@ -280,58 +279,35 @@ func (s *Service) GetUpdateChain(latestKnown *GetUpdateChain) (network.Message, 
 	return reply, nil
 }
 
+// syncChain communicates with conodes in the Roster via getBlocks
+// in order to find the latest block.
 func (s *Service) syncChain(roster *onet.Roster, latest SkipBlockID) error {
-	// TODO: what if GetUpdateChain happened to choose US? Why doesn't it so far?
-	// TODO: maybe it is missing us because Go stdlib math/rand is never seeded? (in tests maybe
-	// that's correct, but in prod not so much)
-	// TODO: if GetUpdateChain happens to choose a server that's down,
-	// we need to retry (up to a limit)
-	reply, cerr := NewClient().GetUpdateChain(roster, latest)
-	if cerr != nil {
-		return cerr
-	}
-	for _, sb := range reply.Update {
-		for _, bid := range sb.BackLinkIDs {
-			// for every back link of block sb, do the following
-			// 1, find the block identified by the back link, call it back-block
-			// 2, ask for the same back-block from other nodes
-			//    the new new-block should have forward links
-			// 3, check the forward links are signed correctly
-			// 4, check the forward links are at the right height
-			back := s.db.GetByID(bid)
-			if back == nil {
-				continue
-			}
-
-			// get the one block with hash == back.Hash
-			result, cerr := s.getBlocks(roster, back.Hash, 1)
-			if cerr != nil {
-				return cerr
-			}
-			if len(result) != 1 {
-				return fmt.Errorf("expected to find 1 block, got %v", len(result))
-			}
-			newBack := result[0]
-
-			for _, fl := range newBack.ForwardLink {
-				if err := fl.Verify(Suite, roster.Publics()); err != nil {
-					return err
-				}
-			}
-			s.db.Store(newBack)
-		}
-		if err := sb.VerifyForwardSignatures(); err != nil {
+	// loop on getBlocks, fetching 10 at a time
+	for {
+		blocks, err := s.getBlocks(roster, latest, 10)
+		if err != nil {
 			return err
 		}
-		if !s.blockIsFriendly(sb) {
-			return fmt.Errorf("%s: block is not friendly: %x", s.ServerIdentity(), sb.Hash)
+
+		for _, sb := range blocks {
+			log.Lvl3("syncChain block", string(sb.Data))
+
+			if err := sb.VerifyForwardSignatures(); err != nil {
+				return err
+			}
+			if !s.blockIsFriendly(sb) {
+				return fmt.Errorf("%s: block is not friendly: %x", s.ServerIdentity(), sb.Hash)
+			}
+			s.db.Store(sb)
+			if len(sb.ForwardLink) == 0 {
+				return nil
+			}
+			latest = sb.Hash
 		}
-		s.db.Store(sb)
 	}
-	return nil
 }
 
-// getBlocks uses ProtocolGetUpdate to return up to n blocks, traversing the
+// getBlocks uses ProtocolGetBlocks to return up to n blocks, traversing the
 // skiplist forward from id. It contacts a random subgroup of 3 of the nodes
 // in the roster, in order to find an answer, even in the case that a few
 // nodes in the network are down.
@@ -344,17 +320,41 @@ func (s *Service) getBlocks(roster *onet.Roster, id SkipBlockID, n int) ([]*Skip
 
 	pisc := pi.(*GetBlocks)
 	pisc.GetBlocks = &ProtoGetBlocks{
-		SBID:  id,
-		Count: n,
+		SBID:     id,
+		Count:    n,
+		Skipping: true,
 	}
 	if err := pi.Start(); err != nil {
 		log.ErrFatal(err)
 	}
 	select {
 	case result := <-pisc.GetBlocksReply:
+		log.Lvl3("getBlocks result count: ", len(result))
 		return result, nil
 	case <-time.After(s.propTimeout):
-		return nil, errors.New("timeout waiting for GetUpdate reply")
+		return nil, errors.New("timeout waiting for GetBlocks reply")
+	}
+}
+
+// getLastBlock talks one of the servers in roster in order to find the latest
+// block that it knows about.
+func (s *Service) getLastBlock(roster *onet.Roster, latest SkipBlockID) (*SkipBlock, error) {
+	// loop on getBlocks, fetching 10 at a time
+	for {
+		blocks, err := s.getBlocks(roster, latest, 10)
+		if err != nil {
+			return nil, err
+		}
+		if len(blocks) == 0 {
+			return nil, errors.New("getLastBlock got unexpected empty list")
+		}
+		// last block of this batch
+		lb := blocks[len(blocks)-1]
+
+		if len(lb.ForwardLink) == 0 {
+			return lb, nil
+		}
+		latest = lb.Hash
 	}
 }
 
@@ -509,14 +509,14 @@ func (s *Service) AddFollow(add *AddFollow) (*EmptyReply, onet.ClientError) {
 				sis[si.ID.String()] = si
 			}
 		}
+
 		found := false
 		for _, si := range sis {
 			roster := onet.NewRoster([]*network.ServerIdentity{si})
-			s.storageMutex.Unlock()
-			reply, cerr := NewClient().GetUpdateChain(roster, add.SkipchainID)
-			s.storageMutex.Lock()
-			if cerr == nil {
-				last := reply.Update[len(reply.Update)-1]
+			last, err := s.getLastBlock(roster, add.SkipchainID)
+			if err != nil {
+				log.Error("could not get last block: ", err)
+			} else {
 				if last.SkipChainID().Equal(add.SkipchainID) {
 					s.Storage.Follow = append(s.Storage.Follow,
 						FollowChainType{
@@ -535,13 +535,10 @@ func (s *Service) AddFollow(add *AddFollow) (*EmptyReply, onet.ClientError) {
 	case FollowLookup:
 		si := network.NewServerIdentity(Suite.Point(), network.NewTCPAddress(add.Conode))
 		roster := onet.NewRoster([]*network.ServerIdentity{si})
-		s.storageMutex.Unlock()
-		reply, cerr := NewClient().GetUpdateChain(roster, add.SkipchainID)
-		s.storageMutex.Lock()
-		if cerr != nil {
+		last, err := s.getLastBlock(roster, add.SkipchainID)
+		if err != nil {
 			return nil, onet.NewClientErrorCode(ErrorBlockNotFound, "didn't find skipchain at given address")
 		}
-		last := reply.Update[len(reply.Update)-1]
 		if !last.SkipChainID().Equal(add.SkipchainID) {
 			return nil, onet.NewClientErrorCode(ErrorBlockNotFound, "returned block is not correct")
 		}

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -290,8 +290,6 @@ func (s *Service) syncChain(roster *onet.Roster, latest SkipBlockID) error {
 		}
 
 		for _, sb := range blocks {
-			log.Lvl3("syncChain block", string(sb.Data))
-
 			if err := sb.VerifyForwardSignatures(); err != nil {
 				return err
 			}
@@ -329,7 +327,6 @@ func (s *Service) getBlocks(roster *onet.Roster, id SkipBlockID, n int) ([]*Skip
 	}
 	select {
 	case result := <-pisc.GetBlocksReply:
-		log.Lvl3("getBlocks result count: ", len(result))
 		return result, nil
 	case <-time.After(s.propTimeout):
 		return nil, errors.New("timeout waiting for GetBlocks reply")

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -34,12 +34,9 @@ const bftFollowBlock = "SkipchainBFTFollow"
 const storageKey = "skipchainconfig"
 
 func init() {
-	skipchainSID, _ = onet.RegisterNewService(ServiceName, newSkipchainService)
+	onet.RegisterNewService(ServiceName, newSkipchainService)
 	network.RegisterMessages(&Storage{})
 }
-
-// Only used in tests
-var skipchainSID onet.ServiceID
 
 // Service handles adding new SkipBlocks
 type Service struct {
@@ -54,6 +51,8 @@ type Service struct {
 	newBlocks          map[string]bool
 	storageMutex       sync.Mutex
 	Storage            *Storage
+	bftTimeout         time.Duration
+	propTimeout        time.Duration
 }
 
 // Storage is saved to disk.
@@ -282,6 +281,11 @@ func (s *Service) GetUpdateChain(latestKnown *GetUpdateChain) (network.Message, 
 }
 
 func (s *Service) syncChain(roster *onet.Roster, latest SkipBlockID) error {
+	// TODO: what if GetUpdateChain happened to choose US? Why doesn't it so far?
+	// TODO: maybe it is missing us because Go stdlib math/rand is never seeded? (in tests maybe
+	// that's correct, but in prod not so much)
+	// TODO: if GetUpdateChain happens to choose a server that's down,
+	// we need to retry (up to a limit)
 	reply, cerr := NewClient().GetUpdateChain(roster, latest)
 	if cerr != nil {
 		return cerr
@@ -635,11 +639,17 @@ func (s *Service) callGetBlock(known *SkipBlock, unknown SkipBlockID) (*SkipBloc
 		&GetBlock{unknown}); err != nil {
 		return nil, errors.New("Couldn't get updated block: " + known.Short())
 	}
+
+	to := s.propTimeout
+	if to == 0 {
+		to = defaultPropagateTimeout
+	}
+
 	var block *SkipBlock
 	select {
 	case block = <-request:
 		log.Lvl3("Got block", block)
-	case <-time.After(time.Millisecond * time.Duration(propagateTimeout)):
+	case <-time.After(to):
 		return nil, errors.New("Couldn't get updated block in time: " + unknown.Short())
 	}
 	return block, nil
@@ -766,13 +776,19 @@ func (s *Service) bftVerifyFollowBlock(msg []byte, data []byte) bool {
 // verifyNewBlock makes sure that a signature-request for a forward-link
 // is valid.
 func (s *Service) bftVerifyNewBlock(msg []byte, data []byte) bool {
+	// TODO: check length of data before slicing it
+
 	log.Lvlf4("%s verifying block %x", s.ServerIdentity(), msg)
 	_, newSBi, err := network.Unmarshal(data[32:], Suite)
 	if err != nil {
 		log.Error("Couldn't unmarshal SkipBlock", data)
 		return false
 	}
-	newSB := newSBi.(*SkipBlock)
+	newSB, ok := newSBi.(*SkipBlock)
+	if !ok {
+		log.Errorf("Got unexpected type %T in bftVerifyNewBlock", newSBi)
+		return false
+	}
 	if !newSB.Hash.Equal(SkipBlockID(msg)) {
 		log.Lvlf2("Dest skipBlock different from msg %x %x", msg, []byte(newSB.Hash))
 		return false
@@ -801,7 +817,7 @@ func (s *Service) bftVerifyNewBlock(msg []byte, data []byte) bool {
 		return false
 	}
 
-	ok := func() bool {
+	ok = func() bool {
 		for _, ver := range newSB.VerifierIDs {
 			f, ok := s.verifiers[ver]
 			if !ok {
@@ -965,7 +981,6 @@ func (s *Service) startBFT(proto string, roster *onet.Roster, msg, data []byte) 
 			return nil, errors.New("failed in cosi")
 		}
 		return sig, nil
-		//return nil, errors.New("need more than 1 entry for Roster")
 	}
 
 	// Start the protocol
@@ -973,6 +988,10 @@ func (s *Service) startBFT(proto string, roster *onet.Roster, msg, data []byte) 
 	// Register the function generating the protocol instance
 	root.Msg = msg
 	root.Data = data
+
+	if s.bftTimeout != 0 {
+		root.Timeout = s.bftTimeout
+	}
 
 	// function that will be called when protocol is finished by the root
 	done := make(chan bool)
@@ -1009,12 +1028,16 @@ func (s *Service) startPropagation(blocks []*SkipBlock) error {
 	}
 	roster := onet.NewRoster(siList)
 
-	replies, err := s.propagate(roster, &PropagateSkipBlocks{blocks}, propagateTimeout)
+	to := s.propTimeout
+	if to == 0 {
+		to = defaultPropagateTimeout
+	}
+	replies, err := s.propagate(roster, &PropagateSkipBlocks{blocks}, to)
 	if err != nil {
 		return err
 	}
 	if replies != len(roster.List) {
-		log.Warn("Did only get", replies, "out of", len(roster.List))
+		log.Warn("Only got", replies, "out of", len(roster.List))
 	}
 	return nil
 }

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dedis/cothority"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/sign/schnorr"
 	"github.com/dedis/kyber/util/key"
@@ -43,10 +44,10 @@ func TestService_StoreSkipBlock(t *testing.T) {
 
 func storeSkipBlock(t *testing.T, fail bool) {
 	// First create a roster to attach the data to it
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, el, genService := local.MakeHELS(4, skipchainSID, Suite)
+	servers, el, genService := local.MakeHELS(4, skipchainSID, cothority.Suite)
 	service := genService.(*Service)
 	// This is the poor server who will play the part of the dead server
 	// for us.
@@ -141,12 +142,12 @@ func storeSkipBlock(t *testing.T, fail bool) {
 func TestService_GetUpdateChain(t *testing.T) {
 	// Create a small chain and test whether we can get from one element
 	// of the chain to the last element with a valid slice of SkipBlocks
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	conodes := 10
 	sbCount := conodes - 1
-	servers, el, gs := local.MakeHELS(conodes, skipchainSID, Suite)
+	servers, el, gs := local.MakeHELS(conodes, skipchainSID, cothority.Suite)
 	s := gs.(*Service)
 
 	sbs := make([]*SkipBlock, sbCount)
@@ -206,10 +207,10 @@ func TestService_SetChildrenSkipBlock(t *testing.T) {
 	// How many nodes in Root
 	nodesRoot := 3
 
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	hosts, el, genService := local.MakeHELS(nodesRoot, skipchainSID, Suite)
+	hosts, el, genService := local.MakeHELS(nodesRoot, skipchainSID, cothority.Suite)
 	service := genService.(*Service)
 
 	// Setting up two chains and linking one to the other
@@ -263,10 +264,10 @@ func TestService_SetChildrenSkipBlock(t *testing.T) {
 }
 
 func TestService_MultiLevel(t *testing.T) {
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, el, genService := local.MakeHELS(3, skipchainSID, Suite)
+	servers, el, genService := local.MakeHELS(3, skipchainSID, cothority.Suite)
 	services := make([]*Service, len(servers))
 	for i, s := range local.GetServices(servers, skipchainSID) {
 		services[i] = s.(*Service)
@@ -314,11 +315,11 @@ func TestService_MultiLevel(t *testing.T) {
 }
 
 func TestService_Verification(t *testing.T) {
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	sbLength := 4
-	_, el, genService := local.MakeHELS(sbLength, skipchainSID, Suite)
+	_, el, genService := local.MakeHELS(sbLength, skipchainSID, cothority.Suite)
 	service := genService.(*Service)
 
 	elRoot := onet.NewRoster(el.List[0:3])
@@ -347,10 +348,10 @@ func TestService_Verification(t *testing.T) {
 
 func TestService_SignBlock(t *testing.T) {
 	// Testing whether we sign correctly the SkipBlocks
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	_, el, genService := local.MakeHELS(3, skipchainSID, Suite)
+	_, el, genService := local.MakeHELS(3, skipchainSID, cothority.Suite)
 	service := genService.(*Service)
 
 	sbRoot, err := makeGenesisRosterArgs(service, el, nil, VerificationNone, 1, 1)
@@ -369,10 +370,10 @@ func TestService_SignBlock(t *testing.T) {
 
 func TestService_ProtocolVerification(t *testing.T) {
 	// Testing whether we sign correctly the SkipBlocks
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	_, el, s := local.MakeHELS(3, skipchainSID, Suite)
+	_, el, s := local.MakeHELS(3, skipchainSID, cothority.Suite)
 	s1 := s.(*Service)
 	count := make(chan bool, 3)
 	verifyFunc := func(newID []byte, newSB *SkipBlock) bool {
@@ -402,7 +403,7 @@ func TestService_ProtocolVerification(t *testing.T) {
 func TestService_RegisterVerification(t *testing.T) {
 	// Testing whether we sign correctly the SkipBlocks
 	onet.RegisterNewService("ServiceVerify", newServiceVerify)
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	hosts, el, s1 := makeHELS(local, 3)
@@ -429,7 +430,7 @@ func TestService_RegisterVerification(t *testing.T) {
 
 func TestService_StoreSkipBlock2(t *testing.T) {
 	nbrHosts := 3
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	hosts, roster, s1 := makeHELS(local, nbrHosts)
@@ -481,7 +482,7 @@ func TestService_StoreSkipBlock2(t *testing.T) {
 func TestService_StoreSkipBlockSpeed(t *testing.T) {
 	t.Skip("This is a hidden benchmark")
 	nbrHosts := 3
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	_, roster, s1 := makeHELS(local, nbrHosts)
@@ -514,7 +515,7 @@ func TestService_ParallelStore(t *testing.T) {
 		t.Skip("parallel store does not run on travis, see #1000")
 	}
 	nbrRoutines := 10
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	_, roster, s1 := makeHELS(local, 3)
@@ -564,10 +565,11 @@ func TestService_Propagation(t *testing.T) {
 		t.Skip("propagation does not run on travis, see #1000")
 	}
 	nbrNodes := 60
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
+
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, ro, genService := local.MakeHELS(nbrNodes, skipchainSID, Suite)
+	servers, ro, genService := local.MakeHELS(nbrNodes, skipchainSID, cothority.Suite)
 	services := make([]*Service, len(servers))
 	for i, s := range local.GetServices(servers, skipchainSID) {
 		services[i] = s.(*Service)
@@ -583,10 +585,10 @@ func TestService_Propagation(t *testing.T) {
 }
 
 func TestService_AddFollow(t *testing.T) {
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, ro, _ := local.MakeHELS(3, skipchainSID, Suite)
+	servers, ro, _ := local.MakeHELS(3, skipchainSID, cothority.Suite)
 	services := make([]*Service, len(servers))
 	for i, s := range local.GetServices(servers, skipchainSID) {
 		services[i] = s.(*Service)
@@ -607,7 +609,7 @@ func TestService_AddFollow(t *testing.T) {
 	// Wrong server signature
 	priv0 := local.GetPrivate(servers[0])
 	priv1 := local.GetPrivate(servers[1])
-	sig, err := schnorr.Sign(Suite, priv1, ssb.NewBlock.CalculateHash())
+	sig, err := schnorr.Sign(cothority.Suite, priv1, ssb.NewBlock.CalculateHash())
 	log.ErrFatal(err)
 	ssb.Signature = &sig
 	_, cerr = service.StoreSkipBlock(ssb)
@@ -615,7 +617,7 @@ func TestService_AddFollow(t *testing.T) {
 
 	// Correct server signature
 	log.Lvl2("correct server signature")
-	sig, err = schnorr.Sign(Suite, priv0, ssb.NewBlock.CalculateHash())
+	sig, err = schnorr.Sign(cothority.Suite, priv0, ssb.NewBlock.CalculateHash())
 	log.ErrFatal(err)
 	ssb.Signature = &sig
 	master0, cerr := service.StoreSkipBlock(ssb)
@@ -628,7 +630,7 @@ func TestService_AddFollow(t *testing.T) {
 	sb = sb.Copy()
 	ssb.NewBlock = sb
 	sb.Roster = onet.NewRoster([]*network.ServerIdentity{ro.List[0], ro.List[1]}) // two in roster
-	sig, err = schnorr.Sign(Suite, priv0, ssb.NewBlock.CalculateHash())
+	sig, err = schnorr.Sign(cothority.Suite, priv0, ssb.NewBlock.CalculateHash())
 	log.ErrFatal(err)
 	ssb.Signature = &sig
 	require.Equal(t, 0, services[1].db.Length())
@@ -642,7 +644,7 @@ func TestService_AddFollow(t *testing.T) {
 		Block:    master0.Latest,
 		NewChain: NewChainAnyNode,
 	}}
-	sig, err = schnorr.Sign(Suite, priv0, ssb.NewBlock.CalculateHash())
+	sig, err = schnorr.Sign(cothority.Suite, priv0, ssb.NewBlock.CalculateHash())
 	log.ErrFatal(err)
 	ssb.Signature = &sig
 	master1, cerr := service.StoreSkipBlock(ssb)
@@ -659,7 +661,7 @@ func TestService_AddFollow(t *testing.T) {
 	sb.Hash = sb.CalculateHash()
 	ssb.NewBlock = sb
 	ssb.LatestID = master1.Latest.Hash
-	sig, err = schnorr.Sign(Suite, priv1, ssb.NewBlock.CalculateHash())
+	sig, err = schnorr.Sign(cothority.Suite, priv1, ssb.NewBlock.CalculateHash())
 	log.ErrFatal(err)
 	ssb.Signature = &sig
 	sbs, err := service.db.getAll()
@@ -673,10 +675,10 @@ func TestService_AddFollow(t *testing.T) {
 }
 
 func TestService_CreateLinkPrivate(t *testing.T) {
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, _, _ := local.MakeHELS(3, skipchainSID, Suite)
+	servers, _, _ := local.MakeHELS(3, skipchainSID, cothority.Suite)
 	server := servers[0]
 	service := local.GetServices(servers, skipchainSID)[0].(*Service)
 	require.Equal(t, 0, len(service.Storage.Clients))
@@ -687,7 +689,7 @@ func TestService_CreateLinkPrivate(t *testing.T) {
 	require.NotNil(t, cerr)
 	msg, err := server.ServerIdentity.Public.MarshalBinary()
 	require.Nil(t, err)
-	sig, err := schnorr.Sign(Suite, local.GetPrivate(servers[0]), msg)
+	sig, err := schnorr.Sign(cothority.Suite, local.GetPrivate(servers[0]), msg)
 	log.ErrFatal(err)
 	_, cerr = service.CreateLinkPrivate(&CreateLinkPrivate{Public: servers[0].ServerIdentity.Public, Signature: sig})
 	log.ErrFatal(cerr)
@@ -698,16 +700,16 @@ func TestService_CreateLinkPrivate(t *testing.T) {
 }
 
 func TestService_Unlink(t *testing.T) {
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, _, _ := local.MakeHELS(3, skipchainSID, Suite)
+	servers, _, _ := local.MakeHELS(3, skipchainSID, cothority.Suite)
 	server := servers[0]
 	service := local.GetServices(servers, skipchainSID)[0].(*Service)
 
-	kp := key.NewKeyPair(Suite)
+	kp := key.NewKeyPair(cothority.Suite)
 	msg, _ := kp.Public.MarshalBinary()
-	sig, err := schnorr.Sign(Suite, local.GetPrivate(servers[0]), msg)
+	sig, err := schnorr.Sign(cothority.Suite, local.GetPrivate(servers[0]), msg)
 	log.ErrFatal(err)
 	_, cerr := service.CreateLinkPrivate(&CreateLinkPrivate{Public: kp.Public, Signature: sig})
 	log.ErrFatal(cerr)
@@ -724,7 +726,7 @@ func TestService_Unlink(t *testing.T) {
 	// Inexistant public key
 	msg, _ = server.ServerIdentity.Public.MarshalBinary()
 	msg = append([]byte("unlink:"), msg...)
-	sig, err = schnorr.Sign(Suite, local.GetPrivate(servers[0]), msg)
+	sig, err = schnorr.Sign(cothority.Suite, local.GetPrivate(servers[0]), msg)
 	_, cerr = service.Unlink(&Unlink{
 		Public:    servers[0].ServerIdentity.Public,
 		Signature: sig,
@@ -735,7 +737,7 @@ func TestService_Unlink(t *testing.T) {
 	// Wrong signature
 	msg, _ = kp.Public.MarshalBinary()
 	msg = append([]byte("unlink:"), msg...)
-	sig, err = schnorr.Sign(Suite, local.GetPrivate(servers[0]), msg)
+	sig, err = schnorr.Sign(cothority.Suite, local.GetPrivate(servers[0]), msg)
 	_, cerr = service.Unlink(&Unlink{
 		Public:    kp.Public,
 		Signature: sig,
@@ -746,7 +748,7 @@ func TestService_Unlink(t *testing.T) {
 	// Correct signautre and existing public key
 	msg, _ = kp.Public.MarshalBinary()
 	msg = append([]byte("unlink:"), msg...)
-	sig, err = schnorr.Sign(Suite, kp.Private, msg)
+	sig, err = schnorr.Sign(cothority.Suite, kp.Private, msg)
 	_, cerr = service.Unlink(&Unlink{
 		Public:    kp.Public,
 		Signature: sig,
@@ -756,25 +758,25 @@ func TestService_Unlink(t *testing.T) {
 }
 
 func TestService_DelFollow(t *testing.T) {
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, _, _ := local.MakeHELS(3, skipchainSID, Suite)
+	servers, _, _ := local.MakeHELS(3, skipchainSID, cothority.Suite)
 	service := local.GetServices(servers, skipchainSID)[0].(*Service)
 
-	privWrong := key.NewKeyPair(Suite).Private
+	privWrong := key.NewKeyPair(cothority.Suite).Private
 	priv := setupFollow(service)
 	iddel := []byte{0}
 	msg := append([]byte("delfollow:"), iddel...)
 
 	// Test wrong signature
-	sig, err := schnorr.Sign(Suite, privWrong, msg)
+	sig, err := schnorr.Sign(cothority.Suite, privWrong, msg)
 	log.ErrFatal(err)
 	_, cerr := service.DelFollow(&DelFollow{SkipchainID: iddel, Signature: sig})
 	require.NotNil(t, cerr)
 	require.Equal(t, 2, len(service.Storage.FollowIDs))
 
-	sig, err = schnorr.Sign(Suite, priv, msg)
+	sig, err = schnorr.Sign(cothority.Suite, priv, msg)
 	log.ErrFatal(err)
 	_, cerr = service.DelFollow(&DelFollow{SkipchainID: iddel, Signature: sig})
 	require.Nil(t, cerr)
@@ -783,7 +785,7 @@ func TestService_DelFollow(t *testing.T) {
 	// Test removal of Follow
 	iddel = []byte{2}
 	msg = append([]byte("delfollow:"), iddel...)
-	sig, err = schnorr.Sign(Suite, priv, msg)
+	sig, err = schnorr.Sign(cothority.Suite, priv, msg)
 	log.ErrFatal(err)
 	_, cerr = service.DelFollow(&DelFollow{SkipchainID: iddel, Signature: sig})
 	require.Nil(t, cerr)
@@ -791,10 +793,10 @@ func TestService_DelFollow(t *testing.T) {
 }
 
 func TestService_ListFollow(t *testing.T) {
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, _, _ := local.MakeHELS(3, skipchainSID, Suite)
+	servers, _, _ := local.MakeHELS(3, skipchainSID, cothority.Suite)
 	service := local.GetServices(servers, skipchainSID)[0].(*Service)
 
 	priv := setupFollow(service)
@@ -803,7 +805,7 @@ func TestService_ListFollow(t *testing.T) {
 	msg, err := servers[1].ServerIdentity.Public.MarshalBinary()
 	log.ErrFatal(err)
 	msg = append([]byte("listfollow:"), msg...)
-	sig, err := schnorr.Sign(Suite, priv, msg)
+	sig, err := schnorr.Sign(cothority.Suite, priv, msg)
 	log.ErrFatal(err)
 	lf, cerr := service.ListFollow(&ListFollow{Signature: sig})
 	require.NotNil(t, cerr)
@@ -811,7 +813,7 @@ func TestService_ListFollow(t *testing.T) {
 	msg, err = servers[0].ServerIdentity.Public.MarshalBinary()
 	log.ErrFatal(err)
 	msg = append([]byte("listfollow:"), msg...)
-	sig, err = schnorr.Sign(Suite, priv, msg)
+	sig, err = schnorr.Sign(cothority.Suite, priv, msg)
 	log.ErrFatal(err)
 	lf, cerr = service.ListFollow(&ListFollow{Signature: sig})
 	require.Nil(t, cerr)
@@ -820,7 +822,7 @@ func TestService_ListFollow(t *testing.T) {
 }
 
 func setupFollow(s *Service) kyber.Scalar {
-	kp := key.NewKeyPair(Suite)
+	kp := key.NewKeyPair(cothority.Suite)
 	s.Storage.Clients = []kyber.Point{kp.Public}
 	s.Storage.FollowIDs = []SkipBlockID{{0}, {1}}
 	s.Storage.Follow = []FollowChainType{

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -20,6 +20,12 @@ import (
 	"gopkg.in/satori/go.uuid.v1"
 )
 
+func init() {
+	skipchainSID = onet.ServiceFactory.ServiceID(ServiceName)
+}
+
+var skipchainSID onet.ServiceID
+
 func TestMain(m *testing.M) {
 	log.MainTest(m, 2)
 }
@@ -42,6 +48,18 @@ func storeSkipBlock(t *testing.T, fail bool) {
 	defer local.CloseAll()
 	servers, el, genService := local.MakeHELS(4, skipchainSID, Suite)
 	service := genService.(*Service)
+	// This is the poor server who will play the part of the dead server
+	// for us.
+	deadServer := servers[len(servers)-1]
+
+	if fail {
+		// Set low timeout to make the test finish quickly.
+		service.bftTimeout = 50 * time.Millisecond
+		// WATCH OUT: log levels higher than 3 require a timeout of 500 ms.
+		// service.bftTimeout = 500 * time.Millisecond
+
+		service.propTimeout = 5 * service.bftTimeout
+	}
 
 	// Setting up root roster
 	sbRoot, err := makeGenesisRoster(service, el)
@@ -57,19 +75,21 @@ func storeSkipBlock(t *testing.T, fail bool) {
 	genesis.VerifierIDs = VerificationStandard
 	blockCount := 0
 	psbr, err := service.StoreSkipBlock(&StoreSkipBlock{LatestID: nil, NewBlock: genesis})
-	assert.Nil(t, err)
+	if err != nil {
+		t.Fatal("StoreSkipBlock:", err)
+	}
 	latest := psbr.Latest
 	// verify creation of GenesisBlock:
-	assert.Equal(t, blockCount, latest.Index)
+	blockCount++
+	assert.Equal(t, blockCount-1, latest.Index)
 	// the genesis block has a random back-link:
 	assert.Equal(t, 1, len(latest.BackLinkIDs))
 	assert.NotEqual(t, 0, latest.BackLinkIDs)
 
 	// kill one node and it should still work
 	if fail {
-		log.Lvl3("Closing server", servers[len(servers)-1].Address())
-		err = servers[len(servers)-1].Close()
-		log.ErrFatal(err)
+		log.Lvl3("Pausing server", deadServer.Address())
+		deadServer.Pause()
 	}
 
 	next := NewSkipBlock()
@@ -80,20 +100,48 @@ func storeSkipBlock(t *testing.T, fail bool) {
 	next.ParentBlockID = sbRoot.Hash
 	next.Roster = sbRoot.Roster
 	id := psbr.Latest.Hash
+	if id == nil {
+		t.Fatal("second block last id is nil")
+	}
 	psbr2, err := service.StoreSkipBlock(&StoreSkipBlock{LatestID: id, NewBlock: next})
-	assert.Nil(t, err)
-	log.Lvl2(psbr2)
+	if err != nil {
+		t.Fatal("StoreSkipBlock:", err)
+	}
 	assert.NotNil(t, psbr2)
 	assert.NotNil(t, psbr2.Latest)
 	latest2 := psbr2.Latest
 	// verify creation of GenesisBlock:
 	blockCount++
-	assert.Equal(t, blockCount, latest2.Index)
+	assert.Equal(t, blockCount-1, latest2.Index)
 	assert.Equal(t, 1, len(latest2.BackLinkIDs))
 	assert.NotEqual(t, 0, latest2.BackLinkIDs)
 
-	// We've added 2 blocks, + root block = 3
-	assert.Equal(t, 3, service.db.Length())
+	// And add it again, with all nodes running
+	if fail {
+		log.Lvl3("Unpausing server ", deadServer.Address())
+		deadServer.Unpause()
+	}
+
+	next.ParentBlockID = next.Hash
+	psbr3, err := service.StoreSkipBlock(&StoreSkipBlock{LatestID: psbr2.Latest.Hash, NewBlock: next})
+	// Until the catch-up logic is implemented, sometimes this one fails, so skip the checking
+	// in that case.
+	if err == nil {
+		assert.NotNil(t, psbr3)
+		assert.NotNil(t, psbr3.Latest)
+		latest3 := psbr3.Latest
+
+		// verify creation of GenesisBlock:
+		blockCount++
+		assert.Equal(t, blockCount-1, latest3.Index)
+		assert.Equal(t, 2, len(latest3.BackLinkIDs))
+		assert.NotEqual(t, 0, latest3.BackLinkIDs)
+	} else {
+		t.Log("3rd block write err", err)
+	}
+
+	// +1 for the root block
+	assert.Equal(t, blockCount+1, service.db.Length())
 }
 
 func TestService_GetUpdateChain(t *testing.T) {

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -54,7 +54,7 @@ func storeSkipBlock(t *testing.T, fail bool) {
 
 	if fail {
 		// Set low timeout to make the test finish quickly.
-		service.bftTimeout = 50 * time.Millisecond
+		service.bftTimeout = 100 * time.Millisecond
 		// WATCH OUT: log levels higher than 3 require a timeout of 500 ms.
 		// service.bftTimeout = 500 * time.Millisecond
 
@@ -94,8 +94,7 @@ func storeSkipBlock(t *testing.T, fail bool) {
 
 	next := NewSkipBlock()
 	next.Data = []byte("And the earth was without form, and void; " +
-		"and darkness was upon the face of the deep. " +
-		"And the Spirit of God moved upon the face of the waters.")
+		"and darkness was upon the face of the deep. ")
 	next.MaximumHeight = 2
 	next.ParentBlockID = sbRoot.Hash
 	next.Roster = sbRoot.Roster
@@ -110,7 +109,7 @@ func storeSkipBlock(t *testing.T, fail bool) {
 	assert.NotNil(t, psbr2)
 	assert.NotNil(t, psbr2.Latest)
 	latest2 := psbr2.Latest
-	// verify creation of GenesisBlock:
+
 	blockCount++
 	assert.Equal(t, blockCount-1, latest2.Index)
 	assert.Equal(t, 1, len(latest2.BackLinkIDs))
@@ -123,22 +122,17 @@ func storeSkipBlock(t *testing.T, fail bool) {
 	}
 
 	next.ParentBlockID = next.Hash
+	next.Data = []byte("And the Spirit of God moved upon the face of the waters.")
 	psbr3, err := service.StoreSkipBlock(&StoreSkipBlock{LatestID: psbr2.Latest.Hash, NewBlock: next})
-	// Until the catch-up logic is implemented, sometimes this one fails, so skip the checking
-	// in that case.
-	if err == nil {
-		assert.NotNil(t, psbr3)
-		assert.NotNil(t, psbr3.Latest)
-		latest3 := psbr3.Latest
+	assert.NotNil(t, psbr3)
+	assert.NotNil(t, psbr3.Latest)
+	latest3 := psbr3.Latest
 
-		// verify creation of GenesisBlock:
-		blockCount++
-		assert.Equal(t, blockCount-1, latest3.Index)
-		assert.Equal(t, 2, len(latest3.BackLinkIDs))
-		assert.NotEqual(t, 0, latest3.BackLinkIDs)
-	} else {
-		t.Log("3rd block write err", err)
-	}
+	// verify creation of GenesisBlock:
+	blockCount++
+	assert.Equal(t, blockCount-1, latest3.Index)
+	assert.Equal(t, 2, len(latest3.BackLinkIDs))
+	assert.NotEqual(t, 0, latest3.BackLinkIDs)
 
 	// +1 for the root block
 	assert.Equal(t, blockCount+1, service.db.Length())

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -557,7 +557,7 @@ func TestService_ParallelStore(t *testing.T) {
 }
 
 func TestService_Propagation(t *testing.T) {
-	nbrNodes := 10
+	nbrNodes := 60
 	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -510,6 +510,9 @@ func TestService_StoreSkipBlockSpeed(t *testing.T) {
 }
 
 func TestService_ParallelStore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("parallel store does not run on travis, see #1000")
+	}
 	nbrRoutines := 10
 	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)
@@ -557,6 +560,9 @@ func TestService_ParallelStore(t *testing.T) {
 }
 
 func TestService_Propagation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("propagation does not run on travis, see #1000")
+	}
 	nbrNodes := 60
 	local := onet.NewLocalTest(Suite)
 	defer waitPropagationFinished(t, local)

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -18,8 +18,8 @@ import (
 	"gopkg.in/satori/go.uuid.v1"
 )
 
-// How many msec to wait before a timeout is generated in the propagation.
-const propagateTimeout = 5000
+// How long to wait before a timeout is generated in the propagation.
+const defaultPropagateTimeout = 5 * time.Second
 
 // SkipBlockID represents the Hash of the SkipBlock
 type SkipBlockID []byte

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -535,7 +535,7 @@ func (db *SkipBlockDB) GetByID(sbID SkipBlockID) *SkipBlock {
 	})
 
 	if err != nil {
-		log.Error(err.Error())
+		log.Error(err)
 	}
 	return result
 }
@@ -744,7 +744,6 @@ func (db *SkipBlockDB) storeToTx(tx *bolt.Tx, sb *SkipBlock) error {
 	if err != nil {
 		return err
 	}
-
 	return tx.Bucket([]byte(db.bucketName)).Put(key, val)
 }
 

--- a/stable/overwrite/.travis.yml
+++ b/stable/overwrite/.travis.yml
@@ -4,8 +4,10 @@ install:
   - go get -t ./...
   - go get github.com/dedis/Coding || true
 
+go_import_path: gopkg.in/dedis/cothority.v1
+
 script:
-  - make test
+  - make test_stable
 
 notifications:
   email: false

--- a/status/status.go
+++ b/status/status.go
@@ -7,7 +7,6 @@ import (
 
 	"errors"
 
-	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/status/service"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/app"
@@ -68,16 +67,16 @@ func readGroup(tomlFileName string) (*onet.Roster, error) {
 	if err != nil {
 		return nil, err
 	}
-	el, err := app.ReadGroupToml(f, cothority.Suite)
+	g, err := app.ReadGroupDescToml(f)
 	if err != nil {
 		return nil, err
 	}
-	if len(el.List) <= 0 {
+	if len(g.Roster.List) <= 0 {
 		return nil, errors.New("Empty or invalid group file:" +
 			tomlFileName)
 	}
-	log.Lvl3(el)
-	return el, err
+	log.Lvl3(g.Roster)
+	return g.Roster, err
 }
 
 // printConn prints the status response that is returned from the server

--- a/suite_vartime.go
+++ b/suite_vartime.go
@@ -1,4 +1,4 @@
-// +build !vartime
+// +build vartime
 
 package cothority
 
@@ -6,4 +6,4 @@ import "github.com/dedis/kyber/suites"
 
 // Suite is a convenience. It might go away when we decide the a better way to set the
 // suite in repo cothority.
-var Suite = suites.MustFind("Ed25519")
+var Suite = suites.MustFind("P256")


### PR DESCRIPTION
When compiled with "-tags vartime", the suite for cothority is P256.

When the integration tests are run with env var TAGS set to "-tags vartime", the suite for cothority is P256.

When the same env variable is set, run_conode.sh compiles conode with vartime, and the default suite is P256. If you set up a new node, it's suite will be P256. 

The suite is named in the toml files, but if it is not named it defaults to Ed25519, so old files can be used unchanged.

There are still lots of parts of the system that do not allow you to configure the suite at runtime (they use cothority.Suite instead). But at least with these changes, we've been able to identify and fix incorrect assumptions about key lengths.