### PR TITLE
Fix shuffle verification bug

### DIFF
--- a/evoting/lib/container.go
+++ b/evoting/lib/container.go
@@ -83,9 +83,9 @@ func genBox(key kyber.Point, n int) *Box {
 func Split(ballots []*Ballot) (alpha, beta []kyber.Point) {
 	n := len(ballots)
 	alpha, beta = make([]kyber.Point, n), make([]kyber.Point, n)
-	for i, ballot := range ballots {
-		alpha[i] = ballot.Alpha
-		beta[i] = ballot.Beta
+	for i := range ballots {
+		alpha[i] = ballots[i].Alpha
+		beta[i] = ballots[i].Beta
 	}
 	return
 }

--- a/evoting/protocol/decrypt.go
+++ b/evoting/protocol/decrypt.go
@@ -65,18 +65,6 @@ func (d *Decrypt) HandlePrompt(prompt MessagePromptDecrypt) error {
 		return err
 	}
 
-	// var partial *lib.Partial
-	// if !Verify(d.Election.Key, box, mixes) {
-	// 	partial = &lib.Partial{Flag: true, Node: d.Name()}
-	// } else {
-	// 	last := mixes[len(mixes)-1].Ballots
-	// 	points := make([]kyber.Point, len(box.Ballots))
-	// 	for i := range points {
-	// 		points[i] = lib.Decrypt(d.Secret.V, last[i].Alpha, last[i].Beta)
-	// 	}
-	// 	partial = &lib.Partial{Points: points, Flag: false, Node: d.Name()}
-	// }
-
 	last := mixes[len(mixes)-1].Ballots
 	points := make([]kyber.Point, len(box.Ballots))
 	for i := range points {

--- a/evoting/protocol/decrypt_test.go
+++ b/evoting/protocol/decrypt_test.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/dedis/onet"
-	"github.com/dedis/onet/log"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/evoting/lib"
@@ -45,7 +45,7 @@ func (s *decryptService) NewProtocol(node *onet.TreeNodeInstance, conf *onet.Gen
 }
 
 func TestDecryptProtocol(t *testing.T) {
-	for _, nodes := range []int{3} {
+	for _, nodes := range []int{3, 5, 7} {
 		runDecrypt(t, nodes)
 	}
 }
@@ -75,9 +75,9 @@ func runDecrypt(t *testing.T, n int) {
 	case <-decrypt.Finished:
 		partials, _ := election.Partials()
 		for _, partial := range partials {
-			log.Lvl1(partial)
+			require.True(t, partial.Flag)
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(60 * time.Second):
 		assert.True(t, false)
 	}
 }

--- a/evoting/protocol/shuffle.go
+++ b/evoting/protocol/shuffle.go
@@ -82,7 +82,6 @@ func (s *Shuffle) HandlePrompt(prompt MessagePrompt) error {
 
 	a, b := lib.Split(ballots)
 	g, d, prover := shuffle.Shuffle(cothority.Suite, nil, s.Election.Key, a, b, random.New())
-
 	proof, err := proof.HashProve(cothority.Suite, "", prover)
 	if err != nil {
 		return err

--- a/evoting/protocol/shuffle_test.go
+++ b/evoting/protocol/shuffle_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dedis/onet"
 
 	"github.com/dedis/cothority"
@@ -33,6 +35,7 @@ func (s *shuffleService) NewProtocol(n *onet.TreeNodeInstance, c *onet.GenericCo
 		instance, _ := NewShuffle(n)
 		shuffle := instance.(*Shuffle)
 		shuffle.Election = s.election
+
 		return shuffle, nil
 	default:
 		return nil, errors.New("Unknown protocol")
@@ -40,7 +43,7 @@ func (s *shuffleService) NewProtocol(n *onet.TreeNodeInstance, c *onet.GenericCo
 }
 
 func TestShuffleProtocol(t *testing.T) {
-	for _, nodes := range []int{3} {
+	for _, nodes := range []int{3, 5, 7} {
 		runShuffle(t, nodes)
 	}
 }
@@ -66,14 +69,16 @@ func runShuffle(t *testing.T, n int) {
 
 	select {
 	case <-shuffle.Finished:
-		// TODO: find out why this fails from time to time - @qantik is looking into that
-		// box, _ := election.Box()
-		// mixes, _ := election.Mixes()
+		box, _ := election.Box()
+		mixes, _ := election.Mixes()
 
-		// x, y := lib.Split(box.Ballots)
-		// v, w := lib.Split(mixes[0].Ballots)
-		// require.Nil(t, lib.Verify(mixes[0].Proof, election.Key, x, y, v, w))
-	case <-time.After(3 * time.Second):
+		in1, in2 := lib.Split(box.Ballots)
+		for i := range mixes {
+			out1, out2 := lib.Split(mixes[i].Ballots)
+			require.Nil(t, lib.Verify(mixes[i].Proof, election.Key, in1, in2, out1, out2))
+			in1, in2 = out1, out2
+		}
+	case <-time.After(60 * time.Second):
 		t.Fatal("Protocol timeout")
 	}
 }

--- a/evoting/service/service.go
+++ b/evoting/service/service.go
@@ -192,14 +192,14 @@ func (s *Service) Login(req *evoting.Login) (*evoting.LoginReply, error) {
 }
 
 // LookupSciper calls https://people.epfl.ch/cgi-bin/people/vCard?id=sciper
-// to convert scipers to names
+// to convert Sciper numbers to names.
 func (s *Service) LookupSciper(req *evoting.LookupSciper) (*evoting.LookupSciperReply, error) {
 	if len(req.Sciper) != 6 {
-		return nil, errors.New("sciper should be 6 digits only")
+		return nil, errors.New("Sciper should be 6 digits only")
 	}
 	sciper, err := strconv.Atoi(req.Sciper)
 	if err != nil {
-		return nil, errors.New("couldn't convert sciper to integer")
+		return nil, errors.New("Couldn't convert Sciper to integer")
 	}
 
 	url := "https://people.epfl.ch/cgi-bin/people/vCard"
@@ -207,7 +207,7 @@ func (s *Service) LookupSciper(req *evoting.LookupSciper) (*evoting.LookupSciper
 		url = req.LookupURL
 	}
 
-	// Make sure the only varialbe expansion in there is what we want it to be.
+	// Make sure the only variable expansion in there is what we want it to be.
 	if strings.Contains(url, "%") {
 		return nil, errors.New("Percent not allowed in LookupURL")
 	}
@@ -220,7 +220,7 @@ func (s *Service) LookupSciper(req *evoting.LookupSciper) (*evoting.LookupSciper
 	defer resp.Body.Close()
 
 	if resp.Header.Get("Content-type") != "text/x-vcard; charset=utf-8" {
-		return nil, errors.New("invalid or unknown sciper")
+		return nil, errors.New("Invalid or unknown sciper")
 	}
 
 	bodyLimit := io.LimitReader(resp.Body, 1<<17)

--- a/evoting/service/service.go
+++ b/evoting/service/service.go
@@ -28,24 +28,24 @@ import (
 const timeout = 60 * time.Second
 
 var (
-	errInvalidPin       = errors.New("Invalid pin")
-	errInvalidSignature = errors.New("Invalid signature")
-	errNotLoggedIn      = errors.New("User is not logged in")
-	errNotAdmin         = errors.New("Admin privileges required")
-	errNotCreator       = errors.New("User is not election creator")
-	errNotPart          = errors.New("User is not part of election")
+	errInvalidPin       = errors.New("invalid pin")
+	errInvalidSignature = errors.New("invalid signature")
+	errNotLoggedIn      = errors.New("user is not logged in")
+	errNotAdmin         = errors.New("admin privileges required")
+	errNotCreator       = errors.New("user is not election creator")
+	errNotPart          = errors.New("user is not part of election")
 
-	errNotStarted       = errors.New("Election has not started yet")
-	errNotShuffled      = errors.New("Election has not been shuffled yet")
-	errNotDecrypted     = errors.New("Election has not been decrypted yet")
-	errAlreadyShuffled  = errors.New("Election has already been shuffled")
-	errAlreadyDecrypted = errors.New("Election has already been decrypted")
-	errAlreadyClosed    = errors.New("Election has already been closed")
-	errAlreadyEnded     = errors.New("Election has ended")
-	errCorrupt          = errors.New("Election skipchain is corrupt")
+	errNotStarted       = errors.New("election has not started yet")
+	errNotShuffled      = errors.New("election has not been shuffled yet")
+	errNotDecrypted     = errors.New("election has not been decrypted yet")
+	errAlreadyShuffled  = errors.New("election has already been shuffled")
+	errAlreadyDecrypted = errors.New("election has already been decrypted")
+	errAlreadyClosed    = errors.New("election has already been closed")
+	errAlreadyEnded     = errors.New("election has ended")
+	errCorrupt          = errors.New("election skipchain is corrupt")
 
-	errProtocolUnknown = errors.New("Protocol unknown")
-	errProtocolTimeout = errors.New("Protocol timeout")
+	errProtocolUnknown = errors.New("protocol unknown")
+	errProtocolTimeout = errors.New("protocol timeout")
 )
 
 // serviceID is the onet identifier.
@@ -195,11 +195,11 @@ func (s *Service) Login(req *evoting.Login) (*evoting.LoginReply, error) {
 // to convert Sciper numbers to names.
 func (s *Service) LookupSciper(req *evoting.LookupSciper) (*evoting.LookupSciperReply, error) {
 	if len(req.Sciper) != 6 {
-		return nil, errors.New("Sciper should be 6 digits only")
+		return nil, errors.New("sciper should be 6 digits only")
 	}
 	sciper, err := strconv.Atoi(req.Sciper)
 	if err != nil {
-		return nil, errors.New("Couldn't convert Sciper to integer")
+		return nil, errors.New("couldn't convert Sciper to integer")
 	}
 
 	url := "https://people.epfl.ch/cgi-bin/people/vCard"
@@ -209,7 +209,7 @@ func (s *Service) LookupSciper(req *evoting.LookupSciper) (*evoting.LookupSciper
 
 	// Make sure the only variable expansion in there is what we want it to be.
 	if strings.Contains(url, "%") {
-		return nil, errors.New("Percent not allowed in LookupURL")
+		return nil, errors.New("percent not allowed in LookupURL")
 	}
 	url = fmt.Sprintf(url+"?id=%06d", sciper)
 
@@ -220,7 +220,7 @@ func (s *Service) LookupSciper(req *evoting.LookupSciper) (*evoting.LookupSciper
 	defer resp.Body.Close()
 
 	if resp.Header.Get("Content-type") != "text/x-vcard; charset=utf-8" {
-		return nil, errors.New("Invalid or unknown sciper")
+		return nil, errors.New("invalid or unknown sciper")
 	}
 
 	bodyLimit := io.LimitReader(resp.Body, 1<<17)


### PR DESCRIPTION
This fixes a long-standing bug in the Neff shuffle verification routing inside ```evoting/protocol```.
As it turned out the code making sure that only the most recent ballot of a user is fetched from
the skipchain invalidated the correct ballot order.
Thus the Neff shuffle code in ```kyber/shuffle``` works fine.