### PR TITLE
Genesis id 1088

### DIFF
--- a/scmgr/app.go
+++ b/scmgr/app.go
@@ -359,7 +359,7 @@ func scAdd(c *cli.Context) error {
 	}
 	cfg.Db.Store(ssbr.Latest)
 	log.ErrFatal(cfg.save(c))
-	log.Infof("Added new block %x to chain %x", ssbr.Latest.Hash, ssbr.Latest.GenesisID)
+	log.Infof("Added new block %x to chain %x", ssbr.Latest.Hash, ssbr.Latest.SkipChainID())
 	return nil
 }
 
@@ -423,7 +423,7 @@ func dnsFetch(c *cli.Context) error {
 		return err
 	}
 	latest := gcr.Update[len(gcr.Update)-1]
-	genesis := latest.GenesisID
+	genesis := latest.SkipChainID()
 	if genesis == nil {
 		genesis = latest.Hash
 	}
@@ -454,7 +454,7 @@ func dnsList(c *cli.Context) error {
 			return err
 		}
 		for _, sb := range sbs {
-			if sb.GenesisID.Equal(g.Hash) {
+			if sb.SkipChainID().Equal(g.Hash) {
 				sub = append(sub, sb)
 			}
 		}
@@ -490,7 +490,7 @@ func dnsIndex(c *cli.Context) error {
 	log.Info("Going through all skipchain-ids and writing the genesis-block")
 	for i, g := range genesis {
 		block := &blocks.Blocks[i]
-		block.GenesisID = hex.EncodeToString(g.Hash)
+		block.SkipchainID = hex.EncodeToString(g.Hash)
 		block.Servers = make([]string, len(g.Roster.List))
 		block.Data = g.Data
 
@@ -500,8 +500,8 @@ func dnsIndex(c *cli.Context) error {
 
 		// Write the genesis block file
 		content, _ := json.Marshal(block)
-		log.Infof("Writing %s.js", block.GenesisID)
-		err := ioutil.WriteFile(filepath.Join(output, block.GenesisID+".js"), content, 0644)
+		log.Infof("Writing %s.js", block.SkipchainID)
+		err := ioutil.WriteFile(filepath.Join(output, block.SkipchainID+".js"), content, 0644)
 
 		if err != nil {
 			log.Info("Cannot write block-specific file")
@@ -601,9 +601,9 @@ func cleanJSFiles(dir string) error {
 
 // JSON skipblock element to be written in the index.js file
 type jsonBlock struct {
-	GenesisID string
-	Servers   []string
-	Data      []byte
+	SkipchainID string
+	Servers     []string
+	Data        []byte
 }
 
 // JSON list of skipblocks element to be written in the index.js file

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -169,7 +169,7 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, er
 	var prev *SkipBlock
 	var changed []*SkipBlock
 
-	if psbd.LatestID.IsNull() && psbd.NewBlock.GenesisID.IsNull() {
+	if psbd.LatestID.IsNull() && psbd.NewBlock.SkipChainID().IsNull() {
 		// A new chain is created
 		log.Lvl3("Creating new skipchain with roster", psbd.NewBlock.Roster.List)
 		prop.Height = prop.MaximumHeight

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -818,7 +818,6 @@ func (s *Service) forwardLinkLevel0(src, dst *SkipBlock) error {
 		return fmt.Errorf("Couldn't marshal block: %s", err.Error())
 	}
 	fwd := NewForwardLink(src, dst)
-	log.Print()
 	sig, err := s.startBFT(bftNewBlock, roster, fwd.Hash(), data)
 	if err != nil {
 		log.Error(s.ServerIdentity().Address, "startBFT failed with", err)
@@ -936,7 +935,6 @@ func (s *Service) forwardLink(fs *ForwardSignature) error {
 		return err
 	}
 	fl := NewForwardLink(from, fs.Newest)
-	log.Print()
 	sig, err := s.startBFT(bftFollowBlock, from.Roster, fl.Hash(), data)
 	if err != nil {
 		return errors.New("Couldn't get signature: " + err.Error())

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -1310,7 +1310,7 @@ func newSkipchainService(c *onet.Context) (onet.Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = byzcoin.InitBFTCoSiProtocol(cothority.Suite, s.Context,
+	err = byzcoinx.InitBFTCoSiProtocol(cothority.Suite, s.Context,
 		s.bftForwardLink, s.bftForwardLinkAck, bftFollowBlock)
 	if err != nil {
 		return nil, err

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -781,6 +781,7 @@ func TestService_Unlink(t *testing.T) {
 	msg, _ = kp.Public.MarshalBinary()
 	msg = append([]byte("unlink:"), msg...)
 	sig, err = schnorr.Sign(cothority.Suite, kp.Private, msg)
+	require.Nil(t, err)
 	_, err = service.Unlink(&Unlink{
 		Public:    kp.Public,
 		Signature: sig,

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -259,7 +259,9 @@ type SkipBlockFix struct {
 	// SkipBlockParent points to the SkipBlock of the responsible Roster -
 	// is nil if this is the Root-roster
 	ParentBlockID SkipBlockID
-	// GenesisID is the ID of the genesis-block.
+	// GenesisID is the ID of the genesis-block. For the genesis-block, this
+	// is null. The SkipBlockID() methods returns the correct ID both for
+	// the genesis block and for later blocks.
 	GenesisID SkipBlockID
 	// Data is any data to be stored in that SkipBlock
 	Data []byte

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -260,7 +260,7 @@ type SkipBlockFix struct {
 	// is nil if this is the Root-roster
 	ParentBlockID SkipBlockID
 	// GenesisID is the ID of the genesis-block. For the genesis-block, this
-	// is null. The SkipBlockID() methods returns the correct ID both for
+	// is null. The SkipBlockID() method returns the correct ID both for
 	// the genesis block and for later blocks.
 	GenesisID SkipBlockID
 	// Data is any data to be stored in that SkipBlock


### PR DESCRIPTION
Closes #1088 

Instead of making `GenesisID` private, as proposed, it is replaced by `SkipChainID()` wherever possible and a comment on the `GenesisID` field is added.