### PR TITLE
Cisc cleanup

### DIFF
--- a/cisc/README.md
+++ b/cisc/README.md
@@ -9,67 +9,236 @@ Based upon skipchains, cisc serves a data-block with different entries that can 
 
 Besides having devices that can vote on changes, simple followers can download the data-block and get cryptographically signed updates to that data-block to be sure of the authenticity of the new data-block.
 
-For further convenience, a simple mechanism allows for grouping identities with a shared voting-power.
+- CISC - CISC Identity SkipChain
+- Skipchain - blockchain structure developed by the EPFL/DEDIS lab
+- Conode - a server program offering services like CISC and others
+- Device - a computer that has voting power on an identity-skipchain
+- Data - all key/value pairs stored on the SkipChain
+- Proposed Data - data that has been proposed but not yet voted with a threshold
+
+# Example usage
+
+Here is a simple example how cisc can be used with two conodes. You can start
+them on your local computer, and then run cisc against these two conodes. Of
+course you can also start the conodes on your server.
+
+## Installing
+
+To install the conode and start experimenting, we'll use a directory `~/conodes`
+where everything will be stored:
+
+```bash
+go get github.com/dedis/cothority/conode
+go get github.com/dedis/cothority/cisc
+cd $(go env GOPATH)/src/github.com/dedis/cothority/conode
+./run_conode.sh .
+```
+
+## Starting conodes and setting up the first device
+
+For starting two conodes, type the following:
+
+```bash
+cd $(go env GOPATH)/src/github.com/dedis/cothority/conode
+./run_conode.sh local 2 2
+```
+
+If you want to stop the conodes, simply type:
+
+```bash
+pkill conode
+```
+
+### Connecting to one conode
+
+Now we need to connect to one of the conodes. We'll use the PIN authentication:
+
+```bash
+cisc link pin localhost:7002
+```
+
+Now the server should print the PIN to the log. Because you started the conodes
+in the background, the PIN will show up directly on your console. Now you can
+link to it:
+
+```bash
+cisc link pin localhost:7002 123456
+```
+
+of course you'll have another pin than the one shown here.
+
+### Creating an identity
+
+Now we're ready to create a new identity:
+
+```bash
+cisc skipchain create $(go env GOPATH)/src/github.com/dedis/cothority/conode/public.toml
+```
+
+or, if you're still in the conode-directory:
+
+```bash
+cisc skipchain create public.toml
+```
+
+The `public.toml` file gives the definition of the conodes that should be used
+for this new skipchain. It holds the IP-address and the public key for each of
+the conodes.
+This will print an ID of your new skipchain, which is a 64-digit hex number.
+We'll need it later to join the skipchain from another device.
+
+### Storing a key/value pair
+
+The most simple is to store any key/value pair on the skipchain:
+
+```bash
+cisc keyvalue add name linus
+```
+
+This will add a key called _name_ with the value _linus_ to the skipchain and
+vote for it. As there is only one device attached to the skipchain, the new data
+is immediately active.
+
+## Adding a second device
+
+Normally a second device would join from another computer. For easier simulation,
+we can give the configuration-directory to the `cisc` command and simulate a
+second computer. Let's try to join the create skipchain from above:
+
+```bash
+cisc -config device2 skipchain join public.toml 1234...cdef
+```
+
+The `-config device2` indicates that the `cisc` command should now use the `device2`
+directory for storage of all the configuration. This means that we can use
+`cisc` to represent the 1st device, and `cisc -config device2` for the second device.
+Again, the `public.toml` indicates the conodes to use to connect to the skipchain.
+The number `1234...cdef` is the 64-digit hex number from the `cisc skipchain create`
+command from above.
+
+Before we can do anything with the skipchain from this second device, we need to
+approve it from the first one:
+
+```bash
+cisc data vote
+```
+
+`cisc` will present the change in the configuration (new device added) and ask
+you whether you want to accept it. If you press <enter>, the proposed data will
+be signed with your key and sent to the skipchain. You can verify on the second
+device that it has been added correctly:
+
+```bash
+cisc -config device2 data update
+```
+
+This should show that you're now also in the list of allowed devices.
+
+### Adding a new key/value pair
+
+From either the 1st or the 2nd device you can now ask for adding or changing
+key/value pairs:
+
+```bash
+cisc keyvalue add phone 101
+```
+
+The 1st device proposed a new key _phone_ with the value _101_ and votes on it.
+Before a new block on the skipchain is appended, it needs to be accepted by
+the 2nd device:
+
+```bash
+cisc -config device2 data vote
+```
+
+Again it will show the new configuration and ask you to accept it. If you do,
+the 1st device can see the changes:
+
+```bash
+cisc data update
+```
+
+And the new key/value pair should appear in the data-part.
 
 # Command reference
 
 Cisc takes different commands and sub-commands with arguments. The main commands are:
-  * Admin - manages the authentication data for users
-  * Id - manages the identities this device is connected to
-  * Config - handles the data of the identities this device is connected to
+  * Link - manages the authentication towards conodes
+  * Skipchain - manages the identities this device is connected to
+  * Data - handles the data of the identities this device is connected to
+  * Keyvalue - direct key/value pair editing
   * Ssh - interfaces the ssh-data of the identities
-  * Kv - direct key/value pair editing
   * Follow - for servers or other computers that want to follow a Skipchain
-## cisc admin
+  * Web - add a web-page to the SkipChain
 
-Admin's command. It helps connect to conodes and save the authentication data there. To conect and store date, you need to use cisc admin followed by:
-  * Link - Connects to conode.
-  * Store - Saves the authentication data on the conode: PoP
-  * Add - Saves public keys on the conode
+## cisc link
 
-## cisc id
+Commands to connect to conodes and save the authentication data there. To connect and store date, you need to use `cisc link` followed by:
+  * Pin - connect to a conode by providing a PIN
+  * Addfinal - adds a final statement from a pop-party to authorize creating new skipchains
+  * Addpublic - adds a public key to authorize creating new skipchains
+  * keypair - creates a private/public keypair for use with `cisc link addpublic`
+  * list - shows a list of all links stored on this client
 
-Each device can be _connected_ to one identity but _linked_ to multiple identities. You can manage the connections with cisc id followed by:
+The difference between `cisc link pin` and `cisc link add(final|public)` is that the
+first links with administrator rights (allowed to add other links), while the second
+two link only with the rights to add new skipchains.
+
+## cisc skipchain
+
+Each device can be connected to multiple identities. As long as you only have one
+identity linked, you don't need to give the id when working with it. Only if there
+are multiple identities linked, you need to give the id of the identity you want
+to work with. You can manage the connections with `cisc skipchain` followed by:
   * Create - asks the skipchain to create a new identity and returns its id #. It also connects to that identity.
   	Users have to authenticate to get possibility to create skipchain. Current implementation supports two ways of authentication:
-	* Pop-Token - in this case user will keep privacy - service won't know who creates the skipchain
-	* Public keys - no privacy, but no pop-party visit is required
-  * Connect - will ask the devices of the remote skipwchain to vote on the inclusion of this device in the skipchain - each device can only be connected to one identity
-  * Keypair - will create new keypair and ouput it in log
+	   * Pop-Token - in this case user will keep privacy - service won't know who creates the skipchain
+	   * Public keys - no privacy, but no pop-party visit is required
+  * Join - will ask the devices of the remote skipwchain to vote on the inclusion of this device in the skipchain
+  * Del - remove this device from an identity
+  * Roster - change the roster of an identity
+  * List - show all stored skipchains
+  * QRCode - prints a QRCode on the terminal so a remote device can contact
 
-For later:
-  * Remove - removes the link to that skipchain - also needs to be voted upon
-  * Follow - only follows an identity without voting power. Doesn’t need confirmation
-  * Create - If the device is already connected to an identity, it links instead of connecting
-  * Link - like connect, but all devices of the identity share one vote
-The group-skipchains have to be defined.
-
-## cisc config
-Each identity, connected or linked, has data attached to it that can be updated, modified and voted upon. To modify the data, you need to use the appropriate commands (ssh and password). To update and vote, you can use cisc data followed by:
-  * Update - fetches the latest data from all identities from the skipchain as well as all proposed data (the ones which are not yet voted upon)
+## cisc data
+Each identity, connected or linked, has data attached to it that can be updated,
+modified and voted upon. To modify the data, you need to use the appropriate
+commands (`cisc ssh` and `cisc kv`).
+Every time the data is changed, a _proposition_ is created, that has to
+been voted upon by a majority of devices. To update and vote, you can use `cisc data`
+followed by:
+  * Clear - remove all proposed new data
+  * Update - fetches the latest data from all identities from the skipchain as
+  well as all proposed data (the ones which are not yet voted upon with a threshold)
   * List - updates and lists all data associated with all identities
   * Vote - sends a positive vote or a rejection for a specific update-proposition
 
 ## cisc ssh
-The ssh-data-type allows for an easy handling of multiple ssh-identities over a range of devices. It uses the ~/.ssh/config to get the list of ssh-identities on this device. In addition to the usual configurations, each ssh-identity can be preceded by a commented line
+The ssh-data-type allows for an easy handling of multiple ssh-identities over a
+range of devices. It uses the ~/.ssh/config to get the list of ssh-identities
+on this device. In addition to the usual configurations, each ssh-identity can
+be preceded by a commented line
 ```
 #cisc - ID#
 ```
-Which indicates what identity shall be used to follow that ssh-identity. This is useful for configuring groups of identities that share some hosts.
+Which indicates what identity shall be used to follow that ssh-identity.
+This is useful for configuring groups of identities that share some hosts.
 
-The different sub-commands for cisc ssh are:
+The different sub-commands for `cisc ssh` are:
   * Add - creates a new entry in the ~/.ssh/config file for a new host and proposes the new data
   * Del - removes an entry in the ~/.ssh/config file and proposes the new data
   * List - shows all connections for this device
 
 ## cisc kv
-The kv-data-type simply holds a map of key/value pairs that are shared by all devices of the identity. This can be for example the login/password, where the password would be encrypted with a master-password of course.
+The kv-data-type simply holds a map of key/value pairs that are shared by all
+devices of the identity. This can be for example the login/password, where the
+password would be encrypted with a master-password of course.
 
 cisc kv has the following subcommands:
   * List - returns a list of all keys pairs
   * Value - returns the value of a given key
   * Add - adds a key/value pair by proposing the new data to the identity
-  * Rm - removes a key/value pair by proposing the new data to the identity
+  * Del - removes a key/value pair by proposing the new data to the identity
 
 ## cisc follow
 A server can set up cisc to follow a skipchain and update the
@@ -87,14 +256,23 @@ to your `/etc/ssh/sshd_config`. Now sshd will read both files and allow
 any key that is present in either of the files.
 
 `cisc follow` has the following subcommands:
-  * add - takes `group.toml`, `Skipchain-ID` and `service-name` as an
+  * Add - takes `group.toml`, `Skipchain-ID` and `service-name` as an
   argument. It connects to one of the servers in `group.toml` and fetches
   the skipchain with `Skipchain-ID`. All ssh-keys referencing `service-name`
   will be written to `~/.ssh/authorized_keys.cisc`
-  * del - takes `Skipchain-ID` as an argument and removes the reference to
+  * Del - takes `Skipchain-ID` as an argument and removes the reference to
   that skipchain
-  * list - prints a list of all connected skipchains and the keys stored
+  * List - prints a list of all connected skipchains and the keys stored
   in them
-  * update [-p interval] - looks for updates of one of the skipchains. In
+  * Update [-p interval] - looks for updates of one of the skipchains. In
    case it finds a change in the ssh-keys, it will update
    `~/.ssh/authorized_keys.cisc`
+
+## cisc web
+A skipchain can also hold a set of webpages that are stored and updated only when
+a threshold of devices vote on the update. A client can follow the skipchain and
+always have the updated webpage on his device. Viewers are for the moment available
+for browsers (http://status.dedis.ch) and for mobile devices.
+
+The only command for web is `cisc web` which takes a path to a html-file that will
+be put on the skipchain.

--- a/cisc/commands.go
+++ b/cisc/commands.go
@@ -6,296 +6,340 @@ import "gopkg.in/urfave/cli.v1"
 This holds the cli-commands so the main-file is less cluttered.
 */
 
-var commandAdmin, commandID, commandConfig, commandKeyvalue, commandSSH, commandFollow cli.Command
+func getCommands() cli.Commands {
+	return cli.Commands{
+		{
+			Name:    "link",
+			Aliases: []string{"ln"},
+			Usage:   "create and use links with admin privileges",
+			Subcommands: cli.Commands{
+				{
+					Name:      "pin",
+					Aliases:   []string{"p"},
+					Usage:     "links using a pin written to the log-file on the conode",
+					ArgsUsage: "ip:port [PIN]",
+					Action:    linkPin,
+				},
+				{
+					Name:      "addfinal",
+					Aliases:   []string{"af"},
+					Usage:     "adds a final statement to a linked remote node for use by attendees",
+					ArgsUsage: "final_statement.toml ip:port",
+					Action:    linkAddFinal,
+				},
+				{
+					Name:      "addpublic",
+					Aliases:   []string{"ap"},
+					Usage:     "adds a public key to a linked remote node for use by attendees",
+					ArgsUsage: "public_key ip:port",
+					Action:    linkAddPublic,
+				},
+				{
+					Name:    "keypair",
+					Aliases: []string{"kp"},
+					Usage:   "create a keypair for usage in private/public key",
+					Action:  linkPair,
+				},
+				{
+					Name:    "list",
+					Aliases: []string{"ls", "l"},
+					Usage:   "show a list of all links stored on this client",
+					Action:  linkList,
+				},
+			},
+		},
 
-func init() {
-	commandAdmin = cli.Command{
-		Name:  "admin",
-		Usage: "admin options",
-		Subcommands: []cli.Command{
-			{
-				Name:      "link",
-				Usage:     "links admin to cothority",
-				ArgsUsage: "IP address [PIN]",
-				Action:    adminLink,
-			},
-			{
-				Name:      "store",
-				Usage:     "stores the authentication data in cothority",
-				ArgsUsage: "file or string with auth data IP address",
-				Action:    adminStore,
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name: "type,t",
-						Usage: `type of authentication it wants to store
-							: PoP, etc.`,
+		{
+			Name:    "skipchain",
+			Aliases: []string{"sc"},
+			Usage:   "work with the underlying skipchain",
+			Subcommands: []cli.Command{
+				{
+					Name:      "create",
+					Aliases:   []string{"cr", "c"},
+					Usage:     "start a new identity",
+					ArgsUsage: "group.toml",
+					Flags: []cli.Flag{
+						cli.IntFlag{
+							Name:  "threshold, thr",
+							Usage: "the threshold necessary to add a block",
+							Value: 2,
+						},
+						cli.StringFlag{
+							Name:  "name, n",
+							Usage: "name of this device in the cisc",
+						},
+						cli.StringFlag{
+							Name:  "private, priv",
+							Usage: "give the private key to authenticate",
+						},
+						cli.StringFlag{
+							Name:  "token, tok",
+							Usage: "give a pop-token to authenticate",
+						},
 					},
+					Action: scCreate,
 				},
-			},
-			{
-				Name:      "add",
-				Usage:     "adds public keys in cothority",
-				ArgsUsage: "string with keys IP address",
-				Action:    adminAdd,
+				{
+					Name:      "join",
+					Aliases:   []string{"j"},
+					Usage:     "propose to join an existing identity",
+					ArgsUsage: "group.toml id",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "name, n",
+							Usage: "name of the device used in the identity",
+						},
+					},
+					Action: scJoin,
+				},
+				{
+					Name:      "del",
+					Aliases:   []string{"d", "rm"},
+					Usage:     "remove this device from an identity",
+					ArgsUsage: "name [skipchain-id]",
+					Action:    scDel,
+				},
+				{
+					Name:    "list",
+					Aliases: []string{"ls", "l"},
+					Usage:   "show all stored skipchains",
+					Action:  scList,
+				},
+				{
+					Name:      "qrcode",
+					Aliases:   []string{"qr"},
+					Usage:     "print out the qrcode of the identity-skipchain and a node for contact",
+					ArgsUsage: "[skipchain-id]",
+					Action:    scQrcode,
+				},
+				{
+					Name:      "roster",
+					Aliases:   []string{"r"},
+					Usage:     "define a new roster for the skipchain",
+					ArgsUsage: "group.toml [skipchain-id]",
+					Action:    scRoster,
+				},
 			},
 		},
-	}
-	commandID = cli.Command{
-		Name:  "id",
-		Usage: "working on the identity",
-		Subcommands: []cli.Command{
-			{
-				Name:      "create",
-				Aliases:   []string{"cr"},
-				Usage:     "start a new identity",
-				ArgsUsage: "group(public.toml) file(token.toml) or string with auth data  [id-name]",
-				Flags: []cli.Flag{
-					cli.IntFlag{
-						Name:  "thr,threshold",
-						Usage: "the threshold necessary to add a block",
-						Value: 2,
-					},
-					cli.StringFlag{
-						Name:  "type,t",
-						Usage: "type of client authentication: PoP, PIN",
-					},
-					cli.StringFlag{
-						Name:  "cred,credentials",
-						Usage: "auth data : PoP-token file or PIN-string",
+
+		{
+			Name:    "data",
+			Aliases: []string{"cfg"},
+			Usage:   "updating and voting on data",
+			Subcommands: []cli.Command{
+				{
+					Name:      "clear",
+					Aliases:   []string{"c"},
+					Usage:     "clear the proposition",
+					ArgsUsage: "[skipchain-id]",
+					Action:    dataClear,
+				},
+				{
+					Name:      "update",
+					Aliases:   []string{"upd"},
+					Usage:     "fetch the latest data",
+					ArgsUsage: "[skipchain-id]",
+					Action:    dataUpdate,
+				},
+				{
+					Name:    "list",
+					Aliases: []string{"ls", "l"},
+					Usage:   "list existing data and proposed",
+					Action:  dataList,
+					Flags: []cli.Flag{
+						cli.BoolFlag{
+							Name:  "propose, p",
+							Usage: "will also show proposed data",
+						},
+						cli.BoolFlag{
+							Name:  "details, d",
+							Usage: "also show the values of the keys",
+						},
 					},
 				},
-				Action: idCreate,
-			},
-			{
-				Name:    "keypair",
-				Aliases: []string{"kp"},
-				Usage:   "create keypair",
-				Action:  idKeyPair,
-			},
-			{
-				Name:      "connect",
-				Aliases:   []string{"co"},
-				Usage:     "connect to an existing identity",
-				ArgsUsage: "group id [id-name]",
-				Action:    idConnect,
-			},
-			{
-				Name:    "del",
-				Aliases: []string{"rm"},
-				Usage:   "delete an identity",
-				Action:  idDel,
-			},
-			{
-				Name:    "check",
-				Aliases: []string{"ch"},
-				Usage:   "check the health of the cothority",
-				Action:  idCheck,
-			},
-			{
-				Name:    "qrcode",
-				Aliases: []string{"qr"},
-				Usage:   "print out the qrcode of the identity-skipchain and a node for contact",
-				Action:  idQrcode,
+				{
+					Name:      "vote",
+					Aliases:   []string{"v"},
+					Usage:     "vote on proposed data",
+					ArgsUsage: "[skipchain-id]",
+					Action:    dataVote,
+					Flags: []cli.Flag{
+						cli.BoolFlag{
+							Name:  "no",
+							Usage: "refuse vote",
+						},
+						cli.BoolFlag{
+							Name:  "yes",
+							Usage: "accept vote",
+						},
+					},
+				},
 			},
 		},
-	}
-	commandConfig = cli.Command{
-		Name:  "config",
-		Usage: "updating and voting on config",
-		Subcommands: []cli.Command{
-			{
-				Name:    "propose",
-				Aliases: []string{"l"},
-				Usage:   "propose the new config",
-				Action:  configPropose,
-			},
-			{
-				Name:    "update",
-				Aliases: []string{"u"},
-				Usage:   "fetch the latest config",
-				Action:  configUpdate,
-			},
-			{
-				Name:    "list",
-				Aliases: []string{"ls"},
-				Usage:   "list existing config and proposed",
-				Action:  configList,
-				Flags: []cli.Flag{
-					cli.BoolFlag{
-						Name:  "p,propose",
-						Usage: "will also show proposed config",
-					},
-					cli.BoolFlag{
-						Name:  "d,details",
-						Usage: "also show the values of the keys",
-					},
+
+		{
+			Name:    "keyvalue",
+			Aliases: []string{"kv"},
+			Usage:   "storing and retrieving key/value pairs",
+			Subcommands: []cli.Command{
+				{
+					Name:    "list",
+					Aliases: []string{"ls", "l"},
+					Usage:   "list all values",
+					Action:  kvList,
 				},
-			},
-			{
-				Name:      "vote",
-				Aliases:   []string{"v"},
-				Usage:     "vote on existing config",
-				ArgsUsage: "[yn]",
-				Action:    configVote,
+				{
+					Name:      "value",
+					Aliases:   []string{"v"},
+					Usage:     "return the value of a key",
+					ArgsUsage: "key [skipchain-id]",
+					Action:    kvValue,
+				},
+				{
+					Name:      "add",
+					Aliases:   []string{"a"},
+					Usage:     "add a new key/value pair",
+					ArgsUsage: "key value [skipchain-id]",
+					Action:    kvAdd,
+				},
+				{
+					Name:      "del",
+					Aliases:   []string{"d", "rm"},
+					Usage:     "delete a value",
+					ArgsUsage: "key [skipchain-id]",
+					Action:    kvDel,
+				},
 			},
 		},
-	}
-	commandKeyvalue = cli.Command{
-		Name:    "keyvalue",
-		Aliases: []string{"kv"},
-		Usage:   "storing and retrieving key/value pairs",
-		Subcommands: []cli.Command{
-			{
-				Name:    "list",
-				Aliases: []string{"ls"},
-				Usage:   "list all values",
-				Action:  kvList,
-			},
-			{
-				Name:      "value",
-				Aliases:   []string{"v"},
-				Usage:     "return the value of a key",
-				ArgsUsage: "key",
-				Action:    kvValue,
-			},
-			{
-				Name:      "add",
-				Aliases:   []string{"a"},
-				Usage:     "add a new key/value pair",
-				ArgsUsage: "key value",
-				Action:    kvAdd,
-			},
-			{
-				Name:      "addWeb",
-				Usage:     "add a web-site to a skipchain",
-				Aliases:   []string{"a"},
-				ArgsUsage: "path/page.html",
-				Action:    kvAddWeb,
-				Flags: []cli.Flag{
-					cli.BoolFlag{
-						Name:  "inline",
-						Usage: "inline all images, css and scripts",
+
+		{
+			Name:  "ssh",
+			Usage: "interacting with the ssh-keys stored in the skipchain",
+			Subcommands: []cli.Command{
+				{
+					Name:      "add",
+					Aliases:   []string{"a"},
+					Usage:     "adds a new entry to the skipchain",
+					Action:    sshAdd,
+					ArgsUsage: "hostname [skipchain-id]",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "alias, a",
+							Usage: "alias to use for that entry",
+						},
+						cli.StringFlag{
+							Name:  "user, u",
+							Usage: "user for that connection",
+						},
+						cli.StringFlag{
+							Name:  "port, p",
+							Usage: "port for the connection",
+						},
+						cli.IntFlag{
+							Name:  "security, sec",
+							Usage: "how many bits for the key-creation",
+							Value: 2048,
+						},
 					},
 				},
-			},
-			{
-				Name:      "del",
-				Aliases:   []string{"rm"},
-				Usage:     "delete a value",
-				ArgsUsage: "key",
-				Action:    kvDel,
+				{
+					Name:      "del",
+					Aliases:   []string{"d", "rm"},
+					Usage:     "deletes an entry from the skipchain",
+					ArgsUsage: "alias_or_host [skipchain-id]",
+					Action:    sshDel,
+				},
+				{
+					Name:      "list",
+					Aliases:   []string{"ls"},
+					Usage:     "shows all entries for this device",
+					Action:    sshLs,
+					ArgsUsage: "[skipchain-id]",
+					Flags: []cli.Flag{
+						cli.BoolFlag{
+							Name:  "a,all",
+							Usage: "show entries for all devices",
+						},
+					},
+				},
+				{
+					Name:    "rotate",
+					Aliases: []string{"r"},
+					Usage:   "renews all keys - only active once the vote passed",
+					Action:  sshRotate,
+				},
+				{
+					Name:    "sync",
+					Aliases: []string{"s"},
+					Usage:   "sync ssh-config and blockchain - interactive",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "toblockchain, tob",
+							Usage: "force copy of ssh-config-file to blockchain",
+						},
+						cli.StringFlag{
+							Name:  "toconfig, toc",
+							Usage: "force copy of blockchain to ssh-config-file",
+						},
+					},
+					Action: sshSync,
+				},
 			},
 		},
-	}
-	commandSSH = cli.Command{
-		Name:  "ssh",
-		Usage: "handling your ssh-keys",
-		Subcommands: []cli.Command{
-			{
-				Name:    "add",
-				Aliases: []string{"a"},
-				Usage:   "adds a new entry to the config",
-				Action:  sshAdd,
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:  "a,alias",
-						Usage: "alias to use for that entry",
-					},
-					cli.StringFlag{
-						Name:  "u,user",
-						Usage: "user for that connection",
-					},
-					cli.StringFlag{
-						Name:  "p,port",
-						Usage: "port for the connection",
-					},
-					cli.IntFlag{
-						Name:  "sec,security",
-						Usage: "how many bits for the key-creation",
-						Value: 2048,
-					},
+
+		{
+			Name:    "follow",
+			Aliases: []string{"f"},
+			Usage:   "follow skipchains",
+			Subcommands: []cli.Command{
+				{
+					Name:      "add",
+					Aliases:   []string{"a"},
+					Usage:     "add a new skipchain",
+					ArgsUsage: "group ID service-name",
+					Action:    followAdd,
 				},
-			},
-			{
-				Name:      "del",
-				Aliases:   []string{"rm"},
-				Usage:     "deletes an entry from the config",
-				ArgsUsage: "alias_or_host",
-				Action:    sshDel,
-			},
-			{
-				Name:    "list",
-				Aliases: []string{"ls"},
-				Usage:   "shows all entries for this device",
-				Action:  sshLs,
-				Flags: []cli.Flag{
-					cli.BoolFlag{
-						Name:  "a,all",
-						Usage: "show entries for all devices",
-					},
+				{
+					Name:      "del",
+					Aliases:   []string{"d", "rm"},
+					Usage:     "delete a skipchain",
+					ArgsUsage: "ID",
+					Action:    followDel,
 				},
-			},
-			{
-				Name:    "rotate",
-				Aliases: []string{"r"},
-				Usage:   "renews all keys - only active once the vote passed",
-				Action:  sshRotate,
-			},
-			{
-				Name:    "sync",
-				Aliases: []string{"tc"},
-				Usage:   "sync config and blockchain - interactive",
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:  "tob,toblockchain",
-						Usage: "force copy of config-file to blockchain",
-					},
-					cli.StringFlag{
-						Name:  "toc,toconfig",
-						Usage: "force copy of blockchain to config-file",
-					},
+				{
+					Name:    "list",
+					Aliases: []string{"ls", "l"},
+					Usage:   "list all skipchains and keys",
+					Action:  followList,
 				},
-				Action: sshSync,
+				{
+					Name:    "update",
+					Aliases: []string{"upd"},
+					Usage:   "update all skipchains",
+					Flags: []cli.Flag{
+						cli.IntFlag{
+							Name:  "poll, p",
+							Value: 0,
+							Usage: "poll every n seconds",
+						},
+					},
+					Action: followUpdate,
+				},
 			},
 		},
-	}
-	commandFollow = cli.Command{
-		Name:    "follow",
-		Aliases: []string{"f"},
-		Usage:   "follow skipchains",
-		Subcommands: []cli.Command{
-			{
-				Name:      "add",
-				Aliases:   []string{"a"},
-				Usage:     "add a new skipchain",
-				ArgsUsage: "group ID service-name",
-				Action:    followAdd,
-			},
-			{
-				Name:      "del",
-				Aliases:   []string{"rm"},
-				Usage:     "delete a skipchain",
-				ArgsUsage: "ID",
-				Action:    followDel,
-			},
-			{
-				Name:    "list",
-				Aliases: []string{"ls"},
-				Usage:   "list all skipchains and keys",
-				Action:  followList,
-			},
-			{
-				Name:    "update",
-				Aliases: []string{"u"},
-				Usage:   "update all skipchains",
-				Flags: []cli.Flag{
-					cli.IntFlag{
-						Name:  "p,poll",
-						Value: 0,
-						Usage: "poll every n seconds",
-					},
+
+		{
+			Name:      "web",
+			Usage:     "add a web-site to a skipchain",
+			Aliases:   []string{"w"},
+			ArgsUsage: "path/page.html [skipchain-id]",
+			Action:    kvAddWeb,
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "inline",
+					Usage: "inline all images, css and scripts",
 				},
-				Action: followUpdate,
 			},
 		},
 	}

--- a/cisc/test.sh
+++ b/cisc/test.sh
@@ -8,529 +8,542 @@ DBG_APP=2
 NBR=4
 PACKAGE_POP_GO="github.com/dedis/cothority/pop"
 PACKAGE_POP="$(go env GOPATH)/src/$PACKAGE_POP_GO"
-pop=`basename $PACKAGE_POP`
+PACKAGE_SCMGR_GO="github.com/dedis/cothority/scmgr"
+PACKAGE_SCMGR="$(go env GOPATH)/src/$PACKAGE_SCMGR_GO"
+pop=./`basename $PACKAGE_POP`
+scmgr=./`basename $PACKAGE_SCMGR`
 PACKAGE_IDEN="github.com/dedis/cothority/identity"
 
 . $(go env GOPATH)/src/github.com/dedis/onet/app/libtest.sh
 
 main(){
-    startTest
-    addr=()
-    addr[1]=127.0.0.1:2002
-    addr[2]=127.0.0.1:2004
-    addr[3]=127.0.0.1:2006
-    buildKeys
-    buildConode github.com/dedis/cothority/cosi/service $PACKAGE_IDEN $PACKAGE_POP_GO/service
-    build $PACKAGE_POP
-    createFinal 2 > /dev/null
-    createToken 2
+  startTest
+  addr=()
+  addr[1]=localhost:2002
+  addr[2]=localhost:2004
+  addr[3]=localhost:2006
+  buildKeys
+  buildConode github.com/dedis/cothority/cosi/service $PACKAGE_IDEN $PACKAGE_POP_GO/service
+  build $PACKAGE_POP
+  build $PACKAGE_SCMGR
+  createFinal 2 > /dev/null
+  createToken 2
 
-    test Build
-    test Link
-    test Store
-    test Add
-    test ClientSetup
-    test IdKeyPair
-    test IdCreate
-    test IdCreate2
-    test ConfigList
-    test ConfigVote
-    test IdConnect
-    test IdDel
-    test KeyAdd
-    test KeyAdd2
-    test KeyAddWeb
-    test KeyDel
-    test SSHAdd
-    test SSHDel
-    test Follow
-    test SymLink
-    test Revoke
-    stopTest
+  test Build
+  test Link
+  test Final
+  test ClientSetup
+  test ScCreate
+  test ScCreate2
+  test ScCreate3
+  test DataList
+  test DataVote
+  test DataRoster
+  test IdConnect
+  test IdDel
+  test KeyAdd
+  test KeyAdd2
+  test KeyAddWeb
+  test KeyDel
+  test SSHAdd
+  test SSHDel
+  test Follow
+  test SymLink
+  test Revoke
+  stopTest
 }
 
 testRevoke(){
-    clientSetup 3
-    testOK runCl 3 ssh add service1
-    testOK runCl 1 config vote y
-    testOK runCl 2 config vote y
+  clientSetup 3
+  testOK runCl 3 ssh add service1
+  testOK runCl 1 data vote -yes
+  testOK runCl 2 data vote -yes
 
-    testOK runCl 1 id rm client3
-    testOK runCl 2 config vote y
+  testOK runCl 1 skipchain del client3
+  testOK runCl 2 data vote -yes
 
-    testFail runCl 3 ssh add service1
-    testOK runCl 1 config update
+  testFail runCl 3 ssh add service1
+  testOK runCl 1 data update
 }
 
 testSymLink(){
-    clientSetup 1
-    testFail [ -L cl3/authorized_keys ]
-    testNFile cl3/authorized_keys.cisc
-    testOK runCl 3 follow add public.toml $ID service1
-    testOK [ -L cl3/authorized_keys ]
-    testFile cl3/authorized_keys.cisc
-    rm cl3/authorized*
-    echo my_secret_ssh_key > cl3/authorized_keys
-    runCl 3 follow add public.toml $ID service1
-    testFile cl3/authorized_keys
-    testFile cl3/authorized_keys.cisc
+  clientSetup 1
+  testFail [ -L cl3/authorized_keys ]
+  testNFile cl3/authorized_keys.cisc
+  testOK runCl 3 follow add public.toml $ID service1
+  testOK [ -L cl3/authorized_keys ]
+  testFile cl3/authorized_keys.cisc
+  rm cl3/authorized*
+  echo my_secret_ssh_key > cl3/authorized_keys
+  runCl 3 follow add public.toml $ID service1
+  testFile cl3/authorized_keys
+  testFile cl3/authorized_keys.cisc
 }
 
 testFollow(){
-    clientSetup 1
-    echo ID is $ID
-    testNFile cl3/authorized_keys.cisc
-    testFail runCl 3 follow add public.toml 1234 service1
-    testOK runCl 3 follow add public.toml $ID service1
-    testFail grep -q service1 cl3/authorized_keys.cisc
-    testNGrep client1 runCl 3 follow list
-    testGrep $ID runCl 3 follow list
-    testOK runCl 1 ssh add service1
-    testOK runCl 3 follow update
-    testOK grep -q service1 cl3/authorized_keys.cisc
-    testGrep service1 runCl 3 follow list
-    testReGrep client1
-    testOK runCl 3 follow rm $ID
-    testNGrep client1 runCl 3 follow list
-    testReNGrep service1
-    testFail grep -q service1 cl3/authorized_keys.cisc
+  clientSetup 1
+  testNFile cl3/authorized_keys.cisc
+  testFail runCl 3 follow add public.toml 1234 service1
+  testOK runCl 3 follow add public.toml $ID service1
+  testFail grep -q service1 cl3/authorized_keys.cisc
+  testNGrep client1 runCl 3 follow list
+  testGrep $ID runCl 3 follow list
+  testOK runCl 1 ssh add service1
+  testOK runCl 3 follow update
+  testOK grep -q service1 cl3/authorized_keys.cisc
+  testGrep service1 runCl 3 follow list
+  testReGrep client1
+  testOK runCl 3 follow rm $ID
+  testNGrep client1 runCl 3 follow list
+  testReNGrep service1
+  testFail grep -q service1 cl3/authorized_keys.cisc
 }
 
 testSSHDel(){
-    clientSetup 1
-    testOK runCl 1 ssh add service1
-    testOK runCl 1 ssh add -a s2 service2
-    testOK runCl 1 ssh add -a s3 service3
-    testGrep service1 runCl 1 ssh ls
-    testReGrep service2
-    testReGrep service3
-    testOK runCl 1 ssh rm service1
-    testNGrep service1 runCl 1 ssh ls
-    testReGrep service2
-    testReGrep service3
-    testOK runCl 1 ssh rm s2
-    testNGrep service2 runCl 1 ssh ls
-    testOK runCl 1 ssh rm service3
-    testNGrep service3 runCl 1 ssh ls
+  clientSetup 1
+  testOK runCl 1 ssh add service1
+  testOK runCl 1 ssh add -a s2 service2
+  testOK runCl 1 ssh add -a s3 service3
+  testGrep service1 runCl 1 ssh ls
+  testReGrep service2
+  testReGrep service3
+  testOK runCl 1 ssh rm service1
+  testNGrep service1 runCl 1 ssh ls
+  testReGrep service2
+  testReGrep service3
+  testOK runCl 1 ssh rm s2
+  testNGrep service2 runCl 1 ssh ls
+  testOK runCl 1 ssh rm service3
+  testNGrep service3 runCl 1 ssh ls
 }
 
 testSSHAdd(){
-    clientSetup 1
-    testOK runCl 1 ssh add service1
-    testFileGrep "Host service1\n\tHostName service1\n\tIdentityFile cl1/key_service1" cl1/config
-    testFile cl1/key_service1.pub
-    testFile cl1/key_service1
-    testGrep service1 runCl 1 ssh ls
-    testReGrep client1
-    testOK runCl 1 ssh add -a s2 service2
-    testFileGrep "Host s2\n\tHostName service2\n\tIdentityFile cl1/key_s2" cl1/config
-    testFile cl1/key_s2.pub
-    testFile cl1/key_s2
-    testGrep service2 runCl 1 ssh ls
-    testReGrep client1
+  clientSetup 1
+  testOK runCl 1 ssh add service1
+  testFileGrep "Host service1\n\tHostName service1\n\tIdentityFile cl1/key_service1" cl1/config
+  testFile cl1/key_service1.pub
+  testFile cl1/key_service1
+  testGrep service1 runCl 1 ssh ls
+  testReGrep client1
+  testOK runCl 1 ssh add -a s2 service2
+  testFileGrep "Host s2\n\tHostName service2\n\tIdentityFile cl1/key_s2" cl1/config
+  testFile cl1/key_s2.pub
+  testFile cl1/key_s2
+  testGrep service2 runCl 1 ssh ls
+  testReGrep client1
 
-    testOK runCl 1 ssh add -sec 4096 service3
-    if [ $( wc -c < "cl1/key_service1.pub" ) -ne 381 ]; then
-        fail "Public-key of standard (2048) bit key should be of length 381"
-    fi
-    if [ $( wc -c < "cl1/key_service3.pub" ) -ne 725 ]; then
-        fail "Public-key of standard (4096) bit key should be of length 725"
-    fi
+  testOK runCl 1 ssh add -sec 4096 service3
+  if [ $( wc -c < "cl1/key_service1.pub" ) -ne 381 ]; then
+    fail "Public-key of standard (2048) bit key should be of length 381"
+  fi
+  if [ $( wc -c < "cl1/key_service3.pub" ) -ne 725 ]; then
+    fail "Public-key of standard (4096) bit key should be of length 725"
+  fi
 }
 
 testKeyDel(){
-    clientSetup 2
-    testOK runCl 1 kv add key1 value1
-    testOK runCl 1 kv add key2 value2
-    testFail runCl 1 config vote y
-    testOK runCl 2 config update
-    testOK runCl 2 config vote y
-    testOK runCl 1 config update
-    testGrep key1 runCl 1 kv ls
-    testGrep key2 runCl 1 kv ls
-    testFail runCl 1 kv rm key3
-    testOK runCl 1 kv rm key2
-    testFail runCl 1 config vote y
-    testOK runCl 2 config update
-    testOK runCl 2 config vote y
-    testNGrep key2 runCl 2 kv ls
-    testOK runCl 1 config update
-    testNGrep key2 runCl 2 kv ls
+  clientSetup 2
+  testOK runCl 1 kv add key1 value1
+  testOK runCl 1 kv add key2 value2
+  testOK runCl 2 data update
+  testOK runCl 2 data vote -yes
+  testOK runCl 1 data update
+  testGrep key1 runCl 1 kv ls
+  testGrep key2 runCl 1 kv ls
+  testFail runCl 1 kv rm key3
+  testOK runCl 1 kv rm key2
+  testOK runCl 2 data update
+  testOK runCl 2 data vote -yes
+  testNGrep key2 runCl 2 kv ls
+  testOK runCl 1 data update
+  testNGrep key2 runCl 2 kv ls
 }
 
 testKeyAddWeb(){
   clientSetup 2
   mkdir dedis
   echo "<html>DEDIS rocks</html>" > dedis/index.html
-  testOK runCl 1 kv addWeb dedis/index.html
-  testOK runCl 2 config vote y
+  testOK runCl 1 web dedis/index.html
+  testOK runCl 2 data vote -yes
   testGrep "html:dedis:index.html" runCl 1 kv list
   testGrep "DEDIS rocks" runCl 1 kv value "html:dedis:index.html"
   rm -rf dedis/index.html
 }
 
 testKeyAdd2(){
-    MAXCLIENTS=3
-    for C in $( seq $MAXCLIENTS ); do
-        testOut "Running with $C devices"
-        clientSetup $C
-        testOK runCl 1 kv add key1 value1
-        testOK runCl 1 kv add key2 value2
-        if [ $C != 1 ]; then
-            testFail runCl 1 config vote y
-        fi
-        if [ $C -gt 1 ]; then
-            testNGrep key1 runCl 2 kv ls
-            testOK runCl 2 config update
-            testOK runCl 2 config vote y
-            testGrep key1 runCl 2 kv ls
-        fi
-        testOK runCl 1 config update
-        testGrep key1 runCl 1 kv ls
-        testReGrep key2 runCl 1 kv ls
-        cleanup
-    done
+  MAXCLIENTS=3
+  for C in $( seq $MAXCLIENTS ); do
+    testOut "Running with $C devices"
+    clientSetup $C
+    testOK runCl 1 kv add key1 value1
+    testOK runCl 1 kv add key2 value2
+    if [ $C -gt 1 ]; then
+      testNGrep key1 runCl 2 kv ls
+      testOK runCl 2 data update
+      testOK runCl 2 data vote -yes
+      testGrep key1 runCl 2 kv ls
+    fi
+    testOK runCl 1 data update
+    testGrep key1 runCl 1 kv ls
+    testReGrep key2 runCl 1 kv ls
+    cleanup
+  done
 }
 
 testKeyAdd(){
-    clientSetup 2
-    testNGrep key1 runCl 1 kv ls
-    testOK runCl 1 kv add key1 value1
-    testFail runCl 1 config vote y
-    testGrep key1 runCl 1 config ls -p
-    testOK runCl 2 config update
-    testNGrep key1 runCl 2 kv ls
-    testGrep key1 runCl 2 config ls -p
-    testOK runCl 2 config update
-    testOK runCl 2 config vote y
-    testGrep key1 runCl 2 kv ls
-    testOK runCl 1 config update
-    testGrep key1 runCl 1 kv ls
+  clientSetup 2
+  testNGrep key1 runCl 1 kv ls
+  testOK runCl 1 kv add key1 value1
+  testGrep key1 runCl 1 data list -p
+  testOK runCl 2 data update
+  testNGrep key1 runCl 2 kv ls
+  testGrep key1 runCl 2 data list -p
+  testOK runCl 2 data update
+  testOK runCl 2 data vote -yes
+  testGrep key1 runCl 2 kv ls
+  testOK runCl 1 data update
+  testGrep key1 runCl 1 kv ls
 }
 
 testIdDel(){
-    clientSetup 3
-    testOK runCl 2 ssh add server2
-    testOK runCl 1 config vote y
-    testGrep client2 runCl 1 config ls
-    testGrep server2 runCl 1 config ls
-    testOK runCl 1 id del client2
-    testOK runCl 3 config vote y
-    testNGrep client2 runCl 3 config ls
-    testOK runCl 1 config update
-    testNGrep client2 runCl 1 config ls
-    testReNGrep server2
-    testFail runCl 2 ssh add server
-    testOK runCl 2 config update
+  clientSetup 3
+  testOK runCl 2 ssh add server2
+  testOK runCl 1 data vote -yes
+  testGrep client2 runCl 1 data list
+  testGrep server2 runCl 1 data list
+  testOK runCl 1 skipchain del client2
+  testOK runCl 3 data vote -yes
+  testNGrep client2 runCl 3 data list
+  testOK runCl 1 data update
+  testNGrep client2 runCl 1 data list
+  testReNGrep server2
+  testFail runCl 2 ssh add server
+  testOK runCl 2 data update
 }
 
 testIdConnect(){
-    clientSetup
-    dbgOut "Connecting client_2 to ID of client_1: $ID"
-    testFail runCl 2 id co
-    echo test > test.toml
-    testFail runCl 2 id co test.toml
-    testFail runCl 2 id co public.toml
-    testOK runCl 2 id co public.toml $ID client2
-    runGrepSed "Public key" "s/.* //" runCl 2 id co public.toml $ID client2
-    PUBLIC=$SED
-    if [ -z "$PUBLIC" ]; then
-        fail "no public keys received"
-    fi
-    own2="Connected device client2"
-    testNGrep "$own2" runCl 2 config ls
-    testOK runCl 2 config update
-    testGrep "Owner: client2" runCl 2 config ls -p
+  clientSetup
+  dbgOut "Connecting client_2 to ID of client_1: $ID"
+  testFail runCl 2 skipchain join
+  echo test > test.toml
+  testFail runCl 2 skipchain join test.toml
+  testFail runCl 2 skipchain join public.toml
+  testOK runCl 2 skipchain join public.toml $ID client2
+  runGrepSed "Public key" "s/.* //" runCl 2 skipchain join public.toml $ID client2
+  PUBLIC=$SED
+  if [ -z "$PUBLIC" ]; then
+    fail "no public keys received"
+  fi
+  own2="Connected device client2"
+  testNGrep "$own2" runCl 2 data list
+  testOK runCl 2 data update
+  testGrep "Owner: client2" runCl 2 data list -p
 
-    dbgOut "Voting with client_1 - first reject then accept"
-    echo "n" | testGrep $PUBLIC runCl 1 config vote
-    dbgOut
-    echo "n" | testNGrep a$PUBLIC runCl 1 config vote
-    dbgOut
-    testOK runCl 1 config vote n
-    testNGrep "$own2" runCl 1 config ls
-    testOK runCl 2 config update
-    testNGrep "$own2" runCl 2 config ls
+  dbgOut "Voting with client_1 - first reject then accept"
+  echo "n" | testGrep $PUBLIC runCl 1 data vote
+  echo "n" | testNGrep a$PUBLIC runCl 1 data vote
+  testOK runCl 1 data vote -no
+  testNGrep "$own2" runCl 1 data list
+  testOK runCl 2 data update
+  testNGrep "$own2" runCl 2 data list
 
-    testOK runCl 1 config vote y
-    testGrep "$own2" runCl 1 config ls
-    testGrep "$own2" runCl 2 config ls
+  testOK runCl 1 data vote -yes
+  testGrep "$own2" runCl 1 data list
+  testGrep "$own2" runCl 2 data list
 }
 
-testConfigVote(){
-    clientSetup 2
-    testOK runCl 1 kv add one two
-    testFail runCl 1 config vote y
-    testNGrep one runCl 1 kv ls
+testDataVote(){
+  clientSetup 2
+  testOK runCl 1 kv add one two
+  testNGrep one runCl 1 kv ls
 
-    testOK runCl 2 config vote n
-    testNGrep one runCl 2 kv ls
-    echo y | testOK runCl 2 config vote
+  testOK runCl 2 data vote -no
+  testNGrep one runCl 2 kv ls
+  echo "y" | testOK runCl 2 data vote
 
-    testOK runCl 1 kv add three four
-    testNGrep three runCl 1 kv ls
-    echo "n" | testOK runCl 2 config vote
-    testNGrep three runCl 1 kv ls
-    echo "y" | testOK runCl 2 config vote
-    testGrep three runCl 1 kv ls
-    testGrep three runCl 2 kv ls
+  testOK runCl 1 kv add three four
+  testNGrep three runCl 1 kv ls
+  echo "n" | testOK runCl 2 data vote
+  testNGrep three runCl 1 kv ls
+  echo "y" | testOK runCl 2 data vote
+  testGrep three runCl 1 kv ls
+  testGrep three runCl 2 kv ls
 
-    testOK runCl 1 kv add five six
-    echo y | testOK runCl 2 config vote
-    testGrep five runCl 1 kv ls
-    testGrep five runCl 2 kv ls
+  testOK runCl 1 kv add five six
+  echo "y" | testOK runCl 2 data vote
+  testGrep five runCl 1 kv ls
+  testGrep five runCl 2 kv ls
 }
 
-testConfigList(){
-    clientSetup
-    testGrep "name: client1" runCl 1 config ls
-    testReGrep "ID: [0-9a-f]"
+testDataRoster(){
+  runCoBG 1 2 3
+  local KP
+  KP=$( mktemp )
+  runDbgCl 2 1 link keypair > $KP
+  local pub1=$( grep Public $KP | sed -e "s/.* //")
+  local priv1=$( grep Private $KP | sed -e "s/.* //")
+  runAddPublic 3 $pub1
+  testOK runCl 1 skipchain create co1/public.toml
+  testNGrep 2004 runCl 1 data list
+  testOK runCl 1 skipchain roster public.toml
+  testGrep 2004 runCl 1 data list
+  testOK runCl 1 kv add one two
 }
 
-testIdCreate(){
-    runCoBG 1 2 3
-    testFail runCl 1 id cr -t PoP public.toml token.toml
-    runStore 3
-    testFail runCl 1 id cr
-    echo test > test.toml
-    testFail runCl 1 id cr test.toml
-    testFail runCl 1 id cr -t PoP test.toml token.toml
-    cat token.toml > test_token.toml
-    sed -i 's/^Private = .*$/Private = "abcd"/'  test_token.toml
-    testFail runCl 1 id cr -t PoP test_token.toml public.toml
-
-    testOK runCl 1 id cr -t PoP public.toml token.toml
-    testFile cl1/config.bin
-    testGrep $(hostname) runCl 1 id cr -t PoP public.toml token.toml
-    testGrep client1 runCl 1 id cr -t PoP public.toml token.toml client1
-
-    for i in {1..2}; do
-        testOK runCl 1 id cr -t PoP public.toml token.toml
-    done
-    # run out of skipchain creation limit
-    testFail runCl 1 id cr -t PoP public.toml token.toml
-    rm cl1/config.bin
+testDataList(){
+  clientSetup
+  testGrep "name: client1" runCl 1 data list
+  testReGrep "ID: [0-9a-f]"
 }
 
-testIdCreate2(){
-    runCoBG 1 2 3
-    local KP
-    KP=$( mktemp )
-    runDbgCl 2 1 id kp > $KP
-    local pub=$( grep Public $KP | sed -e "s/.* //")
-    local priv=$( grep Private $KP | sed -e "s/.* //")
-    runDbgCl 2 1 id kp > $KP
-    local pub1=$( grep Public $KP | sed -e "s/.* //")
-    pubs="\[\"$pub\",\"$pub1\"\]"
+testScCreate(){
+  runCoBG 1 2 3
+  testFail runCl 1 skipchain create public.toml
+  cat token.toml > test_token.toml
+  perl -pi -e 's/^Private = .*$/Private = "abcd"/' test_token.toml
+  testFail runCl 1 link addfinal test_token.toml ${addr[1]}
 
-    testFail runCl 1 id cr -t Public public.toml $priv
-    runAdd 3 $pubs
-    testFail runCl 1 id cr -t Public public.toml
-    testOK runCl 1 id cr -t Public public.toml $priv
-    testFile cl1/config.bin
-    testGrep $(hostname) runCl 1 id cr -t Public public.toml $priv
-    testGrep client1 runCl 1 id cr -t Public public.toml $priv client1
+  runAddToken 1
+  testOK runCl 1 skipchain create public.toml
+  testFile cl1/config.bin
+  testGrep $(hostname) runCl 1 skipchain create public.toml
+  testGrep client1 runCl 1 skipchain create -name client1 public.toml
 
-    for i in {1..2}; do
-        testOK runCl 1 id cr -t Public public.toml $priv
-    done
-    # run out of skipchain creation limit
-    testFail runCl 1 id cr -t Public public.toml $priv
-    rm cl1/config.bin
+  testOK runCl 1 skipchain create public.toml
+
+  testOK $scmgr link add co1/private.toml
+  testOK runCl 1 skipchain create public.toml
+
+  # run out of skipchain creation limit
+  testFail runCl 1 skipchain create public.toml
+  rm cl1/config.bin
 }
 
-testIdKeyPair(){
-    testOK runCl 1 id kp
-    runDbgCl 2 1 id kp > keypair.1
-    runDbgCl 2 1 id kp > keypair.2
-    cmp keypair.1 keypair.2
-    testOK [ $? -eq 1 ]
+testScCreate2(){
+  runCoBG 1 2 3
+  local KP
+  KP=$( mktemp )
+  runDbgCl 2 1 link keypair > $KP
+  local pub1=$( grep Public $KP | sed -e "s/.* //")
+  local priv1=$( grep Private $KP | sed -e "s/.* //")
+  runDbgCl 2 1 link keypair > $KP
+  local pub2=$( grep Public $KP | sed -e "s/.* //")
+  local priv2=$( grep Private $KP | sed -e "s/.* //")
+
+  testFail runCl 2 skipchain create -private public.toml
+  testFail runCl 2 skipchain create -private $priv1 public.toml
+  runAddPublic 3 $pub1
+  testOK runCl 2 skipchain create -private $priv1 public.toml
+  testFail runCl 2 skipchain create -private $priv2 public.toml
+  testFile cl1/config.bin
+  testGrep $(hostname) runCl 2 skipchain create -private $priv1 public.toml
+  testGrep client1 runCl 2 skipchain create -private $priv1 -name client1 public.toml
+
+  for i in {1..2}; do
+    testOK runCl 2 skipchain create -private $priv1 public.toml
+  done
+  # run out of skipchain creation limit
+  testFail runCl 2 skipchain create -private $priv1 public.toml
+  rm cl1/config.bin
+}
+
+testScCreate3(){
+  runCoBG 1 2 3
+
+  testFail runCl 2 skipchain create -token public.toml
+  testFail runCl 2 skipchain create -token token.toml public.toml
+  runLink 1
+  runCl 1 link addfinal final.toml ${addr[1]}
+  testOK runCl 2 skipchain create -token token.toml public.toml
+  testFile cl1/config.bin
+  testGrep $(hostname) runCl 2 skipchain create -token token.toml public.toml
+  testGrep client1 runCl 2 skipchain create -token token.toml -name client1 public.toml
+
+  for i in {1..2}; do
+    testOK runCl 2 skipchain create -token token.toml public.toml
+  done
+  # run out of skipchain creation limit
+  testFail runCl 2 skipchain create -token token.toml public.toml
+  rm cl1/config.bin
 }
 
 testClientSetup(){
-    MAXCLIENTS=3
-    for t in $( seq $MAXCLIENTS ); do
-        testOut "Starting $t clients"
-        clientSetup $t
-        for u in $( seq $MAXCLIENTS ); do
-            if [ $u -le $t ]; then
-                testGrep client1 runCl $u config ls
-            else
-                testFail runCl $u config ls
-            fi
-        done
-        cleanup
+  MAXCLIENTS=3
+  for t in $( seq $MAXCLIENTS ); do
+    dbgOut "Starting $t clients"
+    clientSetup $t
+    for u in $( seq $MAXCLIENTS ); do
+      if [ $u -le $t ]; then
+        testGrep client1 runCl $u data list
+      else
+        testFail runCl $u data list
+      fi
     done
+    cleanup
+  done
 }
 
-runStore(){
-    runLink $1
-    for (( i=1; i<=$1; i++ ))
-    do
-        runCl 1 admin store -t PoP final.toml ${addr[$i]}
-    done
+runAddToken(){
+  runLink $1
+  for i in $( seq $1 ); do
+    runCl 1 link addfinal final.toml ${addr[$i]}
+  done
 }
 
-runAdd() {
-    runLink $1
-    for (( i=1; i<=$1; i++ ))
-    do
-        runCl 1 admin add $2 ${addr[$i]}
-    done
+runAddPublic() {
+  local cl=$1
+  local pub=$2
+  runLink $cl
+  for i in $( seq $cl ); do
+    runCl 1 link addpublic $pub ${addr[$i]} || fail "adding public to $i"
+  done
 }
-testStore(){
-    runCoBG 1
-    runLink 1
-    testFail runCl 1 admin store -t PoP
-    testOK runCl 1 admin store -t PoP final.toml ${addr[1]}
-}
-
-testAdd(){
-    runCoBG 1
-    runLink 1
-    local KP
-    KP=$( mktemp )
-    runDbgCl 2 1 id kp > $KP
-    local pub=$( grep Public $KP | sed -e "s/.* //")
-    testFail runCl 1 admin add $pub
-    testOK runCl 1 admin  add $pub ${addr[1]}
+testFinal(){
+  runCoBG 1
+  runLink 1
+  testFail runCl 1 link addfinal
+  testOK runCl 1 link addfinal final.toml ${addr[1]}
 }
 
 runLink(){
-    local KP
-    local i
-    for (( i=1; i<=$1; i++ ))
-    do
-        runCl 1 admin link ${addr[$i]}
-        pin=$( grep PIN ${COLOG}$i.log | sed -e "s/.* //" )
-        runCl 1 admin link ${addr[$i]} $pin
-    done
+  local i
+  for i in $( seq $1 ); do
+    runCl 1 link pin ${addr[$i]} || fail "getting pin for $i"
+    pin=$( grep PIN ${COLOG}$i.log | tail -n 1 | sed -e "s/.* //" )
+    runCl 1 link pin ${addr[$i]} $pin || fail "linking with $i"
+  done
 }
 
 testLink(){
-    runCoBG `seq 1`
+  runCoBG 1
 
-    testOK runCl 1 admin link ${addr[1]}
-    testGrep PIN cat ${COLOG}1.log
-    local pin=$( grep PIN ${COLOG}1.log | sed -e "s/.* //" )
-    testFail runCl 1 admin link ${addr[1]} abcdefg
-    testOK runCl 1 admin link ${addr[1]} $pin
-    testFile cl1/config.bin
+  testOK runCl 1 link pin ${addr[1]}
+  testGrep PIN cat ${COLOG}1.log
+  local pin=$( grep PIN ${COLOG}1.log | sed -e "s/.* //" )
+  testFail runCl 1 link pin ${addr[1]} abcdefg
+  testOK runCl 1 link pin ${addr[1]} $pin
+  testFile cl1/config.bin
 }
 
 testBuild(){
-    testOK dbgRun runCo 1 --help
-    testOK dbgRun runCl 1 --help
-}
-
-runCl(){
-    local D=cl$1
-    shift
-    dbgRun ./cisc -d $DBG_APP -c $D --cs $D $@
-}
-
-runDbgCl(){
-    local DBG=$1
-    local CFG=cl$2
-    shift 2
-    ./cisc -d $DBG -c $CFG --cs $CFG $@
+  testOK dbgRun runCo 1 --help
+  testOK dbgRun runCl 1 --help
 }
 
 clientSetup(){
-    runCoBG `seq 3`
-    local CLIENTS=${1:-0} c b
-    # admin
-    runStore 3
-    runDbgCl 0 1 id cr -t PoP public.toml token.toml client1
-    runGrepSed ID "s/.* //" runDbgCl 2 1 config ls
-    ID=$SED
-    echo "ID is" $ID
-    if [ "$CLIENTS" -gt 1 ]; then
-        for c in $( seq 2 $CLIENTS ); do
-            runCl $c id co public.toml $ID client$c
-            for b in 1 2; do
-                if [ $b -lt $c ]; then
-                    runDbgCl 0 $b config update
-                    runDbgCl 0 $b config vote y
-                fi
-            done
-        done
-        for c in $( seq $CLIENTS ); do
-            runDbgCl 0 $c config update
-        done
-    fi
-    rm -f */authorized_keys*
+  runCoBG `seq 3`
+  local CLIENTS=${1:-0} c b
+  # admin
+  runAddToken 3
+  runDbgCl 0 1 skipchain create -name client1 public.toml
+  runGrepSed ID "s/.* //" runDbgCl 2 1 data list
+  ID=$SED
+  dbgOut "ID is" $ID
+  if [ "$CLIENTS" -gt 1 ]; then
+    for c in $( seq 2 $CLIENTS ); do
+      runCl $c skipchain join public.toml $ID client$c
+      for b in 1 2; do
+        if [ $b -lt $c ]; then
+          runDbgCl 0 $b data update
+          runDbgCl 0 $b data vote -yes
+        fi
+      done
+    done
+    for c in $( seq $CLIENTS ); do
+      runDbgCl 0 $c data update
+    done
+  fi
+  rm -f */authorized_keys*
 }
 
 buildKeys(){
-    testOut "Creating keys"
-    for n in $(seq $NBR); do
-        cl=cl$n
-        rm -f $cl/*bin $cl/config $cl/*.{pub,key} $cl/auth*
-        mkdir -p $cl
-        key=$cl/id_rsa
-        if [ ! -f $key ]; then
-            ssh-keygen -t rsa -b 4096 -N "" -f $key > /dev/null
-        fi
-    done
+  testOut "Creating keys"
+  for n in $(seq $NBR); do
+    cl=cl$n
+    rm -f $cl/*bin $cl/config $cl/*.{pub,key} $cl/auth*
+    mkdir -p $cl
+    key=$cl/id_rsa
+    if [ ! -f $key ]; then
+      ssh-keygen -t rsa -b 4096 -N "" -f $key > /dev/null
+    fi
+  done
 }
 
 createPopDesc(){
-    cat << EOF > pop_desc.toml
+  cat << EOF > pop_desc.toml
 Name = "Proof-of-Personhood Party"
 DateTime = "2017-08-08 15:00 UTC"
 Location = "Earth, City"
 EOF
-    local n
-    for (( n=1; n<=$1; n++ ))
-    do
-        sed -n "$((4*$n-3)),$((4*$n))p" public.toml >> pop_desc.toml
-    done
+  local n
+  for (( n=1; n<=$1; n++ ))
+  do
+    sed -n "$((5*$n-4)),$((5*$n))p" public.toml >> pop_desc.toml
+  done
 }
 
 createToken(){
-    cat << EOF > token.toml
+  cat << EOF > token.toml
 Private = "$PRIV_USER"
 Public = "$PUB_USER"
 EOF
-    cat << EOF >> token.toml
+  cat << EOF >> token.toml
 [Final]
 EOF
-    sed -n "1,3p" final.toml >> token.toml
-    cat << EOF >> token.toml
+  sed -n "1,3p" final.toml >> token.toml
+  cat << EOF >> token.toml
 [Final.Desc]
 EOF
-    sed -n "6,10p" final.toml >> token.toml
+  sed -n "6,10p" final.toml >> token.toml
 }
 
 createFinal(){
-    runCoBG 1 2
-    local KP
-    KP=$( mktemp )
-    ./$pop -d 2 attendee create > $KP
-    PRIV_USER=$( grep Private $KP | sed -e "s/.* //")
-    PUB_USER=$( grep Public $KP | sed -e "s/.* //")
+  cleanup
+  runCoBG 1 2
+  local KP
+  KP=$( mktemp )
+  $pop -d 2 attendee create > $KP
+  PRIV_USER=$( grep Private $KP | sed -e "s/.* //")
+  PUB_USER=$( grep Public $KP | sed -e "s/.* //")
 
-    ./$pop -d 2 attendee create > $KP
-    local pub_user1=$( grep Public $KP | sed -e "s/.* //")
-    createPopDesc $1
+  $pop -d 2 attendee create > $KP
+  local pub_user1=$( grep Public $KP | sed -e "s/.* //")
+  createPopDesc $1
 
-    ./$pop -c cl1 org link ${addr[1]}
-    local pin=$( grep PIN ${COLOG}1.log | sed -e "s/.* //" )
-    testOK ./$pop -c cl1 org link ${addr[1]} $pin
+  $pop -c cl1 org link ${addr[1]}
+  local pin=$( grep PIN ${COLOG}1.log | sed -e "s/.* //" )
+  testOK $pop -c cl1 org link ${addr[1]} $pin
 
-    ./$pop -c cl2 org link ${addr[2]}
-    pin=$( grep PIN ${COLOG}2.log | sed -e "s/.* //" )
-    ./$pop -c cl2 org link ${addr[2]} $pin
+  $pop -c cl2 org link ${addr[2]}
+  pin=$( grep PIN ${COLOG}2.log | sed -e "s/.* //" )
+  $pop -c cl2 org link ${addr[2]} $pin
 
-    ./$pop -c cl1 org config pop_desc.toml
-    ./$pop -c cl2 -d 2 org config pop_desc.toml > pop_hash_file
-    pop_hash=$(grep config: pop_hash_file | sed -e "s/.* //")
-    ./$pop -c cl1 org public $PUB_USER $pop_hash
-    ./$pop -c cl2 org public $PUB_USER $pop_hash
-    ./$pop -c cl1 org public $pub_user1 $pop_hash
-    ./$pop -c cl2 org public $pub_user1 $pop_hash
-    ./$pop -c cl1 org final $pop_hash
-    DEBUG_COLOR="" ./$pop -c cl2 -d 2 org final $pop_hash | tail -n +3> final.toml
+  $pop -c cl1 org config pop_desc.toml
+  $pop -c cl2 -d 2 org config pop_desc.toml > pop_hash_file
+  pop_hash=$(grep config: pop_hash_file | sed -e "s/.* //")
+  $pop -c cl1 org public $PUB_USER $pop_hash
+  $pop -c cl2 org public $PUB_USER $pop_hash
+  $pop -c cl1 org public $pub_user1 $pop_hash
+  $pop -c cl2 org public $pub_user1 $pop_hash
+  $pop -c cl1 org final $pop_hash
+  DEBUG_COLOR="" $pop -c cl2 -d 2 org final $pop_hash | tail -n +3> final.toml
 }
+
+runCl(){
+  local D=cl$1
+  shift
+  dbgRun ./cisc -d $DBG_APP -c $D --cs $D $@
+}
+
+runDbgCl(){
+  local DBG=$1
+  local CFG=cl$2
+  shift 2
+  if [ "$DBG" = 0 ]; then
+    ./cisc -d $DBG -c $CFG --cs $CFG $@ > /dev/null || fail "error in command: $@"
+  else
+    ./cisc -d $DBG -c $CFG --cs $CFG $@ || fail "error in command: $@"
+  fi
+}
+
 main

--- a/cosi/test.sh
+++ b/cosi/test.sh
@@ -80,9 +80,9 @@ setupServers(){
     SERVERS=cl$CLIENT/servers.toml
     rm -f srv1/*
     rm -f srv2/*
-    runSrvCfg 1 
+    runSrvCfg 1
     cp srv1/public.toml $SERVERS
-    runSrvCfg 2 
+    runSrvCfg 2
     echo >> $SERVERS
     cat srv2/public.toml >> $SERVERS
     runSrv 1
@@ -98,7 +98,7 @@ runCl(){
 }
 
 runSrvCfg(){
-    echo -e "127.0.0.1:200$(( 2 * $1 ))\nCosi $1\n$(pwd)/srv$1\n" | ./cosi server setup > $OUT
+    echo -e "localhost:200$(( 2 * $1 ))\nCosi $1\n$(pwd)/srv$1\n" | ./cosi server setup > $OUT
 }
 
 runSrv(){

--- a/identity/service.go
+++ b/identity/service.go
@@ -20,11 +20,13 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/messaging"
 	"github.com/dedis/cothority/skipchain"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/sign/anon"
 	"github.com/dedis/kyber/sign/schnorr"
+	"github.com/dedis/kyber/util/key"
 	"github.com/dedis/kyber/util/random"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
@@ -51,39 +53,44 @@ var VerifyIdentity = skipchain.VerifierID(uuid.NewV5(uuid.NamespaceURL, "Identit
 
 func init() {
 	identityService, _ = onet.RegisterNewService(ServiceName, newIdentityService)
-	network.RegisterMessage(&StorageMap{})
 	network.RegisterMessage(&Storage{})
+	network.RegisterMessage(&IDBlock{})
 }
 
-// Service handles identities
+// Service handles.Storage.Identities
 type Service struct {
 	*onet.ServiceProcessor
-	*StorageMap
+	Storage            *Storage
 	anonSuite          anon.Suite
 	propagateIdentity  messaging.PropagationFunc
 	propagateSkipBlock messaging.PropagationFunc
 	propagateData      messaging.PropagationFunc
-	identitiesMutex    sync.Mutex
+	storageMutex       sync.Mutex
 	skipchain          *skipchain.Client
 	// limits on number of skipchain creation. Map keys are link tags
 	tagsLimits map[string]int8
 	// limits on number of skipchain creation. Map keys are public keys
 	pointsLimits map[string]int8
-	auth         authData
 }
 
-// StorageMap holds the map to the storages so it can be marshaled.
-type StorageMap struct {
-	Identities map[string]*Storage
-}
-
-// Storage stores one identity together with the skipblocks.
+// Storage holds the map to the storages so it can be marshaled.
 type Storage struct {
+	Identities map[string]*IDBlock
+	// OldSkipchainKey is a placeholder for protobuf being able to read old config-files
+	OldSkipchainKey kyber.Scalar
+	// The key that is stored in the skipchain service to authenticate
+	// new blocks.
+	SkipchainKeyPair *key.Pair
+	// Auth is a list of all authentications allowed for this service
+	Auth *authData
+}
+
+// IDBlock stores one identity together with the skipblocks.
+type IDBlock struct {
 	sync.Mutex
-	Latest   *Data
-	Proposed *Data
-	SCRoot   *skipchain.SkipBlock
-	SCData   *skipchain.SkipBlock
+	Latest          *Data
+	Proposed        *Data
+	LatestSkipblock *skipchain.SkipBlock
 }
 
 type authData struct {
@@ -112,14 +119,15 @@ func (s *Service) PinRequest(req *PinRequest) (network.Message, error) {
 	log.Lvl3("PinRequest", s.ServerIdentity())
 	if req.PIN == "" {
 		pin := fmt.Sprintf("%06d", random.Int(big.NewInt(1000000), s.Suite().RandomStream()))
-		s.auth.pins[pin] = struct{}{}
+		s.Storage.Auth.pins[pin] = struct{}{}
 		log.Info("PIN:", pin)
 		return nil, ErrorReadPIN
 	}
-	if _, ok := s.auth.pins[req.PIN]; !ok {
+	if _, ok := s.Storage.Auth.pins[req.PIN]; !ok {
 		return nil, errors.New("Wrong PIN")
 	}
-	s.auth.adminKeys = append(s.auth.adminKeys, req.Public)
+	s.Storage.Auth.adminKeys = append(s.Storage.Auth.adminKeys, req.Public)
+	s.Storage.Auth.keys = append(s.Storage.Auth.keys, req.Public)
 	s.save()
 	log.Lvl1("Successfully registered PIN/Public", req.PIN, req.Public)
 	return nil, nil
@@ -170,7 +178,6 @@ func (s *Service) StoreKeys(req *StoreKeys) (network.Message, error) {
 				log.Error("failed to hash public key")
 				return nil, err
 			}
-
 		}
 		msg = h.Sum(nil)
 	default:
@@ -181,7 +188,7 @@ func (s *Service) StoreKeys(req *StoreKeys) (network.Message, error) {
 
 	// check Signature
 	valid := false
-	for _, key := range s.auth.adminKeys {
+	for _, key := range s.Storage.Auth.adminKeys {
 		if schnorr.Verify(s.Suite(), key, msg, req.Sig) == nil {
 			valid = true
 			break
@@ -195,9 +202,9 @@ func (s *Service) StoreKeys(req *StoreKeys) (network.Message, error) {
 	}
 	switch req.Type {
 	case PoPAuth:
-		s.auth.sets = append(s.auth.sets, anon.Set(req.Final.Attendees))
+		s.Storage.Auth.sets = append(s.Storage.Auth.sets, anon.Set(req.Final.Attendees))
 	case PublicAuth:
-		s.auth.keys = append(s.auth.keys, req.Publics...)
+		s.Storage.Auth.keys = append(s.Storage.Auth.keys, req.Publics...)
 	}
 	return nil, nil
 }
@@ -210,7 +217,7 @@ func (s *Service) Authenticate(ap *Authenticate) (*Authenticate, error) {
 	ap.Ctx = []byte(ServiceName + s.ServerIdentity().String())
 	ap.Nonce = make([]byte, nonceSize)
 	random.Bytes(ap.Nonce, s.Suite().RandomStream())
-	s.auth.nonces[string(ap.Nonce)] = struct{}{}
+	s.Storage.Auth.nonces[string(ap.Nonce)] = struct{}{}
 	return ap, nil
 }
 
@@ -218,19 +225,16 @@ func (s *Service) Authenticate(ap *Authenticate) (*Authenticate, error) {
 // managed identities.
 func (s *Service) CreateIdentity(ai *CreateIdentity) (*CreateIdentityReply, error) {
 	ctx := []byte(ServiceName + s.ServerIdentity().String())
-	if _, ok := s.auth.nonces[string(ai.Nonce)]; !ok {
+	if _, ok := s.Storage.Auth.nonces[string(ai.Nonce)]; !ok {
 		log.Error("Given nonce is not stored on ", s.ServerIdentity())
 		return nil, fmt.Errorf("Given nonce is not stored on %s", s.ServerIdentity())
 	}
 	valid := false
 	var tag string
+	var pubStr string
 	switch ai.Type {
 	case PoPAuth:
-		if ai.Public != nil {
-			log.Error("Wrong authentication message")
-			ai.Public = nil
-		}
-		for _, set := range s.auth.sets {
+		for _, set := range s.Storage.Auth.sets {
 			t, err := anon.Verify(s.anonSuite, ai.Nonce, set, ctx, ai.Sig)
 			if err == nil {
 				tag = string(t)
@@ -241,90 +245,71 @@ func (s *Service) CreateIdentity(ai *CreateIdentity) (*CreateIdentityReply, erro
 				} else {
 					if n <= 0 {
 						return nil, errors.New(
-							"No more skipchains is allowed to create")
+							"this pop-token is out of allowed skipchains")
 
 					}
 				}
 				// authentication succeeded. we need to delete the nonce
-				delete(s.auth.nonces, string(ai.Nonce))
+				delete(s.Storage.Auth.nonces, string(ai.Nonce))
 				break
 			}
 		}
 	case PublicAuth:
-		if ai.Public == nil {
-			log.Error("nil public key or signature")
-			return nil, errors.New(
-				"wrong public key authentication data")
-
-		}
-		found := false
-		for _, k := range s.auth.keys {
-			if k.Equal(ai.Public) {
-				found = true
+		for _, k := range s.Storage.Auth.keys {
+			if schnorr.Verify(s.Suite(), k, ai.Nonce, *ai.SchnSig) == nil {
+				valid = true
+				pubStr = k.String()
 				break
 			}
 		}
-		if !found {
-			return nil, errors.New(
-				"No such key is stored")
-
-		}
-		if schnorr.Verify(s.Suite(), ai.Public, ai.Nonce, *ai.SchnSig) != nil {
-			valid = false
-		} else {
-			valid = true
-		}
-		str := ai.Public.String()
-		if n, ok := s.pointsLimits[str]; !ok {
-			s.pointsLimits[str] = defaultNumberSkipchains
+		if n, ok := s.pointsLimits[pubStr]; !ok {
+			s.pointsLimits[pubStr] = defaultNumberSkipchains
 		} else {
 			if n <= 0 {
-				return nil, errors.New(
-					"No more skipchains is allowed to create")
-
+				return nil, errors.New("Already used up all allowed skipchains")
 			}
 		}
 	default:
 		return nil, errors.New("Wrong authentication type")
 	}
 	if !valid {
-		log.Error(s.ServerIdentity(), "Authentication is failed")
+		log.Error(s.ServerIdentity(), "Authentication failed - wrong signature")
 		return nil, errors.New(
 			"Invalid Signature on CreateIdentity")
 
 	}
+	return s.CreateIdentityInternal(ai, tag, pubStr)
+}
 
+// CreateIdentityInternal is not exposed to the websockets interface but can be
+// called directly from another service.
+// tag and pubStr can be "" if called from an internal service.
+func (s *Service) CreateIdentityInternal(ai *CreateIdentity, tag, pubStr string) (*CreateIdentityReply, error) {
 	log.Lvlf3("%s Creating new identity with data %+v", s.ServerIdentity(), ai.Data)
-	ids := &Storage{
+	ids := &IDBlock{
 		Latest: ai.Data,
 	}
-	log.Lvl3("Creating Root-skipchain")
-	var err error
-	ids.SCRoot, err = s.skipchain.CreateGenesis(ai.Roster, 10, 10,
-		[]skipchain.VerifierID{}, nil, nil)
-	if err != nil {
-		return nil, err
-	}
 	log.Lvl3("Creating Data-skipchain", ai.Data)
-	ids.SCData, err = s.skipchain.CreateGenesis(ids.SCRoot.Roster, 10, 10,
-		VerificationIdentity, ai.Data, ids.SCRoot.Hash)
+	var err error
+	priv := s.verifySkipchainAuth()
+	ids.LatestSkipblock, err = s.skipchain.CreateGenesisSignature(ai.Data.Roster, 10, 10,
+		VerificationIdentity, ai.Data, nil, priv)
 	if err != nil {
 		return nil, err
 	}
 
-	roster := ids.SCRoot.Roster
-	replies, err := s.propagateIdentity(roster, &PropagateIdentity{ids, tag, ai.Public}, propagateTimeout)
+	roster := ai.Data.Roster
+	replies, err := s.propagateIdentity(roster, &PropagateIdentity{ids, tag, pubStr}, propagateTimeout)
 	if err != nil {
 		return nil, err
 	}
 	if replies != len(roster.List) {
 		log.Warn("Did only get", replies, "out of", len(roster.List))
 	}
-	log.Lvlf2("New chain is\n%x", []byte(ids.SCData.Hash))
+	log.Lvlf2("New chain is\n%x", []byte(ids.LatestSkipblock.Hash))
 
 	return &CreateIdentityReply{
-		Root: ids.SCRoot,
-		Data: ids.SCData,
+		Genesis: ids.LatestSkipblock,
 	}, nil
 }
 
@@ -338,15 +323,15 @@ func (s *Service) DataUpdate(cu *DataUpdate) (*DataUpdateReply, error) {
 	}
 	sid.Lock()
 	defer sid.Unlock()
-	reply, err := s.skipchain.GetUpdateChain(sid.SCRoot.Roster, sid.SCData.Hash)
+	reply, err := s.skipchain.GetUpdateChain(sid.LatestSkipblock.Roster, sid.LatestSkipblock.Hash)
 	if err != nil {
 		return nil, err
 	}
 	if len(reply.Update) > 1 {
 		log.Lvl3("Got new data")
 		// TODO: check that update-chain has correct forward-links and fits into existing blocks
-		sid.SCData = reply.Update[len(reply.Update)-1]
-		_, dataInt, err := network.Unmarshal(sid.SCData.Data, s.Suite())
+		sid.LatestSkipblock = reply.Update[len(reply.Update)-1]
+		_, dataInt, err := network.Unmarshal(sid.LatestSkipblock.Data, s.Suite())
 		if err != nil {
 			return nil, err
 		}
@@ -370,7 +355,7 @@ func (s *Service) ProposeSend(p *ProposeSend) (network.Message, error) {
 	if sid == nil {
 		return nil, errors.New("Didn't find Identity")
 	}
-	roster := sid.SCRoot.Roster
+	roster := sid.LatestSkipblock.Roster
 	replies, err := s.propagateData(roster, p, propagateTimeout)
 	if err != nil {
 		return nil, err
@@ -398,7 +383,7 @@ func (s *Service) ProposeUpdate(cnc *ProposeUpdate) (*ProposeUpdateReply, error)
 // ProposeVote takes int account a vote for the proposed data. It also verifies
 // that the voter is in the latest data.
 // An empty signature signifies that the vote has been rejected.
-func (s *Service) ProposeVote(v *ProposeVote) (network.Message, error) {
+func (s *Service) ProposeVote(v *ProposeVote) (*ProposeVoteReply, error) {
 	log.Lvl2(s, "Voting on proposal")
 	// First verify if the signature is legitimate
 	sid := s.getIdentityStorage(v.ID)
@@ -427,7 +412,7 @@ func (s *Service) ProposeVote(v *ProposeVote) (network.Message, error) {
 			// It can either be an update-vote (accepted), or a second
 			// vote (refused).
 			if schnorr.Verify(s.Suite(), owner.Point, hash, oldvote) == nil {
-				return errors.New("Already voted for that block")
+				log.Lvl2("Already voted for that block")
 			}
 		}
 		log.Lvl3(v.Signer, "voted", v.Signature)
@@ -444,7 +429,7 @@ func (s *Service) ProposeVote(v *ProposeVote) (network.Message, error) {
 	}
 
 	// Propagate the vote
-	_, err = s.propagateData(sid.SCRoot.Roster, v, propagateTimeout)
+	_, err = s.propagateData(sid.LatestSkipblock.Roster, v, propagateTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -457,7 +442,8 @@ func (s *Service) ProposeVote(v *ProposeVote) (network.Message, error) {
 
 		// Making a new data-skipblock
 		log.Lvl3("Sending data-block with", sid.Proposed.Device)
-		reply, err := s.skipchain.StoreSkipBlock(sid.SCData, nil, sid.Proposed)
+		priv := s.verifySkipchainAuth()
+		reply, err := s.skipchain.StoreSkipBlockSignature(sid.LatestSkipblock, sid.Proposed.Roster, sid.Proposed, priv)
 		if err != nil {
 			return nil, err
 		}
@@ -467,13 +453,13 @@ func (s *Service) ProposeVote(v *ProposeVote) (network.Message, error) {
 			ID:     v.ID,
 			Latest: reply.Latest,
 		}
-		_, err = s.propagateSkipBlock(sid.SCRoot.Roster, usb, propagateTimeout)
+		_, err = s.propagateSkipBlock(sid.LatestSkipblock.Roster, usb, propagateTimeout)
 		if err != nil {
 			return nil, err
 		}
-		return &ProposeVoteReply{sid.SCData}, nil
+		return &ProposeVoteReply{sid.LatestSkipblock}, nil
 	}
-	return nil, nil
+	return &ProposeVoteReply{}, nil
 }
 
 // VerifyBlock makes sure that the new block is legit. This function will be
@@ -501,16 +487,25 @@ func (s *Service) VerifyBlock(sbID []byte, sb *skipchain.SkipBlock) bool {
 		if len(sb.BackLinkIDs) == 0 {
 			return errors.New("No backlinks stored")
 		}
-		s.identitiesMutex.Lock()
-		defer s.identitiesMutex.Unlock()
+		s.storageMutex.Lock()
+		defer s.storageMutex.Unlock()
 		var latest *skipchain.SkipBlock
-		for _, id := range s.Identities {
-			if id.SCData.Hash.Equal(sb.BackLinkIDs[0]) {
-				latest = id.SCData
+		for _, id := range s.Storage.Identities {
+			if id.LatestSkipblock.Hash.Equal(sb.BackLinkIDs[0]) {
+				latest = id.LatestSkipblock
 			}
 		}
 		if latest == nil {
-			return errors.New("Backlink was not our latest block")
+			// If we don't have the block, the leader should have it.
+			var err error
+			latest, err = s.skipchain.GetSingleBlock(sb.Roster, sb.BackLinkIDs[0])
+			if err != nil {
+				return err
+			}
+			if latest == nil {
+				// Block is not here and not with the leader.
+				return errors.New("didn't find latest block")
+			}
 		}
 		_, dataInt, err = network.Unmarshal(latest.Data, s.Suite())
 		if err != nil {
@@ -520,10 +515,11 @@ func (s *Service) VerifyBlock(sbID []byte, sb *skipchain.SkipBlock) bool {
 		sigCnt := 0
 		for dev, sig := range data.Votes {
 			if pub := dataLatest.Device[dev]; pub != nil {
-				if err := schnorr.Verify(s.Suite(), pub.Point, hash, sig); err != nil {
-					return err
+				log.Lvl3("Against public-key", pub.Point)
+				if err := schnorr.Verify(s.Suite(), pub.Point, hash, sig); err == nil {
+					log.Lvl2("Found correct signature of device", dev)
+					sigCnt++
 				}
-				sigCnt++
 			} else {
 				log.Lvl2("Not representative signature detected:", dev)
 			}
@@ -623,7 +619,7 @@ func (s *Service) propagateSkipBlockHandler(msg network.Message) {
 		log.Error(err)
 		return
 	}
-	sid.SCData = skipblock
+	sid.LatestSkipblock = skipblock
 	sid.Latest = al
 	sid.Proposed = nil
 	s.save()
@@ -648,35 +644,34 @@ func (s *Service) propagateIdentityHandler(msg network.Message) {
 			s.tagsLimits[string(pi.Tag)] = defaultNumberSkipchains
 		}
 		s.tagsLimits[string(pi.Tag)]--
-	} else if pi.Public != nil {
-		str := pi.Public.String()
-		if n, ok := s.pointsLimits[str]; ok {
+	} else if pi.PubStr != "" {
+		if n, ok := s.pointsLimits[pi.PubStr]; ok {
 			if n <= 0 {
 				// unreachable in normal work mode of nodes
 				log.Error("No more skipchains is allowed to create")
 				return
 			}
 		} else {
-			s.pointsLimits[str] = defaultNumberSkipchains
+			s.pointsLimits[pi.PubStr] = defaultNumberSkipchains
 		}
-		s.pointsLimits[str]--
+		s.pointsLimits[pi.PubStr]--
 	}
-	id := ID(pi.SCData.Hash)
+	id := ID(pi.LatestSkipblock.Hash)
 	if s.getIdentityStorage(id) != nil {
 		log.Error("Couldn't store new identity")
 		return
 	}
 	log.Lvl3("Storing identity in", s)
-	s.setIdentityStorage(id, pi.Storage)
+	s.setIdentityStorage(id, pi.IDBlock)
 	return
 }
 
 // getIdentityStorage returns the corresponding IdentityStorage or nil
 // if none was found
-func (s *Service) getIdentityStorage(id ID) *Storage {
-	s.identitiesMutex.Lock()
-	defer s.identitiesMutex.Unlock()
-	is, ok := s.Identities[string(id)]
+func (s *Service) getIdentityStorage(id ID) *IDBlock {
+	s.storageMutex.Lock()
+	defer s.storageMutex.Unlock()
+	is, ok := s.Storage.Identities[string(id)]
 	if !ok {
 		return nil
 	}
@@ -684,25 +679,42 @@ func (s *Service) getIdentityStorage(id ID) *Storage {
 }
 
 // setIdentityStorage saves an IdentityStorage
-func (s *Service) setIdentityStorage(id ID, is *Storage) {
-	s.identitiesMutex.Lock()
-	defer s.identitiesMutex.Unlock()
+func (s *Service) setIdentityStorage(id ID, is *IDBlock) {
+	s.storageMutex.Lock()
+	defer s.storageMutex.Unlock()
 	log.Lvlf3("%s %x %v", s.Context.ServerIdentity(), id[0:8], is.Latest.Device)
-	s.Identities[string(id)] = is
+	s.Storage.Identities[string(id)] = is
 	s.save()
+}
+
+// verifySkipchainAuth adds a new key for authentication to the
+// skipchain service, but only if it already has one. Else it would
+// lock down the service directly.
+func (s *Service) verifySkipchainAuth() kyber.Scalar {
+	ss := s.Service(skipchain.ServiceName).(*skipchain.Service)
+	if len(ss.Storage.Clients) > 0 {
+		if s.Storage.SkipchainKeyPair == nil {
+			// Clients are registered with the skipchain, so add a key for
+			// us, too.
+			s.Storage.SkipchainKeyPair = key.NewKeyPair(cothority.Suite)
+		}
+		ss.AddClientKey(s.Storage.SkipchainKeyPair.Public)
+		return s.Storage.SkipchainKeyPair.Private
+	}
+	return nil
 }
 
 // saves the actual identity
 func (s *Service) save() {
 	log.Lvl3("Saving service")
-	err := s.Save("storage", s.StorageMap)
+	err := s.Save("storage", s.Storage)
 	if err != nil {
 		log.Error("Couldn't save file:", err)
 	}
 }
 
 func (s *Service) clearIdentities() {
-	s.Identities = make(map[string]*Storage)
+	s.Storage.Identities = make(map[string]*IDBlock)
 }
 
 // Tries to load the configuration and updates if a configuration
@@ -712,16 +724,26 @@ func (s *Service) tryLoad() error {
 	if err != nil {
 		return err
 	}
-	if msg == nil {
-		return nil
+	if msg != nil {
+		var ok bool
+		s.Storage, ok = msg.(*Storage)
+		if !ok {
+			return errors.New("Data of wrong type")
+		}
 	}
-	var ok bool
-	s.StorageMap, ok = msg.(*StorageMap)
-	if !ok {
-		return errors.New("Data of wrong type")
+	if s.Storage == nil {
+		s.Storage = &Storage{}
 	}
-	if s.Identities == nil {
-		s.Identities = make(map[string]*Storage)
+	if s.Storage.Identities == nil {
+		s.Storage.Identities = make(map[string]*IDBlock)
+	}
+	if s.Storage.Auth == nil {
+		s.Storage.Auth = &authData{
+			pins:      make(map[string]struct{}),
+			nonces:    make(map[string]struct{}),
+			sets:      make([]anon.Set, 0),
+			adminKeys: make([]kyber.Point, 0),
+		}
 	}
 	log.Lvl3("Successfully loaded")
 	return nil
@@ -730,7 +752,6 @@ func (s *Service) tryLoad() error {
 func newIdentityService(c *onet.Context) (onet.Service, error) {
 	s := &Service{
 		ServiceProcessor: onet.NewServiceProcessor(c),
-		StorageMap:       &StorageMap{make(map[string]*Storage)},
 		skipchain:        skipchain.NewClient(),
 	}
 	if as, ok := c.Suite().(anon.Suite); ok {
@@ -766,10 +787,6 @@ func newIdentityService(c *onet.Context) (onet.Service, error) {
 		return nil, err
 	}
 	skipchain.RegisterVerification(c, VerifyIdentity, s.VerifyBlock)
-	s.auth.pins = make(map[string]struct{})
-	s.auth.nonces = make(map[string]struct{})
-	s.auth.sets = make([]anon.Set, 0)
-	s.auth.adminKeys = make([]kyber.Point, 0)
 	s.tagsLimits = make(map[string]int8)
 	s.pointsLimits = make(map[string]int8)
 	return s, nil

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -5,8 +5,8 @@
 #for t in $( find . -name test.sh ); do
 
 # For now, run the ones that are fixed.
-for t in conode/test.sh scmgr/test.sh status/test.sh cosi/test.sh
+for t in conode scmgr status cosi pop cisc
 do
-	echo "Running integration-test $t"
-	( cd $( dirname $t ); ./$( basename $t ) ) || exit 1
+	echo -e "\n** Running integration-test $t"
+	( cd $t; ./test.sh ) || exit 1
 done

--- a/pop/app.go
+++ b/pop/app.go
@@ -115,7 +115,7 @@ func orgLink(c *cli.Context) error {
 	pin := c.Args().Get(1)
 	if err := client.PinRequest(addr, pin, cfg.OrgPublic); err != nil {
 		// Compare by string because this comes over the network.
-		if err.Error() == service.ErrorReadPIN.Error() {
+		if strings.Contains(err.Error(), service.ErrorReadPIN.Error()) {
 			log.Info("Please read PIN in server-log")
 			return nil
 		}

--- a/pop/test.sh
+++ b/pop/test.sh
@@ -20,9 +20,9 @@ main(){
 		mkdir -p $cl
 	done
 	addr=()
-	addr[1]=127.0.0.1:2002
-	addr[2]=127.0.0.1:2004
-	addr[3]=127.0.0.1:2006
+	addr[1]=localhost:2002
+	addr[2]=localhost:2004
+	addr[3]=localhost:2006
 
 	test Build
 	test Check
@@ -47,7 +47,7 @@ main(){
 testMerge(){
 	MERGE_FILE="pop_merge.toml"
 	mkConfig 3 3 2 4
-	
+
 	# att1 - p1, p2; att2 - p2; att3 - p3;
 	runCl 1 org public ${pub[1]} ${pop_hash[1]}
 	runCl 2 org public ${pub[1]} ${pop_hash[1]}
@@ -99,9 +99,7 @@ testMerge(){
 			testOK runCl $i attendee verify msg1 ctx1 ${sig[$j]} ${tag[$j]} $merged_hash
 		done
 	done
-
 }
-
 
 testAtMultipleKey(){
 	mkConfig 2 2 2 3
@@ -404,7 +402,7 @@ EOF
 			local m=$(($n%$2 + 1))
 			sed -n "$((5*$m-4)),$((5*$m))p" public.toml >> pop_desc$n.toml
 		fi
-	done	
+	done
 	rm -f pop_merge.toml
 	for (( n=1; n<=$2; n++ ))
 	do

--- a/scmgr/app.go
+++ b/scmgr/app.go
@@ -763,18 +763,8 @@ func updateNewSIs(roster *onet.Roster, sisNew []*network.ServerIdentity,
 
 func findLinkFromAddress(cfg *config, address string) (*link, error) {
 	var l *link
-	// Else search for the ip:port
-	host, port, err := net.SplitHostPort(address)
-	if err != nil {
-		return nil, errors.New("invalid host:port option: " + err.Error())
-	}
-	resolved, err := net.ResolveIPAddr("ip", host)
-	if err != nil {
-		return nil, errors.New("invalid host: " + err.Error())
-	}
-	ipPort := net.JoinHostPort(resolved.String(), port)
 	for _, o := range cfg.Values.Link {
-		if o.Address == network.NewTCPAddress(ipPort) {
+		if o.Address == network.NewTCPAddress(address) {
 			l = o
 			break
 		}

--- a/scmgr/test.sh
+++ b/scmgr/test.sh
@@ -129,8 +129,8 @@ testLink(){
 	ID=""
 	testFail [ -n "$ID" ]
 	testOK runSc link add co1/private.toml
-	testOK runSc follow add single 00 127.0.0.1:2002
-	testFail runSc follow add single 00 127.0.0.1:2004
+	testOK runSc follow add single 00 localhost:2002
+	testFail runSc follow add single 00 localhost:2004
 	setupGenesis
 	testOK [ -n "$ID" ]
 }
@@ -177,7 +177,7 @@ setupFour(){
 		co=co$n
 		rm -f $co/*
 		mkdir -p $co
-		echo -e "127.0.0.1:200$(( 2 * $n ))\nCot-$n\n$co\n" | dbgRun runCo $n setup
+		echo -e "localhost:200$(( 2 * $n ))\nCot-$n\n$co\n" | dbgRun runCo $n setup
 		if [ ! -f $co/public.toml ]; then
 			echo "Setup failed: file $co/public.toml is missing."
 			exit
@@ -236,9 +236,9 @@ testIndex(){
 	testFail runSc scdns index
 	testOK runSc scdns index $PWD
 	testGrep "$ID" cat index.js
-	testGrep "127.0.0.1" cat index.js
+	testGrep "localhost" cat index.js
 	testGrep "$ID" cat "$ID.js"
-	testGrep "127.0.0.1" cat "$ID.js"
+	testGrep "localhost" cat "$ID.js"
 	testNFile random.js
 	dbgOut ""
 }


### PR DESCRIPTION
# Identity changes
Renamed a lot of identity structures to remove old names:
- cothority -> roster
- StorageMap -> storage

Removed double storage of roster, both in `identity.Identity` and `identity.Data`

Added correct storage of authenticated keys to identity-service (before the authentication keys were discarded upon service restart)

# Cisc changes
Cleanup of the cisc-binary to make commands more intuitive
Fixed authentication
Updated README.md