### PR TITLE
cothorityjs: fix onmessage handler on android

### DIFF
--- a/external/js/cothority/lib/net/net.js
+++ b/external/js/cothority/lib/net/net.js
@@ -67,7 +67,18 @@ function Socket(addr, service) {
 
       ws.onmessage = event => {
         ws.close();
-        const buffer = new Uint8Array(event.data);
+        const { data } = event;
+        let buffer;
+        if (ws.android) {
+          data.rewind();
+          const len = data.limit();
+          buffer = new Uint8Array(len);
+          for (let i = 0; i < len; i++) {
+            buffer[i] = data.get(i);
+          }
+        } else {
+          buffer = new Uint8Array(data);
+        }
         const unmarshal = responseModel.decode(buffer);
         resolve(unmarshal);
       };


### PR DESCRIPTION
Websocket reply on android is of type [java.nio.HeapByteBuffer](https://docs.oracle.com/javase/7/docs/api/java/nio/ByteBuffer.html) which doesn't allow indexed access using square bracket notation. This results in an empty Uint8Array being created in JS and eventually an Error during protobuf decode.

This PR treats the android websocket handler separately and constructs the Uint8Array from the message using `buf.get(i)`