### PR TITLE
Adding schnorr signatures to JS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
 
       before_install:
         - "cd external/js/kyber"
+      after_success:
+        - npm run coveralls
 
       notifications:
         email: false

--- a/cosi/simulation/cosi.toml
+++ b/cosi/simulation/cosi.toml
@@ -2,7 +2,7 @@ Simulation = "CoSimul"
 Servers = 16
 Bf = 3
 Rounds = 10
-RunWait = 6000
+RunWait = 6000s
 Suite = "Ed25519"
 
 Depth

--- a/external/js/kyber/index.js
+++ b/external/js/kyber/index.js
@@ -3,3 +3,4 @@
 const kyber = exports;
 
 kyber.group = require("./lib/group");
+kyber.sign = require("./lib/sign");

--- a/external/js/kyber/lib/sign/index.js
+++ b/external/js/kyber/lib/sign/index.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const schnorr = require("./schnorr/schnorr.js");
+
+module.exports = {
+    schnorr
+};

--- a/external/js/kyber/lib/sign/index.js
+++ b/external/js/kyber/lib/sign/index.js
@@ -3,5 +3,5 @@
 const schnorr = require("./schnorr/schnorr.js");
 
 module.exports = {
-    schnorr
+  schnorr
 };

--- a/external/js/kyber/lib/sign/schnorr/schnorr.js
+++ b/external/js/kyber/lib/sign/schnorr/schnorr.js
@@ -1,0 +1,128 @@
+const group = require("./../../group");
+// XXX to be changed to an interface style
+const nist = group.nist;      
+const curve = nist.Curve;
+const scalarCons = nist.Scalar;
+const pointCons = nist.Point;
+
+const hash = require("hash.js");
+/**
+ *
+ * Sign computes a Schnorr signature over the given message.
+ * 
+ * @param privateKey private key scalar to sign with
+ * @param message message over which the signature is computed
+ * @return signature as a Uint8Array
+ * */
+function Sign(suite, privateKey, message) {
+    if (suite.constructor !== curve) {
+        throw "first argument must be a suite";
+    }
+    if (privateKey.constructor !== scalarCons) {
+        throw "second argument must be a scalar";
+    }
+    if (message.constructor !== Uint8Array) {
+        throw "third argument must be Uint8Array";
+    }
+
+    // generate r & R
+    const r = suite.scalar().pick();
+    const R = suite.point().mul(r,null);
+    const buffR = R.marshalBinary();
+
+    // generate public key
+    const pub = suite.point().mul(privateKey,null);
+    
+    // generate challenge
+    const challenge = hashSchnorr(suite,buffR, pub.marshalBinary(), 
+                         message) 
+
+    // generate signature
+    const s = suite.scalar().mul(privateKey,challenge)
+    s.add(s,r)
+
+    // concatenate R || s
+    const buffS = s.marshalBinary();
+    const buffSig = new Uint8Array(buffR.length + buffS.length);
+    buffSig.set(buffR);
+    buffSig.set(buffS,buffR.length);
+    return buffSig;
+}
+
+/**
+ * 
+ * Verify verify if the signature of the message is valid under the given public
+ * key.
+ *
+ * @params suite suite to use
+ * @params publicKey public key under which to verify the signature
+ * @params message message that is signed
+ * @params signature signature made over the given message
+ * @return boolean true if signature is valid or false otherwise.
+ * */
+function Verify(suite, publicKey, message, signature) {
+    if (suite.constructor !== curve) {
+        throw "first argument must be a suite";
+    }
+    if (publicKey.constructor !== pointCons) {
+        throw "second argument must be a point";
+    }
+    if (message.constructor !== Uint8Array) {
+        throw "third argument must be a Uint8Array";
+    }
+    if (signature.constructor !== Uint8Array) {
+        throw "fourth argument must be a Uint8Array";
+    }
+
+    // check the signature size
+    const plen = suite.pointLen();
+    const slen = suite.scalarLen();
+    const totalSize = plen + slen;
+    if (signature.length != totalSize) {
+        return false;
+    }
+   
+    // unmarshal R || s
+    const buffR = signature.slice(0,plen);
+    const R = suite.point();
+    R.unmarshalBinary(buffR);
+
+    const buffs = signature.slice(plen,signature.lengh);
+    const s = suite.scalar();
+    s.unmarshalBinary(buffs);
+
+    // recompute challenge = H(R || P || M)
+    const buffPub = publicKey.marshalBinary();
+    const challenge = hashSchnorr(suite, buffR, buffPub, message);
+
+    // compute sG
+    const left = suite.point().mul(s,null);
+    // compute R + challenge * Public
+    const right = suite.point().mul(challenge,publicKey)
+    right.add(right,R);
+
+    if (!right.equal(left)) {
+        return false; 
+    }
+    return true;
+}
+
+/**
+ * 
+ * hashSchnorr returns a scalar out of hashing the given inputs.
+ * @params inputs a list of Uint8Array
+ * @return a scalar 
+ *
+ **/
+function hashSchnorr(suite, ...inputs) {
+    const h = hash.sha512();
+    for(let i of inputs) {
+        h.update(i); 
+    }
+    const scalar = suite.scalar()
+    scalar.setBytes(Uint8Array.from(h.digest()));
+    return scalar
+}
+
+module.exports.sign = Sign;
+module.exports.verify = Verify;

--- a/external/js/kyber/lib/sign/schnorr/schnorr.js
+++ b/external/js/kyber/lib/sign/schnorr/schnorr.js
@@ -9,44 +9,43 @@ const hash = require("hash.js");
 /**
  *
  * Sign computes a Schnorr signature over the given message.
- * 
+ *
  * @param privateKey private key scalar to sign with
  * @param message message over which the signature is computed
  * @return signature as a Uint8Array
  * */
 function Sign(suite, privateKey, message) {
-    if (suite.constructor !== curve) {
-        throw "first argument must be a suite";
-    }
-    if (privateKey.constructor !== scalarCons) {
-        throw "second argument must be a scalar";
-    }
-    if (message.constructor !== Uint8Array) {
-        throw "third argument must be Uint8Array";
-    }
+  if (suite.constructor !== curve) {
+    throw "first argument must be a suite";
+  }
+  if (privateKey.constructor !== scalarCons) {
+    throw "second argument must be a scalar";
+  }
+  if (message.constructor !== Uint8Array) {
+    throw "third argument must be Uint8Array";
+  }
 
-    // generate r & R
-    const r = suite.scalar().pick();
-    const R = suite.point().mul(r,null);
-    const buffR = R.marshalBinary();
+  // generate r & R
+  const r = suite.scalar().pick();
+  const R = suite.point().mul(r, null);
+  const buffR = R.marshalBinary();
 
-    // generate public key
-    const pub = suite.point().mul(privateKey,null);
+  // generate public key
+  const pub = suite.point().mul(privateKey, null);
 
-    // generate challenge
-    const challenge = hashSchnorr(suite,buffR, pub.marshalBinary(),
-                         message)
+  // generate challenge
+  const challenge = hashSchnorr(suite, buffR, pub.marshalBinary(), message);
 
-    // generate signature
-    const s = suite.scalar().mul(privateKey,challenge)
-    s.add(s,r)
+  // generate signature
+  const s = suite.scalar().mul(privateKey, challenge);
+  s.add(s, r);
 
-    // concatenate R || s
-    const buffS = s.marshalBinary();
-    const buffSig = new Uint8Array(buffR.length + buffS.length);
-    buffSig.set(buffR);
-    buffSig.set(buffS,buffR.length);
-    return buffSig;
+  // concatenate R || s
+  const buffS = s.marshalBinary();
+  const buffSig = new Uint8Array(buffR.length + buffS.length);
+  buffSig.set(buffR);
+  buffSig.set(buffS, buffR.length);
+  return buffSig;
 }
 
 /**
@@ -61,67 +60,67 @@ function Sign(suite, privateKey, message) {
  * @return boolean true if signature is valid or false otherwise.
  * */
 function Verify(suite, publicKey, message, signature) {
-    if (suite.constructor !== curve) {
-        throw "first argument must be a suite";
-    }
-    if (publicKey.constructor !== pointCons) {
-        throw "second argument must be a point";
-    }
-    if (message.constructor !== Uint8Array) {
-        throw "third argument must be a Uint8Array";
-    }
-    if (signature.constructor !== Uint8Array) {
-        throw "fourth argument must be a Uint8Array";
-    }
+  if (suite.constructor !== curve) {
+    throw "first argument must be a suite";
+  }
+  if (publicKey.constructor !== pointCons) {
+    throw "second argument must be a point";
+  }
+  if (message.constructor !== Uint8Array) {
+    throw "third argument must be a Uint8Array";
+  }
+  if (signature.constructor !== Uint8Array) {
+    throw "fourth argument must be a Uint8Array";
+  }
 
-    // check the signature size
-    const plen = suite.pointLen();
-    const slen = suite.scalarLen();
-    const totalSize = plen + slen;
-    if (signature.length != totalSize) {
-        return false;
-    }
+  // check the signature size
+  const plen = suite.pointLen();
+  const slen = suite.scalarLen();
+  const totalSize = plen + slen;
+  if (signature.length != totalSize) {
+    return false;
+  }
 
-    // unmarshal R || s
-    const buffR = signature.slice(0,plen);
-    const R = suite.point();
-    R.unmarshalBinary(buffR);
+  // unmarshal R || s
+  const buffR = signature.slice(0, plen);
+  const R = suite.point();
+  R.unmarshalBinary(buffR);
 
-    const buffs = signature.slice(plen,signature.lengh);
-    const s = suite.scalar();
-    s.unmarshalBinary(buffs);
+  const buffs = signature.slice(plen, signature.lengh);
+  const s = suite.scalar();
+  s.unmarshalBinary(buffs);
 
-    // recompute challenge = H(R || P || M)
-    const buffPub = publicKey.marshalBinary();
-    const challenge = hashSchnorr(suite, buffR, buffPub, message);
+  // recompute challenge = H(R || P || M)
+  const buffPub = publicKey.marshalBinary();
+  const challenge = hashSchnorr(suite, buffR, buffPub, message);
 
-    // compute sG
-    const left = suite.point().mul(s,null);
-    // compute R + challenge * Public
-    const right = suite.point().mul(challenge,publicKey)
-    right.add(right,R);
+  // compute sG
+  const left = suite.point().mul(s, null);
+  // compute R + challenge * Public
+  const right = suite.point().mul(challenge, publicKey);
+  right.add(right, R);
 
-    if (!right.equal(left)) {
-        return false; 
-    }
-    return true;
+  if (!right.equal(left)) {
+    return false;
+  }
+  return true;
 }
 
 /**
- * 
+ *
  * hashSchnorr returns a scalar out of hashing the given inputs.
  * @params inputs a list of Uint8Array
- * @return a scalar 
+ * @return a scalar
  *
  **/
 function hashSchnorr(suite, ...inputs) {
-    const h = hash.sha512();
-    for(let i of inputs) {
-        h.update(i); 
-    }
-    const scalar = suite.scalar()
-    scalar.setBytes(Uint8Array.from(h.digest()));
-    return scalar
+  const h = hash.sha512();
+  for (let i of inputs) {
+    h.update(i);
+  }
+  const scalar = suite.scalar();
+  scalar.setBytes(Uint8Array.from(h.digest()));
+  return scalar;
 }
 
 module.exports.sign = Sign;

--- a/external/js/kyber/lib/sign/schnorr/schnorr.js
+++ b/external/js/kyber/lib/sign/schnorr/schnorr.js
@@ -50,7 +50,7 @@ function Sign(suite, privateKey, message) {
 
 /**
  *
- * Verify verify if the signature of the message is valid under the given public
+ * Verify verifies if the signature of the message is valid under the given public
  * key.
  *
  * @params suite suite to use

--- a/external/js/kyber/lib/sign/schnorr/schnorr.js
+++ b/external/js/kyber/lib/sign/schnorr/schnorr.js
@@ -1,6 +1,6 @@
 const group = require("./../../group");
 // XXX to be changed to an interface style
-const nist = group.nist;      
+const nist = group.nist;
 const curve = nist.Curve;
 const scalarCons = nist.Scalar;
 const pointCons = nist.Point;
@@ -32,10 +32,10 @@ function Sign(suite, privateKey, message) {
 
     // generate public key
     const pub = suite.point().mul(privateKey,null);
-    
+
     // generate challenge
-    const challenge = hashSchnorr(suite,buffR, pub.marshalBinary(), 
-                         message) 
+    const challenge = hashSchnorr(suite,buffR, pub.marshalBinary(),
+                         message)
 
     // generate signature
     const s = suite.scalar().mul(privateKey,challenge)
@@ -50,7 +50,7 @@ function Sign(suite, privateKey, message) {
 }
 
 /**
- * 
+ *
  * Verify verify if the signature of the message is valid under the given public
  * key.
  *
@@ -81,7 +81,7 @@ function Verify(suite, publicKey, message, signature) {
     if (signature.length != totalSize) {
         return false;
     }
-   
+
     // unmarshal R || s
     const buffR = signature.slice(0,plen);
     const R = suite.point();

--- a/external/js/kyber/package-lock.json
+++ b/external/js/kyber/package-lock.json
@@ -184,6 +184,12 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
+    },
     "asn1.js": {
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
@@ -204,6 +210,12 @@
         "util": "0.10.3"
       }
     },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -220,6 +232,24 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
     "babel-code-frame": {
@@ -535,6 +565,16 @@
       "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
       "dev": true
     },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
@@ -557,6 +597,15 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+    },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "dev": true,
+      "requires": {
+        "hoek": "4.2.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -732,6 +781,12 @@
       "dev": true,
       "optional": true
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
     "catharsis": {
       "version": "0.8.9",
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
@@ -902,6 +957,15 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
     "command-line-args": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.1.tgz",
@@ -1039,6 +1103,27 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "coveralls": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz",
+      "integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.10.0",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.83.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
@@ -1086,6 +1171,26 @@
         "which": "1.3.0"
       }
     },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "dev": true,
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "dev": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
+      }
+    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -1118,6 +1223,15 @@
       "dev": true,
       "requires": {
         "es5-ext": "0.10.38"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
       }
     },
     "date-now": {
@@ -1176,6 +1290,12 @@
         "pinkie-promise": "2.0.1",
         "rimraf": "2.6.2"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "des.js": {
       "version": "1.0.0",
@@ -1258,6 +1378,16 @@
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
         "stream-shift": "1.0.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
       }
     },
     "elliptic": {
@@ -1673,6 +1803,12 @@
         "fill-range": "2.2.3"
       }
     },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
     "external-editor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
@@ -1692,6 +1828,12 @@
       "requires": {
         "is-extglob": "1.0.0"
       }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "1.0.0",
@@ -1841,6 +1983,23 @@
       "dev": true,
       "requires": {
         "for-in": "1.0.2"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
       }
     },
     "from2": {
@@ -2811,6 +2970,15 @@
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -2920,6 +3088,22 @@
         }
       }
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -2953,6 +3137,18 @@
         "minimalistic-assert": "1.0.0"
       }
     },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "dev": true,
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.1.0"
+      }
+    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -2969,6 +3165,12 @@
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
+    "hoek": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
+      "dev": true
+    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -2984,6 +3186,17 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
     },
     "https-browserify": {
       "version": "1.0.0",
@@ -3275,6 +3488,12 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3295,6 +3514,12 @@
       "requires": {
         "isarray": "1.0.0"
       }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "jest-docblock": {
       "version": "21.2.0",
@@ -3326,6 +3551,13 @@
       "requires": {
         "xmlcreate": "1.0.2"
       }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
     },
     "jsdoc": {
       "version": "3.5.5",
@@ -3413,6 +3645,12 @@
       "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
       "dev": true
     },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
@@ -3425,11 +3663,29 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "kind-of": {
       "version": "3.2.2",
@@ -3463,6 +3719,12 @@
       "requires": {
         "invert-kv": "1.0.0"
       }
+    },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "dev": true
     },
     "levn": {
       "version": "0.3.0",
@@ -3541,6 +3803,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "dev": true
+    },
+    "log-driver": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
       "dev": true
     },
     "longest": {
@@ -3663,6 +3931,21 @@
         "brorand": "1.1.0"
       }
     },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
@@ -3764,6 +4047,12 @@
           }
         }
       }
+    },
+    "mocha-lcov-reporter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mocha-lcov-reporter/-/mocha-lcov-reporter-1.3.0.tgz",
+      "integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q=",
+      "dev": true
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -5493,6 +5782,12 @@
         }
       }
     },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5739,6 +6034,12 @@
         "sha.js": "2.4.10"
       }
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -5885,6 +6186,12 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
       "dev": true
     },
     "querystring": {
@@ -6121,6 +6428,36 @@
         "is-finite": "1.0.2"
       }
     },
+    "request": {
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6329,6 +6666,15 @@
         "is-fullwidth-code-point": "2.0.0"
       }
     },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "dev": true,
+      "requires": {
+        "hoek": "4.2.0"
+      }
+    },
     "sort-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-2.0.0.tgz",
@@ -6398,6 +6744,22 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      }
     },
     "ssri": {
       "version": "5.1.0",
@@ -6508,6 +6870,12 @@
       "requires": {
         "safe-buffer": "5.1.1"
       }
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -6671,11 +7039,36 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -6841,6 +7234,12 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "dev": true
+    },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
@@ -6849,6 +7248,17 @@
       "requires": {
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
       }
     },
     "vm-browserify": {

--- a/external/js/kyber/package-lock.json
+++ b/external/js/kyber/package-lock.json
@@ -3899,6 +3899,1600 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
+    "nyc": {
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
+      "integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+      "dev": true,
+      "requires": {
+        "archy": "1.0.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.5.1",
+        "debug-log": "1.0.1",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "2.1.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.2",
+        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-hook": "1.1.0",
+        "istanbul-lib-instrument": "1.9.1",
+        "istanbul-lib-report": "1.1.2",
+        "istanbul-lib-source-maps": "1.2.2",
+        "istanbul-reports": "1.1.3",
+        "md5-hex": "1.3.0",
+        "merge-source-map": "1.0.4",
+        "micromatch": "2.3.11",
+        "mkdirp": "0.5.1",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.6.2",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.4.2",
+        "test-exclude": "4.1.1",
+        "yargs": "10.0.3",
+        "yargs-parser": "8.0.0"
+      },
+      "dependencies": {
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "append-transform": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "1.0.0"
+          }
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0"
+          }
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.4",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "1.8.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "caching-transform": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.3.4"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "1.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "core-js": {
+          "version": "2.5.3",
+          "bundled": true,
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "which": "1.3.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "strip-bom": "2.0.0"
+          }
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "repeating": "2.0.1"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "4.1.1",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fill-range": "2.2.3"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "filename-regex": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "fill-range": {
+          "version": "2.2.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.7",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "for-own": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        },
+        "foreground-child": {
+          "version": "1.5.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "4.0.2",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob-parent": "2.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "bundled": true,
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.29"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.1"
+              }
+            }
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "2.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-dotfile": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-primitive": "2.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "istanbul-lib-coverage": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-hook": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "append-transform": "0.4.0"
+          }
+        },
+        "istanbul-lib-instrument": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-generator": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "istanbul-lib-coverage": "1.1.1",
+            "semver": "5.4.1"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "1.1.1",
+            "mkdirp": "0.5.1",
+            "path-parse": "1.0.5",
+            "supports-color": "3.2.3"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "has-flag": "1.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "3.1.0",
+            "istanbul-lib-coverage": "1.1.1",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "source-map": "0.5.7"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-reports": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "handlebars": "4.0.11"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "bundled": true,
+          "dev": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "md5-hex": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          }
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.1.0"
+          }
+        },
+        "merge-source-map": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "source-map": "0.5.7"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.4.1",
+            "validate-npm-package-license": "3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "1.1.0"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "for-own": "0.1.5",
+            "is-extendable": "0.1.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.3"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-limit": "1.1.0"
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob-base": "0.3.0",
+            "is-dotfile": "1.0.3",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
+            }
+          }
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "randomatic": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+              }
+            }
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "bundled": true,
+          "dev": true
+        },
+        "regex-cache": {
+          "version": "0.4.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-equal-shallow": "0.1.3"
+          }
+        },
+        "remove-trailing-separator": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "0.1.4"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "semver": {
+          "version": "5.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "shebang-regex": "1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true,
+          "dev": true
+        },
+        "spawn-wrap": {
+          "version": "1.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "foreground-child": "1.5.6",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.2",
+            "rimraf": "2.6.2",
+            "signal-exit": "3.0.2",
+            "which": "1.3.0"
+          }
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-license-ids": "1.2.2"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-license-ids": {
+          "version": "1.2.2",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "test-exclude": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "micromatch": "2.3.11",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
+          }
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
+          }
+        },
+        "which": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "10.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "8.0.0"
+          },
+          "dependencies": {
+            "cliui": {
+              "version": "3.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
+              },
+              "dependencies": {
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "8.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",

--- a/external/js/kyber/package.json
+++ b/external/js/kyber/package.json
@@ -8,7 +8,7 @@
     "doc": "node node_modules/.bin/jsdoc2md -f 'lib/**' > doc/doc.md",
     "test": "node node_modules/.bin/mocha --recursive --reporter spec",
     "cover": "nyc --reporter=html --reporter=text mocha --recursive",
-    "coveralls": "npm run cover -- --reporter=text-lcov && cat ./coverage/lcov.info | coveralls"
+    "coveralls": "nyc --reporter=lcov mocha --recursive && cat ./coverage/lcov.info | coveralls"
   },
   "repository": {
     "type": "git",

--- a/external/js/kyber/package.json
+++ b/external/js/kyber/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node node_modules/.bin/webpack",
     "doc": "node node_modules/.bin/jsdoc2md -f 'lib/**' > doc/doc.md",
-    "test": "node node_modules/.bin/mocha --recursive --reporter spec"
+    "test": "node node_modules/.bin/mocha --recursive --reporter spec",
+    "cover": "nyc --reporter=html  --reporter=text mocha --recursive"
   },
   "repository": {
     "type": "git",
@@ -22,7 +23,8 @@
   "homepage": "https://github.com/dedis/cothority",
   "dependencies": {
     "bn.js": "^4.11.8",
-    "elliptic": "^6.4.0"
+    "elliptic": "^6.4.0",
+    "hash.js": "^1.1.3"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
@@ -34,6 +36,7 @@
     "eslint-plugin-prettier": "^2.5.0",
     "jsdoc-to-markdown": "^4.0.1",
     "mocha": "^5.0.0",
+    "nyc": "^11.4.1",
     "prettier": "^1.10.2",
     "uglify-es": "^3.3.9",
     "uglifyjs-webpack-plugin": "^1.1.8",

--- a/external/js/kyber/package.json
+++ b/external/js/kyber/package.json
@@ -7,8 +7,8 @@
     "build": "node node_modules/.bin/webpack",
     "doc": "node node_modules/.bin/jsdoc2md -f 'lib/**' > doc/doc.md",
     "test": "node node_modules/.bin/mocha --recursive --reporter spec",
-    "cover": "nyc --reporter=html  --reporter=text mocha --recursive",
-    "coveralls": "npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls"
+    "cover": "nyc --reporter=html --reporter=text mocha --recursive",
+    "coveralls": "npm run cover -- --reporter=text-lcov && cat ./coverage/lcov.info | coveralls"
   },
   "repository": {
     "type": "git",

--- a/external/js/kyber/package.json
+++ b/external/js/kyber/package.json
@@ -7,7 +7,8 @@
     "build": "node node_modules/.bin/webpack",
     "doc": "node node_modules/.bin/jsdoc2md -f 'lib/**' > doc/doc.md",
     "test": "node node_modules/.bin/mocha --recursive --reporter spec",
-    "cover": "nyc --reporter=html  --reporter=text mocha --recursive"
+    "cover": "nyc --reporter=html  --reporter=text mocha --recursive",
+    "coveralls": "npm run cover -- --report lcovonly && cat ./coverage/lcov.info | coveralls"
   },
   "repository": {
     "type": "git",
@@ -31,11 +32,13 @@
     "babel-loader": "^7.1.2",
     "babel-preset-stage-3": "^6.24.1",
     "chai": "^4.1.2",
+    "coveralls": "^3.0.0",
     "eslint": "^4.16.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.5.0",
     "jsdoc-to-markdown": "^4.0.1",
     "mocha": "^5.0.0",
+    "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^11.4.1",
     "prettier": "^1.10.2",
     "uglify-es": "^3.3.9",

--- a/external/js/kyber/test/sign/schnorr/schnorr.js
+++ b/external/js/kyber/test/sign/schnorr/schnorr.js
@@ -5,16 +5,16 @@ const assert = chai.assert;
 const kyber = require("../../../index.js");
 const schnorr = kyber.sign.schnorr;
 // XXX to be changed to an interface style
-const nist = kyber.group.nist;      
+const nist = kyber.group.nist;
 var group = new nist.Curve(nist.Params.p256);
 const secretKey = group.scalar().pick();
 const publicKey = group.point().mul(secretKey,null);
 const scalarLen = group.scalarLen()
 const pointLen = group.pointLen();
 const message = new Uint8Array([1,2,3,4]);
-    
+
 describe("schnorr signature", () => {
-   
+
     it("fails with wrong suite input", () => {
         chai.expect(schnorr.sign.bind(null,new Number(2),null,null)).to.throw("first argument must be a suite");
     });
@@ -32,7 +32,7 @@ describe("schnorr signature", () => {
         var sigSize = scalarLen + pointLen;
         chai.expect(sig).to.be.an.instanceof(Uint8Array); 
         assert.lengthOf(sig,sigSize);
-        
+
     });
 });
 

--- a/external/js/kyber/test/sign/schnorr/schnorr.js
+++ b/external/js/kyber/test/sign/schnorr/schnorr.js
@@ -1,0 +1,82 @@
+const mocha = require("mocha");
+const chai = require("chai");
+const assert = chai.assert;
+
+const kyber = require("../../../index.js");
+const schnorr = kyber.sign.schnorr;
+// XXX to be changed to an interface style
+const nist = kyber.group.nist;      
+var group = new nist.Curve(nist.Params.p256);
+const secretKey = group.scalar().pick();
+const publicKey = group.point().mul(secretKey,null);
+const scalarLen = group.scalarLen()
+const pointLen = group.pointLen();
+const message = new Uint8Array([1,2,3,4]);
+    
+describe("schnorr signature", () => {
+   
+    it("fails with wrong suite input", () => {
+        chai.expect(schnorr.sign.bind(null,new Number(2),null,null)).to.throw("first argument must be a suite");
+    });
+
+    it("fails with wrong private key input", () => {
+        chai.expect(schnorr.sign.bind(null,group, new Number(3))).to.throw("second argument must be a scalar");
+    });
+
+    it("fails with wrong message input", () => {
+        chai.expect(schnorr.sign.bind(null,group, secretKey,true)).to.throw("third argument must be Uint8Array");
+    });
+
+    it("returns a uint8array signature with good size", () => {
+        var sig = schnorr.sign(group,secretKey,message);
+        var sigSize = scalarLen + pointLen;
+        chai.expect(sig).to.be.an.instanceof(Uint8Array); 
+        assert.lengthOf(sig,sigSize);
+        
+    });
+});
+
+describe("schnorr verification", ()  => {
+    var sig = schnorr.sign(group,secretKey,message);
+
+    it("fails with a wrong suite input", () =>  {
+        chai.expect(schnorr.verify.bind(null,new Number(2))).to.throw("first argument must be a suite"); 
+    });
+
+    it("fails with a wrong public key input", () =>  {
+        chai.expect(schnorr.verify.bind(null,group,new Number(2))).to.throw("second argument must be a point"); 
+    });
+
+    it("fails with a wrong message input", () =>  {
+        chai.expect(schnorr.verify.bind(null,group,publicKey,new Number(2))).
+                to.throw("third argument must be a Uint8Array"); 
+    });
+
+    it("fails with a wrong signature input", () =>  {
+        chai.expect(schnorr.verify.bind(null,group,publicKey,message,new Number(2))).
+                to.throw("fourth argument must be a Uint8Array"); 
+    });
+
+    it("returns false for a wrong signature", () =>  {
+        const r = group.point().pick().marshalBinary();
+        const s = group.point().pick().marshalBinary();
+        const wrongSig = new Uint8Array(r.length + s.length);
+        wrongSig.set(r);
+        wrongSig.set(s,r.length);
+        assert.isFalse(schnorr.verify(group,publicKey,message,wrongSig));
+    });
+
+    it("returns false for a wrong public key", () =>  {
+        const wrongPub = group.point().pick();
+        assert.isFalse(schnorr.verify(group,wrongPub,message,sig));
+    });
+
+    it("returns false for a wrong message", () =>  {
+        const wrongMessage = new Uint8Array(message).reverse();
+        assert.isFalse(schnorr.verify(group,publicKey,wrongMessage,sig));
+    });
+
+    it("returns true for a well formed signature", () => {
+        assert.isTrue(schnorr.verify(group,publicKey,message,sig));
+    });
+});

--- a/external/js/kyber/test/sign/schnorr/schnorr.js
+++ b/external/js/kyber/test/sign/schnorr/schnorr.js
@@ -8,75 +8,93 @@ const schnorr = kyber.sign.schnorr;
 const nist = kyber.group.nist;
 var group = new nist.Curve(nist.Params.p256);
 const secretKey = group.scalar().pick();
-const publicKey = group.point().mul(secretKey,null);
-const scalarLen = group.scalarLen()
+const publicKey = group.point().mul(secretKey, null);
+const scalarLen = group.scalarLen();
 const pointLen = group.pointLen();
-const message = new Uint8Array([1,2,3,4]);
+const message = new Uint8Array([1, 2, 3, 4]);
 
 describe("schnorr signature", () => {
+  it("fails with wrong suite input", () => {
+    chai
+      .expect(schnorr.sign.bind(null, new Number(2), null, null))
+      .to.throw("first argument must be a suite");
+  });
 
-    it("fails with wrong suite input", () => {
-        chai.expect(schnorr.sign.bind(null,new Number(2),null,null)).to.throw("first argument must be a suite");
-    });
+  it("fails with wrong private key input", () => {
+    chai
+      .expect(schnorr.sign.bind(null, group, new Number(3)))
+      .to.throw("second argument must be a scalar");
+  });
 
-    it("fails with wrong private key input", () => {
-        chai.expect(schnorr.sign.bind(null,group, new Number(3))).to.throw("second argument must be a scalar");
-    });
+  it("fails with wrong message input", () => {
+    chai
+      .expect(schnorr.sign.bind(null, group, secretKey, true))
+      .to.throw("third argument must be Uint8Array");
+  });
 
-    it("fails with wrong message input", () => {
-        chai.expect(schnorr.sign.bind(null,group, secretKey,true)).to.throw("third argument must be Uint8Array");
-    });
-
-    it("returns a uint8array signature with good size", () => {
-        var sig = schnorr.sign(group,secretKey,message);
-        var sigSize = scalarLen + pointLen;
-        chai.expect(sig).to.be.an.instanceof(Uint8Array); 
-        assert.lengthOf(sig,sigSize);
-
-    });
+  it("returns a uint8array signature with good size", () => {
+    var sig = schnorr.sign(group, secretKey, message);
+    var sigSize = scalarLen + pointLen;
+    chai.expect(sig).to.be.an.instanceof(Uint8Array);
+    assert.lengthOf(sig, sigSize);
+  });
 });
 
-describe("schnorr verification", ()  => {
-    var sig = schnorr.sign(group,secretKey,message);
+describe("schnorr verification", () => {
+  var sig = schnorr.sign(group, secretKey, message);
 
-    it("fails with a wrong suite input", () =>  {
-        chai.expect(schnorr.verify.bind(null,new Number(2))).to.throw("first argument must be a suite"); 
-    });
+  it("fails with a wrong suite input", () => {
+    chai
+      .expect(schnorr.verify.bind(null, new Number(2)))
+      .to.throw("first argument must be a suite");
+  });
 
-    it("fails with a wrong public key input", () =>  {
-        chai.expect(schnorr.verify.bind(null,group,new Number(2))).to.throw("second argument must be a point"); 
-    });
+  it("fails with a wrong public key input", () => {
+    chai
+      .expect(schnorr.verify.bind(null, group, new Number(2)))
+      .to.throw("second argument must be a point");
+  });
 
-    it("fails with a wrong message input", () =>  {
-        chai.expect(schnorr.verify.bind(null,group,publicKey,new Number(2))).
-                to.throw("third argument must be a Uint8Array"); 
-    });
+  it("fails with a wrong message input", () => {
+    chai
+      .expect(schnorr.verify.bind(null, group, publicKey, new Number(2)))
+      .to.throw("third argument must be a Uint8Array");
+  });
 
-    it("fails with a wrong signature input", () =>  {
-        chai.expect(schnorr.verify.bind(null,group,publicKey,message,new Number(2))).
-                to.throw("fourth argument must be a Uint8Array"); 
-    });
+  it("fails with a wrong signature input", () => {
+    chai
+      .expect(
+        schnorr.verify.bind(null, group, publicKey, message, new Number(2))
+      )
+      .to.throw("fourth argument must be a Uint8Array");
+  });
 
-    it("returns false for a wrong signature", () =>  {
-        const r = group.point().pick().marshalBinary();
-        const s = group.point().pick().marshalBinary();
-        const wrongSig = new Uint8Array(r.length + s.length);
-        wrongSig.set(r);
-        wrongSig.set(s,r.length);
-        assert.isFalse(schnorr.verify(group,publicKey,message,wrongSig));
-    });
+  it("returns false for a wrong signature", () => {
+    const r = group
+      .point()
+      .pick()
+      .marshalBinary();
+    const s = group
+      .point()
+      .pick()
+      .marshalBinary();
+    const wrongSig = new Uint8Array(r.length + s.length);
+    wrongSig.set(r);
+    wrongSig.set(s, r.length);
+    assert.isFalse(schnorr.verify(group, publicKey, message, wrongSig));
+  });
 
-    it("returns false for a wrong public key", () =>  {
-        const wrongPub = group.point().pick();
-        assert.isFalse(schnorr.verify(group,wrongPub,message,sig));
-    });
+  it("returns false for a wrong public key", () => {
+    const wrongPub = group.point().pick();
+    assert.isFalse(schnorr.verify(group, wrongPub, message, sig));
+  });
 
-    it("returns false for a wrong message", () =>  {
-        const wrongMessage = new Uint8Array(message).reverse();
-        assert.isFalse(schnorr.verify(group,publicKey,wrongMessage,sig));
-    });
+  it("returns false for a wrong message", () => {
+    const wrongMessage = new Uint8Array(message).reverse();
+    assert.isFalse(schnorr.verify(group, publicKey, wrongMessage, sig));
+  });
 
-    it("returns true for a well formed signature", () => {
-        assert.isTrue(schnorr.verify(group,publicKey,message,sig));
-    });
+  it("returns true for a well formed signature", () => {
+    assert.isTrue(schnorr.verify(group, publicKey, message, sig));
+  });
 });


### PR DESCRIPTION
This adds another module `kyber.sign.schnorr.{sign,verify}` to sign and verify schnorr signatures. So far it only uses what's available p256. When the ed25519 code from @gnarula will be ready, I'll try to add a compatibility test with eddsa verification.

This also adds coverage reports locally and on travis. Just run `npm run cover` to see a good resume of the current coverage. 