### PR TITLE
A test to make sure that parallel writes from websock work too

### DIFF
--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -35,8 +35,10 @@ const bftFollowBlock = "SkipchainBFTFollow"
 
 var storageKey = []byte("skipchainconfig")
 
+var sid onet.ServiceID
+
 func init() {
-	onet.RegisterNewService(ServiceName, newSkipchainService)
+	sid, _ = onet.RegisterNewService(ServiceName, newSkipchainService)
 	network.RegisterMessages(&Storage{})
 }
 

--- a/status/service/status.go
+++ b/status/service/status.go
@@ -27,9 +27,10 @@ type Stat struct {
 
 // Request treats external request to this service.
 func (st *Stat) Request(req *Request) (network.Message, error) {
-	log.Lvl3("Returning", st.Context.ReportStatus())
+	statuses := st.Context.ReportStatus()
+	log.Lvl4("Returning", statuses)
 	return &Response{
-		Status:         st.Context.ReportStatus(),
+		Status:         statuses,
 		ServerIdentity: st.ServerIdentity(),
 	}, nil
 }


### PR DESCRIPTION
After working on #1073, I had some concerns that websocket clients
would not be able to write in parallel like peer services can.
This test proves there's no worries afterall (wow, was not
expecting that).