### PR TITLE
[cisc] add id flag to list ids only

### DIFF
--- a/cisc/cisc.go
+++ b/cisc/cisc.go
@@ -844,6 +844,10 @@ func followDel(c *cli.Context) error {
 func followList(c *cli.Context) error {
 	cfg := loadConfigOrFail(c)
 	for _, id := range cfg.Follow {
+		if c.Bool("id-only") {
+			fmt.Printf("%x\n", id.ID)
+			continue
+		}
 		log.Infof("SCID: %x", id.ID)
 		server := id.DeviceName
 		log.Infof("Server %s is asked to accept ssh-keys from %s:",

--- a/cisc/commands.go
+++ b/cisc/commands.go
@@ -325,10 +325,11 @@ func getCommands() cli.Commands {
 					Aliases: []string{"ls", "l"},
 					Usage:   "list all skipchains and keys",
 					Action:  followList,
-					Flags: []cli.BoolFlag{
-						Name:  "id-only",
-						Value: false,
-						Usage: "only list the skipchain ID",
+					Flags: []cli.Flag{
+						cli.BoolFlag{
+							Name:  "id-only",
+							Usage: "only list the skipchain ID",
+						},
 					},
 				},
 				{

--- a/cisc/commands.go
+++ b/cisc/commands.go
@@ -325,6 +325,11 @@ func getCommands() cli.Commands {
 					Aliases: []string{"ls", "l"},
 					Usage:   "list all skipchains and keys",
 					Action:  followList,
+					Flags: []cli.BoolFlag{
+						Name:  "id-only",
+						Value: false,
+						Usage: "only list the skipchain ID",
+					},
 				},
 				{
 					Name:    "update",


### PR DESCRIPTION
Title is self-explanatory ... It's just much easier than having to parse a custom output. This is more "unix style" where this output can be piped to other scripts :) (yes I know that `sed 's/.../.../'` is always possible..)