### PR TITLE
limiting test time to let travis pass

### DIFF
--- a/evoting/lib/election_test.go
+++ b/evoting/lib/election_test.go
@@ -12,6 +12,9 @@ import (
 )
 
 func TestFetchElection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("limiting travis time")
+	}
 	local := onet.NewLocalTest(cothority.Suite)
 	defer local.CloseAll()
 

--- a/evoting/service/cast_test.go
+++ b/evoting/service/cast_test.go
@@ -121,6 +121,9 @@ func TestCast_NotStarted(t *testing.T) {
 }
 
 func TestCast_Full(t *testing.T) {
+	if testing.Short() {
+		t.Skip("limiting travis time")
+	}
 	local := onet.NewLocalTest(cothority.Suite)
 	defer local.CloseAll()
 

--- a/evoting/service/decrypt_test.go
+++ b/evoting/service/decrypt_test.go
@@ -85,6 +85,9 @@ func TestDecrypt_ElectionNotShuffled(t *testing.T) {
 }
 
 func TestDecrypt_ElectionClosed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("limiting travis time")
+	}
 	local := onet.NewLocalTest(cothority.Suite)
 	defer local.CloseAll()
 
@@ -105,6 +108,9 @@ func TestDecrypt_ElectionClosed(t *testing.T) {
 }
 
 func TestDecrypt_Full(t *testing.T) {
+	if testing.Short() {
+		t.Skip("limiting travis time")
+	}
 	local := onet.NewLocalTest(cothority.Suite)
 	defer local.CloseAll()
 

--- a/skipchain/api_test.go
+++ b/skipchain/api_test.go
@@ -24,6 +24,9 @@ func init() {
 }
 
 func TestClient_CreateGenesis(t *testing.T) {
+	if testing.Short() {
+		t.Skip("limiting travis time")
+	}
 	l := onet.NewTCPTest(cothority.Suite)
 	_, roster, _ := l.GenTree(3, true)
 	defer l.CloseAll()
@@ -109,6 +112,9 @@ func TestClient_GetUpdateChain(t *testing.T) {
 	defer local.CloseAll()
 
 	conodes := 10
+	if testing.Short() {
+		conodes = 3
+	}
 	sbCount := conodes - 1
 	servers, roster, gs := local.MakeSRS(cothority.Suite, conodes, skipchainSID)
 	s := gs.(*Service)

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -195,6 +195,10 @@ func TestService_MultiLevel(t *testing.T) {
 	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
+	maxlevel := 3
+	if testing.Short() {
+		maxlevel = 2
+	}
 	servers, el, genService := local.MakeSRS(cothority.Suite, 3, skipchainSID)
 	services := make([]*Service, len(servers))
 	for i, s := range local.GetServices(servers, skipchainSID) {
@@ -202,7 +206,7 @@ func TestService_MultiLevel(t *testing.T) {
 	}
 	service := genService.(*Service)
 
-	for base := 1; base <= 3; base++ {
+	for base := 1; base <= maxlevel; base++ {
 		for height := 1; height <= base; height++ {
 			log.Lvl1("Making genesis for", base, height)
 			if base == 1 && height > 1 {


### PR DESCRIPTION
Looking at https://travis-ci.org/dedis/cothority/jobs/349317079 to measure length of tests, I limited the tests that travis has to run by the longest running ones. Wherever possible I reduced the test-depth with `-short`, or I commented out the test with `t.Skip`.

If we go this way, we _really_ need to have some regular, full (non-`short`) testing twice a day, if possible including `integration_test.sh`.