### PR TITLE
js: webpack fixes

### DIFF
--- a/cosi/simulation/cosi.toml
+++ b/cosi/simulation/cosi.toml
@@ -2,7 +2,7 @@ Simulation = "CoSimul"
 Servers = 16
 Bf = 3
 Rounds = 10
-RunWait = 6000s
+RunWait = "6000s"
 Suite = "Ed25519"
 
 Depth

--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cothority",
+  "name": "@dedis/cothority",
   "version": "1.0.0",
   "description": "module for interacting with cothority nodes",
   "main": "dist/bundle.node.min.js",
@@ -41,5 +41,10 @@
     "uglify-es": "^3.3.9",
     "uglifyjs-webpack-plugin": "^1.1.8",
     "webpack": "^3.10.0"
-  }
+  },
+  "files": [
+	"dist",
+	"doc",
+	"index.html"
+  ]
 }

--- a/external/js/cothority/webpack.config.js
+++ b/external/js/cothority/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
+const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 
 const nodeConfig = {
   target: "node",
@@ -23,9 +23,7 @@ const nodeConfig = {
       }
     ]
   },
-  plugins: [
-    new UglifyJsPlugin()
-  ]
+  plugins: [new UglifyJsPlugin()]
 };
 
 const browserConfig = {
@@ -33,7 +31,8 @@ const browserConfig = {
   output: {
     filename: "bundle.min.js",
     path: path.resolve(__dirname, "dist"),
-    library: "cothority"
+    library: "cothority",
+    libraryTarget: "umd"
   },
   module: {
     rules: [
@@ -49,9 +48,7 @@ const browserConfig = {
       }
     ]
   },
-  plugins: [
-    new UglifyJsPlugin()
-  ]
+  plugins: [new UglifyJsPlugin()]
 };
 
 module.exports = [nodeConfig, browserConfig];

--- a/external/js/kyber/webpack.config.js
+++ b/external/js/kyber/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
+const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 
 const nodeConfig = {
   target: "node",
@@ -23,9 +23,7 @@ const nodeConfig = {
       }
     ]
   },
-  plugins: [
-    new UglifyJsPlugin()
-  ]
+  plugins: [new UglifyJsPlugin()]
 };
 
 const browserConfig = {
@@ -33,7 +31,8 @@ const browserConfig = {
   output: {
     filename: "bundle.min.js",
     path: path.resolve(__dirname, "dist"),
-    library: "kyber"
+    library: "kyber",
+    libraryTarget: "umd"
   },
   module: {
     rules: [
@@ -49,9 +48,7 @@ const browserConfig = {
       }
     ]
   },
-  plugins: [
-    new UglifyJsPlugin()
-  ]
+  plugins: [new UglifyJsPlugin()]
 };
 
 module.exports = [nodeConfig, browserConfig];


### PR DESCRIPTION
set libraryTarget to umd. This allows importing/requiring the browser target
which is useful for projects in Vue/React