### PR TITLE
Skipchain signature

### DIFF
--- a/scmgr/app.go
+++ b/scmgr/app.go
@@ -380,7 +380,7 @@ func scPrint(c *cli.Context) error {
 		log.Infof("BackwardLink[%d] = %x", i, bl)
 	}
 	for i, fl := range sb.ForwardLink {
-		log.Infof("ForwardLink[%d] = %x", i, fl.Msg)
+		log.Infof("ForwardLink[%d] = %x", i, fl.To)
 	}
 	log.Infof("Data: %#v", string(sb.Data))
 	for i, vf := range sb.VerifierIDs {

--- a/skipchain/api_test.go
+++ b/skipchain/api_test.go
@@ -156,9 +156,9 @@ func TestClient_GetUpdateChain(t *testing.T) {
 				if h2 < height {
 					height = h2
 				}
-				require.True(t, sb1.ForwardLink[height-1].Hash().Equal(sb2.Hash),
+				require.True(t, sb1.ForwardLink[height-1].To.Equal(sb2.Hash),
 					"Forward-pointer[%v/%v] of update %v %x is different from hash in %v %x",
-					height-1, len(sb1.ForwardLink), up, sb1.ForwardLink[height-1].Hash(), up+1, sb2.Hash)
+					height-1, len(sb1.ForwardLink), up, sb1.ForwardLink[height-1].To, up+1, sb2.Hash)
 			}
 		}
 	}
@@ -191,7 +191,7 @@ func TestClient_StoreSkipBlock(t *testing.T) {
 	log.ErrFatal(err)
 	require.True(t, sb2.Previous.Equal(sb1.Latest),
 		"New previous should be previous latest")
-	require.True(t, bytes.Equal(sb2.Previous.ForwardLink[0].Hash(), sb2.Latest.Hash),
+	require.True(t, bytes.Equal(sb2.Previous.ForwardLink[0].To, sb2.Latest.Hash),
 		"second should point to third SkipBlock")
 
 	log.Lvl1("Checking update-chain")

--- a/skipchain/api_test.go
+++ b/skipchain/api_test.go
@@ -134,7 +134,7 @@ func TestClient_GetUpdateChain(t *testing.T) {
 
 	for i := 0; i < sbCount; i++ {
 		sbc, err := c.GetUpdateChain(sbs[i].Roster, sbs[i].Hash)
-		log.ErrFatal(err)
+		require.Nil(t, err)
 
 		require.True(t, len(sbc.Update) > 0, "Empty update-chain")
 		if !sbc.Update[0].Equal(sbs[i]) {

--- a/skipchain/msgs.go
+++ b/skipchain/msgs.go
@@ -124,8 +124,6 @@ type ForwardSignature struct {
 	Previous SkipBlockID
 	// Newest is the newest skipblock, signed by previous
 	Newest *SkipBlock
-	// ForwardLink is the signature from Previous to Newest
-	ForwardLink *BlockLink
 }
 
 // GetSingleBlock asks for a single block.

--- a/skipchain/protocol.go
+++ b/skipchain/protocol.go
@@ -251,7 +251,7 @@ func (p *GetBlocks) HandleGetBlocks(msg ProtoStructGetBlocks) error {
 		if msg.Skipping {
 			linkNum = len(s.ForwardLink) - 1
 		}
-		next = s.ForwardLink[linkNum].Hash()
+		next = s.ForwardLink[linkNum].To
 	}
 	if len(result) == 0 {
 		// Not found, so send no reply. Another conode will

--- a/skipchain/protocol_test.go
+++ b/skipchain/protocol_test.go
@@ -42,11 +42,9 @@ func TestGB(t *testing.T) {
 	sb1.Roster = ro
 	sb1.BackLinkIDs = []skipchain.SkipBlockID{sb0.Hash}
 	sb1.Hash = sb1.CalculateHash()
-	sb0.ForwardLink = []*skipchain.BlockLink{
-		&skipchain.BlockLink{
-			BFTSignature: bftcosi.BFTSignature{Msg: sb1.Hash, Sig: []byte{}},
-		},
-	}
+	sig0 := skipchain.NewForwardLink(sb0, sb1)
+	sig0.Signature = bftcosi.BFTSignature{Msg: sig0.Hash(), Sig: []byte{}}
+	sb0.ForwardLink = []*skipchain.ForwardLink{sig0}
 
 	sb2 := skipchain.NewSkipBlock()
 	sb2.BackLinkIDs = []skipchain.SkipBlockID{sb1.Hash}
@@ -55,20 +53,17 @@ func TestGB(t *testing.T) {
 	sb3 := skipchain.NewSkipBlock()
 	sb3.BackLinkIDs = []skipchain.SkipBlockID{sb2.Hash}
 	sb3.Hash = sb3.CalculateHash()
-	sb2.ForwardLink = []*skipchain.BlockLink{
-		&skipchain.BlockLink{
-			BFTSignature: bftcosi.BFTSignature{Msg: sb3.Hash, Sig: []byte{}},
-		},
-	}
+	sig2 := skipchain.NewForwardLink(sb2, sb3)
+	sig2.Signature = bftcosi.BFTSignature{Msg: sig2.Hash(), Sig: []byte{}}
+	sb2.ForwardLink = []*skipchain.ForwardLink{sig2}
+
 	// and make sb1 forward[1] point to sb3 as well.
-	sb1.ForwardLink = []*skipchain.BlockLink{
-		&skipchain.BlockLink{
-			BFTSignature: bftcosi.BFTSignature{Msg: sb2.Hash, Sig: []byte{}},
-		},
-		&skipchain.BlockLink{
-			BFTSignature: bftcosi.BFTSignature{Msg: sb3.Hash, Sig: []byte{}},
-		},
-	}
+	sig12 := skipchain.NewForwardLink(sb1, sb2)
+	sig12.Signature = bftcosi.BFTSignature{Msg: sig12.Hash(), Sig: []byte{}}
+
+	sig13 := skipchain.NewForwardLink(sb1, sb3)
+	sig13.Signature = bftcosi.BFTSignature{Msg: sig13.Hash(), Sig: []byte{}}
+	sb1.ForwardLink = []*skipchain.ForwardLink{sig12, sig13}
 
 	db, bucket := ts0.GetAdditionalBucket("skipblocks")
 	ts0.Db = skipchain.NewSkipBlockDB(db, bucket)

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -236,7 +236,7 @@ func TestService_MultiLevel(t *testing.T) {
 							bl, err := s.GetSingleBlock(&GetSingleBlock{i})
 							log.ErrFatal(err)
 							if len(bl.ForwardLink) == n+1 &&
-								bl.ForwardLink[n].Hash().Equal(sb.Hash) {
+								bl.ForwardLink[n].To.Equal(sb.Hash) {
 								break
 							}
 							time.Sleep(200 * time.Millisecond)
@@ -605,7 +605,7 @@ func TestService_AddFollow(t *testing.T) {
 	}
 	master2, err := services[1].StoreSkipBlock(ssb)
 	log.ErrFatal(err)
-	require.True(t, services[1].db.GetByID(master1.Latest.Hash).ForwardLink[0].Hash().Equal(master2.Latest.Hash))
+	require.True(t, services[1].db.GetByID(master1.Latest.Hash).ForwardLink[0].To.Equal(master2.Latest.Hash))
 }
 
 func TestService_CreateLinkPrivate(t *testing.T) {
@@ -951,7 +951,7 @@ func nukeBlocksFrom(t *testing.T, db *SkipBlockDB, where SkipBlockID) {
 		}
 
 		// nuke it
-		t.Log("nuking block", sb.Index)
+		log.Lvl2("nuking block", sb.Index)
 		err := db.Update(func(tx *bolt.Tx) error {
 			err := tx.Bucket([]byte(db.bucketName)).Delete(where)
 			if err != nil {
@@ -967,7 +967,7 @@ func nukeBlocksFrom(t *testing.T, db *SkipBlockDB, where SkipBlockID) {
 		if len(sb.ForwardLink) == 0 {
 			return
 		}
-		where = sb.ForwardLink[0].Hash()
+		where = sb.ForwardLink[0].To
 	}
 }
 

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -491,24 +491,20 @@ func (fl *ForwardLink) Hash() SkipBlockID {
 
 // Copy makes a deep copy of a ForwardLink
 func (fl *ForwardLink) Copy() *ForwardLink {
-	sigCopy := make([]byte, len(fl.Signature.Sig))
-	copy(sigCopy, fl.Signature.Sig)
-
-	msgCopy := make([]byte, len(fl.Signature.Msg))
-	copy(msgCopy, fl.Signature.Msg)
-
-	exsCopy := make([]bftcosi.Exception, len(fl.Signature.Exceptions))
-	copy(exsCopy, fl.Signature.Exceptions)
-
+	var newRoster *onet.Roster
+	if fl.NewRoster != nil {
+		newRoster = onet.NewRoster(fl.NewRoster.List)
+		newRoster.ID = onet.RosterID([uuid.Size]byte(fl.NewRoster.ID))
+	}
 	return &ForwardLink{
 		Signature: bftcosi.BFTSignature{
-			Sig:        sigCopy,
-			Msg:        msgCopy,
-			Exceptions: exsCopy,
+			Sig:        append([]byte{}, fl.Signature.Sig...),
+			Msg:        append([]byte{}, fl.Signature.Msg...),
+			Exceptions: append([]bftcosi.Exception{}, fl.Signature.Exceptions...),
 		},
-		From:      fl.From,
-		To:        fl.To,
-		NewRoster: fl.NewRoster,
+		From:      append([]byte{}, fl.From...),
+		To:        append([]byte{}, fl.To...),
+		NewRoster: newRoster,
 	}
 }
 

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -121,7 +121,7 @@ func TestBlockLink_Copy(t *testing.T) {
 	b1 := &ForwardLink{}
 	b1.Signature.Sig = []byte{1}
 	b2 := b1.Copy()
-	b2.Signature.Sig = []byte{2}
+	b2.Signature.Sig[0] = byte(2)
 	if bytes.Equal(b1.Signature.Sig, b2.Signature.Sig) {
 		t.Fatal("They should not be equal")
 	}

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -118,11 +118,11 @@ func TestSkipBlock_Hash2(t *testing.T) {
 
 func TestBlockLink_Copy(t *testing.T) {
 	// Test if copy is deep or only shallow
-	b1 := &BlockLink{}
-	b1.Sig = []byte{1}
+	b1 := &ForwardLink{}
+	b1.Signature.Sig = []byte{1}
 	b2 := b1.Copy()
-	b2.Sig = []byte{2}
-	if bytes.Equal(b1.Sig, b2.Sig) {
+	b2.Signature.Sig = []byte{2}
+	if bytes.Equal(b1.Signature.Sig, b2.Signature.Sig) {
 		t.Fatal("They should not be equal")
 	}
 

--- a/skipchain/verification.go
+++ b/skipchain/verification.go
@@ -9,9 +9,11 @@ This file holds all verification-functions for the skipchain.
 // VerifyBase checks basic parameters between two skipblocks.
 func (s *Service) verifyFuncBase(newID []byte, newSB *SkipBlock) bool {
 	if !newSB.Hash.Equal(newID) {
+		log.Lvl2("Hashes are not equal")
 		return false
 	}
 	if s.verifyBlock(newSB) != nil {
+		log.Lvl2("verifyBlock failed")
 		return false
 	}
 	log.Lvl4("No verification - accepted")


### PR DESCRIPTION
This changes the forward-signatures to something more reasonable like:

```
type ForwardLink struct {
	// From - where this forward link comes from
	From SkipBlockID
	// To - where this forward link points to
	To SkipBlockID
	// NewRoster is only set to non-nil if the From block has a
	// different roster from the To-block.
	NewRoster *onet.Roster
	// Signature is calculated on the
	// sha256(From.Hash()|To.Hash()|NewRoster.ID)
	// In the case that NewRoster is nil, the signature is
	// calculated on the sha256(From.Hash()|To.Hash())
	Signature bftcosi.BFTSignature
}
```

This prevents re-use of a ForwardSignature in a wrong context. It also allows later to get updates
using `ForwardSignature`s only, as it will be enough jumping from one ForwardSignature to the next, given that the `NewRoster` will indicate the Roster that will be responsible for the new Block.