### PR TITLE
kyberjs: rename group module to curves and expose abstract classes

### DIFF
--- a/external/js/kyber/doc/doc.md
+++ b/external/js/kyber/doc/doc.md
@@ -3,22 +3,36 @@
 <dl>
 <dt><a href="#module_constants">constants</a></dt>
 <dd></dd>
-<dt><a href="#module_group/edwards25519/curve">group/edwards25519/curve</a></dt>
+<dt><a href="#module_curves/edwards25519/curve">curves/edwards25519/curve</a></dt>
 <dd></dd>
-<dt><a href="#module_group/edwards25519/point">group/edwards25519/point</a></dt>
+<dt><a href="#module_curves/edwards25519/point">curves/edwards25519/point</a></dt>
 <dd></dd>
-<dt><a href="#module_group/edwards25519/scalar">group/edwards25519/scalar</a></dt>
+<dt><a href="#module_curves/edwards25519/scalar">curves/edwards25519/scalar</a></dt>
 <dd></dd>
-<dt><a href="#module_group">group</a></dt>
+<dt><a href="#module_curves/nist/curve">curves/nist/curve</a></dt>
 <dd></dd>
-<dt><a href="#module_group/nist/curve">group/nist/curve</a></dt>
+<dt><a href="#module_curves/nist/point">curves/nist/point</a></dt>
 <dd></dd>
-<dt><a href="#module_group/nist/point">group/nist/point</a></dt>
-<dd></dd>
-<dt><a href="#module_group/nist/scalar">group/nist/scalar</a></dt>
+<dt><a href="#module_curves/nist/scalar">curves/nist/scalar</a></dt>
 <dd></dd>
 <dt><a href="#module_sign/schnorr">sign/schnorr</a></dt>
 <dd></dd>
+</dl>
+
+## Classes
+
+<dl>
+<dt><a href="#Group">Group</a></dt>
+<dd><p>Group is an abstract class for curves</p>
+</dd>
+<dt><a href="#Point">Point</a></dt>
+<dd><p>Point is an abstract class for representing
+a point on an elliptic curve</p>
+</dd>
+<dt><a href="#Scalar">Scalar</a></dt>
+<dd><p>Scalar is an abstract class for representing a scalar
+to be used in elliptic curve operations</p>
+</dd>
 </dl>
 
 ## Functions
@@ -48,198 +62,198 @@ Constants
 | --- | --- | --- |
 | zeroBN | <code>BN.jsObject</code> | BN.js object representing 0 |
 
-<a name="module_group/edwards25519/curve"></a>
+<a name="module_curves/edwards25519/curve"></a>
 
-## group/edwards25519/curve
+## curves/edwards25519/curve
 
-* [group/edwards25519/curve](#module_group/edwards25519/curve)
-    * [~Edwards25519](#module_group/edwards25519/curve..Edwards25519)
-        * [.string()](#module_group/edwards25519/curve..Edwards25519+string) ⇒ <code>string</code>
-        * [.scalarLen()](#module_group/edwards25519/curve..Edwards25519+scalarLen) ⇒ <code>number</code>
-        * [.scalar()](#module_group/edwards25519/curve..Edwards25519+scalar) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-        * [.pointLen()](#module_group/edwards25519/curve..Edwards25519+pointLen) ⇒ <code>number</code>
-        * [.point()](#module_group/edwards25519/curve..Edwards25519+point) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-        * [.newKey()](#module_group/edwards25519/curve..Edwards25519+newKey) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
+* [curves/edwards25519/curve](#module_curves/edwards25519/curve)
+    * [~Edwards25519](#module_curves/edwards25519/curve..Edwards25519)
+        * [.string()](#module_curves/edwards25519/curve..Edwards25519+string) ⇒ <code>string</code>
+        * [.scalarLen()](#module_curves/edwards25519/curve..Edwards25519+scalarLen) ⇒ <code>number</code>
+        * [.scalar()](#module_curves/edwards25519/curve..Edwards25519+scalar) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+        * [.pointLen()](#module_curves/edwards25519/curve..Edwards25519+pointLen) ⇒ <code>number</code>
+        * [.point()](#module_curves/edwards25519/curve..Edwards25519+point) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+        * [.newKey()](#module_curves/edwards25519/curve..Edwards25519+newKey) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
 
-<a name="module_group/edwards25519/curve..Edwards25519"></a>
+<a name="module_curves/edwards25519/curve..Edwards25519"></a>
 
-### group/edwards25519/curve~Edwards25519
+### curves/edwards25519/curve~Edwards25519
 Represents an Ed25519 curve
 
-**Kind**: inner class of [<code>group/edwards25519/curve</code>](#module_group/edwards25519/curve)  
+**Kind**: inner class of [<code>curves/edwards25519/curve</code>](#module_curves/edwards25519/curve)  
 
-* [~Edwards25519](#module_group/edwards25519/curve..Edwards25519)
-    * [.string()](#module_group/edwards25519/curve..Edwards25519+string) ⇒ <code>string</code>
-    * [.scalarLen()](#module_group/edwards25519/curve..Edwards25519+scalarLen) ⇒ <code>number</code>
-    * [.scalar()](#module_group/edwards25519/curve..Edwards25519+scalar) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-    * [.pointLen()](#module_group/edwards25519/curve..Edwards25519+pointLen) ⇒ <code>number</code>
-    * [.point()](#module_group/edwards25519/curve..Edwards25519+point) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-    * [.newKey()](#module_group/edwards25519/curve..Edwards25519+newKey) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
+* [~Edwards25519](#module_curves/edwards25519/curve..Edwards25519)
+    * [.string()](#module_curves/edwards25519/curve..Edwards25519+string) ⇒ <code>string</code>
+    * [.scalarLen()](#module_curves/edwards25519/curve..Edwards25519+scalarLen) ⇒ <code>number</code>
+    * [.scalar()](#module_curves/edwards25519/curve..Edwards25519+scalar) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+    * [.pointLen()](#module_curves/edwards25519/curve..Edwards25519+pointLen) ⇒ <code>number</code>
+    * [.point()](#module_curves/edwards25519/curve..Edwards25519+point) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+    * [.newKey()](#module_curves/edwards25519/curve..Edwards25519+newKey) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
 
-<a name="module_group/edwards25519/curve..Edwards25519+string"></a>
+<a name="module_curves/edwards25519/curve..Edwards25519+string"></a>
 
 #### edwards25519.string() ⇒ <code>string</code>
 Return the name of the curve
 
-**Kind**: instance method of [<code>Edwards25519</code>](#module_group/edwards25519/curve..Edwards25519)  
-<a name="module_group/edwards25519/curve..Edwards25519+scalarLen"></a>
+**Kind**: instance method of [<code>Edwards25519</code>](#module_curves/edwards25519/curve..Edwards25519)  
+<a name="module_curves/edwards25519/curve..Edwards25519+scalarLen"></a>
 
 #### edwards25519.scalarLen() ⇒ <code>number</code>
 Returns 32, the size in bytes of a Scalar on Ed25519 curve
 
-**Kind**: instance method of [<code>Edwards25519</code>](#module_group/edwards25519/curve..Edwards25519)  
-<a name="module_group/edwards25519/curve..Edwards25519+scalar"></a>
+**Kind**: instance method of [<code>Edwards25519</code>](#module_curves/edwards25519/curve..Edwards25519)  
+<a name="module_curves/edwards25519/curve..Edwards25519+scalar"></a>
 
-#### edwards25519.scalar() ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
+#### edwards25519.scalar() ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
 Returns a new Scalar for the prime-order subgroup of Ed25519 curve
 
-**Kind**: instance method of [<code>Edwards25519</code>](#module_group/edwards25519/curve..Edwards25519)  
-<a name="module_group/edwards25519/curve..Edwards25519+pointLen"></a>
+**Kind**: instance method of [<code>Edwards25519</code>](#module_curves/edwards25519/curve..Edwards25519)  
+<a name="module_curves/edwards25519/curve..Edwards25519+pointLen"></a>
 
 #### edwards25519.pointLen() ⇒ <code>number</code>
 Returns 32, the size of a Point on Ed25519 curve
 
-**Kind**: instance method of [<code>Edwards25519</code>](#module_group/edwards25519/curve..Edwards25519)  
-<a name="module_group/edwards25519/curve..Edwards25519+point"></a>
+**Kind**: instance method of [<code>Edwards25519</code>](#module_curves/edwards25519/curve..Edwards25519)  
+<a name="module_curves/edwards25519/curve..Edwards25519+point"></a>
 
-#### edwards25519.point() ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
+#### edwards25519.point() ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
 Creates a new point on the Ed25519 curve
 
-**Kind**: instance method of [<code>Edwards25519</code>](#module_group/edwards25519/curve..Edwards25519)  
-<a name="module_group/edwards25519/curve..Edwards25519+newKey"></a>
+**Kind**: instance method of [<code>Edwards25519</code>](#module_curves/edwards25519/curve..Edwards25519)  
+<a name="module_curves/edwards25519/curve..Edwards25519+newKey"></a>
 
-#### edwards25519.newKey() ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
+#### edwards25519.newKey() ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
 NewKey returns a formatted Ed25519 key (avoiding subgroup attack by requiring
 it to be a multiple of 8).
 
-**Kind**: instance method of [<code>Edwards25519</code>](#module_group/edwards25519/curve..Edwards25519)  
-<a name="module_group/edwards25519/point"></a>
+**Kind**: instance method of [<code>Edwards25519</code>](#module_curves/edwards25519/curve..Edwards25519)  
+<a name="module_curves/edwards25519/point"></a>
 
-## group/edwards25519/point
+## curves/edwards25519/point
 
-* [group/edwards25519/point](#module_group/edwards25519/point)
-    * [~Point](#module_group/edwards25519/point..Point)
-        * [new Point(curve, X, Y, Z, T)](#new_module_group/edwards25519/point..Point_new)
-        * [.toString()](#module_group/edwards25519/point..Point+toString) ⇒ <code>string</code>
-        * [.equal(p2)](#module_group/edwards25519/point..Point+equal) ⇒ <code>boolean</code>
-        * [.set(p2)](#module_group/edwards25519/point..Point+set) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-        * [.clone()](#module_group/edwards25519/point..Point+clone) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-        * [.null()](#module_group/edwards25519/point..Point+null) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-        * [.base()](#module_group/edwards25519/point..Point+base) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-        * [.embedLen()](#module_group/edwards25519/point..Point+embedLen) ⇒ <code>number</code>
-        * [.embed(data, callback)](#module_group/edwards25519/point..Point+embed) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-        * [.data()](#module_group/edwards25519/point..Point+data) ⇒ <code>Uint8Array</code>
-        * [.add(p1, p2)](#module_group/edwards25519/point..Point+add) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-        * [.sub(p1, p2)](#module_group/edwards25519/point..Point+sub) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-        * [.neg(p)](#module_group/edwards25519/point..Point+neg) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-        * [.mul(s, [p])](#module_group/edwards25519/point..Point+mul) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-        * [.pick(callback)](#module_group/edwards25519/point..Point+pick) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-        * [.marshalBinary()](#module_group/edwards25519/point..Point+marshalBinary) ⇒ <code>Uint8Array</code>
-        * [.unmarshalBinary(bytes)](#module_group/edwards25519/point..Point+unmarshalBinary) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
+* [curves/edwards25519/point](#module_curves/edwards25519/point)
+    * [~Point](#module_curves/edwards25519/point..Point)
+        * [new Point(curve, X, Y, Z, T)](#new_module_curves/edwards25519/point..Point_new)
+        * [.toString()](#module_curves/edwards25519/point..Point+toString) ⇒ <code>string</code>
+        * [.equal(p2)](#module_curves/edwards25519/point..Point+equal) ⇒ <code>boolean</code>
+        * [.set(p2)](#module_curves/edwards25519/point..Point+set) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+        * [.clone()](#module_curves/edwards25519/point..Point+clone) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+        * [.null()](#module_curves/edwards25519/point..Point+null) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+        * [.base()](#module_curves/edwards25519/point..Point+base) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+        * [.embedLen()](#module_curves/edwards25519/point..Point+embedLen) ⇒ <code>number</code>
+        * [.embed(data, callback)](#module_curves/edwards25519/point..Point+embed) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+        * [.data()](#module_curves/edwards25519/point..Point+data) ⇒ <code>Uint8Array</code>
+        * [.add(p1, p2)](#module_curves/edwards25519/point..Point+add) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+        * [.sub(p1, p2)](#module_curves/edwards25519/point..Point+sub) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+        * [.neg(p)](#module_curves/edwards25519/point..Point+neg) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+        * [.mul(s, [p])](#module_curves/edwards25519/point..Point+mul) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+        * [.pick(callback)](#module_curves/edwards25519/point..Point+pick) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+        * [.marshalBinary()](#module_curves/edwards25519/point..Point+marshalBinary) ⇒ <code>Uint8Array</code>
+        * [.unmarshalBinary(bytes)](#module_curves/edwards25519/point..Point+unmarshalBinary) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
 
-<a name="module_group/edwards25519/point..Point"></a>
+<a name="module_curves/edwards25519/point..Point"></a>
 
-### group/edwards25519/point~Point
+### curves/edwards25519/point~Point
 Represents a Point on the twisted edwards curve
 (X:Y:Z:T) satisfying x=X/Z, y=Y/Z, XY=ZT
 
 The value of the parameters is expcurveted in little endian form if being
 passed as a Uint8Array
 
-**Kind**: inner class of [<code>group/edwards25519/point</code>](#module_group/edwards25519/point)  
+**Kind**: inner class of [<code>curves/edwards25519/point</code>](#module_curves/edwards25519/point)  
 
-* [~Point](#module_group/edwards25519/point..Point)
-    * [new Point(curve, X, Y, Z, T)](#new_module_group/edwards25519/point..Point_new)
-    * [.toString()](#module_group/edwards25519/point..Point+toString) ⇒ <code>string</code>
-    * [.equal(p2)](#module_group/edwards25519/point..Point+equal) ⇒ <code>boolean</code>
-    * [.set(p2)](#module_group/edwards25519/point..Point+set) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-    * [.clone()](#module_group/edwards25519/point..Point+clone) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-    * [.null()](#module_group/edwards25519/point..Point+null) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-    * [.base()](#module_group/edwards25519/point..Point+base) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-    * [.embedLen()](#module_group/edwards25519/point..Point+embedLen) ⇒ <code>number</code>
-    * [.embed(data, callback)](#module_group/edwards25519/point..Point+embed) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-    * [.data()](#module_group/edwards25519/point..Point+data) ⇒ <code>Uint8Array</code>
-    * [.add(p1, p2)](#module_group/edwards25519/point..Point+add) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-    * [.sub(p1, p2)](#module_group/edwards25519/point..Point+sub) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-    * [.neg(p)](#module_group/edwards25519/point..Point+neg) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-    * [.mul(s, [p])](#module_group/edwards25519/point..Point+mul) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-    * [.pick(callback)](#module_group/edwards25519/point..Point+pick) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
-    * [.marshalBinary()](#module_group/edwards25519/point..Point+marshalBinary) ⇒ <code>Uint8Array</code>
-    * [.unmarshalBinary(bytes)](#module_group/edwards25519/point..Point+unmarshalBinary) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
+* [~Point](#module_curves/edwards25519/point..Point)
+    * [new Point(curve, X, Y, Z, T)](#new_module_curves/edwards25519/point..Point_new)
+    * [.toString()](#module_curves/edwards25519/point..Point+toString) ⇒ <code>string</code>
+    * [.equal(p2)](#module_curves/edwards25519/point..Point+equal) ⇒ <code>boolean</code>
+    * [.set(p2)](#module_curves/edwards25519/point..Point+set) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+    * [.clone()](#module_curves/edwards25519/point..Point+clone) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+    * [.null()](#module_curves/edwards25519/point..Point+null) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+    * [.base()](#module_curves/edwards25519/point..Point+base) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+    * [.embedLen()](#module_curves/edwards25519/point..Point+embedLen) ⇒ <code>number</code>
+    * [.embed(data, callback)](#module_curves/edwards25519/point..Point+embed) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+    * [.data()](#module_curves/edwards25519/point..Point+data) ⇒ <code>Uint8Array</code>
+    * [.add(p1, p2)](#module_curves/edwards25519/point..Point+add) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+    * [.sub(p1, p2)](#module_curves/edwards25519/point..Point+sub) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+    * [.neg(p)](#module_curves/edwards25519/point..Point+neg) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+    * [.mul(s, [p])](#module_curves/edwards25519/point..Point+mul) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+    * [.pick(callback)](#module_curves/edwards25519/point..Point+pick) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
+    * [.marshalBinary()](#module_curves/edwards25519/point..Point+marshalBinary) ⇒ <code>Uint8Array</code>
+    * [.unmarshalBinary(bytes)](#module_curves/edwards25519/point..Point+unmarshalBinary) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
 
-<a name="new_module_group/edwards25519/point..Point_new"></a>
+<a name="new_module_curves/edwards25519/point..Point_new"></a>
 
 #### new Point(curve, X, Y, Z, T)
 
 | Param | Type |
 | --- | --- |
-| curve | <code>module:group/edwards25519~Edwards25519</code> | 
+| curve | <code>module:curves/edwards25519~Edwards25519</code> | 
 | X | <code>number</code> \| <code>Uint8Array</code> \| <code>BN.jsObjcurvet</code> | 
 | Y | <code>number</code> \| <code>Uint8Array</code> \| <code>BN.jsObjcurvet</code> | 
 | Z | <code>number</code> \| <code>Uint8Array</code> \| <code>BN.jsObjcurvet</code> | 
 | T | <code>number</code> \| <code>Uint8Array</code> \| <code>BN.jsObjcurvet</code> | 
 
-<a name="module_group/edwards25519/point..Point+toString"></a>
+<a name="module_curves/edwards25519/point..Point+toString"></a>
 
 #### point.toString() ⇒ <code>string</code>
 Returns the little endian representation of the y coordinate of
 the Point
 
-**Kind**: instance method of [<code>Point</code>](#module_group/edwards25519/point..Point)  
-<a name="module_group/edwards25519/point..Point+equal"></a>
+**Kind**: instance method of [<code>Point</code>](#module_curves/edwards25519/point..Point)  
+<a name="module_curves/edwards25519/point..Point+equal"></a>
 
 #### point.equal(p2) ⇒ <code>boolean</code>
 Tests for equality between two Points derived from the same group
 
-**Kind**: instance method of [<code>Point</code>](#module_group/edwards25519/point..Point)  
+**Kind**: instance method of [<code>Point</code>](#module_curves/edwards25519/point..Point)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| p2 | [<code>Point</code>](#module_group/edwards25519/point..Point) | Point module:group/edwards25519/point~Point to compare |
+| p2 | [<code>Point</code>](#module_curves/edwards25519/point..Point) | Point module:curves/edwards25519/point~Point to compare |
 
-<a name="module_group/edwards25519/point..Point+set"></a>
+<a name="module_curves/edwards25519/point..Point+set"></a>
 
-#### point.set(p2) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
+#### point.set(p2) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
 set Set the current point to be equal to p2
 
-**Kind**: instance method of [<code>Point</code>](#module_group/edwards25519/point..Point)  
+**Kind**: instance method of [<code>Point</code>](#module_curves/edwards25519/point..Point)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| p2 | [<code>Point</code>](#module_group/edwards25519/point..Point) | Point module:group/edwards25519/point~Point |
+| p2 | [<code>Point</code>](#module_curves/edwards25519/point..Point) | Point module:curves/edwards25519/point~Point |
 
-<a name="module_group/edwards25519/point..Point+clone"></a>
+<a name="module_curves/edwards25519/point..Point+clone"></a>
 
-#### point.clone() ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
+#### point.clone() ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
 Creates a copy of the current point
 
-**Kind**: instance method of [<code>Point</code>](#module_group/edwards25519/point..Point)  
-**Returns**: [<code>Point</code>](#module_group/edwards25519/point..Point) - new Point module:group/edwards25519/point~Point  
-<a name="module_group/edwards25519/point..Point+null"></a>
+**Kind**: instance method of [<code>Point</code>](#module_curves/edwards25519/point..Point)  
+**Returns**: [<code>Point</code>](#module_curves/edwards25519/point..Point) - new Point module:curves/edwards25519/point~Point  
+<a name="module_curves/edwards25519/point..Point+null"></a>
 
-#### point.null() ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
+#### point.null() ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
 Set to the neutral element, which is (0, 1) for twisted Edwards
 Curve
 
-**Kind**: instance method of [<code>Point</code>](#module_group/edwards25519/point..Point)  
-<a name="module_group/edwards25519/point..Point+base"></a>
+**Kind**: instance method of [<code>Point</code>](#module_curves/edwards25519/point..Point)  
+<a name="module_curves/edwards25519/point..Point+base"></a>
 
-#### point.base() ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
+#### point.base() ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
 Set to the standard base point for this curve
 
-**Kind**: instance method of [<code>Point</code>](#module_group/edwards25519/point..Point)  
-<a name="module_group/edwards25519/point..Point+embedLen"></a>
+**Kind**: instance method of [<code>Point</code>](#module_curves/edwards25519/point..Point)  
+<a name="module_curves/edwards25519/point..Point+embedLen"></a>
 
 #### point.embedLen() ⇒ <code>number</code>
 Returns the length (in bytes) of the embedded data
 
-**Kind**: instance method of [<code>Point</code>](#module_group/edwards25519/point..Point)  
-<a name="module_group/edwards25519/point..Point+embed"></a>
+**Kind**: instance method of [<code>Point</code>](#module_curves/edwards25519/point..Point)  
+<a name="module_curves/edwards25519/point..Point+embed"></a>
 
-#### point.embed(data, callback) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
+#### point.embed(data, callback) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
 Returns a Point with data embedded in the y coordinate
 
-**Kind**: instance method of [<code>Point</code>](#module_group/edwards25519/point..Point)  
+**Kind**: instance method of [<code>Point</code>](#module_curves/edwards25519/point..Point)  
 **Throws**:
 
 - <code>TypeError</code> if data is not Uint8Array
@@ -251,92 +265,92 @@ Returns a Point with data embedded in the y coordinate
 | data | <code>Uint8Array</code> | to embed with length <= embedLen |
 | callback | <code>function</code> | to generate a random byte array of given length |
 
-<a name="module_group/edwards25519/point..Point+data"></a>
+<a name="module_curves/edwards25519/point..Point+data"></a>
 
 #### point.data() ⇒ <code>Uint8Array</code>
 Extract embedded data from a point
 
-**Kind**: instance method of [<code>Point</code>](#module_group/edwards25519/point..Point)  
+**Kind**: instance method of [<code>Point</code>](#module_curves/edwards25519/point..Point)  
 **Throws**:
 
 - <code>Error</code> when length of embedded data > embedLen
 
-<a name="module_group/edwards25519/point..Point+add"></a>
+<a name="module_curves/edwards25519/point..Point+add"></a>
 
-#### point.add(p1, p2) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
+#### point.add(p1, p2) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
 Returns the sum of two points on the curve
 
-**Kind**: instance method of [<code>Point</code>](#module_group/edwards25519/point..Point)  
-**Returns**: [<code>Point</code>](#module_group/edwards25519/point..Point) - p1 + p2  
+**Kind**: instance method of [<code>Point</code>](#module_curves/edwards25519/point..Point)  
+**Returns**: [<code>Point</code>](#module_curves/edwards25519/point..Point) - p1 + p2  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| p1 | [<code>Point</code>](#module_group/edwards25519/point..Point) | Point module:group/edwards25519/point~Point, addend |
-| p2 | [<code>Point</code>](#module_group/edwards25519/point..Point) | Point module:group/edwards25519/point~Point, addend |
+| p1 | [<code>Point</code>](#module_curves/edwards25519/point..Point) | Point module:curves/edwards25519/point~Point, addend |
+| p2 | [<code>Point</code>](#module_curves/edwards25519/point..Point) | Point module:curves/edwards25519/point~Point, addend |
 
-<a name="module_group/edwards25519/point..Point+sub"></a>
+<a name="module_curves/edwards25519/point..Point+sub"></a>
 
-#### point.sub(p1, p2) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
+#### point.sub(p1, p2) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
 Subtract two points
 
-**Kind**: instance method of [<code>Point</code>](#module_group/edwards25519/point..Point)  
-**Returns**: [<code>Point</code>](#module_group/edwards25519/point..Point) - p1 - p2  
+**Kind**: instance method of [<code>Point</code>](#module_curves/edwards25519/point..Point)  
+**Returns**: [<code>Point</code>](#module_curves/edwards25519/point..Point) - p1 - p2  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| p1 | [<code>Point</code>](#module_group/edwards25519/point..Point) | Point module:group/edwards25519/point~Point |
-| p2 | [<code>Point</code>](#module_group/edwards25519/point..Point) | Point module:group/edwards25519/point~Point |
+| p1 | [<code>Point</code>](#module_curves/edwards25519/point..Point) | Point module:curves/edwards25519/point~Point |
+| p2 | [<code>Point</code>](#module_curves/edwards25519/point..Point) | Point module:curves/edwards25519/point~Point |
 
-<a name="module_group/edwards25519/point..Point+neg"></a>
+<a name="module_curves/edwards25519/point..Point+neg"></a>
 
-#### point.neg(p) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
+#### point.neg(p) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
 Finds the negative of a point p
 For Edwards Curves, the negative of (x, y) is (-x, y)
 
-**Kind**: instance method of [<code>Point</code>](#module_group/edwards25519/point..Point)  
-**Returns**: [<code>Point</code>](#module_group/edwards25519/point..Point) - -p  
+**Kind**: instance method of [<code>Point</code>](#module_curves/edwards25519/point..Point)  
+**Returns**: [<code>Point</code>](#module_curves/edwards25519/point..Point) - -p  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| p | [<code>Point</code>](#module_group/edwards25519/point..Point) | Point to negate |
+| p | [<code>Point</code>](#module_curves/edwards25519/point..Point) | Point to negate |
 
-<a name="module_group/edwards25519/point..Point+mul"></a>
+<a name="module_curves/edwards25519/point..Point+mul"></a>
 
-#### point.mul(s, [p]) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
+#### point.mul(s, [p]) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
 Multiply point p by scalar s
 
-**Kind**: instance method of [<code>Point</code>](#module_group/edwards25519/point..Point)  
+**Kind**: instance method of [<code>Point</code>](#module_curves/edwards25519/point..Point)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| s | [<code>Point</code>](#module_group/edwards25519/point..Point) | Scalar |
-| [p] | [<code>Point</code>](#module_group/edwards25519/point..Point) | Point |
+| s | [<code>Point</code>](#module_curves/edwards25519/point..Point) | Scalar |
+| [p] | [<code>Point</code>](#module_curves/edwards25519/point..Point) | Point |
 
-<a name="module_group/edwards25519/point..Point+pick"></a>
+<a name="module_curves/edwards25519/point..Point+pick"></a>
 
-#### point.pick(callback) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
+#### point.pick(callback) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
 Selects a random point
 
-**Kind**: instance method of [<code>Point</code>](#module_group/edwards25519/point..Point)  
+**Kind**: instance method of [<code>Point</code>](#module_curves/edwards25519/point..Point)  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | callback | <code>function</code> | to generate a random byte array of given length |
 
-<a name="module_group/edwards25519/point..Point+marshalBinary"></a>
+<a name="module_curves/edwards25519/point..Point+marshalBinary"></a>
 
 #### point.marshalBinary() ⇒ <code>Uint8Array</code>
 Convert a ed25519 curve point into a byte representation
 
-**Kind**: instance method of [<code>Point</code>](#module_group/edwards25519/point..Point)  
+**Kind**: instance method of [<code>Point</code>](#module_curves/edwards25519/point..Point)  
 **Returns**: <code>Uint8Array</code> - byte representation  
-<a name="module_group/edwards25519/point..Point+unmarshalBinary"></a>
+<a name="module_curves/edwards25519/point..Point+unmarshalBinary"></a>
 
-#### point.unmarshalBinary(bytes) ⇒ [<code>Point</code>](#module_group/edwards25519/point..Point)
+#### point.unmarshalBinary(bytes) ⇒ [<code>Point</code>](#module_curves/edwards25519/point..Point)
 Convert a Uint8Array back to a ed25519 curve point
 [tools.ietf.org/html/rfc8032#scurvetion-5.1.3](tools.ietf.org/html/rfc8032#scurvetion-5.1.3)
 
-**Kind**: instance method of [<code>Point</code>](#module_group/edwards25519/point..Point)  
+**Kind**: instance method of [<code>Point</code>](#module_curves/edwards25519/point..Point)  
 **Throws**:
 
 - <code>TypeError</code> when bytes is not Uint8Array
@@ -347,173 +361,173 @@ Convert a Uint8Array back to a ed25519 curve point
 | --- | --- |
 | bytes | <code>Uint8Array</code> | 
 
-<a name="module_group/edwards25519/scalar"></a>
+<a name="module_curves/edwards25519/scalar"></a>
 
-## group/edwards25519/scalar
+## curves/edwards25519/scalar
 
-* [group/edwards25519/scalar](#module_group/edwards25519/scalar)
-    * [~Scalar](#module_group/edwards25519/scalar..Scalar)
-        * [.equal(s2)](#module_group/edwards25519/scalar..Scalar+equal) ⇒ <code>boolean</code>
-        * [.set(a)](#module_group/edwards25519/scalar..Scalar+set) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-        * [.clone()](#module_group/edwards25519/scalar..Scalar+clone) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-        * [.zero()](#module_group/edwards25519/scalar..Scalar+zero) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-        * [.add(s1, s2)](#module_group/edwards25519/scalar..Scalar+add) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-        * [.sub(s1, s2)](#module_group/edwards25519/scalar..Scalar+sub) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-        * [.neg(a)](#module_group/edwards25519/scalar..Scalar+neg) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-        * [.one()](#module_group/edwards25519/scalar..Scalar+one) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-        * [.mul(s1, s2)](#module_group/edwards25519/scalar..Scalar+mul) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-        * [.div(s1, s2)](#module_group/edwards25519/scalar..Scalar+div) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-        * [.inv(a)](#module_group/edwards25519/scalar..Scalar+inv) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-        * [.setBytes(b)](#module_group/edwards25519/scalar..Scalar+setBytes) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-        * [.bytes()](#module_group/edwards25519/scalar..Scalar+bytes) ⇒ <code>Uint8Array</code>
-        * [.pick(callback)](#module_group/edwards25519/scalar..Scalar+pick) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-        * [.marshalBinary()](#module_group/edwards25519/scalar..Scalar+marshalBinary) ⇒ <code>Uint8Array</code>
-        * [.unmarshalBinary(bytes)](#module_group/edwards25519/scalar..Scalar+unmarshalBinary)
+* [curves/edwards25519/scalar](#module_curves/edwards25519/scalar)
+    * [~Scalar](#module_curves/edwards25519/scalar..Scalar)
+        * [.equal(s2)](#module_curves/edwards25519/scalar..Scalar+equal) ⇒ <code>boolean</code>
+        * [.set(a)](#module_curves/edwards25519/scalar..Scalar+set) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+        * [.clone()](#module_curves/edwards25519/scalar..Scalar+clone) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+        * [.zero()](#module_curves/edwards25519/scalar..Scalar+zero) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+        * [.add(s1, s2)](#module_curves/edwards25519/scalar..Scalar+add) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+        * [.sub(s1, s2)](#module_curves/edwards25519/scalar..Scalar+sub) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+        * [.neg(a)](#module_curves/edwards25519/scalar..Scalar+neg) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+        * [.one()](#module_curves/edwards25519/scalar..Scalar+one) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+        * [.mul(s1, s2)](#module_curves/edwards25519/scalar..Scalar+mul) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+        * [.div(s1, s2)](#module_curves/edwards25519/scalar..Scalar+div) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+        * [.inv(a)](#module_curves/edwards25519/scalar..Scalar+inv) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+        * [.setBytes(b)](#module_curves/edwards25519/scalar..Scalar+setBytes) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+        * [.bytes()](#module_curves/edwards25519/scalar..Scalar+bytes) ⇒ <code>Uint8Array</code>
+        * [.pick(callback)](#module_curves/edwards25519/scalar..Scalar+pick) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+        * [.marshalBinary()](#module_curves/edwards25519/scalar..Scalar+marshalBinary) ⇒ <code>Uint8Array</code>
+        * [.unmarshalBinary(bytes)](#module_curves/edwards25519/scalar..Scalar+unmarshalBinary)
 
-<a name="module_group/edwards25519/scalar..Scalar"></a>
+<a name="module_curves/edwards25519/scalar..Scalar"></a>
 
-### group/edwards25519/scalar~Scalar
+### curves/edwards25519/scalar~Scalar
 Scalar represents a value in GF(2^252 + 27742317777372353535851937790883648493)
 
-**Kind**: inner class of [<code>group/edwards25519/scalar</code>](#module_group/edwards25519/scalar)  
+**Kind**: inner class of [<code>curves/edwards25519/scalar</code>](#module_curves/edwards25519/scalar)  
 
-* [~Scalar](#module_group/edwards25519/scalar..Scalar)
-    * [.equal(s2)](#module_group/edwards25519/scalar..Scalar+equal) ⇒ <code>boolean</code>
-    * [.set(a)](#module_group/edwards25519/scalar..Scalar+set) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-    * [.clone()](#module_group/edwards25519/scalar..Scalar+clone) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-    * [.zero()](#module_group/edwards25519/scalar..Scalar+zero) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-    * [.add(s1, s2)](#module_group/edwards25519/scalar..Scalar+add) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-    * [.sub(s1, s2)](#module_group/edwards25519/scalar..Scalar+sub) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-    * [.neg(a)](#module_group/edwards25519/scalar..Scalar+neg) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-    * [.one()](#module_group/edwards25519/scalar..Scalar+one) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-    * [.mul(s1, s2)](#module_group/edwards25519/scalar..Scalar+mul) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-    * [.div(s1, s2)](#module_group/edwards25519/scalar..Scalar+div) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-    * [.inv(a)](#module_group/edwards25519/scalar..Scalar+inv) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-    * [.setBytes(b)](#module_group/edwards25519/scalar..Scalar+setBytes) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-    * [.bytes()](#module_group/edwards25519/scalar..Scalar+bytes) ⇒ <code>Uint8Array</code>
-    * [.pick(callback)](#module_group/edwards25519/scalar..Scalar+pick) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
-    * [.marshalBinary()](#module_group/edwards25519/scalar..Scalar+marshalBinary) ⇒ <code>Uint8Array</code>
-    * [.unmarshalBinary(bytes)](#module_group/edwards25519/scalar..Scalar+unmarshalBinary)
+* [~Scalar](#module_curves/edwards25519/scalar..Scalar)
+    * [.equal(s2)](#module_curves/edwards25519/scalar..Scalar+equal) ⇒ <code>boolean</code>
+    * [.set(a)](#module_curves/edwards25519/scalar..Scalar+set) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+    * [.clone()](#module_curves/edwards25519/scalar..Scalar+clone) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+    * [.zero()](#module_curves/edwards25519/scalar..Scalar+zero) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+    * [.add(s1, s2)](#module_curves/edwards25519/scalar..Scalar+add) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+    * [.sub(s1, s2)](#module_curves/edwards25519/scalar..Scalar+sub) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+    * [.neg(a)](#module_curves/edwards25519/scalar..Scalar+neg) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+    * [.one()](#module_curves/edwards25519/scalar..Scalar+one) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+    * [.mul(s1, s2)](#module_curves/edwards25519/scalar..Scalar+mul) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+    * [.div(s1, s2)](#module_curves/edwards25519/scalar..Scalar+div) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+    * [.inv(a)](#module_curves/edwards25519/scalar..Scalar+inv) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+    * [.setBytes(b)](#module_curves/edwards25519/scalar..Scalar+setBytes) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+    * [.bytes()](#module_curves/edwards25519/scalar..Scalar+bytes) ⇒ <code>Uint8Array</code>
+    * [.pick(callback)](#module_curves/edwards25519/scalar..Scalar+pick) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
+    * [.marshalBinary()](#module_curves/edwards25519/scalar..Scalar+marshalBinary) ⇒ <code>Uint8Array</code>
+    * [.unmarshalBinary(bytes)](#module_curves/edwards25519/scalar..Scalar+unmarshalBinary)
 
-<a name="module_group/edwards25519/scalar..Scalar+equal"></a>
+<a name="module_curves/edwards25519/scalar..Scalar+equal"></a>
 
 #### scalar.equal(s2) ⇒ <code>boolean</code>
 Equality test for two Scalars derived from the same Group
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| s2 | [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar) | Scalar |
+| s2 | [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar) | Scalar |
 
-<a name="module_group/edwards25519/scalar..Scalar+set"></a>
+<a name="module_curves/edwards25519/scalar..Scalar+set"></a>
 
-#### scalar.set(a) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
+#### scalar.set(a) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
 Sets the receiver equal to another Scalar a
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| a | [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar) | Scalar |
+| a | [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar) | Scalar |
 
-<a name="module_group/edwards25519/scalar..Scalar+clone"></a>
+<a name="module_curves/edwards25519/scalar..Scalar+clone"></a>
 
-#### scalar.clone() ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
+#### scalar.clone() ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
 Returns a copy of the scalar
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)  
-<a name="module_group/edwards25519/scalar..Scalar+zero"></a>
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)  
+<a name="module_curves/edwards25519/scalar..Scalar+zero"></a>
 
-#### scalar.zero() ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
+#### scalar.zero() ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
 Set to the additive identity (0)
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)  
-<a name="module_group/edwards25519/scalar..Scalar+add"></a>
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)  
+<a name="module_curves/edwards25519/scalar..Scalar+add"></a>
 
-#### scalar.add(s1, s2) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
+#### scalar.add(s1, s2) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
 Set to the modular sums of scalars s1 and s2
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)  
-**Returns**: [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar) - s1 + s2  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)  
+**Returns**: [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar) - s1 + s2  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| s1 | [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar) | Scalar |
-| s2 | [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar) | Scalar |
+| s1 | [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar) | Scalar |
+| s2 | [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar) | Scalar |
 
-<a name="module_group/edwards25519/scalar..Scalar+sub"></a>
+<a name="module_curves/edwards25519/scalar..Scalar+sub"></a>
 
-#### scalar.sub(s1, s2) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
+#### scalar.sub(s1, s2) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
 Set to the modular difference
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)  
-**Returns**: [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar) - s1 - s2  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)  
+**Returns**: [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar) - s1 - s2  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| s1 | [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar) | Scalar |
-| s2 | [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar) | Scalar |
+| s1 | [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar) | Scalar |
+| s2 | [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar) | Scalar |
 
-<a name="module_group/edwards25519/scalar..Scalar+neg"></a>
+<a name="module_curves/edwards25519/scalar..Scalar+neg"></a>
 
-#### scalar.neg(a) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
+#### scalar.neg(a) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
 Set to the modular negation of scalar a
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| a | [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar) | Scalar |
+| a | [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar) | Scalar |
 
-<a name="module_group/edwards25519/scalar..Scalar+one"></a>
+<a name="module_curves/edwards25519/scalar..Scalar+one"></a>
 
-#### scalar.one() ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
+#### scalar.one() ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
 Set to the multiplicative identity (1)
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)  
-<a name="module_group/edwards25519/scalar..Scalar+mul"></a>
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)  
+<a name="module_curves/edwards25519/scalar..Scalar+mul"></a>
 
-#### scalar.mul(s1, s2) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
+#### scalar.mul(s1, s2) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
 Set to the modular products of scalars s1 and s2
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)  
 
 | Param | Type |
 | --- | --- |
-| s1 | [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar) | 
-| s2 | [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar) | 
+| s1 | [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar) | 
+| s2 | [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar) | 
 
-<a name="module_group/edwards25519/scalar..Scalar+div"></a>
+<a name="module_curves/edwards25519/scalar..Scalar+div"></a>
 
-#### scalar.div(s1, s2) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
+#### scalar.div(s1, s2) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
 Set to the modular division of scalar s1 by scalar s2
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)  
 
 | Param |
 | --- |
 | s1 | 
 | s2 | 
 
-<a name="module_group/edwards25519/scalar..Scalar+inv"></a>
+<a name="module_curves/edwards25519/scalar..Scalar+inv"></a>
 
-#### scalar.inv(a) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
+#### scalar.inv(a) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
 Set to the modular inverse of scalar a
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)  
 
 | Param |
 | --- |
 | a | 
 
-<a name="module_group/edwards25519/scalar..Scalar+setBytes"></a>
+<a name="module_curves/edwards25519/scalar..Scalar+setBytes"></a>
 
-#### scalar.setBytes(b) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
+#### scalar.setBytes(b) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
 Sets the scalar from little-endian Uint8Array
 and reduces to the appropriate modulus
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)  
 **Throws**:
 
 - <code>TypeError</code> when b is not Uint8Array
@@ -523,99 +537,70 @@ and reduces to the appropriate modulus
 | --- | --- | --- |
 | b | <code>Uint8Array</code> | bytes |
 
-<a name="module_group/edwards25519/scalar..Scalar+bytes"></a>
+<a name="module_curves/edwards25519/scalar..Scalar+bytes"></a>
 
 #### scalar.bytes() ⇒ <code>Uint8Array</code>
 Returns a big-endian representation of the scalar
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)  
-<a name="module_group/edwards25519/scalar..Scalar+pick"></a>
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)  
+<a name="module_curves/edwards25519/scalar..Scalar+pick"></a>
 
-#### scalar.pick(callback) ⇒ [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)
+#### scalar.pick(callback) ⇒ [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)
 Set to a random scalar
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | callback | <code>function</code> | to generate random byte array of given length |
 
-<a name="module_group/edwards25519/scalar..Scalar+marshalBinary"></a>
+<a name="module_curves/edwards25519/scalar..Scalar+marshalBinary"></a>
 
 #### scalar.marshalBinary() ⇒ <code>Uint8Array</code>
 Returns the binary representation (little endian) of the scalar
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)  
-<a name="module_group/edwards25519/scalar..Scalar+unmarshalBinary"></a>
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)  
+<a name="module_curves/edwards25519/scalar..Scalar+unmarshalBinary"></a>
 
 #### scalar.unmarshalBinary(bytes)
 Reads the binary representation (little endian) of scalar
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/edwards25519/scalar..Scalar)  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/edwards25519/scalar..Scalar)  
 
 | Param |
 | --- |
 | bytes | 
 
-<a name="module_group"></a>
+<a name="module_curves/nist/curve"></a>
 
-## group
+## curves/nist/curve
 
-* [group](#module_group)
-    * [~Group](#module_group..Group)
-    * [~Point](#module_group..Point)
-    * [~Scalar](#module_group..Scalar)
+* [curves/nist/curve](#module_curves/nist/curve)
+    * [~Weierstrass](#module_curves/nist/curve..Weierstrass)
+        * [new Weierstrass(config)](#new_module_curves/nist/curve..Weierstrass_new)
+        * [.string()](#module_curves/nist/curve..Weierstrass+string) ⇒ <code>string</code>
+        * [.scalarLen()](#module_curves/nist/curve..Weierstrass+scalarLen) ⇒ <code>number</code>
+        * [.scalar()](#module_curves/nist/curve..Weierstrass+scalar) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+        * [.pointLen()](#module_curves/nist/curve..Weierstrass+pointLen) ⇒ <code>number</code>
+        * [.point()](#module_curves/nist/curve..Weierstrass+point) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
 
-<a name="module_group..Group"></a>
+<a name="module_curves/nist/curve..Weierstrass"></a>
 
-### group~Group
-Group is an abstract class for curves
-
-**Kind**: inner class of [<code>group</code>](#module_group)  
-<a name="module_group..Point"></a>
-
-### group~Point
-Point is an abstract class for representing
-a point on an elliptic curve
-
-**Kind**: inner class of [<code>group</code>](#module_group)  
-<a name="module_group..Scalar"></a>
-
-### group~Scalar
-Scalar is an abstract class for representing a scalar
-to be used in elliptic curve operations
-
-**Kind**: inner class of [<code>group</code>](#module_group)  
-<a name="module_group/nist/curve"></a>
-
-## group/nist/curve
-
-* [group/nist/curve](#module_group/nist/curve)
-    * [~Weierstrass](#module_group/nist/curve..Weierstrass)
-        * [new Weierstrass(config)](#new_module_group/nist/curve..Weierstrass_new)
-        * [.string()](#module_group/nist/curve..Weierstrass+string) ⇒ <code>string</code>
-        * [.scalarLen()](#module_group/nist/curve..Weierstrass+scalarLen) ⇒ <code>number</code>
-        * [.scalar()](#module_group/nist/curve..Weierstrass+scalar) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-        * [.pointLen()](#module_group/nist/curve..Weierstrass+pointLen) ⇒ <code>number</code>
-        * [.point()](#module_group/nist/curve..Weierstrass+point) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-
-<a name="module_group/nist/curve..Weierstrass"></a>
-
-### group/nist/curve~Weierstrass
+### curves/nist/curve~Weierstrass
 Class Weierstrass defines the weierstrass form of
 elliptic curves
 
-**Kind**: inner class of [<code>group/nist/curve</code>](#module_group/nist/curve)  
+**Kind**: inner class of [<code>curves/nist/curve</code>](#module_curves/nist/curve)  
 
-* [~Weierstrass](#module_group/nist/curve..Weierstrass)
-    * [new Weierstrass(config)](#new_module_group/nist/curve..Weierstrass_new)
-    * [.string()](#module_group/nist/curve..Weierstrass+string) ⇒ <code>string</code>
-    * [.scalarLen()](#module_group/nist/curve..Weierstrass+scalarLen) ⇒ <code>number</code>
-    * [.scalar()](#module_group/nist/curve..Weierstrass+scalar) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-    * [.pointLen()](#module_group/nist/curve..Weierstrass+pointLen) ⇒ <code>number</code>
-    * [.point()](#module_group/nist/curve..Weierstrass+point) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
+* [~Weierstrass](#module_curves/nist/curve..Weierstrass)
+    * [new Weierstrass(config)](#new_module_curves/nist/curve..Weierstrass_new)
+    * [.string()](#module_curves/nist/curve..Weierstrass+string) ⇒ <code>string</code>
+    * [.scalarLen()](#module_curves/nist/curve..Weierstrass+scalarLen) ⇒ <code>number</code>
+    * [.scalar()](#module_curves/nist/curve..Weierstrass+scalar) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+    * [.pointLen()](#module_curves/nist/curve..Weierstrass+pointLen) ⇒ <code>number</code>
+    * [.point()](#module_curves/nist/curve..Weierstrass+point) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
 
-<a name="new_module_group/nist/curve..Weierstrass_new"></a>
+<a name="new_module_curves/nist/curve..Weierstrass_new"></a>
 
 #### new Weierstrass(config)
 Create a new Weierstrass Curve
@@ -633,161 +618,161 @@ Create a new Weierstrass Curve
 | config.gy | <code>String</code> \| <code>Uint8Array</code> \| <code>BN.jsObject</code> | y coordinate of the base point. Little Endian if string or Uint8Array |
 | config.bitSize | <code>number</code> | the size of the underlying field. |
 
-<a name="module_group/nist/curve..Weierstrass+string"></a>
+<a name="module_curves/nist/curve..Weierstrass+string"></a>
 
 #### weierstrass.string() ⇒ <code>string</code>
 Returns the name of the curve
 
-**Kind**: instance method of [<code>Weierstrass</code>](#module_group/nist/curve..Weierstrass)  
-<a name="module_group/nist/curve..Weierstrass+scalarLen"></a>
+**Kind**: instance method of [<code>Weierstrass</code>](#module_curves/nist/curve..Weierstrass)  
+<a name="module_curves/nist/curve..Weierstrass+scalarLen"></a>
 
 #### weierstrass.scalarLen() ⇒ <code>number</code>
 Returns the size in bytes of a scalar
 
-**Kind**: instance method of [<code>Weierstrass</code>](#module_group/nist/curve..Weierstrass)  
-<a name="module_group/nist/curve..Weierstrass+scalar"></a>
+**Kind**: instance method of [<code>Weierstrass</code>](#module_curves/nist/curve..Weierstrass)  
+<a name="module_curves/nist/curve..Weierstrass+scalar"></a>
 
-#### weierstrass.scalar() ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
+#### weierstrass.scalar() ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
 Returns the size in bytes of a point
 
-**Kind**: instance method of [<code>Weierstrass</code>](#module_group/nist/curve..Weierstrass)  
-<a name="module_group/nist/curve..Weierstrass+pointLen"></a>
+**Kind**: instance method of [<code>Weierstrass</code>](#module_curves/nist/curve..Weierstrass)  
+<a name="module_curves/nist/curve..Weierstrass+pointLen"></a>
 
 #### weierstrass.pointLen() ⇒ <code>number</code>
 Returns the size in bytes of a point
 
-**Kind**: instance method of [<code>Weierstrass</code>](#module_group/nist/curve..Weierstrass)  
-<a name="module_group/nist/curve..Weierstrass+point"></a>
+**Kind**: instance method of [<code>Weierstrass</code>](#module_curves/nist/curve..Weierstrass)  
+<a name="module_curves/nist/curve..Weierstrass+point"></a>
 
-#### weierstrass.point() ⇒ [<code>Point</code>](#module_group/nist/point..Point)
+#### weierstrass.point() ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
 Returns a new Point
 
-**Kind**: instance method of [<code>Weierstrass</code>](#module_group/nist/curve..Weierstrass)  
-<a name="module_group/nist/point"></a>
+**Kind**: instance method of [<code>Weierstrass</code>](#module_curves/nist/curve..Weierstrass)  
+<a name="module_curves/nist/point"></a>
 
-## group/nist/point
+## curves/nist/point
 
-* [group/nist/point](#module_group/nist/point)
-    * [~Point](#module_group/nist/point..Point)
-        * [new Point(curve, x, y)](#new_module_group/nist/point..Point_new)
-        * [.toString()](#module_group/nist/point..Point+toString) ⇒ <code>string</code>
-        * [.equal(p2)](#module_group/nist/point..Point+equal) ⇒ <code>boolean</code>
-        * [.set(p2)](#module_group/nist/point..Point+set) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-        * [.clone()](#module_group/nist/point..Point+clone) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-        * [.null()](#module_group/nist/point..Point+null) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-        * [.base()](#module_group/nist/point..Point+base) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-        * [.embedLen()](#module_group/nist/point..Point+embedLen) ⇒ <code>number</code>
-        * [.embed(data, [callback])](#module_group/nist/point..Point+embed) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-        * [.data()](#module_group/nist/point..Point+data) ⇒ <code>Uint8Array</code>
-        * [.add(p1, p2)](#module_group/nist/point..Point+add) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-        * [.sub(p1, p2)](#module_group/nist/point..Point+sub) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-        * [.neg(p)](#module_group/nist/point..Point+neg) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-        * [.mul(s, [p])](#module_group/nist/point..Point+mul) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-        * [.pick([callback])](#module_group/nist/point..Point+pick) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-        * [.marshalBinary()](#module_group/nist/point..Point+marshalBinary) ⇒ <code>Uint8Array</code>
-        * [.unmarshalBinary(bytes)](#module_group/nist/point..Point+unmarshalBinary)
+* [curves/nist/point](#module_curves/nist/point)
+    * [~Point](#module_curves/nist/point..Point)
+        * [new Point(curve, x, y)](#new_module_curves/nist/point..Point_new)
+        * [.toString()](#module_curves/nist/point..Point+toString) ⇒ <code>string</code>
+        * [.equal(p2)](#module_curves/nist/point..Point+equal) ⇒ <code>boolean</code>
+        * [.set(p2)](#module_curves/nist/point..Point+set) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+        * [.clone()](#module_curves/nist/point..Point+clone) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+        * [.null()](#module_curves/nist/point..Point+null) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+        * [.base()](#module_curves/nist/point..Point+base) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+        * [.embedLen()](#module_curves/nist/point..Point+embedLen) ⇒ <code>number</code>
+        * [.embed(data, [callback])](#module_curves/nist/point..Point+embed) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+        * [.data()](#module_curves/nist/point..Point+data) ⇒ <code>Uint8Array</code>
+        * [.add(p1, p2)](#module_curves/nist/point..Point+add) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+        * [.sub(p1, p2)](#module_curves/nist/point..Point+sub) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+        * [.neg(p)](#module_curves/nist/point..Point+neg) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+        * [.mul(s, [p])](#module_curves/nist/point..Point+mul) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+        * [.pick([callback])](#module_curves/nist/point..Point+pick) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+        * [.marshalBinary()](#module_curves/nist/point..Point+marshalBinary) ⇒ <code>Uint8Array</code>
+        * [.unmarshalBinary(bytes)](#module_curves/nist/point..Point+unmarshalBinary)
 
-<a name="module_group/nist/point..Point"></a>
+<a name="module_curves/nist/point..Point"></a>
 
-### group/nist/point~Point
+### curves/nist/point~Point
 Represents a Point on the nist curve
 
 The value of the parameters is expected in little endian form if being
 passed as a Uint8Array
 
-**Kind**: inner class of [<code>group/nist/point</code>](#module_group/nist/point)  
+**Kind**: inner class of [<code>curves/nist/point</code>](#module_curves/nist/point)  
 
-* [~Point](#module_group/nist/point..Point)
-    * [new Point(curve, x, y)](#new_module_group/nist/point..Point_new)
-    * [.toString()](#module_group/nist/point..Point+toString) ⇒ <code>string</code>
-    * [.equal(p2)](#module_group/nist/point..Point+equal) ⇒ <code>boolean</code>
-    * [.set(p2)](#module_group/nist/point..Point+set) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-    * [.clone()](#module_group/nist/point..Point+clone) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-    * [.null()](#module_group/nist/point..Point+null) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-    * [.base()](#module_group/nist/point..Point+base) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-    * [.embedLen()](#module_group/nist/point..Point+embedLen) ⇒ <code>number</code>
-    * [.embed(data, [callback])](#module_group/nist/point..Point+embed) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-    * [.data()](#module_group/nist/point..Point+data) ⇒ <code>Uint8Array</code>
-    * [.add(p1, p2)](#module_group/nist/point..Point+add) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-    * [.sub(p1, p2)](#module_group/nist/point..Point+sub) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-    * [.neg(p)](#module_group/nist/point..Point+neg) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-    * [.mul(s, [p])](#module_group/nist/point..Point+mul) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-    * [.pick([callback])](#module_group/nist/point..Point+pick) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
-    * [.marshalBinary()](#module_group/nist/point..Point+marshalBinary) ⇒ <code>Uint8Array</code>
-    * [.unmarshalBinary(bytes)](#module_group/nist/point..Point+unmarshalBinary)
+* [~Point](#module_curves/nist/point..Point)
+    * [new Point(curve, x, y)](#new_module_curves/nist/point..Point_new)
+    * [.toString()](#module_curves/nist/point..Point+toString) ⇒ <code>string</code>
+    * [.equal(p2)](#module_curves/nist/point..Point+equal) ⇒ <code>boolean</code>
+    * [.set(p2)](#module_curves/nist/point..Point+set) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+    * [.clone()](#module_curves/nist/point..Point+clone) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+    * [.null()](#module_curves/nist/point..Point+null) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+    * [.base()](#module_curves/nist/point..Point+base) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+    * [.embedLen()](#module_curves/nist/point..Point+embedLen) ⇒ <code>number</code>
+    * [.embed(data, [callback])](#module_curves/nist/point..Point+embed) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+    * [.data()](#module_curves/nist/point..Point+data) ⇒ <code>Uint8Array</code>
+    * [.add(p1, p2)](#module_curves/nist/point..Point+add) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+    * [.sub(p1, p2)](#module_curves/nist/point..Point+sub) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+    * [.neg(p)](#module_curves/nist/point..Point+neg) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+    * [.mul(s, [p])](#module_curves/nist/point..Point+mul) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+    * [.pick([callback])](#module_curves/nist/point..Point+pick) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
+    * [.marshalBinary()](#module_curves/nist/point..Point+marshalBinary) ⇒ <code>Uint8Array</code>
+    * [.unmarshalBinary(bytes)](#module_curves/nist/point..Point+unmarshalBinary)
 
-<a name="new_module_group/nist/point..Point_new"></a>
+<a name="new_module_curves/nist/point..Point_new"></a>
 
 #### new Point(curve, x, y)
 
 | Param | Type | Description |
 | --- | --- | --- |
-| curve | <code>module:group/nist/curve~Weirstrass</code> | Weierstrass curve |
+| curve | <code>module:curves/nist/curve~Weirstrass</code> | Weierstrass curve |
 | x | <code>number</code> \| <code>Uint8Array</code> \| <code>BN.jsObject</code> |  |
 | y | <code>number</code> \| <code>Uint8Array</code> \| <code>BN.jsObject</code> |  |
 
-<a name="module_group/nist/point..Point+toString"></a>
+<a name="module_curves/nist/point..Point+toString"></a>
 
 #### point.toString() ⇒ <code>string</code>
 Returns the little endian representation of the y coordinate of
 the Point
 
-**Kind**: instance method of [<code>Point</code>](#module_group/nist/point..Point)  
-<a name="module_group/nist/point..Point+equal"></a>
+**Kind**: instance method of [<code>Point</code>](#module_curves/nist/point..Point)  
+<a name="module_curves/nist/point..Point+equal"></a>
 
 #### point.equal(p2) ⇒ <code>boolean</code>
 Tests for equality between two Points derived from the same group
 
-**Kind**: instance method of [<code>Point</code>](#module_group/nist/point..Point)  
+**Kind**: instance method of [<code>Point</code>](#module_curves/nist/point..Point)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| p2 | [<code>Point</code>](#module_group/nist/point..Point) | Point object to compare |
+| p2 | [<code>Point</code>](#module_curves/nist/point..Point) | Point object to compare |
 
-<a name="module_group/nist/point..Point+set"></a>
+<a name="module_curves/nist/point..Point+set"></a>
 
-#### point.set(p2) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
+#### point.set(p2) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
 set Set the current point to be equal to p2
 
-**Kind**: instance method of [<code>Point</code>](#module_group/nist/point..Point)  
+**Kind**: instance method of [<code>Point</code>](#module_curves/nist/point..Point)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| p2 | [<code>Point</code>](#module_group/nist/point..Point) | Point object |
+| p2 | [<code>Point</code>](#module_curves/nist/point..Point) | Point object |
 
-<a name="module_group/nist/point..Point+clone"></a>
+<a name="module_curves/nist/point..Point+clone"></a>
 
-#### point.clone() ⇒ [<code>Point</code>](#module_group/nist/point..Point)
+#### point.clone() ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
 Creates a copy of the current point
 
-**Kind**: instance method of [<code>Point</code>](#module_group/nist/point..Point)  
-**Returns**: [<code>Point</code>](#module_group/nist/point..Point) - new Point object  
-<a name="module_group/nist/point..Point+null"></a>
+**Kind**: instance method of [<code>Point</code>](#module_curves/nist/point..Point)  
+**Returns**: [<code>Point</code>](#module_curves/nist/point..Point) - new Point object  
+<a name="module_curves/nist/point..Point+null"></a>
 
-#### point.null() ⇒ [<code>Point</code>](#module_group/nist/point..Point)
+#### point.null() ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
 Set to the neutral element for the curve
 Modifies the receiver
 
-**Kind**: instance method of [<code>Point</code>](#module_group/nist/point..Point)  
-<a name="module_group/nist/point..Point+base"></a>
+**Kind**: instance method of [<code>Point</code>](#module_curves/nist/point..Point)  
+<a name="module_curves/nist/point..Point+base"></a>
 
-#### point.base() ⇒ [<code>Point</code>](#module_group/nist/point..Point)
+#### point.base() ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
 Set to the standard base point for this curve
 Modifies the receiver
 
-**Kind**: instance method of [<code>Point</code>](#module_group/nist/point..Point)  
-<a name="module_group/nist/point..Point+embedLen"></a>
+**Kind**: instance method of [<code>Point</code>](#module_curves/nist/point..Point)  
+<a name="module_curves/nist/point..Point+embedLen"></a>
 
 #### point.embedLen() ⇒ <code>number</code>
 Returns the length (in bytes) of the embedded data
 
-**Kind**: instance method of [<code>Point</code>](#module_group/nist/point..Point)  
-<a name="module_group/nist/point..Point+embed"></a>
+**Kind**: instance method of [<code>Point</code>](#module_curves/nist/point..Point)  
+<a name="module_curves/nist/point..Point+embed"></a>
 
-#### point.embed(data, [callback]) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
+#### point.embed(data, [callback]) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
 Returns a Point with data embedded in the y coordinate
 
-**Kind**: instance method of [<code>Point</code>](#module_group/nist/point..Point)  
+**Kind**: instance method of [<code>Point</code>](#module_curves/nist/point..Point)  
 **Throws**:
 
 - <code>TypeError</code> if data is not Uint8Array
@@ -799,97 +784,97 @@ Returns a Point with data embedded in the y coordinate
 | data | <code>Uint8Array</code> | data to embed with length <= embedLen |
 | [callback] | <code>function</code> | to generate a random byte array of given length |
 
-<a name="module_group/nist/point..Point+data"></a>
+<a name="module_curves/nist/point..Point+data"></a>
 
 #### point.data() ⇒ <code>Uint8Array</code>
 Extract embedded data from a point
 
-**Kind**: instance method of [<code>Point</code>](#module_group/nist/point..Point)  
+**Kind**: instance method of [<code>Point</code>](#module_curves/nist/point..Point)  
 **Throws**:
 
 - <code>Error</code> when length of embedded data > embedLen
 
-<a name="module_group/nist/point..Point+add"></a>
+<a name="module_curves/nist/point..Point+add"></a>
 
-#### point.add(p1, p2) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
+#### point.add(p1, p2) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
 Returns the sum of two points on the curve
 Modifies the receiver
 
-**Kind**: instance method of [<code>Point</code>](#module_group/nist/point..Point)  
-**Returns**: [<code>Point</code>](#module_group/nist/point..Point) - p1 + p2  
+**Kind**: instance method of [<code>Point</code>](#module_curves/nist/point..Point)  
+**Returns**: [<code>Point</code>](#module_curves/nist/point..Point) - p1 + p2  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| p1 | [<code>Point</code>](#module_group/nist/point..Point) | Point object, addend |
-| p2 | [<code>Point</code>](#module_group/nist/point..Point) | Point object, addend |
+| p1 | [<code>Point</code>](#module_curves/nist/point..Point) | Point object, addend |
+| p2 | [<code>Point</code>](#module_curves/nist/point..Point) | Point object, addend |
 
-<a name="module_group/nist/point..Point+sub"></a>
+<a name="module_curves/nist/point..Point+sub"></a>
 
-#### point.sub(p1, p2) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
+#### point.sub(p1, p2) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
 Subtract two points
 Modifies the receiver
 
-**Kind**: instance method of [<code>Point</code>](#module_group/nist/point..Point)  
-**Returns**: [<code>Point</code>](#module_group/nist/point..Point) - p1 - p2  
+**Kind**: instance method of [<code>Point</code>](#module_curves/nist/point..Point)  
+**Returns**: [<code>Point</code>](#module_curves/nist/point..Point) - p1 - p2  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| p1 | [<code>Point</code>](#module_group/nist/point..Point) | Point object |
-| p2 | [<code>Point</code>](#module_group/nist/point..Point) | Point object |
+| p1 | [<code>Point</code>](#module_curves/nist/point..Point) | Point object |
+| p2 | [<code>Point</code>](#module_curves/nist/point..Point) | Point object |
 
-<a name="module_group/nist/point..Point+neg"></a>
+<a name="module_curves/nist/point..Point+neg"></a>
 
-#### point.neg(p) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
+#### point.neg(p) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
 Finds the negative of a point p
 Modifies the receiver
 
-**Kind**: instance method of [<code>Point</code>](#module_group/nist/point..Point)  
-**Returns**: [<code>Point</code>](#module_group/nist/point..Point) - -p  
+**Kind**: instance method of [<code>Point</code>](#module_curves/nist/point..Point)  
+**Returns**: [<code>Point</code>](#module_curves/nist/point..Point) - -p  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| p | [<code>Point</code>](#module_group/nist/point..Point) | Point to negate |
+| p | [<code>Point</code>](#module_curves/nist/point..Point) | Point to negate |
 
-<a name="module_group/nist/point..Point+mul"></a>
+<a name="module_curves/nist/point..Point+mul"></a>
 
-#### point.mul(s, [p]) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
+#### point.mul(s, [p]) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
 Multiply point p by scalar s.
 If p is not passed then multiplies the base point of the curve with
 scalar s
 Modifies the receiver
 
-**Kind**: instance method of [<code>Point</code>](#module_group/nist/point..Point)  
+**Kind**: instance method of [<code>Point</code>](#module_curves/nist/point..Point)  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| s | [<code>Scalar</code>](#module_group/nist/scalar..Scalar) |  | Scalar |
-| [p] | [<code>Point</code>](#module_group/nist/point..Point) | <code></code> | Point |
+| s | [<code>Scalar</code>](#module_curves/nist/scalar..Scalar) |  | Scalar |
+| [p] | [<code>Point</code>](#module_curves/nist/point..Point) | <code></code> | Point |
 
-<a name="module_group/nist/point..Point+pick"></a>
+<a name="module_curves/nist/point..Point+pick"></a>
 
-#### point.pick([callback]) ⇒ [<code>Point</code>](#module_group/nist/point..Point)
+#### point.pick([callback]) ⇒ [<code>Point</code>](#module_curves/nist/point..Point)
 Selects a random point
 
-**Kind**: instance method of [<code>Point</code>](#module_group/nist/point..Point)  
+**Kind**: instance method of [<code>Point</code>](#module_curves/nist/point..Point)  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | [callback] | <code>function</code> | to generate a random byte array of given length |
 
-<a name="module_group/nist/point..Point+marshalBinary"></a>
+<a name="module_curves/nist/point..Point+marshalBinary"></a>
 
 #### point.marshalBinary() ⇒ <code>Uint8Array</code>
 converts a point into the form specified in section 4.3.6 of ANSI X9.62.
 
-**Kind**: instance method of [<code>Point</code>](#module_group/nist/point..Point)  
+**Kind**: instance method of [<code>Point</code>](#module_curves/nist/point..Point)  
 **Returns**: <code>Uint8Array</code> - byte representation  
-<a name="module_group/nist/point..Point+unmarshalBinary"></a>
+<a name="module_curves/nist/point..Point+unmarshalBinary"></a>
 
 #### point.unmarshalBinary(bytes)
 Convert a Uint8Array back to a curve point.
 Accepts only uncompressed point as specified in section 4.3.6 of ANSI X9.62
 
-**Kind**: instance method of [<code>Point</code>](#module_group/nist/point..Point)  
+**Kind**: instance method of [<code>Point</code>](#module_curves/nist/point..Point)  
 **Throws**:
 
 - <code>TypeError</code> when bytes is not Uint8Array
@@ -900,184 +885,184 @@ Accepts only uncompressed point as specified in section 4.3.6 of ANSI X9.62
 | --- | --- |
 | bytes | <code>Uint8Array</code> | 
 
-<a name="module_group/nist/scalar"></a>
+<a name="module_curves/nist/scalar"></a>
 
-## group/nist/scalar
+## curves/nist/scalar
 
-* [group/nist/scalar](#module_group/nist/scalar)
-    * [~Scalar](#module_group/nist/scalar..Scalar)
-        * [new Scalar(curve, red)](#new_module_group/nist/scalar..Scalar_new)
-        * [.equal(s2)](#module_group/nist/scalar..Scalar+equal) ⇒ <code>boolean</code>
-        * [.set(a)](#module_group/nist/scalar..Scalar+set) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-        * [.clone()](#module_group/nist/scalar..Scalar+clone) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-        * [.zero()](#module_group/nist/scalar..Scalar+zero) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-        * [.add(s1, s2)](#module_group/nist/scalar..Scalar+add) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-        * [.sub(s1, s2)](#module_group/nist/scalar..Scalar+sub) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-        * [.neg(a)](#module_group/nist/scalar..Scalar+neg) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-        * [.one()](#module_group/nist/scalar..Scalar+one) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-        * [.mul(s1, s2)](#module_group/nist/scalar..Scalar+mul) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-        * [.div(s1, s2)](#module_group/nist/scalar..Scalar+div) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-        * [.inv(a)](#module_group/nist/scalar..Scalar+inv) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-        * [.setBytes(b)](#module_group/nist/scalar..Scalar+setBytes) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-        * [.bytes()](#module_group/nist/scalar..Scalar+bytes) ⇒ <code>Uint8Array</code>
-        * [.pick()](#module_group/nist/scalar..Scalar+pick) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-        * [.marshalBinary()](#module_group/nist/scalar..Scalar+marshalBinary) ⇒ <code>Uint8Array</code>
-        * [.unmarshalBinary(bytes)](#module_group/nist/scalar..Scalar+unmarshalBinary) ⇒ <code>undefined</code>
+* [curves/nist/scalar](#module_curves/nist/scalar)
+    * [~Scalar](#module_curves/nist/scalar..Scalar)
+        * [new Scalar(curve, red)](#new_module_curves/nist/scalar..Scalar_new)
+        * [.equal(s2)](#module_curves/nist/scalar..Scalar+equal) ⇒ <code>boolean</code>
+        * [.set(a)](#module_curves/nist/scalar..Scalar+set) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+        * [.clone()](#module_curves/nist/scalar..Scalar+clone) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+        * [.zero()](#module_curves/nist/scalar..Scalar+zero) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+        * [.add(s1, s2)](#module_curves/nist/scalar..Scalar+add) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+        * [.sub(s1, s2)](#module_curves/nist/scalar..Scalar+sub) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+        * [.neg(a)](#module_curves/nist/scalar..Scalar+neg) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+        * [.one()](#module_curves/nist/scalar..Scalar+one) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+        * [.mul(s1, s2)](#module_curves/nist/scalar..Scalar+mul) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+        * [.div(s1, s2)](#module_curves/nist/scalar..Scalar+div) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+        * [.inv(a)](#module_curves/nist/scalar..Scalar+inv) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+        * [.setBytes(b)](#module_curves/nist/scalar..Scalar+setBytes) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+        * [.bytes()](#module_curves/nist/scalar..Scalar+bytes) ⇒ <code>Uint8Array</code>
+        * [.pick()](#module_curves/nist/scalar..Scalar+pick) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+        * [.marshalBinary()](#module_curves/nist/scalar..Scalar+marshalBinary) ⇒ <code>Uint8Array</code>
+        * [.unmarshalBinary(bytes)](#module_curves/nist/scalar..Scalar+unmarshalBinary) ⇒ <code>undefined</code>
 
-<a name="module_group/nist/scalar..Scalar"></a>
+<a name="module_curves/nist/scalar..Scalar"></a>
 
-### group/nist/scalar~Scalar
+### curves/nist/scalar~Scalar
 Scalar
 
-**Kind**: inner class of [<code>group/nist/scalar</code>](#module_group/nist/scalar)  
+**Kind**: inner class of [<code>curves/nist/scalar</code>](#module_curves/nist/scalar)  
 
-* [~Scalar](#module_group/nist/scalar..Scalar)
-    * [new Scalar(curve, red)](#new_module_group/nist/scalar..Scalar_new)
-    * [.equal(s2)](#module_group/nist/scalar..Scalar+equal) ⇒ <code>boolean</code>
-    * [.set(a)](#module_group/nist/scalar..Scalar+set) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-    * [.clone()](#module_group/nist/scalar..Scalar+clone) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-    * [.zero()](#module_group/nist/scalar..Scalar+zero) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-    * [.add(s1, s2)](#module_group/nist/scalar..Scalar+add) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-    * [.sub(s1, s2)](#module_group/nist/scalar..Scalar+sub) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-    * [.neg(a)](#module_group/nist/scalar..Scalar+neg) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-    * [.one()](#module_group/nist/scalar..Scalar+one) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-    * [.mul(s1, s2)](#module_group/nist/scalar..Scalar+mul) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-    * [.div(s1, s2)](#module_group/nist/scalar..Scalar+div) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-    * [.inv(a)](#module_group/nist/scalar..Scalar+inv) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-    * [.setBytes(b)](#module_group/nist/scalar..Scalar+setBytes) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-    * [.bytes()](#module_group/nist/scalar..Scalar+bytes) ⇒ <code>Uint8Array</code>
-    * [.pick()](#module_group/nist/scalar..Scalar+pick) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
-    * [.marshalBinary()](#module_group/nist/scalar..Scalar+marshalBinary) ⇒ <code>Uint8Array</code>
-    * [.unmarshalBinary(bytes)](#module_group/nist/scalar..Scalar+unmarshalBinary) ⇒ <code>undefined</code>
+* [~Scalar](#module_curves/nist/scalar..Scalar)
+    * [new Scalar(curve, red)](#new_module_curves/nist/scalar..Scalar_new)
+    * [.equal(s2)](#module_curves/nist/scalar..Scalar+equal) ⇒ <code>boolean</code>
+    * [.set(a)](#module_curves/nist/scalar..Scalar+set) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+    * [.clone()](#module_curves/nist/scalar..Scalar+clone) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+    * [.zero()](#module_curves/nist/scalar..Scalar+zero) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+    * [.add(s1, s2)](#module_curves/nist/scalar..Scalar+add) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+    * [.sub(s1, s2)](#module_curves/nist/scalar..Scalar+sub) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+    * [.neg(a)](#module_curves/nist/scalar..Scalar+neg) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+    * [.one()](#module_curves/nist/scalar..Scalar+one) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+    * [.mul(s1, s2)](#module_curves/nist/scalar..Scalar+mul) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+    * [.div(s1, s2)](#module_curves/nist/scalar..Scalar+div) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+    * [.inv(a)](#module_curves/nist/scalar..Scalar+inv) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+    * [.setBytes(b)](#module_curves/nist/scalar..Scalar+setBytes) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+    * [.bytes()](#module_curves/nist/scalar..Scalar+bytes) ⇒ <code>Uint8Array</code>
+    * [.pick()](#module_curves/nist/scalar..Scalar+pick) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
+    * [.marshalBinary()](#module_curves/nist/scalar..Scalar+marshalBinary) ⇒ <code>Uint8Array</code>
+    * [.unmarshalBinary(bytes)](#module_curves/nist/scalar..Scalar+unmarshalBinary) ⇒ <code>undefined</code>
 
-<a name="new_module_group/nist/scalar..Scalar_new"></a>
+<a name="new_module_curves/nist/scalar..Scalar_new"></a>
 
 #### new Scalar(curve, red)
 
 | Param | Type | Description |
 | --- | --- | --- |
-| curve | <code>module:group/nist/curve~Weirstrass</code> |  |
+| curve | <code>module:curves/nist/curve~Weirstrass</code> |  |
 | red | <code>BN.Red</code> | BN.js Reduction context |
 
-<a name="module_group/nist/scalar..Scalar+equal"></a>
+<a name="module_curves/nist/scalar..Scalar+equal"></a>
 
 #### scalar.equal(s2) ⇒ <code>boolean</code>
 Equality test for two Scalars derived from the same Group
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/nist/scalar..Scalar)  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| s2 | [<code>Scalar</code>](#module_group/nist/scalar..Scalar) | Scalar |
+| s2 | [<code>Scalar</code>](#module_curves/nist/scalar..Scalar) | Scalar |
 
-<a name="module_group/nist/scalar..Scalar+set"></a>
+<a name="module_curves/nist/scalar..Scalar+set"></a>
 
-#### scalar.set(a) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
+#### scalar.set(a) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
 Sets the receiver equal to another Scalar a
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/nist/scalar..Scalar)  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| a | [<code>Scalar</code>](#module_group/nist/scalar..Scalar) | Scalar |
+| a | [<code>Scalar</code>](#module_curves/nist/scalar..Scalar) | Scalar |
 
-<a name="module_group/nist/scalar..Scalar+clone"></a>
+<a name="module_curves/nist/scalar..Scalar+clone"></a>
 
-#### scalar.clone() ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
+#### scalar.clone() ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
 Returns a copy of the scalar
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/nist/scalar..Scalar)  
-<a name="module_group/nist/scalar..Scalar+zero"></a>
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)  
+<a name="module_curves/nist/scalar..Scalar+zero"></a>
 
-#### scalar.zero() ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
+#### scalar.zero() ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
 Set to the additive identity (0)
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/nist/scalar..Scalar)  
-<a name="module_group/nist/scalar..Scalar+add"></a>
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)  
+<a name="module_curves/nist/scalar..Scalar+add"></a>
 
-#### scalar.add(s1, s2) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
+#### scalar.add(s1, s2) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
 Set to the modular sums of scalars s1 and s2
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/nist/scalar..Scalar)  
-**Returns**: [<code>Scalar</code>](#module_group/nist/scalar..Scalar) - s1 + s2  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)  
+**Returns**: [<code>Scalar</code>](#module_curves/nist/scalar..Scalar) - s1 + s2  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| s1 | [<code>Scalar</code>](#module_group/nist/scalar..Scalar) | Scalar |
-| s2 | [<code>Scalar</code>](#module_group/nist/scalar..Scalar) | Scalar |
+| s1 | [<code>Scalar</code>](#module_curves/nist/scalar..Scalar) | Scalar |
+| s2 | [<code>Scalar</code>](#module_curves/nist/scalar..Scalar) | Scalar |
 
-<a name="module_group/nist/scalar..Scalar+sub"></a>
+<a name="module_curves/nist/scalar..Scalar+sub"></a>
 
-#### scalar.sub(s1, s2) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
+#### scalar.sub(s1, s2) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
 Set to the modular difference
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/nist/scalar..Scalar)  
-**Returns**: [<code>Scalar</code>](#module_group/nist/scalar..Scalar) - s1 - s2  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)  
+**Returns**: [<code>Scalar</code>](#module_curves/nist/scalar..Scalar) - s1 - s2  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| s1 | [<code>Scalar</code>](#module_group/nist/scalar..Scalar) | Scalar |
-| s2 | [<code>Scalar</code>](#module_group/nist/scalar..Scalar) | Scalar |
+| s1 | [<code>Scalar</code>](#module_curves/nist/scalar..Scalar) | Scalar |
+| s2 | [<code>Scalar</code>](#module_curves/nist/scalar..Scalar) | Scalar |
 
-<a name="module_group/nist/scalar..Scalar+neg"></a>
+<a name="module_curves/nist/scalar..Scalar+neg"></a>
 
-#### scalar.neg(a) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
+#### scalar.neg(a) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
 Set to the modular negation of scalar a
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/nist/scalar..Scalar)  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| a | [<code>Scalar</code>](#module_group/nist/scalar..Scalar) | Scalar |
+| a | [<code>Scalar</code>](#module_curves/nist/scalar..Scalar) | Scalar |
 
-<a name="module_group/nist/scalar..Scalar+one"></a>
+<a name="module_curves/nist/scalar..Scalar+one"></a>
 
-#### scalar.one() ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
+#### scalar.one() ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
 Set to the multiplicative identity (1)
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/nist/scalar..Scalar)  
-<a name="module_group/nist/scalar..Scalar+mul"></a>
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)  
+<a name="module_curves/nist/scalar..Scalar+mul"></a>
 
-#### scalar.mul(s1, s2) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
+#### scalar.mul(s1, s2) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
 Set to the modular products of scalars s1 and s2
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/nist/scalar..Scalar)  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)  
 
 | Param | Type |
 | --- | --- |
-| s1 | [<code>Scalar</code>](#module_group/nist/scalar..Scalar) | 
-| s2 | [<code>Scalar</code>](#module_group/nist/scalar..Scalar) | 
+| s1 | [<code>Scalar</code>](#module_curves/nist/scalar..Scalar) | 
+| s2 | [<code>Scalar</code>](#module_curves/nist/scalar..Scalar) | 
 
-<a name="module_group/nist/scalar..Scalar+div"></a>
+<a name="module_curves/nist/scalar..Scalar+div"></a>
 
-#### scalar.div(s1, s2) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
+#### scalar.div(s1, s2) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
 Set to the modular division of scalar s1 by scalar s2
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/nist/scalar..Scalar)  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)  
 
 | Param | Type |
 | --- | --- |
-| s1 | [<code>Scalar</code>](#module_group/nist/scalar..Scalar) | 
-| s2 | [<code>Scalar</code>](#module_group/nist/scalar..Scalar) | 
+| s1 | [<code>Scalar</code>](#module_curves/nist/scalar..Scalar) | 
+| s2 | [<code>Scalar</code>](#module_curves/nist/scalar..Scalar) | 
 
-<a name="module_group/nist/scalar..Scalar+inv"></a>
+<a name="module_curves/nist/scalar..Scalar+inv"></a>
 
-#### scalar.inv(a) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
+#### scalar.inv(a) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
 Set to the modular inverse of scalar a
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/nist/scalar..Scalar)  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)  
 
 | Param | Type |
 | --- | --- |
-| a | [<code>Scalar</code>](#module_group/nist/scalar..Scalar) | 
+| a | [<code>Scalar</code>](#module_curves/nist/scalar..Scalar) | 
 
-<a name="module_group/nist/scalar..Scalar+setBytes"></a>
+<a name="module_curves/nist/scalar..Scalar+setBytes"></a>
 
-#### scalar.setBytes(b) ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
+#### scalar.setBytes(b) ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
 Sets the scalar from big-endian Uint8Array
 and reduces to the appropriate modulus
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/nist/scalar..Scalar)  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)  
 **Throws**:
 
 - <code>TypeError</code> when b is not Uint8Array
@@ -1087,32 +1072,32 @@ and reduces to the appropriate modulus
 | --- | --- |
 | b | <code>Uint8Array</code> | 
 
-<a name="module_group/nist/scalar..Scalar+bytes"></a>
+<a name="module_curves/nist/scalar..Scalar+bytes"></a>
 
 #### scalar.bytes() ⇒ <code>Uint8Array</code>
 Returns a big-endian representation of the scalar
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/nist/scalar..Scalar)  
-<a name="module_group/nist/scalar..Scalar+pick"></a>
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)  
+<a name="module_curves/nist/scalar..Scalar+pick"></a>
 
-#### scalar.pick() ⇒ [<code>Scalar</code>](#module_group/nist/scalar..Scalar)
+#### scalar.pick() ⇒ [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)
 Set to a random scalar
 
 param {function} [callback] - to generate randomBytes of given length
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/nist/scalar..Scalar)  
-<a name="module_group/nist/scalar..Scalar+marshalBinary"></a>
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)  
+<a name="module_curves/nist/scalar..Scalar+marshalBinary"></a>
 
 #### scalar.marshalBinary() ⇒ <code>Uint8Array</code>
 Returns the binary representation (big endian) of the scalar
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/nist/scalar..Scalar)  
-<a name="module_group/nist/scalar..Scalar+unmarshalBinary"></a>
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)  
+<a name="module_curves/nist/scalar..Scalar+unmarshalBinary"></a>
 
 #### scalar.unmarshalBinary(bytes) ⇒ <code>undefined</code>
 Reads the binary representation (big endian) of scalar
 
-**Kind**: instance method of [<code>Scalar</code>](#module_group/nist/scalar..Scalar)  
+**Kind**: instance method of [<code>Scalar</code>](#module_curves/nist/scalar..Scalar)  
 
 | Param | Type |
 | --- | --- |
@@ -1124,7 +1109,7 @@ Reads the binary representation (big endian) of scalar
 
 * [sign/schnorr](#module_sign/schnorr)
     * [~Verify(suite, publicKey, message, signature)](#module_sign/schnorr..Verify) ⇒ <code>boolean</code>
-    * [~hashSchnorr(...inputs)](#module_sign/schnorr..hashSchnorr) ⇒ [<code>Scalar</code>](#module_group..Scalar)
+    * [~hashSchnorr(...inputs)](#module_sign/schnorr..hashSchnorr) ⇒ [<code>Scalar</code>](#Scalar)
 
 <a name="module_sign/schnorr..Verify"></a>
 
@@ -1137,14 +1122,14 @@ key.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| suite | [<code>Group</code>](#module_group..Group) | suite to use |
-| publicKey | [<code>Point</code>](#module_group..Point) | public key under which to verify the signature |
+| suite | [<code>Group</code>](#Group) | suite to use |
+| publicKey | [<code>Point</code>](#Point) | public key under which to verify the signature |
 | message | <code>Uint8Array</code> | message that is signed |
 | signature | <code>Uint8Array</code> | signature made over the given message |
 
 <a name="module_sign/schnorr..hashSchnorr"></a>
 
-### sign/schnorr~hashSchnorr(...inputs) ⇒ [<code>Scalar</code>](#module_group..Scalar)
+### sign/schnorr~hashSchnorr(...inputs) ⇒ [<code>Scalar</code>](#Scalar)
 hashSchnorr returns a scalar out of hashing the given inputs.
 
 **Kind**: inner method of [<code>sign/schnorr</code>](#module_sign/schnorr)  
@@ -1153,6 +1138,26 @@ hashSchnorr returns a scalar out of hashing the given inputs.
 | --- | --- |
 | ...inputs | <code>Uint8Array</code> | 
 
+<a name="Group"></a>
+
+## Group
+Group is an abstract class for curves
+
+**Kind**: global class  
+<a name="Point"></a>
+
+## Point
+Point is an abstract class for representing
+a point on an elliptic curve
+
+**Kind**: global class  
+<a name="Scalar"></a>
+
+## Scalar
+Scalar is an abstract class for representing a scalar
+to be used in elliptic curve operations
+
+**Kind**: global class  
 <a name="bits"></a>
 
 ## bits(bitlen, exact, callback) ⇒ <code>Uint8Array</code>

--- a/external/js/kyber/index.js
+++ b/external/js/kyber/index.js
@@ -2,5 +2,10 @@
 
 const kyber = exports;
 
-kyber.group = require("./lib/group");
+kyber.curves = require("./lib/group");
 kyber.sign = require("./lib/sign");
+const abstractCls = require("./lib/index.js");
+
+kyber.Group = abstractCls.Group;
+kyber.Point = abstractCls.Point;
+kyber.Scalar = abstractCls.Scalar;

--- a/external/js/kyber/lib/group/edwards25519/curve.js
+++ b/external/js/kyber/lib/group/edwards25519/curve.js
@@ -8,10 +8,10 @@ const EdDSA = elliptic.eddsa;
 const ec = new EdDSA("ed25519");
 const BN = require("bn.js");
 const orderRed = BN.red(ec.curve.n);
-const group = require("../group.js");
+const group = require("../../index.js");
 
 /**
- * @module group/edwards25519/curve
+ * @module curves/edwards25519/curve
  */
 
 /**
@@ -45,7 +45,7 @@ class Edwards25519 extends group.Group {
   /**
    * Returns a new Scalar for the prime-order subgroup of Ed25519 curve
    *
-   * @returns {module:group/edwards25519/scalar~Scalar}
+   * @returns {module:curves/edwards25519/scalar~Scalar}
    */
   scalar() {
     return new Scalar(this, this.orderRed);
@@ -63,7 +63,7 @@ class Edwards25519 extends group.Group {
   /**
    * Creates a new point on the Ed25519 curve
    *
-   * @returns {module:group/edwards25519/point~Point}
+   * @returns {module:curves/edwards25519/point~Point}
    */
   point() {
     return new Point(this);
@@ -72,7 +72,7 @@ class Edwards25519 extends group.Group {
   /**
    * NewKey returns a formatted Ed25519 key (avoiding subgroup attack by requiring
    * it to be a multiple of 8).
-   * @returns {module:group/edwards25519/scalar~Scalar}
+   * @returns {module:curves/edwards25519/scalar~Scalar}
    */
   newKey() {
     let bytes = crypto.randomBytes(32);

--- a/external/js/kyber/lib/group/edwards25519/point.js
+++ b/external/js/kyber/lib/group/edwards25519/point.js
@@ -3,10 +3,10 @@
 const BN = require("bn.js");
 const crypto = require("crypto");
 const Scalar = require("./scalar");
-const group = require("../group.js");
+const group = require("../../index.js");
 
 /**
- * @module group/edwards25519/point
+ * @module curves/edwards25519/point
  */
 
 /**
@@ -17,7 +17,7 @@ const group = require("../group.js");
  * passed as a Uint8Array
  * @constructor
  *
- * @param {module:group/edwards25519~Edwards25519} curve
+ * @param {module:curves/edwards25519~Edwards25519} curve
  * @param {(number|Uint8Array|BN.jsObjcurvet)} X
  * @param {(number|Uint8Array|BN.jsObjcurvet)} Y
  * @param {(number|Uint8Array|BN.jsObjcurvet)} Z
@@ -43,7 +43,7 @@ class Point extends group.Point {
     if (T !== undefined && T.constructor === Uint8Array) {
       _T = new BN(T, 16, "le");
     }
-    // the point reference is stored in an module:group/edwards25519/point~Point to make set()
+    // the point reference is stored in an module:curves/edwards25519/point~Point to make set()
     // consistent.
     this.ref = {
       point: curve.curve.point(_X, _Y, _Z, _T),
@@ -70,7 +70,7 @@ class Point extends group.Point {
   /**
    * Tests for equality between two Points derived from the same group
    *
-   * @param {module:group/edwards25519/point~Point} p2 Point module:group/edwards25519/point~Point to compare
+   * @param {module:curves/edwards25519/point~Point} p2 Point module:curves/edwards25519/point~Point to compare
    * @returns {boolean}
    */
   equal(p2) {
@@ -89,8 +89,8 @@ class Point extends group.Point {
   /**
    * set Set the current point to be equal to p2
    *
-   * @param {module:group/edwards25519/point~Point} p2 Point module:group/edwards25519/point~Point
-   * @returns {module:group/edwards25519/point~Point}
+   * @param {module:curves/edwards25519/point~Point} p2 Point module:curves/edwards25519/point~Point
+   * @returns {module:curves/edwards25519/point~Point}
    */
   set(p2) {
     this.ref = p2.ref;
@@ -100,7 +100,7 @@ class Point extends group.Point {
   /**
    * Creates a copy of the current point
    *
-   * @returns {module:group/edwards25519/point~Point} new Point module:group/edwards25519/point~Point
+   * @returns {module:curves/edwards25519/point~Point} new Point module:curves/edwards25519/point~Point
    */
   clone() {
     const point = this.ref.point;
@@ -111,7 +111,7 @@ class Point extends group.Point {
    * Set to the neutral element, which is (0, 1) for twisted Edwards
    * Curve
    *
-   * @returns {module:group/edwards25519/point~Point}
+   * @returns {module:curves/edwards25519/point~Point}
    */
   null() {
     this.ref.point = this.ref.curve.curve.point(0, 1, 1, 0);
@@ -121,7 +121,7 @@ class Point extends group.Point {
   /**
    * Set to the standard base point for this curve
    *
-   * @returns {module:group/edwards25519/point~Point}
+   * @returns {module:curves/edwards25519/point~Point}
    */
   base() {
     this.ref.point = this.ref.curve.curve.point(
@@ -151,7 +151,7 @@ class Point extends group.Point {
    *
    * @throws {TypeError} if data is not Uint8Array
    * @throws {Error} if data.length > embedLen
-   * @returns {module:group/edwards25519/point~Point}
+   * @returns {module:curves/edwards25519/point~Point}
    */
   embed(data, callback) {
     if (data.constructor !== Uint8Array) {
@@ -224,9 +224,9 @@ class Point extends group.Point {
   /**
    * Returns the sum of two points on the curve
    *
-   * @param {module:group/edwards25519/point~Point} p1 Point module:group/edwards25519/point~Point, addend
-   * @param {module:group/edwards25519/point~Point} p2 Point module:group/edwards25519/point~Point, addend
-   * @returns {module:group/edwards25519/point~Point} p1 + p2
+   * @param {module:curves/edwards25519/point~Point} p1 Point module:curves/edwards25519/point~Point, addend
+   * @param {module:curves/edwards25519/point~Point} p2 Point module:curves/edwards25519/point~Point, addend
+   * @returns {module:curves/edwards25519/point~Point} p1 + p2
    */
   add(p1, p2) {
     const point = p1.ref.point;
@@ -239,9 +239,9 @@ class Point extends group.Point {
   /**
    * Subtract two points
    *
-   * @param {module:group/edwards25519/point~Point} p1 Point module:group/edwards25519/point~Point
-   * @param {module:group/edwards25519/point~Point} p2 Point module:group/edwards25519/point~Point
-   * @returns {module:group/edwards25519/point~Point} p1 - p2
+   * @param {module:curves/edwards25519/point~Point} p1 Point module:curves/edwards25519/point~Point
+   * @param {module:curves/edwards25519/point~Point} p2 Point module:curves/edwards25519/point~Point
+   * @returns {module:curves/edwards25519/point~Point} p1 - p2
    */
   sub(p1, p2) {
     const point = p1.ref.point;
@@ -255,8 +255,8 @@ class Point extends group.Point {
    * Finds the negative of a point p
    * For Edwards Curves, the negative of (x, y) is (-x, y)
    *
-   * @param {module:group/edwards25519/point~Point} p Point to negate
-   * @returns {module:group/edwards25519/point~Point} -p
+   * @param {module:curves/edwards25519/point~Point} p Point to negate
+   * @returns {module:curves/edwards25519/point~Point} -p
    */
   neg(p) {
     this.ref.point = p.ref.point.neg();
@@ -266,9 +266,9 @@ class Point extends group.Point {
   /**
    * Multiply point p by scalar s
    *
-   * @param {module:group/edwards25519/point~Point} s Scalar
-   * @param {module:group/edwards25519/point~Point} [p] Point
-   * @returns {module:group/edwards25519/point~Point}
+   * @param {module:curves/edwards25519/point~Point} s Scalar
+   * @param {module:curves/edwards25519/point~Point} [p] Point
+   * @returns {module:curves/edwards25519/point~Point}
    */
   mul(s, p) {
     if (s.constructor !== Scalar) {
@@ -285,7 +285,7 @@ class Point extends group.Point {
    * Selects a random point
    *
    * @param {function} callback - to generate a random byte array of given length
-   * @returns {module:group/edwards25519/point~Point}
+   * @returns {module:curves/edwards25519/point~Point}
    */
   pick(callback) {
     return this.embed(new Uint8Array(), callback);
@@ -316,7 +316,7 @@ class Point extends group.Point {
    *
    * @throws {TypeError} when bytes is not Uint8Array
    * @throws {Error} when bytes does not correspond to a valid point
-   * @returns {module:group/edwards25519/point~Point}
+   * @returns {module:curves/edwards25519/point~Point}
    */
   unmarshalBinary(bytes) {
     if (bytes.constructor !== Uint8Array) {

--- a/external/js/kyber/lib/group/edwards25519/scalar.js
+++ b/external/js/kyber/lib/group/edwards25519/scalar.js
@@ -3,10 +3,10 @@
 const BN = require("bn.js");
 const crypto = require("crypto");
 const random = require("../../random");
-const group = require("../group.js");
+const group = require("../../index.js");
 
 /**
- * @module group/edwards25519/scalar
+ * @module curves/edwards25519/scalar
  */
 
 /**
@@ -28,7 +28,7 @@ class Scalar extends group.Scalar {
   /**
    * Equality test for two Scalars derived from the same Group
    *
-   * @param {module:group/edwards25519/scalar~Scalar} s2 Scalar
+   * @param {module:curves/edwards25519/scalar~Scalar} s2 Scalar
    * @returns {boolean}
    */
   equal(s2) {
@@ -38,8 +38,8 @@ class Scalar extends group.Scalar {
   /**
    * Sets the receiver equal to another Scalar a
    *
-   * @param {module:group/edwards25519/scalar~Scalar} a Scalar
-   * @returns {module:group/edwards25519/scalar~Scalar}
+   * @param {module:curves/edwards25519/scalar~Scalar} a Scalar
+   * @returns {module:curves/edwards25519/scalar~Scalar}
    */
   set(a) {
     this.ref = a.ref;
@@ -49,7 +49,7 @@ class Scalar extends group.Scalar {
   /**
    * Returns a copy of the scalar
    *
-   * @returns {module:group/edwards25519/scalar~Scalar}
+   * @returns {module:curves/edwards25519/scalar~Scalar}
    */
   clone() {
     return new Scalar(this.ref.curve, this.ref.red).setBytes(
@@ -60,7 +60,7 @@ class Scalar extends group.Scalar {
   /**
    * Set to the additive identity (0)
    *
-   * @returns {module:group/edwards25519/scalar~Scalar}
+   * @returns {module:curves/edwards25519/scalar~Scalar}
    */
   zero() {
     this.ref.arr = new BN(0, 16).toRed(this.ref.red);
@@ -70,9 +70,9 @@ class Scalar extends group.Scalar {
   /**
    * Set to the modular sums of scalars s1 and s2
    *
-   * @param {module:group/edwards25519/scalar~Scalar} s1 Scalar
-   * @param {module:group/edwards25519/scalar~Scalar} s2 Scalar
-   * @returns {module:group/edwards25519/scalar~Scalar} s1 + s2
+   * @param {module:curves/edwards25519/scalar~Scalar} s1 Scalar
+   * @param {module:curves/edwards25519/scalar~Scalar} s2 Scalar
+   * @returns {module:curves/edwards25519/scalar~Scalar} s1 + s2
    */
   add(s1, s2) {
     this.ref.arr = s1.ref.arr.redAdd(s2.ref.arr);
@@ -82,9 +82,9 @@ class Scalar extends group.Scalar {
   /**
    * Set to the modular difference
    *
-   * @param {module:group/edwards25519/scalar~Scalar} s1 Scalar
-   * @param {module:group/edwards25519/scalar~Scalar} s2 Scalar
-   * @returns {module:group/edwards25519/scalar~Scalar} s1 - s2
+   * @param {module:curves/edwards25519/scalar~Scalar} s1 Scalar
+   * @param {module:curves/edwards25519/scalar~Scalar} s2 Scalar
+   * @returns {module:curves/edwards25519/scalar~Scalar} s1 - s2
    */
   sub(s1, s2) {
     this.ref.arr = s1.ref.arr.redSub(s2.ref.arr);
@@ -94,8 +94,8 @@ class Scalar extends group.Scalar {
   /**
    * Set to the modular negation of scalar a
    *
-   * @param {module:group/edwards25519/scalar~Scalar} a Scalar
-   * @returns {module:group/edwards25519/scalar~Scalar}
+   * @param {module:curves/edwards25519/scalar~Scalar} a Scalar
+   * @returns {module:curves/edwards25519/scalar~Scalar}
    */
   neg(a) {
     this.ref.arr = a.ref.arr.redNeg();
@@ -105,7 +105,7 @@ class Scalar extends group.Scalar {
   /**
    * Set to the multiplicative identity (1)
    *
-   * @returns {module:group/edwards25519/scalar~Scalar}
+   * @returns {module:curves/edwards25519/scalar~Scalar}
    */
   one() {
     this.ref.arr = new BN(1, 16).toRed(this.ref.red);
@@ -115,9 +115,9 @@ class Scalar extends group.Scalar {
   /**
    * Set to the modular products of scalars s1 and s2
    *
-   * @param {module:group/edwards25519/scalar~Scalar} s1
-   * @param {module:group/edwards25519/scalar~Scalar} s2
-   * @returns {module:group/edwards25519/scalar~Scalar}
+   * @param {module:curves/edwards25519/scalar~Scalar} s1
+   * @param {module:curves/edwards25519/scalar~Scalar} s2
+   * @returns {module:curves/edwards25519/scalar~Scalar}
    */
   mul(s1, s2) {
     this.ref.arr = s1.ref.arr.redMul(s2.ref.arr);
@@ -129,7 +129,7 @@ class Scalar extends group.Scalar {
    *
    * @param s1
    * @param s2
-   * @returns {module:group/edwards25519/scalar~Scalar}
+   * @returns {module:curves/edwards25519/scalar~Scalar}
    */
   div(s1, s2) {
     this.ref.arr = s1.ref.arr.redMul(s2.ref.arr.redInvm());
@@ -140,7 +140,7 @@ class Scalar extends group.Scalar {
    * Set to the modular inverse of scalar a
    *
    * @param a
-   * @returns {module:group/edwards25519/scalar~Scalar}
+   * @returns {module:curves/edwards25519/scalar~Scalar}
    */
   inv(a) {
     this.ref.arr = a.ref.arr.redInvm();
@@ -153,7 +153,7 @@ class Scalar extends group.Scalar {
    * @param {Uint8Array} b - bytes
    *
    * @throws {TypeError} when b is not Uint8Array
-   * @returns {module:group/edwards25519/scalar~Scalar}
+   * @returns {module:curves/edwards25519/scalar~Scalar}
    */
   setBytes(b) {
     if (b.constructor !== Uint8Array) {
@@ -183,7 +183,7 @@ class Scalar extends group.Scalar {
    * Set to a random scalar
    *
    * @param {function} callback - to generate random byte array of given length
-   * @returns {module:group/edwards25519/scalar~Scalar}
+   * @returns {module:curves/edwards25519/scalar~Scalar}
    */
   pick(callback) {
     callback = callback || crypto.randomBytes;
@@ -222,4 +222,3 @@ class Scalar extends group.Scalar {
   }
 }
 module.exports = Scalar;
-

--- a/external/js/kyber/lib/group/nist/curve.js
+++ b/external/js/kyber/lib/group/nist/curve.js
@@ -5,10 +5,10 @@ const Point = require("./point");
 const crypto = require("crypto");
 const elliptic = require("elliptic");
 const BN = require("bn.js");
-const group = require("../group.js");
+const group = require("../../index.js");
 
 /**
- * @module group/nist/curve
+ * @module curves/nist/curve
  */
 
 /**
@@ -70,7 +70,7 @@ class Weierstrass extends group.Group {
   /**
    * Returns the size in bytes of a point
    *
-   * @returns {module:group/nist/scalar~Scalar}
+   * @returns {module:curves/nist/scalar~Scalar}
    */
   scalar() {
     return new Scalar(this, this.redN);
@@ -89,7 +89,7 @@ class Weierstrass extends group.Group {
   /**
    * Returns a new Point
    *
-   * @returns {module:group/nist/point~Point}
+   * @returns {module:curves/nist/point~Point}
    */
   point() {
     return new Point(this);

--- a/external/js/kyber/lib/group/nist/point.js
+++ b/external/js/kyber/lib/group/nist/point.js
@@ -4,10 +4,10 @@ const BN = require("bn.js");
 const crypto = require("crypto");
 const Scalar = require("./scalar");
 const constants = require("../../constants");
-const group = require("../group.js");
+const group = require("../../index.js");
 
 /**
- * @module group/nist/point
+ * @module curves/nist/point
  */
 
 /**
@@ -16,7 +16,7 @@ const group = require("../group.js");
  * The value of the parameters is expected in little endian form if being
  * passed as a Uint8Array
  *
- * @param {module:group/nist/curve~Weirstrass} curve - Weierstrass curve
+ * @param {module:curves/nist/curve~Weirstrass} curve - Weierstrass curve
  * @param {(number|Uint8Array|BN.jsObject)} x
  * @param {(number|Uint8Array|BN.jsObject)} y
  */
@@ -63,11 +63,10 @@ class Point extends group.Point {
     );
   }
 
-
   /**
    * Tests for equality between two Points derived from the same group
    *
-   * @param {module:group/nist/point~Point} p2 Point object to compare
+   * @param {module:curves/nist/point~Point} p2 Point object to compare
    * @return {boolean}
    */
   equal(p2) {
@@ -88,8 +87,8 @@ class Point extends group.Point {
   /**
    * set Set the current point to be equal to p2
    *
-   * @param {module:group/nist/point~Point} p2 Point object
-   * @return {module:group/nist/point~Point}
+   * @param {module:curves/nist/point~Point} p2 Point object
+   * @return {module:curves/nist/point~Point}
    */
   set(p2) {
     this.ref = p2.ref;
@@ -99,7 +98,7 @@ class Point extends group.Point {
   /**
    * Creates a copy of the current point
    *
-   * @return {module:group/nist/point~Point} new Point object
+   * @return {module:curves/nist/point~Point} new Point object
    */
   clone() {
     const point = this.ref.point;
@@ -110,7 +109,7 @@ class Point extends group.Point {
    * Set to the neutral element for the curve
    * Modifies the receiver
    *
-   * @return {module:group/nist/point~Point}
+   * @return {module:curves/nist/point~Point}
    */
   null() {
     this.ref.point = this.ref.curve.curve.point(null, null);
@@ -121,7 +120,7 @@ class Point extends group.Point {
    * Set to the standard base point for this curve
    * Modifies the receiver
    *
-   * @return {module:group/nist/point~Point}
+   * @return {module:curves/nist/point~Point}
    */
   base() {
     const g = this.ref.curve.curve.g;
@@ -149,7 +148,7 @@ class Point extends group.Point {
    *
    * @throws {TypeError} if data is not Uint8Array
    * @throws {Error} if data.length > embedLen
-   * @return {module:group/nist/point~Point}
+   * @return {module:curves/nist/point~Point}
    */
   embed(data, callback) {
     if (data.constructor !== Uint8Array) {
@@ -233,9 +232,9 @@ class Point extends group.Point {
    * Returns the sum of two points on the curve
    * Modifies the receiver
    *
-   * @param {module:group/nist/point~Point} p1 Point object, addend
-   * @param {module:group/nist/point~Point} p2 Point object, addend
-   * @return {module:group/nist/point~Point} p1 + p2
+   * @param {module:curves/nist/point~Point} p1 Point object, addend
+   * @param {module:curves/nist/point~Point} p2 Point object, addend
+   * @return {module:curves/nist/point~Point} p1 + p2
    */
   add(p1, p2) {
     const point = p1.ref.point;
@@ -249,9 +248,9 @@ class Point extends group.Point {
    * Subtract two points
    * Modifies the receiver
    *
-   * @param {module:group/nist/point~Point} p1 Point object
-   * @param {module:group/nist/point~Point} p2 Point object
-   * @return {module:group/nist/point~Point} p1 - p2
+   * @param {module:curves/nist/point~Point} p1 Point object
+   * @param {module:curves/nist/point~Point} p2 Point object
+   * @return {module:curves/nist/point~Point} p1 - p2
    */
   sub(p1, p2) {
     const point = p1.ref.point;
@@ -265,8 +264,8 @@ class Point extends group.Point {
    * Finds the negative of a point p
    * Modifies the receiver
    *
-   * @param {module:group/nist/point~Point} p Point to negate
-   * @return {module:group/nist/point~Point} -p
+   * @param {module:curves/nist/point~Point} p Point to negate
+   * @return {module:curves/nist/point~Point} -p
    */
   neg(p) {
     this.ref.point = p.ref.point.neg();
@@ -279,9 +278,9 @@ class Point extends group.Point {
    * scalar s
    * Modifies the receiver
    *
-   * @param {module:group/nist/scalar~Scalar} s Scalar
-   * @param {module:group/nist/point~Point} [p=null] Point
-   * @return {module:group/nist/point~Point}
+   * @param {module:curves/nist/scalar~Scalar} s Scalar
+   * @param {module:curves/nist/point~Point} [p=null] Point
+   * @return {module:curves/nist/point~Point}
    */
   mul(s, p) {
     if (s.constructor !== Scalar) {
@@ -298,7 +297,7 @@ class Point extends group.Point {
    * Selects a random point
    *
    * @param {function} [callback] - to generate a random byte array of given length
-   * @return {module:group/nist/point~Point}
+   * @return {module:curves/nist/point~Point}
    */
   pick(callback) {
     return this.embed(new Uint8Array(), callback);

--- a/external/js/kyber/lib/group/nist/scalar.js
+++ b/external/js/kyber/lib/group/nist/scalar.js
@@ -3,15 +3,15 @@
 const BN = require("bn.js");
 const crypto = require("crypto");
 const random = require("../../random");
-const group = require("../group.js");
+const group = require("../../index.js");
 
 /**
- * @module group/nist/scalar
+ * @module curves/nist/scalar
  */
 
 /**
  * Scalar
- * @param {module:group/nist/curve~Weirstrass} curve
+ * @param {module:curves/nist/curve~Weirstrass} curve
  * @param {BN.Red} red - BN.js Reduction context
  * @constructor
  */
@@ -30,7 +30,7 @@ class Scalar extends group.Scalar {
   /**
    * Equality test for two Scalars derived from the same Group
    *
-   * @param {module:group/nist/scalar~Scalar} s2 Scalar
+   * @param {module:curves/nist/scalar~Scalar} s2 Scalar
    * @return {boolean}
    */
   equal(s2) {
@@ -40,8 +40,8 @@ class Scalar extends group.Scalar {
   /**
    * Sets the receiver equal to another Scalar a
    *
-   * @param {module:group/nist/scalar~Scalar} a Scalar
-   * @return {module:group/nist/scalar~Scalar}
+   * @param {module:curves/nist/scalar~Scalar} a Scalar
+   * @return {module:curves/nist/scalar~Scalar}
    */
   set(a) {
     this.ref = a.ref;
@@ -51,7 +51,7 @@ class Scalar extends group.Scalar {
   /**
    * Returns a copy of the scalar
    *
-   * @return {module:group/nist/scalar~Scalar}
+   * @return {module:curves/nist/scalar~Scalar}
    */
   clone() {
     return new Scalar(this.ref.curve, this.ref.red).setBytes(
@@ -62,7 +62,7 @@ class Scalar extends group.Scalar {
   /**
    * Set to the additive identity (0)
    *
-   * @return {module:group/nist/scalar~Scalar}
+   * @return {module:curves/nist/scalar~Scalar}
    */
   zero() {
     this.ref.arr = new BN(0, 16).toRed(this.ref.red);
@@ -72,9 +72,9 @@ class Scalar extends group.Scalar {
   /**
    * Set to the modular sums of scalars s1 and s2
    *
-   * @param {module:group/nist/scalar~Scalar} s1 Scalar
-   * @param {module:group/nist/scalar~Scalar} s2 Scalar
-   * @return {module:group/nist/scalar~Scalar} s1 + s2
+   * @param {module:curves/nist/scalar~Scalar} s1 Scalar
+   * @param {module:curves/nist/scalar~Scalar} s2 Scalar
+   * @return {module:curves/nist/scalar~Scalar} s1 + s2
    */
   add(s1, s2) {
     this.ref.arr = s1.ref.arr.redAdd(s2.ref.arr);
@@ -84,9 +84,9 @@ class Scalar extends group.Scalar {
   /**
    * Set to the modular difference
    *
-   * @param {module:group/nist/scalar~Scalar} s1 Scalar
-   * @param {module:group/nist/scalar~Scalar} s2 Scalar
-   * @return {module:group/nist/scalar~Scalar} s1 - s2
+   * @param {module:curves/nist/scalar~Scalar} s1 Scalar
+   * @param {module:curves/nist/scalar~Scalar} s2 Scalar
+   * @return {module:curves/nist/scalar~Scalar} s1 - s2
    */
   sub(s1, s2) {
     this.ref.arr = s1.ref.arr.redSub(s2.ref.arr);
@@ -96,8 +96,8 @@ class Scalar extends group.Scalar {
   /**
    * Set to the modular negation of scalar a
    *
-   * @param {module:group/nist/scalar~Scalar} a Scalar
-   * @return {module:group/nist/scalar~Scalar}
+   * @param {module:curves/nist/scalar~Scalar} a Scalar
+   * @return {module:curves/nist/scalar~Scalar}
    */
   neg(a) {
     this.ref.arr = a.ref.arr.redNeg();
@@ -107,7 +107,7 @@ class Scalar extends group.Scalar {
   /**
    * Set to the multiplicative identity (1)
    *
-   * @return {module:group/nist/scalar~Scalar}
+   * @return {module:curves/nist/scalar~Scalar}
    */
   one() {
     this.ref.arr = new BN(1, 16).toRed(this.ref.red);
@@ -117,9 +117,9 @@ class Scalar extends group.Scalar {
   /**
    * Set to the modular products of scalars s1 and s2
    *
-   * @param {module:group/nist/scalar~Scalar} s1
-   * @param {module:group/nist/scalar~Scalar} s2
-   * @return {module:group/nist/scalar~Scalar}
+   * @param {module:curves/nist/scalar~Scalar} s1
+   * @param {module:curves/nist/scalar~Scalar} s2
+   * @return {module:curves/nist/scalar~Scalar}
    */
   mul(s1, s2) {
     this.ref.arr = s1.ref.arr.redMul(s2.ref.arr);
@@ -129,9 +129,9 @@ class Scalar extends group.Scalar {
   /**
    * Set to the modular division of scalar s1 by scalar s2
    *
-   * @param {module:group/nist/scalar~Scalar} s1
-   * @param {module:group/nist/scalar~Scalar} s2
-   * @return {module:group/nist/scalar~Scalar}
+   * @param {module:curves/nist/scalar~Scalar} s1
+   * @param {module:curves/nist/scalar~Scalar} s2
+   * @return {module:curves/nist/scalar~Scalar}
    */
   div(s1, s2) {
     this.ref.arr = s1.ref.arr.redMul(s2.ref.arr.redInvm());
@@ -141,8 +141,8 @@ class Scalar extends group.Scalar {
   /**
    * Set to the modular inverse of scalar a
    *
-   * @param {module:group/nist/scalar~Scalar} a
-   * @return {module:group/nist/scalar~Scalar}
+   * @param {module:curves/nist/scalar~Scalar} a
+   * @return {module:curves/nist/scalar~Scalar}
    */
   inv(a) {
     this.ref.arr = a.ref.arr.redInvm();
@@ -155,7 +155,7 @@ class Scalar extends group.Scalar {
    * @param {Uint8Array} b
    *
    * @throws {TypeError} when b is not Uint8Array
-   * @return {module:group/nist/scalar~Scalar}
+   * @return {module:curves/nist/scalar~Scalar}
    */
   setBytes(b) {
     if (b.constructor !== Uint8Array) {
@@ -185,7 +185,7 @@ class Scalar extends group.Scalar {
    * Set to a random scalar
    *
    * param {function} [callback] - to generate randomBytes of given length
-   * @return {module:group/nist/scalar~Scalar}
+   * @return {module:curves/nist/scalar~Scalar}
    */
   pick(callback) {
     callback = callback || crypto.randomBytes;

--- a/external/js/kyber/lib/index.js
+++ b/external/js/kyber/lib/index.js
@@ -1,8 +1,4 @@
 /**
- * @module group
- */
-
-/**
  * Group is an abstract class for curves
  */
 class Group {

--- a/external/js/kyber/lib/sign/schnorr/schnorr.js
+++ b/external/js/kyber/lib/sign/schnorr/schnorr.js
@@ -1,4 +1,4 @@
-const group = require("../../group/group.js");
+const group = require("../../index.js");
 
 const hash = require("hash.js");
 
@@ -10,7 +10,7 @@ const hash = require("hash.js");
  *
  * Sign computes a Schnorr signature over the given message.
  *
- * @param {module:group~Scalar} privateKey - private key scalar to sign with
+ * @param {Scalar} privateKey - private key scalar to sign with
  * @param {Uint8Array} message - message over which the signature is computed
  * @return {Uint8Array} signature as a Uint8Array
  * */
@@ -53,8 +53,8 @@ function Sign(suite, privateKey, message) {
  * Verify verifies if the signature of the message is valid under the given public
  * key.
  *
- * @param {module:group~Group} suite - suite to use
- * @param {module:group~Point} publicKey public key under which to verify the signature
+ * @param {Group} suite - suite to use
+ * @param {Point} publicKey public key under which to verify the signature
  * @param {Uint8Array} message - message that is signed
  * @param {Uint8Array} signature - signature made over the given message
  * @return {boolean}  true if signature is valid or false otherwise.
@@ -110,7 +110,7 @@ function Verify(suite, publicKey, message, signature) {
  *
  * hashSchnorr returns a scalar out of hashing the given inputs.
  * @param {...Uint8Array} inputs
- * @return {module:group~Scalar}
+ * @return {Scalar}
  *
  **/
 function hashSchnorr(suite, ...inputs) {

--- a/external/js/kyber/test/group/edwards25519/index.js
+++ b/external/js/kyber/test/group/edwards25519/index.js
@@ -1,7 +1,7 @@
 const EdDSA = require("elliptic").eddsa;
 const ec = new EdDSA("ed25519");
 const kyber = require("../../../index.js");
-const edwards25519 = kyber.group.edwards25519;
+const edwards25519 = kyber.curves.edwards25519;
 const BN = require("bn.js");
 const util = require("../../util");
 const unhexlify = util.unhexlify;

--- a/external/js/kyber/test/group/nist/index.js
+++ b/external/js/kyber/test/group/nist/index.js
@@ -1,5 +1,5 @@
 const kyber = require("../../../index.js");
-const nist = kyber.group.nist;
+const nist = kyber.curves.nist;
 const BN = require("bn.js");
 const assert = require("chai").assert;
 const PRNG = require("../../util").PRNG;

--- a/external/js/kyber/test/sign/schnorr/schnorr.js
+++ b/external/js/kyber/test/sign/schnorr/schnorr.js
@@ -5,7 +5,7 @@ const assert = chai.assert;
 const kyber = require("../../../index.js");
 const schnorr = kyber.sign.schnorr;
 // XXX to be changed to an interface style
-const nist = kyber.group.nist;
+const nist = kyber.curves.nist;
 var group = new nist.Curve(nist.Params.p256);
 const secretKey = group.scalar().pick();
 const publicKey = group.point().mul(secretKey, null);


### PR DESCRIPTION
exposes kyber.Group, kyber.Point and kyber.Scalar and changes
kyber.group module to kyber.curves to avoid ambiguity