### PR TITLE
Correctly add genesis block

### DIFF
--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -169,7 +169,7 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, er
 	var prev *SkipBlock
 	var changed []*SkipBlock
 
-	if psbd.LatestID.IsNull() && psbd.NewBlock.SkipChainID().IsNull() {
+	if psbd.LatestID.IsNull() && psbd.NewBlock.Index == 0 {
 		// A new chain is created
 		log.Lvl3("Creating new skipchain with roster", psbd.NewBlock.Roster.List)
 		prop.Height = prop.MaximumHeight


### PR DESCRIPTION
Previously, in https://github.com/dedis/cothority/pull/1102, `psbd.NewBlock.GenesisID.IsNull()` was changed to `psbd.NewBlock.SkipChainID().IsNull()`. This change affected the logic of `StoreSkipBlock` because `psbd.NewBlock.SkipChainID().IsNull()` is always false and the `TestService_ParallelStoreBlock` test started failing.

I'm curious why this bug didn't break more tests.