### PR TITLE
Use []byte for bucketName/Load/Save

### DIFF
--- a/identity/service.go
+++ b/identity/service.go
@@ -49,6 +49,8 @@ var VerificationIdentity = []skipchain.VerifierID{skipchain.VerifyBase, VerifyId
 // VerifyIdentity makes sure that each new block is signed by a threshold of devices.
 var VerifyIdentity = skipchain.VerifierID(uuid.NewV5(uuid.NamespaceURL, "Identity"))
 
+var storageKey = []byte("storage")
+
 func init() {
 	identityService, _ = onet.RegisterNewService(ServiceName, newIdentityService)
 	network.RegisterMessage(&Storage{})
@@ -705,7 +707,7 @@ func (s *Service) verifySkipchainAuth() kyber.Scalar {
 // saves the actual identity
 func (s *Service) save() {
 	log.Lvl3("Saving service")
-	err := s.Save("storage", s.Storage)
+	err := s.Save(storageKey, s.Storage)
 	if err != nil {
 		log.Error("Couldn't save file:", err)
 	}
@@ -718,7 +720,7 @@ func (s *Service) clearIdentities() {
 // Tries to load the configuration and updates if a configuration
 // is found, else it returns an error.
 func (s *Service) tryLoad() error {
-	msg, err := s.Load("storage")
+	msg, err := s.Load(storageKey)
 	if err != nil {
 		return err
 	}

--- a/pop/service/service.go
+++ b/pop/service/service.go
@@ -67,9 +67,7 @@ const Name = "PoPServer"
 const cfgName = "pop.bin"
 const bftSignFinal = "BFTFinal"
 const bftSignMerge = "PopBFTSignMerge"
-
 const propagFinal = "PoPPropagateFinal"
-
 const timeout = 60 * time.Second
 
 // SIGSIZE size of signature
@@ -85,6 +83,8 @@ var mergeConfigID network.MessageTypeID
 var mergeConfigReplyID network.MessageTypeID
 var mergeCheckID network.MessageTypeID
 var mergeCheckReplyID network.MessageTypeID
+
+var storageKey = []byte("storage")
 
 // Service represents data needed for one pop-party.
 type Service struct {
@@ -899,7 +899,7 @@ func (s *Service) merge(final *FinalStatement, m *merge) (*FinalStatement,
 // saves the actual identity
 func (s *Service) save() {
 	log.Lvl2("Saving service", s.ServerIdentity())
-	err := s.Save("storage", s.data)
+	err := s.Save(storageKey, s.data)
 	if err != nil {
 		log.Error("Couldn't save data:", err)
 	}
@@ -908,7 +908,7 @@ func (s *Service) save() {
 // Tries to load the configuration and updates if a configuration
 // is found, else it returns an error.
 func (s *Service) tryLoad() error {
-	msg, err := s.Load("storage")
+	msg, err := s.Load(storageKey)
 	if err != nil {
 		return err
 	}

--- a/scmgr/app.go
+++ b/scmgr/app.go
@@ -33,6 +33,8 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
+var bucketName = []byte("skipblocks")
+
 type config struct {
 	// The database holding all skipblocks
 	Db *skipchain.SkipBlockDB
@@ -688,7 +690,7 @@ func loadConfig(c *cli.Context) (*config, error) {
 				return nil, err
 			}
 			db.Update(func(tx *bolt.Tx) error {
-				_, err := tx.CreateBucket([]byte("skipblocks"))
+				_, err := tx.CreateBucket(bucketName)
 				if err != nil {
 					return fmt.Errorf("create bucket: %s", err)
 				}
@@ -698,7 +700,7 @@ func loadConfig(c *cli.Context) (*config, error) {
 				}
 				return nil
 			})
-			cfg.Db = skipchain.NewSkipBlockDB(db, "skipblocks")
+			cfg.Db = skipchain.NewSkipBlockDB(db, bucketName)
 			return cfg, nil
 		}
 		return nil, fmt.Errorf("Could not open file %s", cfgPath)
@@ -707,7 +709,7 @@ func loadConfig(c *cli.Context) (*config, error) {
 	if err != nil {
 		return nil, err
 	}
-	cfg.Db = skipchain.NewSkipBlockDB(db, "skipblocks")
+	cfg.Db = skipchain.NewSkipBlockDB(db, bucketName)
 	err = cfg.Db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte("config"))
 		v := b.Get([]byte("values"))

--- a/skipchain/protocol_test.go
+++ b/skipchain/protocol_test.go
@@ -65,13 +65,13 @@ func TestGB(t *testing.T) {
 	sig13.Signature = bftcosi.FinalSignature{Msg: sig13.Hash(), Sig: []byte{}}
 	sb1.ForwardLink = []*skipchain.ForwardLink{sig12, sig13}
 
-	db, bucket := ts0.GetAdditionalBucket("skipblocks")
+	db, bucket := ts0.GetAdditionalBucket([]byte("skipblocks"))
 	ts0.Db = skipchain.NewSkipBlockDB(db, bucket)
 	ts0.Db.Store(sb0)
 	ts0.Db.Store(sb1)
 	ts0.Db.Store(sb2)
 	ts0.Db.Store(sb3)
-	db, bucket = ts1.GetAdditionalBucket("skipblocks")
+	db, bucket = ts1.GetAdditionalBucket([]byte("skipblocks"))
 	ts1.Db = skipchain.NewSkipBlockDB(db, bucket)
 	ts1.Db.Store(sb0)
 	ts1.Db.Store(sb1)

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -32,7 +32,8 @@ import (
 const ServiceName = "Skipchain"
 const bftNewBlock = "SkipchainBFTNew"
 const bftFollowBlock = "SkipchainBFTFollow"
-const storageKey = "skipchainconfig"
+
+var storageKey = []byte("skipchainconfig")
 
 func init() {
 	onet.RegisterNewService(ServiceName, newSkipchainService)
@@ -1258,7 +1259,7 @@ func sliceToArr(msg []byte) [32]byte {
 }
 
 func newSkipchainService(c *onet.Context) (onet.Service, error) {
-	db, bucket := c.GetAdditionalBucket("skipblocks")
+	db, bucket := c.GetAdditionalBucket([]byte("skipblocks"))
 	s := &Service{
 		ServiceProcessor: onet.NewServiceProcessor(c),
 		db:               NewSkipBlockDB(db, bucket),

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -526,11 +526,11 @@ func (fl *ForwardLink) Verify(suite cosi.Suite, pubs []kyber.Point) error {
 // It is a wrapper to embed bolt.DB.
 type SkipBlockDB struct {
 	*bolt.DB
-	bucketName string
+	bucketName []byte
 }
 
 // NewSkipBlockDB returns an initialized SkipBlockDB structure.
-func NewSkipBlockDB(db *bolt.DB, bn string) *SkipBlockDB {
+func NewSkipBlockDB(db *bolt.DB, bn []byte) *SkipBlockDB {
 	return &SkipBlockDB{
 		DB:         db,
 		bucketName: bn,

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -215,5 +215,5 @@ func setupSkipBlockDB(t *testing.T) (*SkipBlockDB, string) {
 	})
 	require.Nil(t, err)
 
-	return &SkipBlockDB{db, "skipblock-test"}, fname
+	return &SkipBlockDB{db, []byte("skipblock-test")}, fname
 }


### PR DESCRIPTION
Use `[]byte` for `bucketName` to avoid alocation and use `[]byte` in the DB wrapper functions such as Load/Save.

Depends on https://github.com/dedis/onet/pull/350

Fixes #1010 