### PR TITLE
Only update known skipchains unless the -new flag is given

### DIFF
--- a/scmgr/app.go
+++ b/scmgr/app.go
@@ -454,7 +454,7 @@ func dnsList(c *cli.Context) error {
 			return err
 		}
 		for _, sb := range sbs {
-			if sb.SkipChainID().Equal(g.Hash) {
+			if sb.SkipChainID().Equal(g.Hash) && sb.Index > 0 {
 				sub = append(sub, sb)
 			}
 		}
@@ -569,12 +569,16 @@ func dnsUpdate(c *cli.Context) error {
 			continue
 		}
 		for _, sb := range gasr.SkipChains {
-			log.Infof("Found skipchain %x", sb.SkipChainID())
-			cfg.Db.Store(sb)
-			if fetchNew {
-				log.Info("Recursive fetch")
+			if cfg.Db.GetByID(sb.SkipChainID()) == nil {
+				if !fetchNew {
+					log.Lvlf2("Ignoring unknown skipchain %x", sb.SkipChainID())
+					continue
+				}
+				log.Lvl1("Adding new roster to search")
 				sisNew = updateNewSIs(sb.Roster, sisNew, sisAll)
 			}
+			log.Infof("Found skipchain %x", sb.SkipChainID())
+			cfg.Db.Store(sb)
 		}
 	}
 	return cfg.save(c)

--- a/scmgr/test.sh
+++ b/scmgr/test.sh
@@ -11,6 +11,7 @@ main(){
 	startTest
 	buildConode github.com/dedis/cothority/skipchain
 	CFG=$BUILDDIR/scmgr_config
+	test DNSUpdate
 	test Restart
 	test Config
 	test Create
@@ -25,6 +26,20 @@ main(){
 	test NewChain
 	test Failure
 	stopTest
+}
+
+testDNSUpdate(){
+	startCl
+	setupGenesis
+	testOK runSc scdns fetch public.toml $ID
+	testOK [ "$(runSc scdns list | grep Genesis | wc -l)" -eq 1 ]
+	mv $CFG tmpcfg
+	setupGenesis
+	mv tmpcfg $CFG
+	testOK runSc scdns update
+	testOK [ "$(runSc scdns list | grep Genesis | wc -l)" -eq 1 ]
+	testOK runSc scdns update -new
+	testOK [ "$(runSc scdns list | grep Genesis | wc -l)" -eq 2 ]
 }
 
 testNewChain(){


### PR DESCRIPTION
There is (at least one) error in `scmgr` that lets it fetch all new skipchains from a conode, even when `-new` is not given. Fixed and added an integration test.