### PR TITLE
Implement leader catchup

### DIFF
--- a/bftcosi/bftcosi.go
+++ b/bftcosi/bftcosi.go
@@ -486,9 +486,10 @@ func (bft *ProtocolBFTCoSi) handleResponsePrepare(c chan responseChan) error {
 	if err := sig.Verify(bft.Suite(), bft.Roster().Publics()); err != nil {
 		log.Error(bft.Name(), "Verification of the signature failed:", err)
 		bft.signRefusal = true
-	} else {
-		log.Lvl3(bft.Name(), "Verification of signature successful")
+		return err
 	}
+	log.Lvl3(bft.Name(), "Verification of signature successful")
+
 	// Start the challenge of the 'commit'-round
 	if err := bft.startChallenge(RoundCommit); err != nil {
 		log.Error(bft.Name(), err)

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -149,8 +149,8 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, on
 			// If we don't know this chain, we give up (so that
 			// they cannot make us run useless chainSyncs and attack
 			// other conodes).
-			var gen *SkipBlock
-			if gen = s.db.GetByID(psbd.NewBlock.SkipChainID()); gen == nil {
+			gen := s.db.GetByID(psbd.NewBlock.SkipChainID())
+			if gen == nil {
 				return nil, onet.NewClientErrorCode(ErrorBlockNotFound,
 					"Unknown latest block, unknown chain-id")
 			}


### PR DESCRIPTION
If a leader does not know of the latest block that a client
mentions, but it does know of the chain, it can ask others in the
chain's roster to catch it up.

Test it by nuking blocks from the db in order to simulate what would
happen if you started a leader with a database backup that was out of
date.

Also: Test follower catchup, which was already working correctly.