### PR TITLE
adding test for failure in localTest

### DIFF
--- a/bftcosi/bftcosi.go
+++ b/bftcosi/bftcosi.go
@@ -588,7 +588,7 @@ func (bft *ProtocolBFTCoSi) readCommitChan(c chan commitChan, t RoundType) error
 		case <-time.After(bft.Timeout):
 			// in some cases this might be ok because we accept a certain number of faults
 			// the caller is responsible for checking if enough messages are received
-			log.Error("timeout while trying to read commit messages")
+			log.Lvl1("timeout while trying to read commit messages")
 			return nil
 		}
 	}
@@ -625,7 +625,7 @@ func (bft *ProtocolBFTCoSi) readResponseChan(c chan responseChan, t RoundType) e
 				}
 			}
 		case <-time.After(bft.Timeout):
-			log.Error("timeout while trying to read response messages")
+			log.Lvl1("timeout while trying to read response messages")
 			return nil
 		}
 	}

--- a/pop/app.go
+++ b/pop/app.go
@@ -127,7 +127,6 @@ func orgLink(c *cli.Context) error {
 			log.Info("Please read PIN in server-log")
 			return nil
 		}
-		log.Print()
 		return err
 	}
 	cfg.Address = addr

--- a/scmgr/app.go
+++ b/scmgr/app.go
@@ -316,7 +316,10 @@ func scAdd(c *cli.Context) error {
 		roster = group.Roster
 	}
 	cfg := getConfigOrFail(c)
-	sb := cfg.Db.GetFuzzy(c.Args().First())
+	sb, err := cfg.Db.GetFuzzy(c.Args().First())
+	if err != nil {
+		return err
+	}
 	if sb == nil {
 		return errors.New("didn't find this skipchain")
 	}
@@ -349,7 +352,10 @@ func scPrint(c *cli.Context) error {
 		return errors.New("Please give a skipchain-id")
 	}
 	cfg := getConfigOrFail(c)
-	sb := cfg.Db.GetFuzzy(c.Args().First())
+	sb, err := cfg.Db.GetFuzzy(c.Args().First())
+	if err != nil {
+		return err
+	}
 	if sb == nil {
 		return errors.New("didn't find this skipblock")
 	}

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -219,7 +219,7 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, on
 					prev.GetForward(0)}); err != nil {
 				// This is not a critical failure - we have at least
 				// one forward-link
-				log.Error("Couldn't get old block to sign: " + err.Error())
+				log.Lvl1("Couldn't get old block to sign: " + err.Error())
 			} else {
 				changed = append(changed, back)
 			}
@@ -715,12 +715,12 @@ func (s *Service) forwardSignature(fs *ForwardSignature) error {
 func (s *Service) deprecatedProcessorGetBlock(env *network.Envelope) {
 	gb, ok := env.Msg.(*GetBlock)
 	if !ok {
-		log.Error("Didn't receive GetBlock")
+		log.Lvl1("Didn't receive GetBlock")
 		return
 	}
 	sb := s.db.GetByID(gb.ID)
 	if sb == nil {
-		log.Errorf("Did not find block %v", gb.ID)
+		log.Lvl1("Did not find block %v", gb.ID)
 		return
 	}
 	if i, _ := sb.Roster.Search(s.ServerIdentity().ID); i < 0 {
@@ -733,7 +733,7 @@ func (s *Service) deprecatedProcessorGetBlock(env *network.Envelope) {
 		}
 	}
 	if err := s.SendRaw(env.ServerIdentity, &GetBlockReply{sb}); err != nil {
-		log.Error(err)
+		log.Lvl1(err)
 	}
 }
 
@@ -1061,7 +1061,7 @@ func (s *Service) startPropagation(blocks []*SkipBlock) error {
 		return err
 	}
 	if replies != len(roster.List) {
-		log.Warn("Only got", replies, "out of", len(roster.List))
+		log.Lvl1(s.ServerIdentity(), "Only got", replies, "out of", len(roster.List))
 	}
 	return nil
 }

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -701,15 +701,13 @@ func (db *SkipBlockDB) GetLatest(sb *SkipBlock) (*SkipBlock, error) {
 //  1. as prefix - if none is found
 //  2. as suffix - if none is found
 //  3. anywhere
-func (db *SkipBlockDB) GetFuzzy(id string) *SkipBlock {
+func (db *SkipBlockDB) GetFuzzy(id string) (*SkipBlock, error) {
 	match, err := hex.DecodeString(id)
 	if err != nil {
-		log.Error("Failed to decode " + id)
-		return nil
+		return nil, errors.New("Failed to decode " + id)
 	}
 	if len(match) == 0 {
-		log.Error("id is empty")
-		return nil
+		return nil, errors.New("id is empty")
 	}
 
 	var sb *SkipBlock
@@ -719,8 +717,7 @@ func (db *SkipBlockDB) GetFuzzy(id string) *SkipBlock {
 			if bytes.HasPrefix(k, match) {
 				_, msg, err := network.Unmarshal(v, cothority.Suite)
 				if err != nil {
-					log.Error("Unmarshal failed with error: " + err.Error())
-					return err
+					return errors.New("Unmarshal failed with error: " + err.Error())
 				}
 				sb = msg.(*SkipBlock).Copy()
 				return nil
@@ -730,17 +727,15 @@ func (db *SkipBlockDB) GetFuzzy(id string) *SkipBlock {
 			if bytes.HasSuffix(k, match) {
 				_, msg, err := network.Unmarshal(v, cothority.Suite)
 				if err != nil {
-					log.Error("Unmarshal failed with error: " + err.Error())
-					return err
+					return errors.New("Unmarshal failed with error: " + err.Error())
 				}
 				sb = msg.(*SkipBlock).Copy()
 				return nil
 			}
 		}
-		log.Info("Cannot find key that matches " + id)
 		return nil
 	})
-	return sb
+	return sb, nil
 }
 
 // GetSkipchains returns all latest skipblocks from all skipchains.

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -218,30 +218,39 @@ func TestSkipBlock_GetFuzzy(t *testing.T) {
 		return nil
 	})
 
-	require.Nil(t, db.GetFuzzy(""))
+	sb, err := db.GetFuzzy("")
+	require.Nil(t, sb)
+	require.NotNil(t, err)
 
-	sb := db.GetFuzzy("01")
+	sb, err = db.GetFuzzy("01")
+	require.Nil(t, err)
 	require.NotNil(t, sb)
 	require.Equal(t, sb.Data[0], sb0.Data[0])
 
-	sb = db.GetFuzzy("02")
+	sb, err = db.GetFuzzy("02")
+	require.Nil(t, err)
 	require.NotNil(t, sb)
 	require.Equal(t, sb.Data[0], sb1.Data[0])
 
-	sb = db.GetFuzzy("03")
+	sb, err = db.GetFuzzy("03")
+	require.Nil(t, err)
 	require.Nil(t, sb)
 
-	sb = db.GetFuzzy("04")
+	sb, err = db.GetFuzzy("04")
+	require.Nil(t, err)
 	require.Nil(t, sb)
 
-	sb = db.GetFuzzy("05")
+	sb, err = db.GetFuzzy("05")
+	require.Nil(t, err)
 	require.NotNil(t, sb)
 	require.Equal(t, sb.Data[0], sb0.Data[0])
 
-	sb = db.GetFuzzy("06")
+	sb, err = db.GetFuzzy("06")
+	require.Nil(t, err)
 	require.Nil(t, sb)
 
-	sb = db.GetFuzzy("0102030605")
+	sb, err = db.GetFuzzy("0102030605")
+	require.Nil(t, err)
 	require.NotNil(t, sb)
 	require.Equal(t, sb.Data[0], sb0.Data[0])
 }


### PR DESCRIPTION
Fixed a failure in the skipchain-test and some cleanup:

- one failure was due to `onet/local.CloseAll` misbehaving (dedis/onet#313)
- missing lock on testService
- cleaned up error reporting for clean tests

Depends on dedis/onet#313