### PR TITLE
evoting: Election - replace Data with Candidates and add MaxChoices

### DIFF
--- a/evoting/lib/chains_test.go
+++ b/evoting/lib/chains_test.go
@@ -19,7 +19,7 @@ func TestChain(t *testing.T) {
 	_, err := chain(roster, []byte{})
 	assert.NotNil(t, err)
 
-	election := &Election{Roster: roster, Stage: Running, Data: []byte{}}
+	election := &Election{Roster: roster, Stage: Running}
 	_ = election.GenChain(10)
 
 	chain, _ := chain(roster, election.ID)

--- a/evoting/lib/election.go
+++ b/evoting/lib/election.go
@@ -35,7 +35,7 @@ type Election struct {
 	Stage  uint32                // Stage indicates the phase of the election.
 
 	Candidates  []uint32 // Candidates is the list of candidate scipers.
-	MaxChoices  uint32   // MaxChoices is the max votes in allowed in a ballot.
+	MaxChoices  int      // MaxChoices is the max votes in allowed in a ballot.
 	Description string   // Description in string format.
 	Start       int64    // Start denotes the election start unix timestamp
 	End         int64    // End (termination) datetime as unix timestamp.

--- a/evoting/lib/election.go
+++ b/evoting/lib/election.go
@@ -37,6 +37,7 @@ type Election struct {
 	Candidates  []uint32 // Candidates is the list of candidate scipers.
 	MaxChoices  uint32   // MaxChoices is the max votes in allowed in a ballot.
 	Description string   // Description in string format.
+	Start       int64    // Start denotes the election start unix timestamp
 	End         int64    // End (termination) datetime as unix timestamp.
 }
 

--- a/evoting/lib/election.go
+++ b/evoting/lib/election.go
@@ -37,7 +37,7 @@ type Election struct {
 	Candidates  []uint32 // Candidates is the list of candidate scipers.
 	MaxChoices  uint32   // MaxChoices is the max votes in allowed in a ballot.
 	Description string   // Description in string format.
-	End         string   // End (termination) date.
+	End         int64    // End (termination) datetime as unix timestamp.
 }
 
 func init() {

--- a/evoting/lib/election.go
+++ b/evoting/lib/election.go
@@ -34,9 +34,10 @@ type Election struct {
 	Key    kyber.Point           // Key is the DKG public key.
 	Stage  uint32                // Stage indicates the phase of the election.
 
-	Data        []byte // Data can hold auxiliary information.
-	Description string // Description in string format.
-	End         string // End (termination) date.
+	Candidates  []uint32 // Candidates is the list of candidate scipers.
+	MaxChoices  uint32   // MaxChoices is the max votes in allowed in a ballot.
+	Description string   // Description in string format.
+	End         string   // End (termination) date.
 }
 
 func init() {

--- a/evoting/lib/election_test.go
+++ b/evoting/lib/election_test.go
@@ -20,28 +20,28 @@ func TestFetchElection(t *testing.T) {
 	_, err := FetchElection(roster, []byte{})
 	assert.NotNil(t, err)
 
-	election := &Election{Roster: roster, Stage: Running, Data: []byte{}}
+	election := &Election{Roster: roster, Stage: Running}
 	_ = election.GenChain(10)
 
 	e, _ := FetchElection(roster, election.ID)
 	assert.Equal(t, election.ID, e.ID)
 	assert.Equal(t, Running, int(e.Stage))
 
-	election = &Election{Roster: roster, Stage: Shuffled, Data: []byte{}}
+	election = &Election{Roster: roster, Stage: Shuffled}
 	_ = election.GenChain(10)
 
 	e, _ = FetchElection(roster, election.ID)
 	assert.Equal(t, election.ID, e.ID)
 	assert.Equal(t, Shuffled, int(e.Stage))
 
-	election = &Election{Roster: roster, Stage: Decrypted, Data: []byte{}}
+	election = &Election{Roster: roster, Stage: Decrypted}
 	_ = election.GenChain(10)
 
 	e, _ = FetchElection(roster, election.ID)
 	assert.Equal(t, election.ID, e.ID)
 	assert.Equal(t, Decrypted, int(e.Stage))
 
-	election = &Election{Roster: roster, Stage: Shuffled, Data: []byte{}}
+	election = &Election{Roster: roster, Stage: Shuffled}
 	_ = election.GenChain(10)
 	_ = election.Store(&Mix{Proof: []byte{}})
 
@@ -55,7 +55,7 @@ func TestStore(t *testing.T) {
 
 	_, roster, _ := local.GenBigTree(3, 3, 1, true)
 
-	election := &Election{Roster: roster, Stage: Running, Data: []byte{}}
+	election := &Election{Roster: roster, Stage: Running}
 	_ = election.GenChain(10)
 
 	election.Store(&Ballot{User: 1000})
@@ -71,7 +71,7 @@ func TestBox(t *testing.T) {
 
 	_, roster, _ := local.GenBigTree(3, 3, 1, true)
 
-	election := &Election{Roster: roster, Stage: Running, Data: []byte{}}
+	election := &Election{Roster: roster, Stage: Running}
 	_ = election.GenChain(10)
 
 	box, _ := election.Box()
@@ -84,7 +84,7 @@ func TestMixes(t *testing.T) {
 
 	_, roster, _ := local.GenBigTree(3, 3, 1, true)
 
-	election := &Election{Roster: roster, Stage: Shuffled, Data: []byte{}}
+	election := &Election{Roster: roster, Stage: Shuffled}
 	_ = election.GenChain(10)
 
 	mixes, _ := election.Mixes()
@@ -97,7 +97,7 @@ func TestPartials(t *testing.T) {
 
 	_, roster, _ := local.GenBigTree(3, 3, 1, true)
 
-	election := &Election{Roster: roster, Stage: Decrypted, Data: []byte{}}
+	election := &Election{Roster: roster, Stage: Decrypted}
 	_ = election.GenChain(10)
 
 	partials, _ := election.Partials()
@@ -105,13 +105,13 @@ func TestPartials(t *testing.T) {
 }
 
 func TestIsUser(t *testing.T) {
-	e := &Election{Creator: 0, Users: []uint32{0}, Data: []byte{}}
+	e := &Election{Creator: 0, Users: []uint32{0}}
 	assert.True(t, e.IsUser(0))
 	assert.False(t, e.IsUser(1))
 }
 
 func TestIsCreator(t *testing.T) {
-	e := &Election{Creator: 0, Users: []uint32{0, 1}, Data: []byte{}}
+	e := &Election{Creator: 0, Users: []uint32{0, 1}}
 	assert.True(t, e.IsCreator(0))
 	assert.False(t, e.IsCreator(1))
 }

--- a/evoting/protocol/decrypt_test.go
+++ b/evoting/protocol/decrypt_test.go
@@ -55,7 +55,7 @@ func runDecrypt(t *testing.T, n int) {
 
 	nodes, roster, tree := local.GenBigTree(n, n, 1, true)
 
-	election := &lib.Election{Roster: roster, Stage: lib.Shuffled, Data: []byte{}}
+	election := &lib.Election{Roster: roster, Stage: lib.Shuffled}
 	dkgs := election.GenChain(n)
 
 	services := local.GetServices(nodes, decryptServiceID)

--- a/evoting/protocol/shuffle_test.go
+++ b/evoting/protocol/shuffle_test.go
@@ -51,7 +51,7 @@ func runShuffle(t *testing.T, n int) {
 
 	nodes, roster, tree := local.GenBigTree(n, n, 1, true)
 
-	election := &lib.Election{Roster: roster, Stage: lib.Running, Data: []byte{}}
+	election := &lib.Election{Roster: roster, Stage: lib.Running}
 	_ = election.GenChain(n)
 
 	services := local.GetServices(nodes, shuffleServiceID)

--- a/evoting/service/cast_test.go
+++ b/evoting/service/cast_test.go
@@ -97,7 +97,27 @@ func TestCast_ElectionEnded(t *testing.T) {
 
 	_, err := s.Cast(&evoting.Cast{Token: token, ID: election.ID})
 	assert.Equal(t, errAlreadyEnded, err)
+}
 
+func TestCast_NotStarted(t *testing.T) {
+	local := onet.NewLocalTest(cothority.Suite)
+	defer local.CloseAll()
+
+	nodes, roster, _ := local.GenBigTree(3, 3, 1, true)
+	s := local.GetServices(nodes, serviceID)[0].(*Service)
+	token := s.state.register(0, false)
+
+	election := &lib.Election{
+		Roster:  roster,
+		Creator: 0,
+		Users:   []uint32{0},
+		Stage:   lib.Running,
+		Start:   time.Now().Unix() + 3600,
+	}
+	_ = election.GenChain(3)
+
+	_, err := s.Cast(&evoting.Cast{Token: token, ID: election.ID})
+	assert.Equal(t, errNotStarted, err)
 }
 
 func TestCast_Full(t *testing.T) {

--- a/evoting/service/cast_test.go
+++ b/evoting/service/cast_test.go
@@ -39,7 +39,6 @@ func TestCast_UserNotPart(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Running,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 
@@ -60,7 +59,6 @@ func TestCast_ElectionAlreadyClosed(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Shuffled,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 
@@ -72,7 +70,6 @@ func TestCast_ElectionAlreadyClosed(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Decrypted,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 
@@ -93,7 +90,6 @@ func TestCast_Full(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{1000},
 		Stage:   lib.Running,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 

--- a/evoting/service/decrypt_test.go
+++ b/evoting/service/decrypt_test.go
@@ -37,7 +37,6 @@ func TestDecrypt_UserNotAdmin(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Running,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 
@@ -58,7 +57,6 @@ func TestDecrypt_UserNotCreator(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0, 1},
 		Stage:   lib.Running,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 
@@ -79,7 +77,6 @@ func TestDecrypt_ElectionNotShuffled(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Running,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 
@@ -100,7 +97,6 @@ func TestDecrypt_ElectionClosed(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Decrypted,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 
@@ -123,7 +119,6 @@ func TestDecrypt_Full(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Shuffled,
-		Data:    []byte{},
 	}
 	dkgs := election.GenChain(3)
 	s0.secrets[election.ID.Short()], _ = lib.NewSharedSecret(dkgs[0])

--- a/evoting/service/getbox_test.go
+++ b/evoting/service/getbox_test.go
@@ -37,7 +37,6 @@ func TestGetBox_NotPart(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Running,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 
@@ -58,7 +57,6 @@ func TestGetBox_Full(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Running,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 

--- a/evoting/service/getmixes_test.go
+++ b/evoting/service/getmixes_test.go
@@ -37,7 +37,6 @@ func TestGetMixes_UserNotPart(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Shuffled,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 
@@ -58,7 +57,6 @@ func TestGetMixes_ElectionNotShuffled(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Running,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 
@@ -79,7 +77,6 @@ func TestGetMixes_Full(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Shuffled,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(10)
 

--- a/evoting/service/login_test.go
+++ b/evoting/service/login_test.go
@@ -68,7 +68,6 @@ func TestLogin_Full(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Running,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 

--- a/evoting/service/login_test.go
+++ b/evoting/service/login_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"testing"
+	"time"
 
 	"github.com/dedis/onet"
 
@@ -54,6 +55,41 @@ func TestLogin_InvalidSignature(t *testing.T) {
 
 	_, err := s.Login(l)
 	assert.NotNil(t, err)
+}
+
+func TestLogin_StartTime(t *testing.T) {
+	local := onet.NewLocalTest(cothority.Suite)
+	defer local.CloseAll()
+
+	nodes, roster, _ := local.GenBigTree(3, 3, 1, true)
+	s := local.GetServices(nodes, serviceID)[0].(*Service)
+
+	election := &lib.Election{
+		Roster:  roster,
+		Creator: 42,
+		Users:   []uint32{0},
+		Stage:   lib.Running,
+		Start:   time.Now().Unix() + 3600, // starts in 60 minutes from now
+	}
+	_ = election.GenChain(3)
+
+	x, X := lib.RandomKeyPair()
+	master := &lib.Master{Roster: roster, Key: X}
+	master.GenChain(election.ID)
+
+	// try with normal user
+	l := &evoting.Login{User: 0, ID: master.ID}
+	l.Sign(x)
+
+	r, _ := s.Login(l)
+	assert.Equal(t, 0, len(r.Elections))
+
+	// try logging with election creator
+	creator := &evoting.Login{User: 42, ID: master.ID}
+	creator.Sign(x)
+
+	r, _ = s.Login(creator)
+	assert.Equal(t, election.ID, r.Elections[0].ID)
 }
 
 func TestLogin_Full(t *testing.T) {

--- a/evoting/service/open_test.go
+++ b/evoting/service/open_test.go
@@ -76,7 +76,7 @@ func TestOpen_Full(t *testing.T) {
 	master := &lib.Master{Roster: roster}
 	master.GenChain(nil)
 
-	election := &lib.Election{Data: []byte{}}
+	election := &lib.Election{}
 	r, _ := s.Open(&evoting.Open{Token: token, ID: master.ID, Election: election})
 	assert.NotNil(t, r)
 

--- a/evoting/service/reconstruct_test.go
+++ b/evoting/service/reconstruct_test.go
@@ -38,7 +38,6 @@ func TestReconstruct_ElectionNotDecrypted(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Shuffled,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 
@@ -59,7 +58,6 @@ func TestReconstruct_Full(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Decrypted,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(7)
 

--- a/evoting/service/service.go
+++ b/evoting/service/service.go
@@ -40,6 +40,7 @@ var (
 	errAlreadyShuffled  = errors.New("Election has already been shuffled")
 	errAlreadyDecrypted = errors.New("Election has already been decrypted")
 	errAlreadyClosed    = errors.New("Election has already been closed")
+	errAlreadyEnded     = errors.New("Election has ended")
 	errCorrupt          = errors.New("Election skipchain is corrupt")
 
 	errProtocolUnknown = errors.New("Protocol unknown")
@@ -241,6 +242,10 @@ func (s *Service) Cast(req *evoting.Cast) (*evoting.CastReply, error) {
 
 	if election.Stage >= lib.Shuffled {
 		return nil, errAlreadyClosed
+	}
+
+	if election.End < time.Now().Unix() {
+		return nil, errAlreadyEnded
 	}
 
 	if err = election.Store(req.Ballot); err != nil {

--- a/evoting/service/shuffle_test.go
+++ b/evoting/service/shuffle_test.go
@@ -37,7 +37,6 @@ func TestShuffle_UserNotAdmin(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Running,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 
@@ -58,7 +57,6 @@ func TestShuffle_UserNotCreator(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0, 1},
 		Stage:   lib.Running,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 
@@ -79,7 +77,6 @@ func TestShuffle_ElectionClosed(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Shuffled,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 
@@ -91,7 +88,6 @@ func TestShuffle_ElectionClosed(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Decrypted,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 
@@ -112,7 +108,6 @@ func TestShuffle_Full(t *testing.T) {
 		Creator: 0,
 		Users:   []uint32{0},
 		Stage:   lib.Running,
-		Data:    []byte{},
 	}
 	_ = election.GenChain(3)
 


### PR DESCRIPTION
Replaces `Election.Data` with `Election.Candidates`. Changed the field type to `[]uint32` since scipers will be stored in it. Also introduced `Election.MaxChoices` to store maximum votes allowed in a ballot. Added a `Start` field to denote election start unix timestamp.