### PR TITLE
Finish removing SendRaw from skipchain

### DIFF
--- a/messaging/propagate.go
+++ b/messaging/propagate.go
@@ -76,6 +76,8 @@ type propagationContext interface {
 // NewPropagationFunc registers a new protocol name with the context c and will
 // set f as handler for every new instance of that protocol.
 // The protocol will fail if more than t nodes per subtree fail to respond.
+// If t == -1, t defaults to len(n.Roster().List-1)/3. Thus, for a roster of
+// 5, t = int(4/3) = 1, e.g. 1 node out of the 5 can fail.
 func NewPropagationFunc(c propagationContext, name string, f PropagationStore, t int) (PropagationFunc, error) {
 	pid, err := c.ProtocolRegister(name, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
 		if t == -1 {

--- a/pop/app.go
+++ b/pop/app.go
@@ -114,7 +114,7 @@ func orgLink(c *cli.Context) error {
 	}
 	cfg, client := getConfigClient(c)
 
-	addr := network.NewTCPAddress(c.Args().First())
+	addr := network.NewAddress(network.PlainTCP, c.Args().First())
 	pin := c.Args().Get(1)
 	if err := client.PinRequest(addr, pin, cfg.OrgPublic); err != nil {
 		// Compare by string because this comes over the network.

--- a/scmgr/app.go
+++ b/scmgr/app.go
@@ -779,7 +779,7 @@ func updateNewSIs(roster *onet.Roster, sisNew []*network.ServerIdentity,
 func findLinkFromAddress(cfg *config, address string) (*link, error) {
 	var l *link
 	for _, o := range cfg.Values.Link {
-		if o.Address == network.NewTCPAddress(address) {
+		if o.Address == network.NewAddress(network.PlainTCP, address) {
 			l = o
 			break
 		}

--- a/skipchain/api_test.go
+++ b/skipchain/api_test.go
@@ -156,11 +156,8 @@ func TestClient_GetUpdateChain(t *testing.T) {
 				if h2 < height {
 					height = h2
 				}
-				if !bytes.Equal(sb1.ForwardLink[height-1].Hash(),
-					sb2.Hash) {
-					t.Fatal("Forward-pointer of update", up,
-						"is different from hash in", up+1)
-				}
+				require.True(t, sb1.ForwardLink[height-1].Hash().Equal(sb2.Hash),
+					"Forward-pointer of update", up, "is different from hash in", up+1)
 			}
 		}
 	}

--- a/skipchain/msgs.go
+++ b/skipchain/msgs.go
@@ -45,10 +45,6 @@ func init() {
 		&PropagateSkipBlocks{},
 		// Request forward-signature
 		&ForwardSignature{},
-		// Request updated block
-		&GetBlock{},
-		// Updated block reply
-		&GetBlockReply{},
 		// - Data structures
 		&SkipBlockFix{},
 		&SkipBlock{},

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -1218,6 +1218,7 @@ func newSkipchainService(c *onet.Context) (onet.Service, error) {
 		s.GetSingleBlock, s.GetSingleBlockByIndex, s.GetAllSkipchains,
 		s.CreateLinkPrivate, s.Unlink, s.AddFollow, s.ListFollow,
 		s.DelFollow, s.Listlink))
+	s.ServiceProcessor.RegisterStatusReporter("Skipblock", s.db)
 
 	if err := s.registerVerification(VerifyBase, s.verifyFuncBase); err != nil {
 		return nil, err

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -295,11 +295,11 @@ func (s *Service) GetUpdateChain(guc *GetUpdateChain) (network.Message, error) {
 		link := block.ForwardLink[block.GetForwardLen()-1]
 		next := s.db.GetByID(link.Hash())
 		if next == nil {
-			// Next not found means that maybe the roster has evolved
-			// and we are no longer aware of this chain. The caller
-			// (in this case, api.go) will be responsible to issue
-			// a new GetUpdateChain with the latest Roster to keep
-			// traversing.
+			// Next not found means that maybe the roster
+			// has evolved and we are no longer aware of
+			// this chain. The caller will be responsible
+			// to issue a new GetUpdateChain with the
+			// latest Roster to keep traversing.
 			break
 		} else {
 			if i, _ := next.Roster.Search(s.ServerIdentity().ID); i < 0 {
@@ -312,7 +312,7 @@ func (s *Service) GetUpdateChain(guc *GetUpdateChain) (network.Message, error) {
 		blocks = append(blocks, next.Copy())
 	}
 	log.Lvl3("Found", len(blocks), "blocks")
-	reply := &GetUpdateChainReply{blocks}
+	reply := &GetUpdateChainReply{Update: blocks}
 
 	return reply, nil
 }

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -42,17 +42,15 @@ func init() {
 // Service handles adding new SkipBlocks
 type Service struct {
 	*onet.ServiceProcessor
-	db                 *SkipBlockDB
-	propagate          messaging.PropagationFunc
-	verifiers          map[VerifierID]SkipBlockVerifier
-	blockRequestsMutex sync.Mutex
-	blockRequests      map[string]chan *SkipBlock
-	newBlocksMutex     sync.Mutex
-	newBlocks          map[string]bool
-	storageMutex       sync.Mutex
-	Storage            *Storage
-	bftTimeout         time.Duration
-	propTimeout        time.Duration
+	db             *SkipBlockDB
+	propagate      messaging.PropagationFunc
+	verifiers      map[VerifierID]SkipBlockVerifier
+	newBlocksMutex sync.Mutex
+	newBlocks      map[string]bool
+	storageMutex   sync.Mutex
+	Storage        *Storage
+	bftTimeout     time.Duration
+	propTimeout    time.Duration
 }
 
 // Storage is saved to disk.
@@ -152,24 +150,27 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, er
 		// We're appending a block to an existing chain
 		prev = s.db.GetByID(psbd.LatestID)
 		if prev == nil {
-			// Did not find the block they claim is the latest.
+			// Did not find the block they claim is the latest. So
+			// if this is a chain we are supposed to be following
+			// (is friendly), then talk to peers to catch up.
 
-			// If we don't know this chain, we give up (so that
-			// they cannot make us run useless chainSyncs and attack
-			// other conodes).
+			if !s.blockIsFriendly(psbd.NewBlock) {
+				log.Lvlf2("%s: block is not friendly: %x", s.ServerIdentity(), psbd.NewBlock.Hash)
+				return nil, errors.New("chain not followed")
+			}
+
 			gen := s.db.GetByID(psbd.NewBlock.SkipChainID())
 			if gen == nil {
-				return nil, errors.New(
-					"Unknown latest block, unknown chain-id")
+				return nil, errors.New("unknown latest block, unknown chain-id")
 
 			}
+
 			// If we know of this chain, try to sync it.
 			latest := s.findLatest(gen)
 			log.Lvlf2("Catching up chain %x from index %v", gen.Hash, latest.Index)
 			err := s.syncChain(latest.Roster, latest.Hash)
 			if err != nil {
-				return nil, errors.New(
-					"failed to catch up")
+				return nil, errors.New("failed to catch up")
 
 			}
 			prev = s.db.GetByID(psbd.LatestID)
@@ -279,35 +280,32 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, er
 
 // GetUpdateChain returns a slice of SkipBlocks which describe the part of the
 // skipchain from the latest block the caller knows to the latest
-// SkipBlock we know.
-func (s *Service) GetUpdateChain(latestKnown *GetUpdateChain) (network.Message, error) {
-	block := s.db.GetByID(latestKnown.LatestID)
+// SkipBlock we know. The last block in the returned slice of blocks is
+// not guaranteed to have no forward links. It is up to the caller
+// to continue following forward links with the new roster if necessary.
+func (s *Service) GetUpdateChain(guc *GetUpdateChain) (network.Message, error) {
+	block := s.db.GetByID(guc.LatestID)
 	if block == nil {
 		return nil, errors.New("Couldn't find latest skipblock")
 	}
-	// at least the latest know and the next block:
+
 	blocks := []*SkipBlock{block.Copy()}
 	log.Lvlf3("Starting to search chain at %x", s.Context.ServerIdentity().ID[0:8])
 	for block.GetForwardLen() > 0 {
 		link := block.ForwardLink[block.GetForwardLen()-1]
 		next := s.db.GetByID(link.Hash())
 		if next == nil {
-			log.Lvl3("Didn't find next block, updating block")
-			var err error
-			next, err = s.callGetBlock(block, link.Hash())
-			if err != nil {
-				return nil, err
-
-			}
+			// Next not found means that maybe the roster has evolved
+			// and we are no longer aware of this chain. The caller
+			// (in this case, api.go) will be responsible to issue
+			// a new GetUpdateChain with the latest Roster to keep
+			// traversing.
+			break
 		} else {
 			if i, _ := next.Roster.Search(s.ServerIdentity().ID); i < 0 {
-				log.Lvl3("We're not responsible for", next, "- asking for update")
-				var err error
-				next, err = s.callGetBlock(next, link.Hash())
-				if err != nil {
-					return nil, err
-
-				}
+				// Likewise for the case where we know the block,
+				// but we are no longer in the Roster, stop searching.
+				break
 			}
 		}
 		block = next
@@ -335,7 +333,7 @@ func (s *Service) findLatest(bl *SkipBlock) *SkipBlock {
 }
 
 // syncChain communicates with conodes in the Roster via getBlocks
-// in order to find the latest block.
+// in order traverse the chain and save the blocks locally.
 func (s *Service) syncChain(roster *onet.Roster, latest SkipBlockID) error {
 	// loop on getBlocks, fetching 10 at a time
 	for {
@@ -347,9 +345,6 @@ func (s *Service) syncChain(roster *onet.Roster, latest SkipBlockID) error {
 		for _, sb := range blocks {
 			if err := sb.VerifyForwardSignatures(); err != nil {
 				return err
-			}
-			if !s.blockIsFriendly(sb) {
-				return fmt.Errorf("%s: block is not friendly: %x", s.ServerIdentity(), sb.Hash)
 			}
 			s.db.Store(sb)
 			if len(sb.ForwardLink) == 0 {
@@ -724,32 +719,6 @@ func (s *Service) verifySigs(msg, sig []byte) bool {
 	return false
 }
 
-func (s *Service) callGetBlock(known *SkipBlock, unknown SkipBlockID) (*SkipBlock, error) {
-	s.blockRequestsMutex.Lock()
-	request := make(chan *SkipBlock)
-	s.blockRequests[string(unknown)] = request
-	s.blockRequestsMutex.Unlock()
-	defer func() {
-		s.blockRequestsMutex.Lock()
-		delete(s.blockRequests, string(unknown))
-		s.blockRequestsMutex.Unlock()
-	}()
-	node := known.Roster.RandomServerIdentity()
-	if err := s.SendRaw(node,
-		&GetBlock{unknown}); err != nil {
-		return nil, errors.New("Couldn't get updated block: " + known.Short())
-	}
-
-	var block *SkipBlock
-	select {
-	case block = <-request:
-		log.Lvl3("Got block", block)
-	case <-time.After(s.propTimeout):
-		return nil, errors.New("Couldn't get updated block in time: " + unknown.Short())
-	}
-	return block, nil
-}
-
 // forwardSignature receives a signature request of a newly accepted block.
 // It only needs the 2nd-newest block and the forward-link.
 func (s *Service) forwardSignature(fs *ForwardSignature) error {
@@ -781,51 +750,10 @@ func (s *Service) forwardSignature(fs *ForwardSignature) error {
 	return nil
 }
 
-// deprecated: use CreateProtocol(ProtocolGetBlocks) instead.
-func (s *Service) deprecatedProcessorGetBlock(env *network.Envelope) {
-	gb, ok := env.Msg.(*GetBlock)
-	if !ok {
-		log.Lvl1("Didn't receive GetBlock")
-		return
-	}
-	sb := s.db.GetByID(gb.ID)
-	if sb == nil {
-		log.Lvl1("Did not find block %v", gb.ID)
-		return
-	}
-	if i, _ := sb.Roster.Search(s.ServerIdentity().ID); i < 0 {
-		log.Lvl3("Not responsible for that block, recursing")
-		var err error
-		sb, err = s.callGetBlock(sb, sb.Hash)
-		if err != nil {
-			log.Error(err)
-			sb = nil
-		}
-	}
-	if err := s.SendRaw(env.ServerIdentity, &GetBlockReply{sb}); err != nil {
-		log.Lvl1(err)
-	}
-}
-
-func (s *Service) deprecatedProcessorGetBlockReply(env *network.Envelope) {
-	gbr, ok := env.Msg.(*GetBlockReply)
-	if !ok {
-		log.Error("Didn't receive GetBlock")
-		return
-	}
-	if err := s.db.VerifyLinks(gbr.SkipBlock); err != nil {
-		log.Error("Received invalid skipblock: " + err.Error())
-	}
-	id := s.db.Store(gbr.SkipBlock)
-	log.Lvl3("Sending block to channel")
-	s.blockRequestsMutex.Lock()
-	s.blockRequests[string(id)] <- gbr.SkipBlock
-	s.blockRequestsMutex.Unlock()
-}
-
 // verifyFollowBlock makes sure that a signature-request for a forward-link
 // is valid.
 func (s *Service) bftVerifyFollowBlock(msg []byte, data []byte) bool {
+	log.Lvlf4("%s verify follow block %x", s.ServerIdentity(), msg)
 	err := func() error {
 		_, fsInt, err := network.Unmarshal(data, cothority.Suite)
 		if err != nil {
@@ -894,6 +822,10 @@ func (s *Service) bftVerifyNewBlock(msg []byte, data []byte) (out bool) {
 	srcHash := data[0:32]
 	prevSB := s.db.GetByID(srcHash)
 	if prevSB == nil {
+		if !s.blockIsFriendly(newSB) {
+			log.Lvlf2("%s: block is not friendly: %x", s.ServerIdentity(), newSB.Hash)
+			return
+		}
 		log.Lvl3(s.ServerIdentity(), "Didn't find src-skipblock, trying to sync")
 		if err := s.syncChain(newSB.Roster, srcHash); err != nil {
 			log.Error("failed to sync skipchain", err)
@@ -1203,12 +1135,14 @@ func (s *Service) blockIsFriendly(sb *SkipBlock) bool {
 			return true
 		}
 	}
-	// Accept if there is only one node in the roster or if we're the
-	// root.
+
+	// Accept if we're the root.
 	index, _ := sb.Roster.Search(s.ServerIdentity().ID)
-	if len(sb.Roster.List) == 1 || index == 0 {
+	if index == 0 {
 		return true
 	}
+
+	// For each Follow, find out if it permits this chain.
 	for _, fct := range s.Storage.Follow {
 		err := fct.GetLatest(s.ServerIdentity(), s)
 		if err != nil {
@@ -1273,7 +1207,6 @@ func newSkipchainService(c *onet.Context) (onet.Service, error) {
 		db:               NewSkipBlockDB(db, bucket),
 		Storage:          &Storage{},
 		verifiers:        map[VerifierID]SkipBlockVerifier{},
-		blockRequests:    make(map[string]chan *SkipBlock),
 		newBlocks:        make(map[string]bool),
 		propTimeout:      defaultPropagateTimeout,
 	}
@@ -1285,11 +1218,6 @@ func newSkipchainService(c *onet.Context) (onet.Service, error) {
 		s.GetSingleBlock, s.GetSingleBlockByIndex, s.GetAllSkipchains,
 		s.CreateLinkPrivate, s.Unlink, s.AddFollow, s.ListFollow,
 		s.DelFollow, s.Listlink))
-	s.ServiceProcessor.RegisterStatusReporter("Skipblock", s.db)
-	s.ServiceProcessor.RegisterProcessorFunc(network.MessageType(GetBlock{}),
-		s.deprecatedProcessorGetBlock)
-	s.ServiceProcessor.RegisterProcessorFunc(network.MessageType(GetBlockReply{}),
-		s.deprecatedProcessorGetBlockReply)
 
 	if err := s.registerVerification(VerifyBase, s.verifyFuncBase); err != nil {
 		return nil, err

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -979,7 +979,7 @@ func TestRosterAddCausesSync(t *testing.T) {
 	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
-	servers, _, genService := local.MakeHELS(5, skipchainSID, cothority.Suite)
+	servers, _, genService := local.MakeSRS(cothority.Suite, 5, skipchainSID)
 	leader := genService.(*Service)
 
 	// put last one to sleep, wake it up after the others have added it into the roster

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -207,7 +207,7 @@ var (
 	// that every new block is signed by the keys present in the previous block.
 	VerifyRoot = VerifierID(uuid.NewV5(uuid.NamespaceURL, "Root"))
 	// VerifyControl makes sure this chain is a child of a Root-chain and
-	// that there is now new block if a newer parent is present.
+	// that there is no new block if a newer parent is present.
 	// It also makes sure that no more than 1/3 of the members of the roster
 	// change between two blocks.
 	VerifyControl = VerifierID(uuid.NewV5(uuid.NamespaceURL, "Control"))


### PR DESCRIPTION
Change GetUpdateChain to operate on local blocks only. Delegate
responsibility to the client to go contact other servers according
to the latest roster (implemented in api.go, so that existing
clients do not see a change in behaviour).

Also: Added a test to check a worry I had about if new servers
which were invited into a chain would work correctly.

Fixes #1034.