### PR TITLE
[cisc] replacing csv input by generic file input

### DIFF
--- a/cisc/cisc.go
+++ b/cisc/cisc.go
@@ -560,12 +560,12 @@ func kvAdd(c *cli.Context) error {
 	return addKv(c, cfg, id, prop)
 }
 
-// kvAddCsv reads the input file, and stores it in the data. The key is the
+// kvAddFile reads the input file, and stores it in the data. The key is the
 // name of the file by default or overridden by the key flag. Do not use with
 // big files as it reads all at once.
 func kvAddFile(c *cli.Context) error {
 	cfg := loadConfigOrFail(c)
-	if c.NArg() != 1 {
+	if c.NArg() < 1 {
 		return errors.New("Missing argument: file name")
 	}
 	id, err := cfg.findSC(c.Args().Get(1))

--- a/cisc/cisc.go
+++ b/cisc/cisc.go
@@ -566,7 +566,7 @@ func kvAdd(c *cli.Context) error {
 func kvAddFile(c *cli.Context) error {
 	cfg := loadConfigOrFail(c)
 	if c.NArg() != 1 {
-		return errors.New("Missing argument: csv file")
+		return errors.New("Missing argument: file name")
 	}
 	id, err := cfg.findSC(c.Args().Get(1))
 	if err != nil {

--- a/cisc/cisc.go
+++ b/cisc/cisc.go
@@ -9,7 +9,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/csv"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -503,7 +502,17 @@ func kvList(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	log.Infof("config for id %x", id.ID)
+	// only print value for the given key
+	if c.String("key") != "" {
+		val, ok := id.Data.Storage[c.String("key")]
+		if !ok {
+			return errors.New("key does not exists")
+		}
+		fmt.Println(val)
+		return nil
+	}
+
+	// print everything
 	for k, v := range id.Data.Storage {
 		log.Infof("%s: %s", k, v)
 	}
@@ -551,10 +560,10 @@ func kvAdd(c *cli.Context) error {
 	return addKv(c, cfg, id, prop)
 }
 
-// kvAddCsv reads the input CSV file, lookup its key column and inputs all the
-// csv file at once to the skipchain. The key is given from the "column" args
-// and the value is the whole full row, unmodified.
-func kvAddCsv(c *cli.Context) error {
+// kvAddCsv reads the input file, and stores it in the data. The key is the
+// name of the file by default or overridden by the key flag. Do not use with
+// big files as it reads all at once.
+func kvAddFile(c *cli.Context) error {
 	cfg := loadConfigOrFail(c)
 	if c.NArg() != 1 {
 		return errors.New("Missing argument: csv file")
@@ -564,24 +573,23 @@ func kvAddCsv(c *cli.Context) error {
 		scList(c)
 		return errors.New("Please give skipchain-id")
 	}
+	// read file name
 	file := c.Args().First()
+	// determine the key
+	key := path.Base(file)
+	if c.String("key") != "" {
+		key = c.String("key")
+	}
+	// read file
 	fd, err := os.Open(file)
 	log.ErrFatal(err)
-	reader := csv.NewReader(fd)
-	records, err := reader.ReadAll()
+	buff, err := ioutil.ReadAll(fd)
 	log.ErrFatal(err)
-	if len(records) < 2 {
-		return errors.New("csv file given only contains column name")
-	}
-	column := c.Int("column")
-	log.Info("Column names to insert in cisc: " + strings.Join(records[0], ":"))
-	log.Info("Column name to use as a key: " + records[0][column])
+
+	// store it
+	log.Info("File will be stored under key: " + key)
 	prop := id.GetProposed()
-	for _, row := range records[1:] {
-		key := row[column]
-		value := strings.Join(row, ",")
-		prop.Storage[key] = value
-	}
+	prop.Storage[key] = string(buff)
 	return addKv(c, cfg, id, prop)
 }
 

--- a/cisc/commands.go
+++ b/cisc/commands.go
@@ -188,6 +188,12 @@ func getCommands() cli.Commands {
 					Aliases: []string{"ls", "l"},
 					Usage:   "list all values",
 					Action:  kvList,
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "key",
+							Usage: "only prints the value mapped to this key",
+						},
+					},
 				},
 				{
 					Name:      "value",
@@ -204,15 +210,14 @@ func getCommands() cli.Commands {
 					Action:    kvAdd,
 				},
 				{
-					Name:      "csv",
-					Usage:     "add key/value pairs from a CSV file. Key is the value at a custom defined column. Value is a full row of the csv file.",
+					Name:      "file",
+					Usage:     "add a key/value pair from a file.Key is given in flag, and value is the file in utf-8.",
 					ArgsUsage: "csvFile [skipchain-id]",
-					Action:    kvAddCsv,
+					Action:    kvAddFile,
 					Flags: []cli.Flag{
-						cli.IntFlag{
-							Name:  "column",
-							Usage: "column to choose as the key. default 0.",
-							Value: 0,
+						cli.StringFlag{
+							Name:  "key",
+							Usage: "key name where to add the file. Default is the name of the file",
 						},
 					},
 				},

--- a/cisc/test.sh
+++ b/cisc/test.sh
@@ -33,24 +33,24 @@ main(){
   test Link
   test Final
   test ClientSetup
-  #test ScCreate
-  #test ScCreate2
-  #test ScCreate3
-  #test DataList
-  #test DataVote
-  #test DataRoster
-  #test IdConnect
-  #test IdDel
+  test ScCreate
+  test ScCreate2
+  test ScCreate3
+  test DataList
+  test DataVote
+  test DataRoster
+  test IdConnect
+  test IdDel
   test KeyAdd
   test KeyFile
-#  test KeyAdd2
-  #test KeyAddWeb
-  #test KeyDel
-  #test SSHAdd
-  #test SSHDel
-  #test Follow
-  #test SymLink
-  #test Revoke
+  test KeyAdd2
+  test KeyAddWeb
+  test KeyDel
+  test SSHAdd
+  test SSHDel
+  test Follow
+  test SymLink
+  test Revoke
   stopTest
 }
 

--- a/cisc/test.sh
+++ b/cisc/test.sh
@@ -33,24 +33,24 @@ main(){
   test Link
   test Final
   test ClientSetup
-  test ScCreate
-  test ScCreate2
-  test ScCreate3
-  test DataList
-  test DataVote
-  test DataRoster
-  test IdConnect
-  test IdDel
+  #test ScCreate
+  #test ScCreate2
+  #test ScCreate3
+  #test DataList
+  #test DataVote
+  #test DataRoster
+  #test IdConnect
+  #test IdDel
   test KeyAdd
-  test KeyCsv
-  test KeyAdd2
-  test KeyAddWeb
-  test KeyDel
-  test SSHAdd
-  test SSHDel
-  test Follow
-  test SymLink
-  test Revoke
+  test KeyFile
+#  test KeyAdd2
+  #test KeyAddWeb
+  #test KeyDel
+  #test SSHAdd
+  #test SSHDel
+  #test Follow
+  #test SymLink
+  #test Revoke
   stopTest
 }
 
@@ -206,22 +206,22 @@ testKeyAdd(){
   testGrep key1 runCl 1 kv ls
 }
 
-testKeyCsv() {
+testKeyFile() {
   clientSetup 2
   csvFile=$(mktemp)
   cat > $csvFile  <<EOL
 key,val1,val2
-"jobs","ranger","warrior"
-"types","elf","dwarf"
+jobs,ranger,warrior
+types,elf,dwarf
 EOL
-
-  testOK runCl 1 kv csv $csvFile
+  key="csv"
+  testOK runCl 1 kv file $csvFile --key "$key"
   rm $csvFile
   testOK runCl 2 data update
   testOK runCl 2 data vote -yes
   testOK runCl 1 data update
-  testGrep "jobs: jobs,ranger,warrior" runCl 1 kv ls
-  testGrep "types: types,elf,dwarf" runCl 1 kv ls
+  testGrep "jobs,ranger,warrior" runCl 1 kv ls --key "$key"
+  testGrep "types,elf,dwarf" runCl 1 kv ls --key "$key"
 }
 
 testIdDel(){


### PR DESCRIPTION
This pr fixes the functionality of a previous PR I made because I just realized it's better to make it a bit more generic to fit all uses case. And because I haven't thought that through enough before, I realised the csv functionality is not exactly fitting my use case.
So now it's simpler: input is a file, and it's mapped to the filename or a given key. So the user has to decide what to do with the value instead of cisc deciding how to treat the value.
The test is adapted and works.