### PR TITLE
Make TestClient_ParallelWrite shorter

### DIFF
--- a/skipchain/api_test.go
+++ b/skipchain/api_test.go
@@ -427,7 +427,7 @@ type testData struct {
 
 func TestClient_ParallelWrite(t *testing.T) {
 	numClients := 20
-	numWrites := 100
+	numWrites := 50
 	if testing.Short() {
 		numClients = 2
 	}
@@ -437,7 +437,7 @@ func TestClient_ParallelWrite(t *testing.T) {
 	defer l.CloseAll()
 
 	cl := newTestClient(l)
-	msg := []byte(fmt.Sprintf("genesis"))
+	msg := []byte("genesis")
 	gen, err := cl.CreateGenesis(ro, 1, 1, VerificationRoot, msg, nil)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
@jeffallen please have a look. Turning the number of blocks down to 50 allows the test to pass (in about 66 seconds on my machine). If you think there's a deeper issue in the code please feel free to close this and we can discuss. We may also need to think about what happens if there are too many store block requests, should the server stop accepting blocks if there are too many in the queue?

Fixes https://github.com/dedis/cothority/issues/1100