### PR TITLE
Add forgotten nil check

### DIFF
--- a/skipchain/protocol_test.go
+++ b/skipchain/protocol_test.go
@@ -25,7 +25,6 @@ func init() {
 
 // TestGB tests the GetBlocks protocol
 func TestGB(t *testing.T) {
-	t.Skip("See https://github.com/dedis/cothority/issues/1027")
 	local := onet.NewLocalTest(cothority.Suite)
 	defer local.CloseAll()
 	servers, ro, _ := local.GenTree(3, true)

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -472,7 +472,9 @@ func NewForwardLink(from, to *SkipBlock) *ForwardLink {
 		From: from.Hash,
 		To:   to.Hash,
 	}
-	if !from.Roster.ID.Equal(to.Roster.ID) {
+
+	if from.Roster != nil && to.Roster != nil &&
+		!from.Roster.ID.Equal(to.Roster.ID) {
 		fl.NewRoster = to.Roster
 	}
 	return fl


### PR DESCRIPTION
It is possible that Roster might not be set. Do not crash
when that happens.

Fixes #1027.