### PR TITLE
Clean up status service, client

### DIFF
--- a/scmgr/commands.go
+++ b/scmgr/commands.go
@@ -123,7 +123,7 @@ func getCommands() cli.Commands {
 					Subcommands: cli.Commands{
 						{
 							Name:      "add",
-							Usage:     "create a new block",
+							Usage:     "create a new block on the server and save it in local cache",
 							Aliases:   []string{"a"},
 							ArgsUsage: "skipchain-id",
 							Action:    scAdd,
@@ -133,11 +133,16 @@ func getCommands() cli.Commands {
 									Value: "",
 									Usage: "file containing new roster",
 								},
+								cli.StringFlag{
+									Name:  "data",
+									Value: "",
+									Usage: "data to put into the block",
+								},
 							},
 						},
 						{
 							Name:      "print",
-							Usage:     "show the content of a block",
+							Usage:     "show the content of a block from the local cache",
 							Aliases:   []string{"p"},
 							ArgsUsage: "skipblock-id",
 							Action:    scPrint,
@@ -179,8 +184,9 @@ func getCommands() cli.Commands {
 					Action:    dnsIndex,
 				},
 				{
-					Name:  "update",
-					Usage: "update all locally stored skipchains",
+					Name:    "update",
+					Aliases: []string{"u"},
+					Usage:   "update all locally stored skipchains",
 					Flags: []cli.Flag{
 						cli.BoolFlag{
 							Name:  "new, n",

--- a/scmgr/test.sh
+++ b/scmgr/test.sh
@@ -19,6 +19,7 @@ main(){
 	test Index
 	test Fetch
 	test Link
+	test Linklist
 	test Unlink
 	test Follow
 	test NewChain
@@ -133,6 +134,11 @@ testLink(){
 	testFail runSc follow add single 00 localhost:2004
 	setupGenesis
 	testOK [ -n "$ID" ]
+}
+
+testLinklist(){
+	startCl
+	testOK runSc link list localhost:2002
 }
 
 testUnlink(){

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -1284,7 +1284,8 @@ func newSkipchainService(c *onet.Context) (onet.Service, error) {
 	log.ErrFatal(s.RegisterHandlers(s.StoreSkipBlock, s.GetUpdateChain,
 		s.GetSingleBlock, s.GetSingleBlockByIndex, s.GetAllSkipchains,
 		s.CreateLinkPrivate, s.Unlink, s.AddFollow, s.ListFollow,
-		s.DelFollow))
+		s.DelFollow, s.Listlink))
+	s.ServiceProcessor.RegisterStatusReporter("Skipblock", s.db)
 	s.ServiceProcessor.RegisterProcessorFunc(network.MessageType(GetBlock{}),
 		s.deprecatedProcessorGetBlock)
 	s.ServiceProcessor.RegisterProcessorFunc(network.MessageType(GetBlockReply{}),

--- a/status/README.md
+++ b/status/README.md
@@ -8,7 +8,7 @@ A status is a list of connections and packets sent and received for each server 
 To install the status-binary, enter
 
 ```
-go get github.com/dedis/cothority/app/status
+go get github.com/dedis/cothority/status
 ```
 
 And then you can run

--- a/status/service/status.go
+++ b/status/service/status.go
@@ -30,7 +30,7 @@ type Request struct{}
 
 // Response is what the Status service will reply to clients.
 type Response struct {
-	Msg            map[string]*onet.Status
+	Status         map[string]onet.Status
 	ServerIdentity *network.ServerIdentity
 }
 
@@ -38,7 +38,7 @@ type Response struct {
 func (st *Stat) Request(req *Request) (network.Message, error) {
 	log.Lvl3("Returning", st.Context.ReportStatus())
 	return &Response{
-		Msg:            st.Context.ReportStatus(),
+		Status:         st.Context.ReportStatus(),
 		ServerIdentity: st.ServerIdentity(),
 	}, nil
 }

--- a/status/service/status_test.go
+++ b/status/service/status_test.go
@@ -3,7 +3,6 @@ package status
 import (
 	"testing"
 
-	"github.com/dedis/cothority/example/channels"
 	"github.com/dedis/kyber/suites"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
@@ -25,7 +24,7 @@ func TestServiceStatus(t *testing.T) {
 
 	// generate 5 hosts, they don't connect, they process messages, and they
 	// don't register the tree or entitylist
-	_, el, tr := local.GenTree(5, false)
+	_, el, _ := local.GenTree(5, false)
 	defer local.CloseAll()
 
 	// Send a request to the service
@@ -35,17 +34,11 @@ func TestServiceStatus(t *testing.T) {
 	log.Lvl1(el.List[0])
 	log.ErrFatal(err)
 	log.Lvl1(stat)
-	assert.NotEmpty(t, stat.Msg["Status"].Field["Available_Services"])
-	log.Lvl1(stat.Msg["Status"])
-	log.Lvl1(stat.Msg["Status"].Field["Available_Services"])
-	pi, err := local.CreateProtocol("ExampleChannels", tr)
-	if err != nil {
-		t.Fatal("Couldn't start protocol:", err)
-	}
-	go pi.Start()
-	<-pi.(*channels.ProtocolExampleChannels).ChildCount
+	assert.NotEmpty(t, stat.Status["Generic"]["Available_Services"])
+	log.Lvl1(stat.Status["Generic"])
+	log.Lvl1(stat.Status["Generic"]["Available_Services"])
 	stat, err = client.Request(el.List[0])
 	log.ErrFatal(err)
 	log.Lvl1(stat)
-	assert.NotEmpty(t, stat.Msg["Status"].Field["Available_Services"])
+	assert.Empty(t, stat.Status["Status"]["Available_Services"])
 }

--- a/status/status.go
+++ b/status/status.go
@@ -7,7 +7,7 @@ import (
 
 	"errors"
 
-	"github.com/dedis/cothority/status/service"
+	status "github.com/dedis/cothority/status/service"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/app"
 	"github.com/dedis/onet/log"
@@ -62,7 +62,6 @@ func network(c *cli.Context) error {
 
 // readGroup takes a toml file name and reads the file, returning the entities within
 func readGroup(tomlFileName string) (*onet.Roster, error) {
-	log.Print("Reading From File")
 	f, err := os.Open(tomlFileName)
 	if err != nil {
 		return nil, err
@@ -82,10 +81,11 @@ func readGroup(tomlFileName string) (*onet.Roster, error) {
 // printConn prints the status response that is returned from the server
 func printConn(e *status.Response) {
 	var a []string
-	for key, value := range e.Msg["Status"].Field {
-		a = append(a, (key + ": " + value + "\n"))
+	for sec := range e.Status {
+		for key, value := range e.Status[sec] {
+			a = append(a, (sec + "." + key + ": " + value))
+		}
 	}
 	sort.Strings(a)
-	strings.Join(a, "\n")
-	log.Print(a)
+	log.Print(strings.Join(a, "\n"))
 }

--- a/status/status.go
+++ b/status/status.go
@@ -53,7 +53,11 @@ func network(c *cli.Context) error {
 	cl := status.NewClient()
 	for i := 0; i < len(el.List); i++ {
 		log.Lvl3(el.List[i])
-		sr, _ := cl.Request(el.List[i])
+		sr, err := cl.Request(el.List[i])
+		if err != nil {
+			log.Print("error on server", el.List[i], err)
+			continue
+		}
 		printConn(sr)
 		log.Lvl3(cl)
 	}
@@ -81,6 +85,10 @@ func readGroup(tomlFileName string) (*onet.Roster, error) {
 // printConn prints the status response that is returned from the server
 func printConn(e *status.Response) {
 	var a []string
+	if e.Status == nil {
+		log.Print("no status from ", e.ServerIdentity)
+		return
+	}
 	for sec := range e.Status {
 		for key, value := range e.Status[sec] {
 			a = append(a, (sec + "." + key + ": " + value))


### PR DESCRIPTION
Clean up the type of the status reply, remove a call to an example
that will disappear with #1036.

Correctly display status replies which have multiple parts of the
server reporting stats.

Fixes #940.