### PR TITLE
Correctly handle concurrent skipchain writes

### DIFF
--- a/bftcosi/bftcosi.go
+++ b/bftcosi/bftcosi.go
@@ -414,7 +414,7 @@ func (bft *ProtocolBFTCoSi) handleChallengeCommit(msg challengeCommitChan) error
 	// check if we have no more than threshold failed nodes
 	if len(ch.Signature.Exceptions) > int(bft.allowedExceptions) {
 		log.Errorf("%s: More than threshold (%d/%d) refused to sign - aborting.",
-			bft.Roster(), len(ch.Signature.Exceptions), len(bft.Roster().List))
+			bft.Roster().ID, len(ch.Signature.Exceptions), len(bft.Roster().List))
 		bft.signRefusal = true
 	}
 
@@ -452,7 +452,7 @@ func (bft *ProtocolBFTCoSi) handleResponsePrepare(c chan responseChan) error {
 	bzrReturn, ok := bft.waitResponseVerification()
 	// append response
 	if !ok {
-		log.Lvl2(bft.Roster(), "Refused to sign")
+		log.Lvl2(bft.Roster().ID, "refused to sign")
 	}
 
 	// Return if we're not root

--- a/messaging/propagate.go
+++ b/messaging/propagate.go
@@ -75,11 +75,13 @@ type propagationContext interface {
 
 // NewPropagationFunc registers a new protocol name with the context c and will
 // set f as handler for every new instance of that protocol.
-// The protocol will fail if more than t nodes per subtree fail to respond.
-// If t == -1, t defaults to len(n.Roster().List-1)/3. Thus, for a roster of
+// The protocol will fail if more than thresh nodes per subtree fail to respond.
+// If thresh == -1, the threshold defaults to len(n.Roster().List-1)/3. Thus, for a roster of
 // 5, t = int(4/3) = 1, e.g. 1 node out of the 5 can fail.
-func NewPropagationFunc(c propagationContext, name string, f PropagationStore, t int) (PropagationFunc, error) {
+func NewPropagationFunc(c propagationContext, name string, f PropagationStore, thresh int) (PropagationFunc, error) {
 	pid, err := c.ProtocolRegister(name, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
+		// Make a local copy in order to avoid a data race.
+		t := thresh
 		if t == -1 {
 			t = (len(n.Roster().List) - 1) / 3
 		}

--- a/skipchain/api_test.go
+++ b/skipchain/api_test.go
@@ -179,10 +179,13 @@ func TestClient_StoreSkipBlock(t *testing.T) {
 	var sb1 *StoreSkipBlockReply
 	sb1, err = c.StoreSkipBlock(inter, ro2, nil)
 	log.ErrFatal(err)
-	log.Lvl1("Proposing same roster again")
-	_, err = c.StoreSkipBlock(inter, ro2, nil)
-	require.NotNil(t, err,
-		"Appending two Blocks to the same last block should fail")
+	// This now works, because in order to implement concurrent writes
+	// correctly, we need to have StoreSkipBlock advance latest to the
+	// true latest block, atomically.
+	//log.Lvl1("Proposing same roster again")
+	//_, err = c.StoreSkipBlock(inter, ro2, nil)
+	//require.NotNil(t, err,
+	//	"Appending two Blocks to the same last block should fail")
 	log.Lvl1("Proposing following roster")
 	sb1, err = c.StoreSkipBlock(sb1.Latest, ro2, []byte{1, 2, 3})
 	log.ErrFatal(err)

--- a/skipchain/msgs.go
+++ b/skipchain/msgs.go
@@ -65,11 +65,10 @@ func init() {
 // External calls
 
 // StoreSkipBlock - Requests a new skipblock to be appended to
-// the given SkipBlock. If the given SkipBlock has Index 0 (which
-// is invalid), a new SkipChain will be created.
-// if AuthSkipchain == true, then the signature has to be a valid
-// Schnorr signature on the hash of the NewBlock by either one of the
-// conodes in the roster or by one of the clients.
+// the given SkipBlock. If the given SkipBlock has Index 0
+// a new SkipChain will be created. If LatestID is the zero value,
+// the latest block from the chain with hash NewBlock.GenesisID
+// will be used.
 type StoreSkipBlock struct {
 	LatestID  SkipBlockID
 	NewBlock  *SkipBlock

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -86,12 +86,24 @@ func (cl *chainLocker) lock(chain SkipBlockID) {
 }
 
 func (cl *chainLocker) unlock(chain SkipBlockID) {
+	key := string(chain)
 	cl.Lock()
-	l := cl.chains[string(chain)]
+	l := cl.chains[key]
 	if l != nil {
 		l.Unlock()
 		cl.locks--
 	}
+	// It is not possible to delete the entry from the map in a non-racy way.
+	// Consider 3 goroutines. #1 has the lock and is here unlocking. #2 is
+	// sleeping on the lock. #3 has just received a block for this chain, but has
+	// not tried to lock it. When #1 unlocks, #2 wakes up and runs, locking the
+	// same mutex that #1 just unlocked. If #1 deletes the mutex from the map,
+	// later #2 will unlock it and could just ignore the fact that it is no longer
+	// in the map. But if #3 tries to lock while #2 has it locked, but after #1 has
+	// removed it from the map, #3 makes a new mutex, and gets the lock. Now #2 and #3
+	// are both holding different locks that they each think is the lock for chainId.
+	// Not ok.
+
 	cl.Unlock()
 }
 

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -537,6 +537,11 @@ func TestService_ParallelGenesis(t *testing.T) {
 	default:
 		t.Log("congratulations, no errors")
 	}
+
+	n := s1.db.Length()
+	if n != numBlocks*nbrRoutines {
+		t.Error("num blocks is wrong:", n)
+	}
 }
 
 func TestService_ParallelStoreBlock(t *testing.T) {
@@ -587,6 +592,12 @@ func TestService_ParallelStoreBlock(t *testing.T) {
 		t.Error("got an error", err)
 	default:
 		t.Log("congratulations, no errors")
+	}
+
+	n := s1.db.Length()
+	// plus 1 for the genesis block
+	if n != numBlocks*nbrRoutines+1 {
+		t.Error("num blocks is wrong:", n)
 	}
 }
 

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -176,7 +176,7 @@ func (fct *FollowChainType) AcceptNew(sb *SkipBlock, us *network.ServerIdentity)
 		}
 		return true
 	default:
-		log.Error("unknown AuthSkipchain type")
+		log.Error("unknown policy")
 	}
 	return false
 }


### PR DESCRIPTION
Take locks on a per-chain basis, instead of on a per-parent-block
basis. Hold them until the entire update is done.

Allow the client to say "append to this chain" instead of "append to
this block".

Fixes #1073.