### PR TITLE
pass correct error message

### DIFF
--- a/cisc/cisc.go
+++ b/cisc/cisc.go
@@ -111,7 +111,7 @@ func adminLink(c *cli.Context) error {
 	if err := client.SendProtobuf(si, &identity.PinRequest{PIN: pin, Public: public}, nil); err != nil {
 		// Compare by string because we are on the client, and we will be
 		// be receiving a new error made locally by onet, not the original error.
-		if err.Error() == service.ErrorWrongPIN.Error() && pin == "" {
+		if err.Error() == identity.ErrorReadPIN.Error() {
 			log.Info("Please read PIN in server-log")
 			return nil
 		}

--- a/identity/service.go
+++ b/identity/service.go
@@ -103,6 +103,7 @@ type authData struct {
  * API messages
  */
 
+// ErrorReadPIN means that there is a PIN to read in the server-logs
 var ErrorReadPIN = errors.New("Read PIN in server-log")
 
 // PinRequest will check PIN of admin or print it in case PIN is not provided

--- a/identity/service.go
+++ b/identity/service.go
@@ -103,6 +103,8 @@ type authData struct {
  * API messages
  */
 
+var ErrorReadPIN = errors.New("Read PIN in server-log")
+
 // PinRequest will check PIN of admin or print it in case PIN is not provided
 // then save the admin's public key
 func (s *Service) PinRequest(req *PinRequest) (network.Message, error) {
@@ -111,7 +113,7 @@ func (s *Service) PinRequest(req *PinRequest) (network.Message, error) {
 		pin := fmt.Sprintf("%06d", random.Int(big.NewInt(1000000), s.Suite().RandomStream()))
 		s.auth.pins[pin] = struct{}{}
 		log.Info("PIN:", pin)
-		return nil, errors.New("Read PIN in server-log")
+		return nil, ErrorReadPIN
 	}
 	if _, ok := s.auth.pins[req.PIN]; !ok {
 		return nil, errors.New("Wrong PIN")

--- a/pop/app.go
+++ b/pop/app.go
@@ -124,7 +124,7 @@ func orgLink(c *cli.Context) error {
 	pin := c.Args().Get(1)
 	if err := client.PinRequest(addr, pin, cfg.OrgPublic); err != nil {
 		// Compare by string because this comes over the network.
-		if err.Error() == service.ErrorWrongPIN.Error() && pin == "" {
+		if err.Error() == service.ErrorReadPIN.Error() {
 			log.Info("Please read PIN in server-log")
 			return nil
 		}

--- a/pop/service/service.go
+++ b/pop/service/service.go
@@ -128,6 +128,7 @@ type sync struct {
 	mcChannel chan *mergeConfigReply
 }
 
+// ErrorReadPIN means that there is a PIN to read in the server-logs
 var ErrorReadPIN = errors.New("Read PIN in server-log")
 
 // PinRequest prints out a pin if none is given, else it verifies it has the

--- a/pop/service/service.go
+++ b/pop/service/service.go
@@ -128,8 +128,7 @@ type sync struct {
 	mcChannel chan *mergeConfigReply
 }
 
-// ErrorWrongPIN means that they provided the wrong PIN.
-var ErrorWrongPIN = errors.New("Wrong PIN")
+var ErrorReadPIN = errors.New("Read PIN in server-log")
 
 // PinRequest prints out a pin if none is given, else it verifies it has the
 // correct pin, and if so, it stores the public key as reference.
@@ -137,10 +136,10 @@ func (s *Service) PinRequest(req *PinRequest) (network.Message, error) {
 	if req.Pin == "" {
 		s.data.Pin = fmt.Sprintf("%06d", random.Int(big.NewInt(1000000), s.Suite().RandomStream()))
 		log.Info("PIN:", s.data.Pin)
-		return nil, errors.New("Read PIN in server-log")
+		return nil, ErrorReadPIN
 	}
 	if req.Pin != s.data.Pin {
-		return nil, ErrorWrongPIN
+		return nil, errors.New("Wrong PIN")
 	}
 	s.data.Public = req.Public
 	s.save()


### PR DESCRIPTION
The `var` defined the error message for a wrong pin, but the app needed an error message for an empty pin. Changed the error message and referenced the correct package.