### PR TITLE
Fixes so that suite can be changed at runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: go
 install:
   - go get -t ./...
   - go get github.com/dedis/Coding || true
-  - go get golang.org/x/tools/cmd/cover
-  - go get github.com/dedis/goveralls
 
 script:
   - make test

--- a/bftcosi/bftcosi_test.go
+++ b/bftcosi/bftcosi_test.go
@@ -72,8 +72,6 @@ func TestThreshold(t *testing.T) {
 		return NewBFTCoSiProtocol(n, verify)
 	})
 
-	local := onet.NewLocalTest(tSuite)
-	defer local.CloseAll()
 	tests := []struct{ h, t int }{
 		{1, 0},
 		{2, 0},
@@ -83,6 +81,7 @@ func TestThreshold(t *testing.T) {
 		{6, 2},
 	}
 	for _, s := range tests {
+		local := onet.NewLocalTest(tSuite)
 		hosts, thr := s.h, s.t
 		log.Lvl3("Hosts is", hosts)
 		_, _, tree := local.GenBigTree(hosts, hosts, min(2, hosts-1), true)

--- a/bftcosi/packets.go
+++ b/bftcosi/packets.go
@@ -59,7 +59,7 @@ func (bs *BFTSignature) Verify(s network.Suite, publics []kyber.Point) error {
 		aggPublic.Add(aggPublic, publics[i])
 	}
 	// compute the reduced public aggregate key (all - exception)
-	aggReducedPublic := s.Point().Null().Add(s.Point().Null(), aggPublic)
+	aggReducedPublic := aggPublic.Clone()
 
 	// compute the aggregate commit of exception
 	aggExCommit := s.Point().Null()
@@ -71,6 +71,10 @@ func (bs *BFTSignature) Verify(s network.Suite, publics []kyber.Point) error {
 	origCommit := s.Point()
 	pointLen := s.PointLen()
 	sigLen := pointLen + s.ScalarLen()
+
+	if len(bs.Sig) < sigLen {
+		return errors.New("signature too short")
+	}
 	if err := origCommit.UnmarshalBinary(bs.Sig[0:pointLen]); err != nil {
 		return err
 	}

--- a/cisc/lib.go
+++ b/cisc/lib.go
@@ -208,7 +208,7 @@ func getGroup(c *cli.Context) *app.Group {
 	gr, err := os.Open(gfile)
 	log.ErrFatal(err)
 	defer gr.Close()
-	groups, err := app.ReadGroupDescToml(gr, cothority.Suite)
+	groups, err := app.ReadGroupDescToml(gr)
 	log.ErrFatal(err)
 	if groups == nil || groups.Roster == nil || len(groups.Roster.List) == 0 {
 		log.Fatal("No servers found in roster from", gfile)

--- a/conode/conode.go
+++ b/conode/conode.go
@@ -60,7 +60,7 @@ func main() {
 				if c.String("debug") != "" {
 					log.Fatal("[-] Debug option cannot be used for the 'setup' command")
 				}
-				app.InteractiveConfig("conode")
+				app.InteractiveConfig("conode", cothority.Suite)
 				return nil
 			},
 		},
@@ -102,7 +102,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "config, c",
-			Value: app.GetDefaultConfigFile("cothority"),
+			Value: app.GetDefaultConfigFile("conode"),
 			Usage: "Configuration file of the server",
 		},
 	}
@@ -118,8 +118,7 @@ func main() {
 func runServer(ctx *cli.Context) {
 	// first check the options
 	config := ctx.GlobalString("config")
-
-	app.RunServer(config, cothority.Suite)
+	app.RunServer(config)
 }
 
 // checkConfig contacts all servers and verifies if it receives a valid

--- a/conode/run_conode.sh
+++ b/conode/run_conode.sh
@@ -7,23 +7,25 @@ set -e
 
 MAILADDR=linus.gasser@epfl.ch
 MAILCMD=/usr/bin/mail
-CONODE_BIN=conode
-DEDIS_PATH="$(go env GOPATH)/src/github.com/dedis"
-COTHORITY_PATH=$DEDIS_PATH/cothority
-ONET_PATH="$(go env GOPATH)/src/github.com/dedis/onet"
-CONODE_PATH=$COTHORITY_PATH/conode
-CONODE_GO=github.com/dedis/cothority/conode
+
+# Find out which package this copy of run_conode.sh is checked into.
+dir=$(dirname $(realpath $0))
+pkg=`cd $dir && go list ..`
+all_args="$*"
+
 # increment version sub if there's something about cothority that changes
 # and requires a migration, but onet does not change.
 VERSION_SUB="1"
 # increment version in onet if there's something that changes that needs
 # migration.
+ONET_PATH="$(go env GOPATH)/src/github.com/dedis/onet"
 VERSION_ONET=$( grep "const Version" $ONET_PATH/onet.go | sed -e "s/.* \"\(.*\)\"/\1/g" )
 VERSION="$VERSION_ONET-$VERSION_SUB"
-RUN_CONODE=$0
-ALL_ARGS="$*"
-LOG=/tmp/conode-$$.log
-MEMLIMIT=""
+
+# TAGS should be passed in from the environment if you want to add extra
+# build tags to all calls to go. For example to turn on vartime algorithms:
+#   TAGS="-tags vartime" ./run_conode.sh
+# Note: TAGS is also used by the integration tests.
 
 main(){
 	if [ ! "$1" ]; then
@@ -114,8 +116,8 @@ runLocal(){
 		shift
 	done
 
-	killall -9 $CONODE_BIN || true
-	go install $CONODE_GO
+	killall -9 conode || true
+	go install $TAGS $pkg/conode
 
 	rm -f public.toml
 	for n in $( seq $NBR ); do
@@ -128,14 +130,14 @@ runLocal(){
 			if grep 'Public =' $co/public.toml|grep -q =\"; then
 				echo "Detected base64 public key for $co: converting"
 				mv $co/public.toml $co/public.toml.bak
-				$CONODE_BIN convert64 < $co/public.toml.bak > $co/public.toml
+				conode convert64 < $co/public.toml.bak > $co/public.toml
 			fi
 		fi
 
 		if [ ! -d $co ]; then
-			echo -e "127.0.0.1:$((7000 + 2 * $n))\nConode_$n\n$co" | $CONODE_BIN setup
+			echo -e "127.0.0.1:$((7000 + 2 * $n))\nConode_$n\n$co" | conode setup
 		fi
-		$CONODE_BIN -d $DEBUG -c $co/private.toml server &
+		conode -d $DEBUG -c $co/private.toml server &
 		cat $co/public.toml >> public.toml
 	done
 	sleep 1
@@ -184,9 +186,9 @@ runPublic(){
 			fi
 			;;
 		-memory)
-			MEMORY=$2
+			MEMLIMIT=$2
 			shift
-			if [ "$MEMORY" -lt 500 ]; then
+			if [ "$MEMLIMIT" -lt 500 ]; then
 				echo "It will not run with less than 500 MBytes of RAM."
 				exit 1
 			fi
@@ -200,12 +202,12 @@ runPublic(){
 	if [ "$UPDATE" ]; then
 		update
 	else
-		go install $CONODE_GO
+		go install $TAGS $pkg/conode
 	fi
 	migrate
 	if [ ! -f $PATH_CONODE/private.toml ]; then
 		echo "Didn't find private.toml in $PATH_CONODE - setting up conode"
-		if $CONODE_BIN setup; then
+		if conode setup; then
 			echo "Successfully setup conode."
 			exit 0
 		else
@@ -216,18 +218,21 @@ runPublic(){
 
 	echo "Running conode with args: $ARGS and debug: $DEBUG"
 	# Thanks to Pavel Shved from http://unix.stackexchange.com/questions/44985/limit-memory-usage-for-a-single-linux-process
-	if [ "$MEMLIMIT" ]; then
+	if [ -n "$MEMLIMIT" ]; then
 		ulimit -Sv $(( MEMLIMIT * 1024 ))
 	fi
-	$CONODE_BIN -d $DEBUG $ARGS server | tee $LOG
+
+	log=/tmp/conode-$$.log
+	conode -d $DEBUG $ARGS server 2>&1 | tee $log
 	if [ "$MAIL" ]; then
-		tail -n 200 $LOG | $MAILCMD -s "conode-log from $(hostname):$(date)" $MAILADDR
+		tail -n 200 $log | $MAILCMD -s "conode-log from $(hostname):$(date)" $MAILADDR
 		echo "Waiting one minute before launching conode again"
 		sleep 60
 	fi
-	rm $LOG
+	rm $log
 	echo "Conode exited at $(date) - restarting"
-	exec $RUN_CONODE "$ALL_ARGS"
+	sleep 5
+	exec $0 $all_args
 }
 
 migrate(){
@@ -269,7 +274,7 @@ migrate(){
 				co="$PATH_CONODE"
 			echo "Converting base64 public key in $co"
 				mv $co/public.toml $co/public.toml.bak
-			$CONODE_BIN convert64 < $co/public.toml.bak > $co/public.toml
+			conode convert64 < $co/public.toml.bak > $co/public.toml
 			echo $VERSION > $PATH_VERSION
 			echo "Migration to $VERSION complete"
 			;;
@@ -295,9 +300,9 @@ update(){
 	TEST=$1
 	cat - > $TMP << EOF
 if [ ! "$TEST" ]; then
-  go get -u $COTHORITY_PATH/...
+  go get -u $pkg/...
 fi
-exec $RUN_CONODE $ACTION -update_rec $TMP
+exec $0 $ACTION -update_rec $TMP
 EOF
 	chmod a+x $TMP
 	exec $TMP
@@ -317,7 +322,7 @@ test(){
 testPublic(){
 	runPublic &
 	sleep 5
-	testGrep $CONODE_BIN pgrep -lf $CONODE_BIN
+	testGrep conode pgrep -lf conode
 }
 
 testLocal(){
@@ -326,11 +331,11 @@ testLocal(){
 		sleep 1
 	done
 	sleep 2
-	local found=$( pgrep $CONODE_BIN | wc -l | sed -e "s/ *//g" )
+	local found=$( pgrep conode | wc -l | sed -e "s/ *//g" )
 	if [ "$found" != 3 ]; then
 		fail "Didn't find 3 servers, but $found"
 	fi
-	pkill -9 $CONODE_BIN
+	pkill -9 conode
 }
 
 testMigrate(){

--- a/conode/test.sh
+++ b/conode/test.sh
@@ -15,9 +15,9 @@ main(){
 testConode(){
     runCoBG 1 2
     cp co1/public.toml .
-    tail -n 4 co2/public.toml >> public.toml
+    cat co2/public.toml >> public.toml
     testOK runCo 1 check -g public.toml
-    tail -n 4 co3/public.toml >> public.toml
+    cat co3/public.toml >> public.toml
     testFail runCo 1 check -g public.toml
 }
 

--- a/cosi/check/check.go
+++ b/cosi/check/check.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dedis/cothority"
 	"github.com/dedis/kyber"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/app"
@@ -32,7 +31,7 @@ var RequestTimeOut = time.Second * 10
 func Config(tomlFileName string, detail bool) error {
 	f, err := os.Open(tomlFileName)
 	log.ErrFatal(err, "Couldn't open group definition file")
-	group, err := app.ReadGroupDescToml(f, cothority.Suite)
+	group, err := app.ReadGroupDescToml(f)
 	log.ErrFatal(err, "Error while reading group definition file", err)
 	if len(group.Roster.List) == 0 {
 		log.ErrFatalf(err, "Empty entity or invalid group defintion in: %s",

--- a/cosi/client.go
+++ b/cosi/client.go
@@ -96,16 +96,16 @@ func sign(r io.Reader, tomlFileName string) (*s.SignatureResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	el, err := app.ReadGroupToml(f, cothority.Suite)
+	g, err := app.ReadGroupDescToml(f)
 	if err != nil {
 		return nil, err
 	}
-	if len(el.List) <= 0 {
+	if len(g.Roster.List) <= 0 {
 		return nil, errors.New("Empty or invalid cosi group file:" +
 			tomlFileName)
 	}
-	log.Lvl2("Sending signature to", el)
-	res, err := signStatement(r, el)
+	log.Lvl2("Sending signature to", g.Roster)
+	res, err := signStatement(r, g.Roster)
 	if err != nil {
 		return nil, err
 	}
@@ -185,12 +185,12 @@ func verify(fileName, sigFileName, groupToml string) error {
 		return err
 	}
 	log.Lvl4("Reading group definition")
-	el, err := app.ReadGroupToml(fGroup, cothority.Suite)
+	g, err := app.ReadGroupDescToml(fGroup)
 	if err != nil {
 		return err
 	}
 	log.Lvl4("Verfifying signature")
-	err = verifySignatureHash(b, sig, el)
+	err = verifySignatureHash(b, sig, g.Roster)
 	return err
 }
 

--- a/cosi/cosi.go
+++ b/cosi/cosi.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/dedis/cothority"
 	"github.com/dedis/onet/app"
 	"github.com/dedis/onet/log"
 	"gopkg.in/urfave/cli.v1"
@@ -124,7 +125,7 @@ func main() {
 						if c.GlobalIsSet("debug") {
 							log.Fatal("[-] Debug option cannot be used for the 'setup' command")
 						}
-						app.InteractiveConfig(BinaryName)
+						app.InteractiveConfig(BinaryName, cothority.Suite)
 						return nil
 					},
 				},

--- a/cosi/server.go
+++ b/cosi/server.go
@@ -5,7 +5,7 @@ import (
 
 	// Empty imports to have the init-functions called which should
 	// register the protocol
-	"github.com/dedis/cothority"
+
 	_ "github.com/dedis/cothority/cosi/protocol"
 	_ "github.com/dedis/cothority/cosi/service"
 	"github.com/dedis/onet/app"
@@ -15,5 +15,5 @@ func runServer(ctx *cli.Context) {
 	// first check the options
 	config := ctx.String("config")
 
-	app.RunServer(config, cothority.Suite)
+	app.RunServer(config)
 }

--- a/cosi/simulation/cosi_test.go
+++ b/cosi/simulation/cosi_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/cosi/crypto"
-	"github.com/dedis/kyber/suites"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
 )
 
-var tSuite = suites.MustFind("Ed25519")
+var tSuite = cothority.Suite
 
 func TestMain(m *testing.M) {
 	raiseLimit()

--- a/identity/api_test.go
+++ b/identity/api_test.go
@@ -46,14 +46,17 @@ func TestIdentity_PinRequest(t *testing.T) {
 	require.Equal(t, pub, srvc.auth.adminKeys[0])
 }
 
-func TestIdentity_StoreKeys(t *testing.T) {
+func suiteSkip(t *testing.T) {
+	// Some of these tests require Ed25519, so skip if we are currently
+	// running with another suite.
 	if tSuite != suites.MustFind("Ed25519") {
-		// StoreKeys eventually calls eddsa.Verify, which will not work
-		// with non?Ed25519 suites.
-		t.Log("Wrong suite, this service will not run.")
+		t.Skip("current suite is not compatible with this test, skipping it")
 		return
 	}
+}
 
+func TestIdentity_StoreKeys(t *testing.T) {
+	suiteSkip(t)
 	local := onet.NewTCPTest(tSuite)
 	defer local.CloseAll()
 	servers := local.GenServers(1)

--- a/identity/api_test.go
+++ b/identity/api_test.go
@@ -83,7 +83,7 @@ func TestIdentity_StoreKeys(t *testing.T) {
 	signature := make(chan []byte)
 	c := node.(*cosi.CoSi)
 	c.RegisterSignatureHook(func(sig []byte) {
-		log.LLvl3("sig", len(sig))
+		log.Lvl3("sig", len(sig))
 		signature <- sig[0 : len(sig)-1]
 	})
 	c.Message = hash

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-for t in $( find . -name test.sh ); do
+# Many integration tests are currently broken. When they are all fixed,
+# this is how to run them.
+#for t in $( find . -name test.sh ); do
+
+# For now, run the ones that are fixed.
+for t in conode/test.sh scmgr/test.sh status/test.sh cosi/test.sh
+do
 	echo "Running integration-test $t"
 	( cd $( dirname $t ); ./$( basename $t ) ) || exit 1
 done

--- a/pop/app.go
+++ b/pop/app.go
@@ -567,13 +567,12 @@ func (cfg *Config) getPartybyHash(hash string) (*PartyConfig, error) {
 func readGroup(name string) *onet.Roster {
 	f, err := os.Open(name)
 	log.ErrFatal(err, "Couldn't open group definition file")
-	roster, err := app.ReadGroupToml(f, cothority.Suite)
+	g, err := app.ReadGroupDescToml(f)
 	log.ErrFatal(err, "Error while reading group definition file", err)
-	if len(roster.List) == 0 {
-		log.ErrFatalf(err, "Empty entity or invalid group defintion in: %s",
-			name)
+	if len(g.Roster.List) == 0 {
+		log.ErrFatalf(err, "Empty entity or invalid group defintion in: %s", name)
 	}
-	return roster
+	return g.Roster
 }
 
 // PopDescGroupToml represents serializable party description

--- a/pop/service/service.go
+++ b/pop/service/service.go
@@ -34,10 +34,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/bftcosi"
 	"github.com/dedis/cothority/messaging"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/sign/schnorr"
+	"github.com/dedis/kyber/suites"
 	"github.com/dedis/kyber/util/random"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
@@ -45,12 +47,16 @@ import (
 )
 
 func init() {
-	onet.RegisterNewService(Name, newService)
-	network.RegisterMessage(&saveData{})
-	checkConfigID = network.RegisterMessage(checkConfig{})
-	checkConfigReplyID = network.RegisterMessage(checkConfigReply{})
-	mergeConfigID = network.RegisterMessage(mergeConfig{})
-	mergeConfigReplyID = network.RegisterMessage(mergeConfigReply{})
+	// This service depends on EDDSA signatures, so it must not
+	// be instantiated with other suites.
+	if cothority.Suite == suites.MustFind("Ed25519") {
+		onet.RegisterNewService(Name, newService)
+		network.RegisterMessage(&saveData{})
+		checkConfigID = network.RegisterMessage(checkConfig{})
+		checkConfigReplyID = network.RegisterMessage(checkConfigReply{})
+		mergeConfigID = network.RegisterMessage(mergeConfig{})
+		mergeConfigReplyID = network.RegisterMessage(mergeConfigReply{})
+	}
 }
 
 // Name is the name to refer to the Template service from another

--- a/pop/service/service_test.go
+++ b/pop/service/service_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/sign/schnorr"
+	"github.com/dedis/kyber/suites"
 	"github.com/dedis/kyber/util/key"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
@@ -25,12 +26,9 @@ func TestMain(m *testing.M) {
 }
 
 func svc(t *testing.T, local *onet.LocalTest, n int) *Service {
+	suiteSkip(t)
 	servers := local.GenServers(n)
 	services := local.GetServices(servers, serviceID)
-	if services[0] == nil {
-		t.Log("The service is not available to test due to incompatible suite.")
-		return nil
-	}
 	return services[0].(*Service)
 }
 
@@ -67,15 +65,12 @@ func TestService_PinRequest(t *testing.T) {
 }
 
 func TestService_StoreConfig(t *testing.T) {
+	suiteSkip(t)
 	local := onet.NewTCPTest(tSuite)
 	defer local.CloseAll()
 
 	nodes, r, _ := local.GenTree(2, true)
 	services := local.GetServices(nodes, serviceID)
-	if services[0] == nil {
-		t.Log("The service is not available to test due to incompatible suite.")
-		return
-	}
 	service := services[0].(*Service)
 
 	desc := &PopDesc{
@@ -98,15 +93,12 @@ func TestService_StoreConfig(t *testing.T) {
 }
 
 func TestService_CheckConfigMessage(t *testing.T) {
+	suiteSkip(t)
 	local := onet.NewTCPTest(tSuite)
 	defer local.CloseAll()
 	nodes, r, _ := local.GenTree(2, true)
 	svcs := local.GetServices(nodes, serviceID)
 	descs, atts, srvcs, _ := storeDesc(svcs, r, 2, 2)
-	if len(srvcs) == 0 {
-		t.Log("The service is not available to test due to incompatible suite.")
-		return
-	}
 	for _, s := range srvcs {
 		for _, desc := range descs {
 			hash := string(desc.Hash())
@@ -137,14 +129,11 @@ func TestService_CheckConfigMessage(t *testing.T) {
 }
 
 func TestService_CheckConfigReply(t *testing.T) {
+	suiteSkip(t)
 	local := onet.NewTCPTest(tSuite)
 	defer local.CloseAll()
 	nodes, r, _ := local.GenTree(2, true)
 	descs, atts, srvcs, _ := storeDesc(local.GetServices(nodes, serviceID), r, 2, 2)
-	if len(srvcs) == 0 {
-		t.Log("The service is not available to test due to incompatible suite.")
-		return
-	}
 	for _, desc := range descs {
 		hash := string(desc.Hash())
 		s0 := srvcs[0]
@@ -176,6 +165,7 @@ func TestService_CheckConfigReply(t *testing.T) {
 }
 
 func TestService_FinalizeRequest(t *testing.T) {
+	suiteSkip(t)
 	local := onet.NewTCPTest(tSuite)
 	defer local.CloseAll()
 	nbrNodes := 3
@@ -185,10 +175,6 @@ func TestService_FinalizeRequest(t *testing.T) {
 
 	// Get all service-instances
 	descs, atts, services, privs := storeDesc(local.GetServices(nodes, serviceID), r, nbrAtt, ndescs)
-	if len(services) == 0 {
-		t.Log("The service is not available to test due to incompatible suite.")
-		return
-	}
 	for _, desc := range descs {
 		// Clear config of first one
 		descHash := desc.Hash()
@@ -240,6 +226,7 @@ func TestService_FinalizeRequest(t *testing.T) {
 }
 
 func TestService_FetchFinal(t *testing.T) {
+	suiteSkip(t)
 	local := onet.NewTCPTest(tSuite)
 	defer local.CloseAll()
 	nbrNodes := 2
@@ -249,10 +236,6 @@ func TestService_FetchFinal(t *testing.T) {
 
 	// Get all service-instances
 	descs, atts, services, priv := storeDesc(local.GetServices(nodes, serviceID), r, nbrAtt, ndescs)
-	if len(services) == 0 {
-		t.Log("The service is not available to test due to incompatible suite.")
-		return
-	}
 
 	for _, desc := range descs {
 		descHash := desc.Hash()
@@ -295,6 +278,7 @@ func TestService_FetchFinal(t *testing.T) {
 }
 
 func TestService_MergeConfig(t *testing.T) {
+	suiteSkip(t)
 	local := onet.NewTCPTest(tSuite)
 	defer local.CloseAll()
 	nbrNodes := 4
@@ -302,10 +286,6 @@ func TestService_MergeConfig(t *testing.T) {
 	nodes, r, _ := local.GenTree(nbrNodes, true)
 
 	descs, atts, srvcs, priv := storeDescMerge(local.GetServices(nodes, serviceID), r, nbrAtt)
-	if len(srvcs) == 0 {
-		t.Log("The service is not available to test due to incompatible suite.")
-		return
-	}
 	hash := make([]string, nbrNodes/2)
 	hash[0] = string(descs[0].Hash())
 	hash[1] = string(descs[1].Hash())
@@ -361,17 +341,23 @@ func TestService_MergeConfig(t *testing.T) {
 		"Server 2 statementsMap")
 }
 
+func suiteSkip(t *testing.T) {
+	// Some of these tests require Ed25519, so skip if we are currently
+	// running with another suite.
+	if tSuite != suites.MustFind("Ed25519") {
+		t.Skip("current suite is not compatible with this test, skipping it")
+		return
+	}
+}
+
 func TestService_MergeRequest(t *testing.T) {
+	suiteSkip(t)
 	local := onet.NewTCPTest(tSuite)
 	defer local.CloseAll()
 	nbrNodes := 4
 	nbrAtt := 4
 	nodes, r, _ := local.GenTree(nbrNodes, true)
 	descs, atts, srvcs, priv := storeDescMerge(local.GetServices(nodes, serviceID), r, nbrAtt)
-	if len(srvcs) == 0 {
-		t.Log("The service is not available to test due to incompatible suite.")
-		return
-	}
 	hash := make([]string, nbrNodes/2)
 	hash[0] = string(descs[0].Hash())
 	hash[1] = string(descs[1].Hash())

--- a/pop/test.sh
+++ b/pop/test.sh
@@ -47,7 +47,7 @@ main(){
 testMerge(){
 	MERGE_FILE="pop_merge.toml"
 	mkConfig 3 3 2 4
-
+	
 	# att1 - p1, p2; att2 - p2; att3 - p3;
 	runCl 1 org public ${pub[1]} ${pop_hash[1]}
 	runCl 2 org public ${pub[1]} ${pop_hash[1]}
@@ -398,13 +398,13 @@ EOF
 	done
 	for (( n=1; n<=$2; n++ ))
 	do
-		sed -n "$((4*$n-3)),$((4*$n))p" public.toml >> pop_desc$n.toml
+	        sed -n "$((5*$n-4)),$((5*$n))p" public.toml >> pop_desc$n.toml
 		if [[ $2 -gt 1 ]]
 		then
 			local m=$(($n%$2 + 1))
-			sed -n "$((4*$m-3)),$((4*$m))p" public.toml >> pop_desc$n.toml
+			sed -n "$((5*$m-4)),$((5*$m))p" public.toml >> pop_desc$n.toml
 		fi
-	done
+	done	
 	rm -f pop_merge.toml
 	for (( n=1; n<=$2; n++ ))
 	do
@@ -413,10 +413,10 @@ EOF
 Location = "Earth, City$n"
 EOF
 		echo "[[parties.servers]]" >> pop_merge.toml
-		sed -n "$((4*$n-2)),$((4*$n))p" public.toml >> pop_merge.toml
+		sed -n "$((5*$n-4)),$((5*$n))p" public.toml >> pop_merge.toml
 		local m=$(($n%$2 + 1))
 		echo "[[parties.servers]]" >> pop_merge.toml
-		sed -n "$((4*$m-2)),$((4*$m))p" public.toml >> pop_merge.toml
+		sed -n "$((5*$m-4)),$((5*$m))p" public.toml >> pop_merge.toml
 	done
 }
 
@@ -425,9 +425,11 @@ testSave(){
 	mkPopConfig 1 2
 
 	testFail runCl 1 org config pop_desc1.toml
-	pkill -9 -f conode
+	pkill conode
+	sleep .1
 	mkLink 2
-	pkill -9 -f conode
+	pkill conode
+	sleep .1
 	runCoBG 1 2
 	testOK runCl 1 org config pop_desc1.toml
 }

--- a/scmgr/app.go
+++ b/scmgr/app.go
@@ -93,16 +93,16 @@ func linkAdd(c *cli.Context) error {
 	if err != nil {
 		return errors.New("error while reading private.toml: " + err.Error())
 	}
-	conodePriv, err := encoding.StringHexToScalar(skipchain.Suite, remote.Private)
+	conodePriv, err := encoding.StringHexToScalar(cothority.Suite, remote.Private)
 	if err != nil {
 		return errors.New("couldn't decode private key: " + err.Error())
 	}
-	conodePub, err := encoding.StringHexToPoint(skipchain.Suite, remote.Public)
+	conodePub, err := encoding.StringHexToPoint(cothority.Suite, remote.Public)
 	if err != nil {
 		return errors.New("couldn't decode public key: " + err.Error())
 	}
 	cfg := getConfigOrFail(c)
-	kp := key.NewKeyPair(skipchain.Suite)
+	kp := key.NewKeyPair(cothority.Suite)
 	si := network.NewServerIdentity(conodePub, remote.Address)
 	cfg.Values.Link[si.Public.String()] = &link{
 		Private: kp.Private,
@@ -139,7 +139,7 @@ func linkList(c *cli.Context) error {
 	cfg := getConfigOrFail(c)
 	for _, link := range cfg.Values.Link {
 		log.Infof("Linked public key for conode %s: %s", link.Address,
-			skipchain.Suite.Point().Mul(link.Private, nil))
+			cothority.Suite.Point().Mul(link.Private, nil))
 	}
 	return nil
 }
@@ -625,7 +625,7 @@ func readGroupArgs(c *cli.Context, pos int) *app.Group {
 func readGroup(name string) *app.Group {
 	f, err := os.Open(name)
 	log.ErrFatal(err, "Couldn't open group definition file")
-	group, err := app.ReadGroupDescToml(f, cothority.Suite)
+	group, err := app.ReadGroupDescToml(f)
 	log.ErrFatal(err, "Error while reading group definition file", err)
 	if len(group.Roster.List) == 0 {
 		log.ErrFatalf(err, "Empty entity or invalid group defintion in: %s",

--- a/scmgr/test.sh
+++ b/scmgr/test.sh
@@ -3,7 +3,7 @@
 DBG_TEST=1
 # Debug-level for app
 DBG_APP=2
-DBG_SRV=2
+# DBG_SRV=2
 
 . $(go env GOPATH)/src/github.com/dedis/onet/app/libtest.sh
 

--- a/skipchain/api_test.go
+++ b/skipchain/api_test.go
@@ -9,6 +9,7 @@ import (
 
 	"sync"
 
+	"github.com/dedis/cothority"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/util/key"
 	"github.com/dedis/onet"
@@ -21,7 +22,7 @@ func init() {
 }
 
 func TestClient_CreateGenesis(t *testing.T) {
-	l := onet.NewTCPTest(Suite)
+	l := onet.NewTCPTest(cothority.Suite)
 	_, roster, _ := l.GenTree(3, true)
 	defer l.CloseAll()
 	c := newTestClient(l)
@@ -39,7 +40,7 @@ func TestClient_CreateGenesis(t *testing.T) {
 }
 
 func TestClient_CreateRootControl(t *testing.T) {
-	l := onet.NewTCPTest(Suite)
+	l := onet.NewTCPTest(cothority.Suite)
 	_, roster, _ := l.GenTree(3, true)
 	defer l.CloseAll()
 	c := newTestClient(l)
@@ -51,7 +52,7 @@ func TestClient_GetUpdateChain(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Long run not good for Travis")
 	}
-	l := onet.NewTCPTest(Suite)
+	l := onet.NewTCPTest(cothority.Suite)
 	_, ro, _ := l.GenTree(5, true)
 	defer l.CloseAll()
 
@@ -75,7 +76,7 @@ func TestClient_GetUpdateChain(t *testing.T) {
 }
 
 func TestClient_CreateRootInter(t *testing.T) {
-	l := onet.NewTCPTest(Suite)
+	l := onet.NewTCPTest(cothority.Suite)
 	_, ro, _ := l.GenTree(5, true)
 	defer l.CloseAll()
 
@@ -100,7 +101,7 @@ func TestClient_CreateRootInter(t *testing.T) {
 
 func TestClient_StoreSkipBlock(t *testing.T) {
 	nbrHosts := 3
-	l := onet.NewTCPTest(Suite)
+	l := onet.NewTCPTest(cothority.Suite)
 	_, ro, _ := l.GenTree(nbrHosts, true)
 	defer l.CloseAll()
 
@@ -146,7 +147,7 @@ func TestClient_StoreSkipBlock(t *testing.T) {
 
 func TestClient_GetAllSkipchains(t *testing.T) {
 	nbrHosts := 3
-	l := onet.NewTCPTest(Suite)
+	l := onet.NewTCPTest(cothority.Suite)
 	_, ro, _ := l.GenTree(nbrHosts, true)
 	defer l.CloseAll()
 
@@ -173,7 +174,7 @@ func TestClient_GetAllSkipchains(t *testing.T) {
 
 func TestClient_GetSingleBlockByIndex(t *testing.T) {
 	nbrHosts := 3
-	l := onet.NewTCPTest(Suite)
+	l := onet.NewTCPTest(cothority.Suite)
 	_, roster, _ := l.GenTree(nbrHosts, true)
 	defer l.CloseAll()
 
@@ -328,9 +329,9 @@ type linkStruct struct {
 }
 
 func linked(nbr int) *linkStruct {
-	kp := key.NewKeyPair(Suite)
+	kp := key.NewKeyPair(cothority.Suite)
 	ls := &linkStruct{
-		local: onet.NewTCPTest(Suite),
+		local: onet.NewTCPTest(cothority.Suite),
 		priv:  kp.Private,
 		pub:   kp.Public,
 	}

--- a/skipchain/protocol.go
+++ b/skipchain/protocol.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dedis/cothority"
 	"github.com/dedis/kyber/sign/schnorr"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
@@ -107,7 +108,7 @@ func (p *ExtendRoster) HandleExtendRoster(msg ProtoStructExtendRoster) error {
 
 	log.Lvlf3("%s: Check block with roster %s", p.ServerIdentity(), msg.Block.Roster.List)
 	if p.isBlockAccepted(msg.ServerIdentity, &msg.Block) {
-		sig, err := schnorr.Sign(Suite, p.Private(), msg.Block.SkipChainID())
+		sig, err := schnorr.Sign(cothority.Suite, p.Private(), msg.Block.SkipChainID())
 		if err != nil {
 			log.Error("couldn't sign genesis-block")
 			return p.SendToParent(&ProtoExtendRosterReply{})
@@ -195,7 +196,7 @@ func (p *ExtendRoster) HandleExtendRosterReply(r ProtoStructExtendRosterReply) e
 		if r.Signature == nil {
 			return false
 		}
-		if schnorr.Verify(Suite, r.ServerIdentity.Public, p.ExtendRoster.Block.SkipChainID(), *r.Signature) != nil {
+		if schnorr.Verify(cothority.Suite, r.ServerIdentity.Public, p.ExtendRoster.Block.SkipChainID(), *r.Signature) != nil {
 			log.Lvl3("Signature verification failed")
 			return false
 		}

--- a/skipchain/protocol_test.go
+++ b/skipchain/protocol_test.go
@@ -3,6 +3,7 @@ package skipchain_test
 import (
 	"testing"
 
+	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/bftcosi"
 	"github.com/dedis/cothority/skipchain"
 	"github.com/dedis/kyber/sign/schnorr"
@@ -14,7 +15,6 @@ import (
 const tsName = "tsName"
 
 var tsID onet.ServiceID
-var tSuite = skipchain.Suite
 
 func init() {
 	var err error
@@ -24,7 +24,7 @@ func init() {
 
 // TestGB tests the GetBlocks protocol
 func TestGB(t *testing.T) {
-	local := onet.NewLocalTest(tSuite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer local.CloseAll()
 	servers, ro, _ := local.GenTree(3, true)
 	tss := local.GetServices(servers, tsID)
@@ -143,7 +143,7 @@ func TestER(t *testing.T) {
 
 func testER(t *testing.T, tsid onet.ServiceID, nbrNodes int) {
 	log.Lvl1("Testing", nbrNodes, "nodes")
-	local := onet.NewLocalTest(tSuite)
+	local := onet.NewLocalTest(cothority.Suite)
 	servers, roster, tree := local.GenBigTree(nbrNodes, nbrNodes, nbrNodes, true)
 	tss := local.GetServices(servers, tsid)
 
@@ -159,7 +159,7 @@ func testER(t *testing.T, tsid onet.ServiceID, nbrNodes int) {
 	local.CloseAll()
 
 	// Check inclusion of new chains
-	local = onet.NewLocalTest(tSuite)
+	local = onet.NewLocalTest(cothority.Suite)
 	servers, roster, tree = local.GenBigTree(nbrNodes, nbrNodes, nbrNodes, true)
 	tss = local.GetServices(servers, tsid)
 	for _, t := range tss {
@@ -174,14 +174,14 @@ func testER(t *testing.T, tsid onet.ServiceID, nbrNodes int) {
 	for _, s := range sigs {
 		_, si := roster.Search(s.SI)
 		require.NotNil(t, si)
-		require.Nil(t, schnorr.Verify(tSuite, si.Public, sb.SkipChainID(), s.Signature))
+		require.Nil(t, schnorr.Verify(cothority.Suite, si.Public, sb.SkipChainID(), s.Signature))
 	}
 	local.CloseAll()
 
 	// When only one node refuse,
 	// we should be able to proceed because skipchain is fault tolerant
 	if nbrNodes > 4 {
-		local = onet.NewLocalTest(tSuite)
+		local = onet.NewLocalTest(cothority.Suite)
 		servers, roster, tree = local.GenBigTree(nbrNodes, nbrNodes, nbrNodes, true)
 		tss = local.GetServices(servers, tsid)
 		for i := 3; i < nbrNodes; i++ {

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/bftcosi"
 	"github.com/dedis/cothority/cosi/crypto"
 	"github.com/dedis/cothority/messaging"
@@ -412,7 +413,7 @@ func (s *Service) CreateLinkPrivate(link *CreateLinkPrivate) (*EmptyReply, onet.
 	if err != nil {
 		return nil, onet.NewClientErrorCode(ErrorOnet, "couldn't marshal public key: "+err.Error())
 	}
-	if err = schnorr.Verify(Suite, s.ServerIdentity().Public, msg, link.Signature); err != nil {
+	if err = schnorr.Verify(cothority.Suite, s.ServerIdentity().Public, msg, link.Signature); err != nil {
 		return nil, onet.NewClientErrorCode(ErrorParameterWrong, "wrong signature on public key: "+err.Error())
 	}
 	s.storageMutex.Lock()
@@ -531,7 +532,7 @@ func (s *Service) AddFollow(add *AddFollow) (*EmptyReply, onet.ClientError) {
 		}
 		log.Lvlf2("%s FollowSearch %s %x", s.ServerIdentity(), add.Conode, add.SkipchainID)
 	case FollowLookup:
-		si := network.NewServerIdentity(Suite.Point(), network.NewTCPAddress(add.Conode))
+		si := network.NewServerIdentity(cothority.Suite.Point().Null(), network.NewTCPAddress(add.Conode))
 		roster := onet.NewRoster([]*network.ServerIdentity{si})
 		last, err := s.getLastBlock(roster, add.SkipchainID)
 		if err != nil {
@@ -646,7 +647,7 @@ func (s *Service) verifySigs(msg, sig []byte) bool {
 	}
 
 	for _, cl := range s.Storage.Clients {
-		if schnorr.Verify(Suite, cl, msg, sig) == nil {
+		if schnorr.Verify(cothority.Suite, cl, msg, sig) == nil {
 			return true
 		}
 	}
@@ -756,7 +757,7 @@ func (s *Service) deprecatedProcessorGetBlockReply(env *network.Envelope) {
 // is valid.
 func (s *Service) bftVerifyFollowBlock(msg []byte, data []byte) bool {
 	err := func() error {
-		_, fsInt, err := network.Unmarshal(data, Suite)
+		_, fsInt, err := network.Unmarshal(data, cothority.Suite)
 		if err != nil {
 			return err
 		}
@@ -772,7 +773,7 @@ func (s *Service) bftVerifyFollowBlock(msg []byte, data []byte) bool {
 		if len(newest.BackLinkIDs) <= fs.TargetHeight {
 			return errors.New("Asked for signing too high a backlink")
 		}
-		if err := fs.ForwardLink.Verify(Suite, previous.Roster.Publics()); err != nil {
+		if err := fs.ForwardLink.Verify(cothority.Suite, previous.Roster.Publics()); err != nil {
 			return errors.New("Wrong forward-link signature: " + err.Error())
 		}
 		if !fs.ForwardLink.Hash().Equal(newest.Hash) {
@@ -806,7 +807,7 @@ func (s *Service) bftVerifyNewBlock(msg []byte, data []byte) bool {
 		return false
 	}
 	log.Lvlf4("%s verifying block %x", s.ServerIdentity(), msg)
-	_, newSBi, err := network.Unmarshal(data[32:], Suite)
+	_, newSBi, err := network.Unmarshal(data[32:], cothority.Suite)
 	if err != nil {
 		log.Error("Couldn't unmarshal SkipBlock", data)
 		return false
@@ -981,8 +982,8 @@ func (s *Service) startBFT(proto string, roster *onet.Roster, msg, data []byte) 
 		return nil, errors.New("found empty Roster")
 	case 1:
 		pubs := []kyber.Point{s.ServerIdentity().Public}
-		co := crypto.NewCosi(Suite, root.Private(), pubs)
-		co.CreateCommitment(Suite.RandomStream())
+		co := crypto.NewCosi(cothority.Suite, root.Private(), pubs)
+		co.CreateCommitment(cothority.Suite.RandomStream())
 		co.CreateChallenge(msg)
 		co.CreateResponse()
 		// This is when using kyber-cosi
@@ -1004,7 +1005,7 @@ func (s *Service) startBFT(proto string, roster *onet.Roster, msg, data []byte) 
 			Sig:        co.Signature(),
 			Exceptions: []bftcosi.Exception{},
 		}
-		if crypto.VerifySignature(Suite, pubs, msg, sig.Sig) != nil {
+		if crypto.VerifySignature(cothority.Suite, pubs, msg, sig.Sig) != nil {
 			return nil, errors.New("failed in cosi")
 		}
 		return sig, nil
@@ -1091,20 +1092,20 @@ func (s *Service) newBlockEnd(sb *SkipBlock) bool {
 // authenticate searches if this node or any follower-node can verify the
 // schnorr-signature.
 func (s *Service) authenticate(msg []byte, sig []byte) bool {
-	if err := schnorr.Verify(Suite, s.ServerIdentity().Public, msg, sig); err == nil {
+	if err := schnorr.Verify(cothority.Suite, s.ServerIdentity().Public, msg, sig); err == nil {
 		return true
 	}
 	s.storageMutex.Lock()
 	defer s.storageMutex.Unlock()
 	for _, fct := range s.Storage.Follow {
 		for _, si := range fct.Block.Roster.List {
-			if err := schnorr.Verify(Suite, si.Public, msg, sig); err == nil {
+			if err := schnorr.Verify(cothority.Suite, si.Public, msg, sig); err == nil {
 				return true
 			}
 		}
 	}
 	for _, cl := range s.Storage.Clients {
-		if err := schnorr.Verify(Suite, cl, msg, sig); err == nil {
+		if err := schnorr.Verify(cothority.Suite, cl, msg, sig); err == nil {
 			return true
 		}
 	}

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dedis/cothority"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/sign/schnorr"
 	"github.com/dedis/kyber/util/key"
@@ -43,10 +44,10 @@ func TestService_StoreSkipBlock(t *testing.T) {
 
 func storeSkipBlock(t *testing.T, fail bool) {
 	// First create a roster to attach the data to it
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, el, genService := local.MakeHELS(4, skipchainSID, Suite)
+	servers, el, genService := local.MakeHELS(4, skipchainSID, cothority.Suite)
 	service := genService.(*Service)
 	// This is the poor server who will play the part of the dead server
 	// for us.
@@ -141,12 +142,12 @@ func storeSkipBlock(t *testing.T, fail bool) {
 func TestService_GetUpdateChain(t *testing.T) {
 	// Create a small chain and test whether we can get from one element
 	// of the chain to the last element with a valid slice of SkipBlocks
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	conodes := 10
 	sbCount := conodes - 1
-	servers, el, gs := local.MakeHELS(conodes, skipchainSID, Suite)
+	servers, el, gs := local.MakeHELS(conodes, skipchainSID, cothority.Suite)
 	s := gs.(*Service)
 
 	sbs := make([]*SkipBlock, sbCount)
@@ -206,10 +207,10 @@ func TestService_SetChildrenSkipBlock(t *testing.T) {
 	// How many nodes in Root
 	nodesRoot := 3
 
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	hosts, el, genService := local.MakeHELS(nodesRoot, skipchainSID, Suite)
+	hosts, el, genService := local.MakeHELS(nodesRoot, skipchainSID, cothority.Suite)
 	service := genService.(*Service)
 
 	// Setting up two chains and linking one to the other
@@ -263,10 +264,10 @@ func TestService_SetChildrenSkipBlock(t *testing.T) {
 }
 
 func TestService_MultiLevel(t *testing.T) {
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, el, genService := local.MakeHELS(3, skipchainSID, Suite)
+	servers, el, genService := local.MakeHELS(3, skipchainSID, cothority.Suite)
 	services := make([]*Service, len(servers))
 	for i, s := range local.GetServices(servers, skipchainSID) {
 		services[i] = s.(*Service)
@@ -314,11 +315,11 @@ func TestService_MultiLevel(t *testing.T) {
 }
 
 func TestService_Verification(t *testing.T) {
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	sbLength := 4
-	_, el, genService := local.MakeHELS(sbLength, skipchainSID, Suite)
+	_, el, genService := local.MakeHELS(sbLength, skipchainSID, cothority.Suite)
 	service := genService.(*Service)
 
 	elRoot := onet.NewRoster(el.List[0:3])
@@ -347,10 +348,10 @@ func TestService_Verification(t *testing.T) {
 
 func TestService_SignBlock(t *testing.T) {
 	// Testing whether we sign correctly the SkipBlocks
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	_, el, genService := local.MakeHELS(3, skipchainSID, Suite)
+	_, el, genService := local.MakeHELS(3, skipchainSID, cothority.Suite)
 	service := genService.(*Service)
 
 	sbRoot, err := makeGenesisRosterArgs(service, el, nil, VerificationNone, 1, 1)
@@ -369,10 +370,10 @@ func TestService_SignBlock(t *testing.T) {
 
 func TestService_ProtocolVerification(t *testing.T) {
 	// Testing whether we sign correctly the SkipBlocks
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	_, el, s := local.MakeHELS(3, skipchainSID, Suite)
+	_, el, s := local.MakeHELS(3, skipchainSID, cothority.Suite)
 	s1 := s.(*Service)
 	count := make(chan bool, 3)
 	verifyFunc := func(newID []byte, newSB *SkipBlock) bool {
@@ -402,7 +403,7 @@ func TestService_ProtocolVerification(t *testing.T) {
 func TestService_RegisterVerification(t *testing.T) {
 	// Testing whether we sign correctly the SkipBlocks
 	onet.RegisterNewService("ServiceVerify", newServiceVerify)
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	hosts, el, s1 := makeHELS(local, 3)
@@ -429,7 +430,7 @@ func TestService_RegisterVerification(t *testing.T) {
 
 func TestService_StoreSkipBlock2(t *testing.T) {
 	nbrHosts := 3
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	hosts, roster, s1 := makeHELS(local, nbrHosts)
@@ -481,7 +482,7 @@ func TestService_StoreSkipBlock2(t *testing.T) {
 func TestService_StoreSkipBlockSpeed(t *testing.T) {
 	t.Skip("This is a hidden benchmark")
 	nbrHosts := 3
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	_, roster, s1 := makeHELS(local, nbrHosts)
@@ -514,7 +515,7 @@ func TestService_ParallelStore(t *testing.T) {
 		t.Skip("parallel store does not run on travis, see #1000")
 	}
 	nbrRoutines := 10
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	_, roster, s1 := makeHELS(local, 3)
@@ -564,10 +565,11 @@ func TestService_Propagation(t *testing.T) {
 		t.Skip("propagation does not run on travis, see #1000")
 	}
 	nbrNodes := 60
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
+
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, ro, genService := local.MakeHELS(nbrNodes, skipchainSID, Suite)
+	servers, ro, genService := local.MakeHELS(nbrNodes, skipchainSID, cothority.Suite)
 	services := make([]*Service, len(servers))
 	for i, s := range local.GetServices(servers, skipchainSID) {
 		services[i] = s.(*Service)
@@ -583,10 +585,10 @@ func TestService_Propagation(t *testing.T) {
 }
 
 func TestService_AddFollow(t *testing.T) {
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, ro, _ := local.MakeHELS(3, skipchainSID, Suite)
+	servers, ro, _ := local.MakeHELS(3, skipchainSID, cothority.Suite)
 	services := make([]*Service, len(servers))
 	for i, s := range local.GetServices(servers, skipchainSID) {
 		services[i] = s.(*Service)
@@ -607,7 +609,7 @@ func TestService_AddFollow(t *testing.T) {
 	// Wrong server signature
 	priv0 := local.GetPrivate(servers[0])
 	priv1 := local.GetPrivate(servers[1])
-	sig, err := schnorr.Sign(Suite, priv1, ssb.NewBlock.CalculateHash())
+	sig, err := schnorr.Sign(cothority.Suite, priv1, ssb.NewBlock.CalculateHash())
 	log.ErrFatal(err)
 	ssb.Signature = &sig
 	_, cerr = service.StoreSkipBlock(ssb)
@@ -615,7 +617,7 @@ func TestService_AddFollow(t *testing.T) {
 
 	// Correct server signature
 	log.Lvl2("correct server signature")
-	sig, err = schnorr.Sign(Suite, priv0, ssb.NewBlock.CalculateHash())
+	sig, err = schnorr.Sign(cothority.Suite, priv0, ssb.NewBlock.CalculateHash())
 	log.ErrFatal(err)
 	ssb.Signature = &sig
 	master0, cerr := service.StoreSkipBlock(ssb)
@@ -628,7 +630,7 @@ func TestService_AddFollow(t *testing.T) {
 	sb = sb.Copy()
 	ssb.NewBlock = sb
 	sb.Roster = onet.NewRoster([]*network.ServerIdentity{ro.List[0], ro.List[1]}) // two in roster
-	sig, err = schnorr.Sign(Suite, priv0, ssb.NewBlock.CalculateHash())
+	sig, err = schnorr.Sign(cothority.Suite, priv0, ssb.NewBlock.CalculateHash())
 	log.ErrFatal(err)
 	ssb.Signature = &sig
 	require.Equal(t, 0, services[1].db.Length())
@@ -642,7 +644,7 @@ func TestService_AddFollow(t *testing.T) {
 		Block:    master0.Latest,
 		NewChain: NewChainAnyNode,
 	}}
-	sig, err = schnorr.Sign(Suite, priv0, ssb.NewBlock.CalculateHash())
+	sig, err = schnorr.Sign(cothority.Suite, priv0, ssb.NewBlock.CalculateHash())
 	log.ErrFatal(err)
 	ssb.Signature = &sig
 	master1, cerr := service.StoreSkipBlock(ssb)
@@ -659,7 +661,7 @@ func TestService_AddFollow(t *testing.T) {
 	sb.Hash = sb.CalculateHash()
 	ssb.NewBlock = sb
 	ssb.LatestID = master1.Latest.Hash
-	sig, err = schnorr.Sign(Suite, priv1, ssb.NewBlock.CalculateHash())
+	sig, err = schnorr.Sign(cothority.Suite, priv1, ssb.NewBlock.CalculateHash())
 	log.ErrFatal(err)
 	ssb.Signature = &sig
 	sbs, err := service.db.getAll()
@@ -673,10 +675,10 @@ func TestService_AddFollow(t *testing.T) {
 }
 
 func TestService_CreateLinkPrivate(t *testing.T) {
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, _, _ := local.MakeHELS(3, skipchainSID, Suite)
+	servers, _, _ := local.MakeHELS(3, skipchainSID, cothority.Suite)
 	server := servers[0]
 	service := local.GetServices(servers, skipchainSID)[0].(*Service)
 	require.Equal(t, 0, len(service.Storage.Clients))
@@ -687,7 +689,7 @@ func TestService_CreateLinkPrivate(t *testing.T) {
 	require.NotNil(t, cerr)
 	msg, err := server.ServerIdentity.Public.MarshalBinary()
 	require.Nil(t, err)
-	sig, err := schnorr.Sign(Suite, local.GetPrivate(servers[0]), msg)
+	sig, err := schnorr.Sign(cothority.Suite, local.GetPrivate(servers[0]), msg)
 	log.ErrFatal(err)
 	_, cerr = service.CreateLinkPrivate(&CreateLinkPrivate{Public: servers[0].ServerIdentity.Public, Signature: sig})
 	log.ErrFatal(cerr)
@@ -698,16 +700,16 @@ func TestService_CreateLinkPrivate(t *testing.T) {
 }
 
 func TestService_Unlink(t *testing.T) {
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, _, _ := local.MakeHELS(3, skipchainSID, Suite)
+	servers, _, _ := local.MakeHELS(3, skipchainSID, cothority.Suite)
 	server := servers[0]
 	service := local.GetServices(servers, skipchainSID)[0].(*Service)
 
-	kp := key.NewKeyPair(Suite)
+	kp := key.NewKeyPair(cothority.Suite)
 	msg, _ := kp.Public.MarshalBinary()
-	sig, err := schnorr.Sign(Suite, local.GetPrivate(servers[0]), msg)
+	sig, err := schnorr.Sign(cothority.Suite, local.GetPrivate(servers[0]), msg)
 	log.ErrFatal(err)
 	_, cerr := service.CreateLinkPrivate(&CreateLinkPrivate{Public: kp.Public, Signature: sig})
 	log.ErrFatal(cerr)
@@ -724,7 +726,7 @@ func TestService_Unlink(t *testing.T) {
 	// Inexistant public key
 	msg, _ = server.ServerIdentity.Public.MarshalBinary()
 	msg = append([]byte("unlink:"), msg...)
-	sig, err = schnorr.Sign(Suite, local.GetPrivate(servers[0]), msg)
+	sig, err = schnorr.Sign(cothority.Suite, local.GetPrivate(servers[0]), msg)
 	_, cerr = service.Unlink(&Unlink{
 		Public:    servers[0].ServerIdentity.Public,
 		Signature: sig,
@@ -735,7 +737,7 @@ func TestService_Unlink(t *testing.T) {
 	// Wrong signature
 	msg, _ = kp.Public.MarshalBinary()
 	msg = append([]byte("unlink:"), msg...)
-	sig, err = schnorr.Sign(Suite, local.GetPrivate(servers[0]), msg)
+	sig, err = schnorr.Sign(cothority.Suite, local.GetPrivate(servers[0]), msg)
 	_, cerr = service.Unlink(&Unlink{
 		Public:    kp.Public,
 		Signature: sig,
@@ -746,7 +748,7 @@ func TestService_Unlink(t *testing.T) {
 	// Correct signautre and existing public key
 	msg, _ = kp.Public.MarshalBinary()
 	msg = append([]byte("unlink:"), msg...)
-	sig, err = schnorr.Sign(Suite, kp.Private, msg)
+	sig, err = schnorr.Sign(cothority.Suite, kp.Private, msg)
 	_, cerr = service.Unlink(&Unlink{
 		Public:    kp.Public,
 		Signature: sig,
@@ -756,25 +758,25 @@ func TestService_Unlink(t *testing.T) {
 }
 
 func TestService_DelFollow(t *testing.T) {
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, _, _ := local.MakeHELS(3, skipchainSID, Suite)
+	servers, _, _ := local.MakeHELS(3, skipchainSID, cothority.Suite)
 	service := local.GetServices(servers, skipchainSID)[0].(*Service)
 
-	privWrong := key.NewKeyPair(Suite).Private
+	privWrong := key.NewKeyPair(cothority.Suite).Private
 	priv := setupFollow(service)
 	iddel := []byte{0}
 	msg := append([]byte("delfollow:"), iddel...)
 
 	// Test wrong signature
-	sig, err := schnorr.Sign(Suite, privWrong, msg)
+	sig, err := schnorr.Sign(cothority.Suite, privWrong, msg)
 	log.ErrFatal(err)
 	_, cerr := service.DelFollow(&DelFollow{SkipchainID: iddel, Signature: sig})
 	require.NotNil(t, cerr)
 	require.Equal(t, 2, len(service.Storage.FollowIDs))
 
-	sig, err = schnorr.Sign(Suite, priv, msg)
+	sig, err = schnorr.Sign(cothority.Suite, priv, msg)
 	log.ErrFatal(err)
 	_, cerr = service.DelFollow(&DelFollow{SkipchainID: iddel, Signature: sig})
 	require.Nil(t, cerr)
@@ -783,7 +785,7 @@ func TestService_DelFollow(t *testing.T) {
 	// Test removal of Follow
 	iddel = []byte{2}
 	msg = append([]byte("delfollow:"), iddel...)
-	sig, err = schnorr.Sign(Suite, priv, msg)
+	sig, err = schnorr.Sign(cothority.Suite, priv, msg)
 	log.ErrFatal(err)
 	_, cerr = service.DelFollow(&DelFollow{SkipchainID: iddel, Signature: sig})
 	require.Nil(t, cerr)
@@ -791,10 +793,10 @@ func TestService_DelFollow(t *testing.T) {
 }
 
 func TestService_ListFollow(t *testing.T) {
-	local := onet.NewLocalTest(Suite)
+	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, _, _ := local.MakeHELS(3, skipchainSID, Suite)
+	servers, _, _ := local.MakeHELS(3, skipchainSID, cothority.Suite)
 	service := local.GetServices(servers, skipchainSID)[0].(*Service)
 
 	priv := setupFollow(service)
@@ -803,7 +805,7 @@ func TestService_ListFollow(t *testing.T) {
 	msg, err := servers[1].ServerIdentity.Public.MarshalBinary()
 	log.ErrFatal(err)
 	msg = append([]byte("listfollow:"), msg...)
-	sig, err := schnorr.Sign(Suite, priv, msg)
+	sig, err := schnorr.Sign(cothority.Suite, priv, msg)
 	log.ErrFatal(err)
 	lf, cerr := service.ListFollow(&ListFollow{Signature: sig})
 	require.NotNil(t, cerr)
@@ -811,7 +813,7 @@ func TestService_ListFollow(t *testing.T) {
 	msg, err = servers[0].ServerIdentity.Public.MarshalBinary()
 	log.ErrFatal(err)
 	msg = append([]byte("listfollow:"), msg...)
-	sig, err = schnorr.Sign(Suite, priv, msg)
+	sig, err = schnorr.Sign(cothority.Suite, priv, msg)
 	log.ErrFatal(err)
 	lf, cerr = service.ListFollow(&ListFollow{Signature: sig})
 	require.Nil(t, cerr)
@@ -820,7 +822,7 @@ func TestService_ListFollow(t *testing.T) {
 }
 
 func setupFollow(s *Service) kyber.Scalar {
-	kp := key.NewKeyPair(Suite)
+	kp := key.NewKeyPair(cothority.Suite)
 	s.Storage.Clients = []kyber.Point{kp.Public}
 	s.Storage.FollowIDs = []SkipBlockID{{0}, {1}}
 	s.Storage.Follow = []FollowChainType{

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -535,7 +535,7 @@ func (db *SkipBlockDB) GetByID(sbID SkipBlockID) *SkipBlock {
 	})
 
 	if err != nil {
-		log.Error(err.Error())
+		log.Error(err)
 	}
 	return result
 }
@@ -757,7 +757,6 @@ func (db *SkipBlockDB) storeToTx(tx *bolt.Tx, sb *SkipBlock) error {
 	if err != nil {
 		return err
 	}
-
 	return tx.Bucket([]byte(db.bucketName)).Put(key, val)
 }
 

--- a/status/status.go
+++ b/status/status.go
@@ -7,7 +7,6 @@ import (
 
 	"errors"
 
-	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/status/service"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/app"
@@ -68,16 +67,16 @@ func readGroup(tomlFileName string) (*onet.Roster, error) {
 	if err != nil {
 		return nil, err
 	}
-	el, err := app.ReadGroupToml(f, cothority.Suite)
+	g, err := app.ReadGroupDescToml(f)
 	if err != nil {
 		return nil, err
 	}
-	if len(el.List) <= 0 {
+	if len(g.Roster.List) <= 0 {
 		return nil, errors.New("Empty or invalid group file:" +
 			tomlFileName)
 	}
-	log.Lvl3(el)
-	return el, err
+	log.Lvl3(g.Roster)
+	return g.Roster, err
 }
 
 // printConn prints the status response that is returned from the server

--- a/suite_vartime.go
+++ b/suite_vartime.go
@@ -1,4 +1,4 @@
-// +build !vartime
+// +build vartime
 
 package cothority
 
@@ -6,4 +6,4 @@ import "github.com/dedis/kyber/suites"
 
 // Suite is a convenience. It might go away when we decide the a better way to set the
 // suite in repo cothority.
-var Suite = suites.MustFind("Ed25519")
+var Suite = suites.MustFind("P256")


### PR DESCRIPTION
cothority.Suite defaults to P256 when vartime is enabled.

Fixes to make it work with P256 (i.e. places where the
length of a signature was hard coded).

Fixes to integration tests to follow these changes.
(But pop/test.sh and cisc/test.sh were already broken and
need to be fixed separately.)

Make run_conode.sh simpler, so that it can run from other
repositories as well unchanged.