### PR TITLE
Bftcosi optimisation byzgen - byzgen_poc

### DIFF
--- a/bftcosi/bftcosi.go
+++ b/bftcosi/bftcosi.go
@@ -487,7 +487,7 @@ func (bft *ProtocolBFTCoSi) handleResponsePrepare(c chan responseChan) error {
 
 	// return if we're not root
 	if !bft.IsRoot() {
-		return bft.SendTo(bft.Parent(), bzrReturn)
+		return bft.SendToParent(bzrReturn)
 	}
 
 	// Since cosi does not support exceptions yet, we have to remove the

--- a/bftcosi/bftcosi.go
+++ b/bftcosi/bftcosi.go
@@ -40,7 +40,8 @@ type ProtocolBFTCoSi struct {
 	Msg []byte
 	// Data going along the msg to the verification
 	Data []byte
-	// Timeout is how long to wait while gathering commits.
+	// Timeout is how long to wait while gathering commits. It should be
+	// set by the caller after creating the protocol.
 	Timeout time.Duration
 	// AllowedExceptions for how much exception is allowed. If more than
 	// AllowedExceptions number of conodes refuse to sign, no signature
@@ -127,7 +128,7 @@ type collectStructs struct {
 }
 
 // NewBFTCoSiProtocol returns a new bftcosi struct
-func NewBFTCoSiProtocol(n *onet.TreeNodeInstance, verify VerificationFunction, to time.Duration) (*ProtocolBFTCoSi, error) {
+func NewBFTCoSiProtocol(n *onet.TreeNodeInstance, verify VerificationFunction) (*ProtocolBFTCoSi, error) {
 	t := (len(n.Tree().List()) - 1) / 3
 	// initialize the bftcosi node/protocol-instance
 	bft := &ProtocolBFTCoSi{
@@ -143,7 +144,7 @@ func NewBFTCoSiProtocol(n *onet.TreeNodeInstance, verify VerificationFunction, t
 		AllowedExceptions:    t,
 		Msg:                  make([]byte, 0),
 		Data:                 make([]byte, 0),
-		Timeout:              to,
+		Timeout:              5 * time.Second,
 	}
 
 	idx, _ := n.Roster().Search(bft.ServerIdentity().ID)
@@ -254,7 +255,7 @@ func (bft *ProtocolBFTCoSi) Dispatch() error {
 			// the prepare phase
 			return nil
 		case <-time.After(bft.Timeout):
-			return fmt.Errorf("timeout waiting for challenge - " +
+			return errors.New("timeout waiting for challenge - " +
 				"might be OK because the protocol already finished")
 		}
 	}

--- a/bftcosi/bftcosi.go
+++ b/bftcosi/bftcosi.go
@@ -21,9 +21,6 @@ import (
 	"github.com/dedis/onet/log"
 )
 
-// Make this variable so we can set it to 100ms in the tests.
-var defaultTimeout = 10 * time.Second
-
 // VerificationFunction can be passes to each protocol node. It will be called
 // (in a go routine) during the (start/handle) challenge prepare phase of the
 // protocol. The passed message is the same as sent in the challenge phase.
@@ -129,7 +126,7 @@ type collectStructs struct {
 }
 
 // NewBFTCoSiProtocol returns a new bftcosi struct
-func NewBFTCoSiProtocol(n *onet.TreeNodeInstance, verify VerificationFunction) (*ProtocolBFTCoSi, error) {
+func NewBFTCoSiProtocol(n *onet.TreeNodeInstance, verify VerificationFunction, to time.Duration) (*ProtocolBFTCoSi, error) {
 	// initialize the bftcosi node/protocol-instance
 	bft := &ProtocolBFTCoSi{
 		TreeNodeInstance: n,
@@ -144,7 +141,7 @@ func NewBFTCoSiProtocol(n *onet.TreeNodeInstance, verify VerificationFunction) (
 		allowedExceptions:    (len(n.Tree().List()) - 1) / 3, // also known as t
 		Msg:                  make([]byte, 0),
 		Data:                 make([]byte, 0),
-		Timeout:              defaultTimeout,
+		Timeout:              to,
 	}
 
 	idx, _ := n.Roster().Search(bft.ServerIdentity().ID)
@@ -267,12 +264,6 @@ func (bft *ProtocolBFTCoSi) Dispatch() error {
 // from a non-root Node.  If the root does not finish correctly, then the
 // signature will be nil.
 func (bft *ProtocolBFTCoSi) Signature() *BFTSignature {
-	bft.successfulMut.Lock()
-	ok := bft.successful
-	bft.successfulMut.Unlock()
-	if !ok {
-		return nil
-	}
 
 	// create exceptions for the nodes that were late to respond in the
 	// commit phase
@@ -285,6 +276,17 @@ func (bft *ProtocolBFTCoSi) Signature() *BFTSignature {
 				Commitment: bft.Suite().Point().Null(),
 			}
 			i++
+		}
+	}
+
+	bft.successfulMut.Lock()
+	ok := bft.successful
+	bft.successfulMut.Unlock()
+	if !ok {
+		return &BFTSignature{
+			Sig:        nil,
+			Msg:        bft.Msg,
+			Exceptions: exceptions,
 		}
 	}
 

--- a/bftcosi/bftcosi.go
+++ b/bftcosi/bftcosi.go
@@ -47,10 +47,6 @@ type ProtocolBFTCoSi struct {
 	Timeout time.Duration
 	// last block computed
 	lastBlock string
-	// refusal to sign for the commit phase or not. This flag is set during the
-	// Challenge of the commit phase and will be used during the response of the
-	// commit phase to put an exception or to sign.
-	signRefusal bool
 	// allowedExceptions for how much exception is allowed. If more than allowedExceptions number
 	// of conodes refuse to sign, no signature will be created.
 	allowedExceptions int
@@ -91,6 +87,9 @@ type ProtocolBFTCoSi struct {
 	closing bool
 	// mutex for closing down properly
 	closingMutex sync.Mutex
+	// successful is a flag to indicate whether the protocol finished successfully
+	successful    bool
+	successfulMut sync.Mutex
 }
 
 // collectStructs holds the variables that are used during the protocol to hold
@@ -110,31 +109,39 @@ type collectStructs struct {
 	tmpMutex sync.Mutex
 	// exceptions given during the rounds that is used in the signature
 	tempExceptions []Exception
+	// respondedNodesPrepare stores a list of nodes that sent a commit
+	// message in the prepare phase
+	respondedNodesPrepare map[kyber.Point]*onet.TreeNode
+	// respondedNodesCommit stores a list of nodes that sent a commit
+	// message in the commit phase
+	respondedNodesCommit map[kyber.Point]*onet.TreeNode
 	// temporary buffer of "prepare" commitments
 	tempPrepareCommit []kyber.Point
 	// temporary buffer of "commit" commitments
 	tempCommitCommit []kyber.Point
 	// temporary buffer of "prepare" responses
 	tempPrepareResponse []kyber.Scalar
-	// temporary buffer of the public keys for nodes that responded
-	tempPrepareResponsePublics []kyber.Point
 	// temporary buffer of "commit" responses
 	tempCommitResponse []kyber.Scalar
+
+	committedInPreparePhase bool
+	committedInCommitPhase  bool
 }
 
 // NewBFTCoSiProtocol returns a new bftcosi struct
 func NewBFTCoSiProtocol(n *onet.TreeNodeInstance, verify VerificationFunction) (*ProtocolBFTCoSi, error) {
 	// initialize the bftcosi node/protocol-instance
-	nodes := len(n.Tree().List())
 	bft := &ProtocolBFTCoSi{
 		TreeNodeInstance: n,
 		collectStructs: collectStructs{
-			prepare: crypto.NewCosi(n.Suite(), n.Private(), n.Roster().Publics()),
-			commit:  crypto.NewCosi(n.Suite(), n.Private(), n.Roster().Publics()),
+			prepare:               crypto.NewCosi(n.Suite(), n.Private(), n.Roster().Publics()),
+			commit:                crypto.NewCosi(n.Suite(), n.Private(), n.Roster().Publics()),
+			respondedNodesPrepare: make(map[kyber.Point]*onet.TreeNode),
+			respondedNodesCommit:  make(map[kyber.Point]*onet.TreeNode),
 		},
 		verifyChan:           make(chan bool),
 		VerificationFunction: verify,
-		allowedExceptions:    nodes - (nodes+1)*2/3,
+		allowedExceptions:    (len(n.Tree().List()) - 1) / 3, // also known as t
 		Msg:                  make([]byte, 0),
 		Data:                 make([]byte, 0),
 		Timeout:              defaultTimeout,
@@ -152,7 +159,6 @@ func NewBFTCoSiProtocol(n *onet.TreeNodeInstance, verify VerificationFunction) (
 	}
 
 	n.OnDoneCallback(bft.nodeDone)
-
 	return bft, nil
 }
 
@@ -174,6 +180,8 @@ func (bft *ProtocolBFTCoSi) Start() error {
 // By closing the channels for the leafs we can avoid having
 // `if !bft.IsLeaf` in the code.
 func (bft *ProtocolBFTCoSi) Dispatch() error {
+	defer bft.Done()
+
 	bft.closingMutex.Lock()
 	if bft.closing {
 		return nil
@@ -210,59 +218,81 @@ func (bft *ProtocolBFTCoSi) Dispatch() error {
 		}
 	}
 
-	// Finish the prepare round
-	if err := bft.handleChallengePrepare(<-bft.challengePrepareChan); err != nil {
-		return err
-	}
-	if !bft.IsLeaf() {
-		if err := bft.handleResponsePrepare(bft.responseChan); err != nil {
-			return err
-		}
-	}
+	var gotChallengePrepare bool
+	for {
+		select {
+		case c := <-bft.challengePrepareChan:
+			if gotChallengePrepare {
+				log.Warn(bft.Name(), "got multiple challenges - potential ddos")
+				continue
+			}
+			// Finish the prepare round
+			if err := bft.handleChallengePrepare(c); err != nil {
+				return err
+			}
+			if !bft.IsLeaf() {
+				if err := bft.handleResponsePrepare(bft.responseChan); err != nil {
+					return err
+				}
+			}
+			gotChallengePrepare = true
+		case c := <-bft.challengeCommitChan:
 
-	// Finish the commit round
-	if err := bft.handleChallengeCommit(<-bft.challengeCommitChan); err != nil {
-		return err
-	}
-	if !bft.IsLeaf() {
-		if err := bft.handleResponseCommit(bft.responseChan); err != nil {
-			return err
+			// Finish the commit round
+			if err := bft.handleChallengeCommit(c); err != nil {
+				return err
+			}
+			if !bft.IsLeaf() {
+				if err := bft.handleResponseCommit(bft.responseChan); err != nil {
+					return err
+				}
+			}
+			bft.successfulMut.Lock()
+			bft.successful = true
+			bft.successfulMut.Unlock()
+			// we return here even when prepare is not done yet,
+			// because we may not have received the challenge for
+			// the prepare phase
+			return nil
+		case <-time.After(bft.Timeout):
+			return fmt.Errorf("timeout waiting for challenge - " +
+				"might be OK because the protocol already finished")
 		}
 	}
-	return nil
 }
 
 // Signature will generate the final signature, the output of the BFTCoSi
-// protocol.
-// The signature contains the commit round signature, with the message.
-// If the prepare phase failed, the signature will be nil and the Exceptions
-// will contain the exception from the prepare phase. It can be useful to see
-// which cosigners refused to sign (each exceptions contains the index of a
-// refusing-to-sign signer).
-// Expect this function to have an undefined behavior when called from a
-// non-root Node.
+// protocol.  The signature contains the commit round signature, with the
+// message.  Expect this function to have an undefined behavior when called
+// from a non-root Node.  If the root does not finish correctly, then the
+// signature will be nil.
 func (bft *ProtocolBFTCoSi) Signature() *BFTSignature {
-	bftSig := &BFTSignature{
-		Sig:        bft.commit.Signature(),
-		Msg:        bft.Msg,
-		Exceptions: nil,
-	}
-	if bft.signRefusal {
-		bftSig.Sig = nil
-		bftSig.Exceptions = bft.tempExceptions
+	bft.successfulMut.Lock()
+	ok := bft.successful
+	bft.successfulMut.Unlock()
+	if !ok {
+		return nil
 	}
 
-	// This is a hack to include exceptions which are the result of offline
-	// nodes rather than nodes that refused to sign.
-	if bftSig.Exceptions == nil {
-		for _, ex := range bft.tempExceptions {
-			if ex.Commitment.Equal(bft.Suite().Point().Null()) {
-				bftSig.Exceptions = append(bftSig.Exceptions, ex)
+	// create exceptions for the nodes that were late to respond in the
+	// commit phase
+	var i int
+	exceptions := make([]Exception, bft.allowedExceptions)
+	for _, tn := range bft.Children() {
+		if _, ok := bft.respondedNodesCommit[tn.ServerIdentity.Public]; !ok {
+			exceptions[i] = Exception{
+				Index:      tn.RosterIndex,
+				Commitment: bft.Suite().Point().Null(),
 			}
+			i++
 		}
 	}
 
-	return bftSig
+	return &BFTSignature{
+		Sig:        bft.commit.Signature(),
+		Msg:        bft.Msg,
+		Exceptions: exceptions,
+	}
 }
 
 // RegisterOnDone registers a callback to call when the bftcosi protocols has
@@ -305,7 +335,11 @@ func (bft *ProtocolBFTCoSi) handleAnnouncement(msg announceChan) error {
 		bft.Timeout = ann.Timeout
 		return bft.startCommitment(ann.TYPE)
 	}
-	return bft.sendToChildren(&ann)
+	errs := bft.SendToChildrenInParallel(&ann)
+	if len(errs) > bft.allowedExceptions {
+		return errs[0]
+	}
+	return nil
 }
 
 // handleCommitmentPrepare handles incoming commit messages in the prepare phase
@@ -322,12 +356,7 @@ func (bft *ProtocolBFTCoSi) handleCommitmentPrepare(c chan commitChan) error {
 		return err
 	}
 
-	// TODO this will not always work for non-star graphs
-	if len(bft.tempPrepareCommit) < len(bft.Children())-bft.allowedExceptions {
-		bft.signRefusal = true
-		log.Error("not enough prepare commitment messages")
-	}
-
+	// at this point we should have n-t commit messages
 	commitment := bft.prepare.Commit(bft.Suite().RandomStream(), bft.tempPrepareCommit)
 	if bft.IsRoot() {
 		return bft.startChallenge(RoundPrepare)
@@ -346,14 +375,11 @@ func (bft *ProtocolBFTCoSi) handleCommitmentCommit(c chan commitChan) error {
 
 	// wait until we have enough RoundCommit commitments or timeout
 	// should do nothing if `c` is closed
-	bft.readCommitChan(c, RoundCommit)
-
-	// TODO this will not always work for non-star graphs
-	if len(bft.tempCommitCommit) < len(bft.Children())-bft.allowedExceptions {
-		bft.signRefusal = true
-		log.Error("not enough commit commitment messages")
+	if err := bft.readCommitChan(c, RoundCommit); err != nil {
+		return err
 	}
 
+	// at this point we should have a threshold number of commitments
 	commitment := bft.commit.Commit(bft.Suite().RandomStream(), bft.tempCommitCommit)
 	if bft.IsRoot() {
 		// do nothing:
@@ -384,9 +410,10 @@ func (bft *ProtocolBFTCoSi) handleChallengePrepare(msg challengePrepareChan) err
 		bft.verifyChan <- bft.VerificationFunction(bft.Msg, bft.Data)
 	}()
 	if bft.IsLeaf() {
-		return bft.startResponse(RoundPrepare)
+		return bft.handleResponsePrepare(bft.responseChan)
 	}
-	return bft.sendToChildren(&ch)
+	// only send to the committed children
+	return bft.multicast(&ch, bft.respondedNodesPrepare)
 }
 
 // handleChallengeCommit verifies the signature and checks if not more than
@@ -408,15 +435,13 @@ func (bft *ProtocolBFTCoSi) handleChallengeCommit(msg challengeCommitChan) error
 		Exceptions: ch.Signature.Exceptions,
 	}
 	if err := bftPrepareSig.Verify(bft.Suite(), bft.Roster().Publics()); err != nil {
-		log.Error(bft.Name(), "Verification of the signature failed:", err)
-		bft.signRefusal = true
+		return fmt.Errorf("%s: Verification of the signature failed: %v", bft.Name(), err)
 	}
 
 	// check if we have no more than threshold failed nodes
 	if len(ch.Signature.Exceptions) > int(bft.allowedExceptions) {
-		log.Errorf("%s: More than threshold (%d/%d) refused to sign - aborting.",
-			bft.Roster().ID, len(ch.Signature.Exceptions), len(bft.Roster().List))
-		bft.signRefusal = true
+		return fmt.Errorf("%s: More than threshold (%d/%d) refused to sign - aborting",
+			bft.Roster(), len(ch.Signature.Exceptions), len(bft.Roster().List))
 	}
 
 	// store the exceptions for later usage
@@ -426,12 +451,13 @@ func (bft *ProtocolBFTCoSi) handleChallengeCommit(msg challengeCommitChan) error
 		// bft.responseChan should be closed
 		return bft.handleResponseCommit(bft.responseChan)
 	}
-	return bft.sendToChildren(&ch)
+	// only send to the committed children
+	return bft.multicast(&ch, bft.respondedNodesCommit)
 }
 
-// handleResponsePrepare handles response messages in the prepare phase.
-// If the node is not the root, it'll aggregate the response and forward to
-// the parent. Otherwise it verifies the response.
+// handleResponsePrepare handles response messages in the prepare phase.  If
+// the node is not the root, it'll aggregate the response and forward to the
+// parent. Otherwise it verifies the response.
 func (bft *ProtocolBFTCoSi) handleResponsePrepare(c chan responseChan) error {
 	bft.tmpMutex.Lock()
 	defer bft.tmpMutex.Unlock() // NOTE potentially locked for the whole timeout
@@ -442,27 +468,19 @@ func (bft *ProtocolBFTCoSi) handleResponsePrepare(c chan responseChan) error {
 		return err
 	}
 
-	// TODO this will only work for star-graphs
-	// check if we have enough messages
-	if len(bft.tempPrepareResponse) < len(bft.Children())-bft.allowedExceptions {
-		log.Error("not enough prepare response messages")
-		bft.signRefusal = true
-	}
-
 	// wait for verification
 	bzrReturn, ok := bft.waitResponseVerification()
-	// append response
 	if !ok {
-		log.Lvl2(bft.Roster().ID, "refused to sign")
+		return fmt.Errorf("%v verification failed", bft.Name())
 	}
 
-	// Return if we're not root
+	// return if we're not root
 	if !bft.IsRoot() {
 		return bft.SendTo(bft.Parent(), bzrReturn)
 	}
 
-	// Since cosi does not support exceptions yet, we have to remove
-	// the responses that are not supposed to be there,i.e. exceptions.
+	// Since cosi does not support exceptions yet, we have to remove the
+	// responses that are not supposed to be there, i.e. exceptions.
 	cosiSig := bft.prepare.Signature()
 	correctResponseBuff, err := bzrReturn.Response.MarshalBinary()
 	if err != nil {
@@ -485,9 +503,7 @@ func (bft *ProtocolBFTCoSi) handleResponsePrepare(c chan responseChan) error {
 	}
 
 	if err := sig.Verify(bft.Suite(), bft.Roster().Publics()); err != nil {
-		log.Error(bft.Name(), "Verification of the signature failed:", err)
-		bft.signRefusal = true
-		return err
+		return fmt.Errorf("%s: Verification of the signature failed: %v", bft.Name(), err)
 	}
 	log.Lvl3(bft.Name(), "Verification of signature successful")
 
@@ -508,13 +524,8 @@ func (bft *ProtocolBFTCoSi) handleResponseCommit(c chan responseChan) error {
 
 	// wait until we have enough RoundCommit responses or timeout
 	// does nothing if channel is closed
-	bft.readResponseChan(c, RoundCommit)
-
-	// TODO this will only work for star-graphs
-	// check if we have enough messages
-	if len(bft.tempCommitResponse) < len(bft.Children())-bft.allowedExceptions {
-		log.Error("not enough commit response messages")
-		bft.signRefusal = true
+	if err := bft.readResponseChan(c, RoundCommit); err != nil {
+		return err
 	}
 
 	r := &Response{
@@ -532,39 +543,27 @@ func (bft *ProtocolBFTCoSi) handleResponseCommit(c chan responseChan) error {
 		return err
 	}
 
-	if bft.signRefusal {
-		r.Exceptions = append(r.Exceptions, Exception{
-			Index:      bft.index,
-			Commitment: bft.commit.GetCommitment(),
-		})
-		// don't include our own!
-		r.Response.Sub(r.Response, bft.commit.GetResponse())
-	}
-
-	// notify we have finished to participate in this signature
-	log.Lvl3(bft.Name(), "refusal=", bft.signRefusal)
 	// if root we have finished
 	if bft.IsRoot() {
 		sig := bft.Signature()
 		if bft.onSignatureDone != nil {
 			bft.onSignatureDone(sig)
 		}
-		bft.Done()
 		return nil
 	}
 
-	// otherwise , send the response up
-	err = bft.SendTo(bft.Parent(), r)
+	err = bft.SendToParent(r)
 	bft.Done()
 	return err
 }
 
-// readCommitChan reads until all commit messages are received or a timeout for message type `t`
+// readCommitChan reads a threshold (n-t) of the commit messages or until the
+// timeout for message type `t`.
 func (bft *ProtocolBFTCoSi) readCommitChan(c chan commitChan, t RoundType) error {
 	timeout := time.After(bft.Timeout)
 	for {
 		if bft.isClosing() {
-			return errors.New("Closing")
+			return errors.New("closing")
 		}
 
 		select {
@@ -574,35 +573,48 @@ func (bft *ProtocolBFTCoSi) readCommitChan(c chan commitChan, t RoundType) error
 				return nil
 			}
 
+			from := msg.ServerIdentity.Public
 			comm := msg.Commitment
 			// store the message and return when we have enough
 			switch comm.TYPE {
 			case RoundPrepare:
+				if bft.committedInPreparePhase {
+					continue
+				}
+				if _, ok := bft.respondedNodesPrepare[from]; ok {
+					log.Warnf("%s: node %v already responded - potential malicious behaviour")
+					continue
+				}
+				bft.respondedNodesPrepare[from] = msg.TreeNode
 				bft.tempPrepareCommit = append(bft.tempPrepareCommit, comm.Commitment)
-				if t == RoundPrepare && len(bft.tempPrepareCommit) == len(bft.Children()) {
+				if t == RoundPrepare && len(bft.tempPrepareCommit) == len(bft.Children())-bft.allowedExceptions {
+					bft.committedInPreparePhase = true
 					return nil
 				}
 			case RoundCommit:
+				if bft.committedInCommitPhase {
+					continue
+				}
+				if _, ok := bft.respondedNodesCommit[from]; ok {
+					log.Warnf("%s: node %v already responded - potential malicious behaviour")
+					continue
+				}
+				bft.respondedNodesCommit[from] = msg.TreeNode
 				bft.tempCommitCommit = append(bft.tempCommitCommit, comm.Commitment)
-				// In case the prepare round had some exceptions, we
-				// will not wait for more commits from the commit
-				// round. The possibility of having a different set
-				// of nodes failing in both cases is inferiour to the
-				// speedup in case of one node failing in both rounds.
-				if t == RoundCommit && len(bft.tempCommitCommit) == len(bft.tempPrepareCommit) {
+				if t == RoundCommit && len(bft.tempCommitCommit) == len(bft.Children())-bft.allowedExceptions {
+					bft.committedInCommitPhase = true
 					return nil
 				}
 			}
 		case <-timeout:
-			// in some cases this might be ok because we accept a certain number of faults
-			// the caller is responsible for checking if enough messages are received
-			log.Lvl1("timeout while trying to read commit message")
-			return nil
+			// if there is a timeout, then we cannot continue
+			return fmt.Errorf("timeout while trying to read commit message for phase %v", t)
 		}
 	}
 }
 
-// should do nothing if the channel is closed
+// readResponseChan reads a threshold (n-t) of response messages, the threshold
+// must be from the committed set of nodes.  It returns an error on timeout.
 func (bft *ProtocolBFTCoSi) readResponseChan(c chan responseChan, t RoundType) error {
 	timeout := time.After(bft.Timeout)
 	for {
@@ -616,31 +628,26 @@ func (bft *ProtocolBFTCoSi) readResponseChan(c chan responseChan, t RoundType) e
 				log.Lvl3("Channel closed")
 				return nil
 			}
-			from := msg.ServerIdentity.Public
 			r := msg.Response
 
 			switch msg.Response.TYPE {
 			case RoundPrepare:
 				bft.tempPrepareResponse = append(bft.tempPrepareResponse, r.Response)
 				bft.tempExceptions = append(bft.tempExceptions, r.Exceptions...)
-				bft.tempPrepareResponsePublics = append(bft.tempPrepareResponsePublics, from)
-				// There is no need to have more responses than we have
-				// commits. We _should_ check here if we get the same
-				// responses from the same nodes. But as this is deprecated
-				// and replaced by ByzCoinX, we'll leave it like that.
+				// NOTE here we assume all nodes that committed will respond
 				if t == RoundPrepare && len(bft.tempPrepareResponse) == len(bft.tempPrepareCommit) {
 					return nil
 				}
 			case RoundCommit:
 				bft.tempCommitResponse = append(bft.tempCommitResponse, r.Response)
-				// Same reasoning as in RoundPrepare.
+				// NOTE here we assume all nodes that committed will respond
 				if t == RoundCommit && len(bft.tempCommitResponse) == len(bft.tempCommitCommit) {
 					return nil
 				}
 			}
 		case <-timeout:
-			log.Lvl1("timeout while trying to read response messages")
-			return nil
+			// if there is a timeout, then we cannot continue
+			return fmt.Errorf("%s: timeout while trying to read response message for phase %v", bft.Name(), t)
 		}
 	}
 }
@@ -658,7 +665,7 @@ func (bft *ProtocolBFTCoSi) startCommitment(t RoundType) error {
 	return bft.SendToParent(&Commitment{TYPE: t, Commitment: cm})
 }
 
-// startChallenge creates the challenge and sends it to its children
+// startChallenge creates the challenge and sends it to children that committed
 func (bft *ProtocolBFTCoSi) startChallenge(t RoundType) error {
 	switch t {
 	case RoundPrepare:
@@ -696,21 +703,6 @@ func (bft *ProtocolBFTCoSi) startChallenge(t RoundType) error {
 	return nil
 }
 
-// startResponse dispatches the response to the correct round-type
-func (bft *ProtocolBFTCoSi) startResponse(t RoundType) error {
-	if !bft.IsLeaf() {
-		panic("Only leaf can call startResponse")
-	}
-
-	switch t {
-	case RoundPrepare:
-		return bft.handleResponsePrepare(bft.responseChan)
-	case RoundCommit:
-		return bft.handleResponseCommit(bft.responseChan)
-	}
-	return nil
-}
-
 // waitResponseVerification waits till the end of the verification and returns
 // the BFTCoSiResponse along with the flag:
 // true => no exception, the verification is correct
@@ -718,7 +710,9 @@ func (bft *ProtocolBFTCoSi) startResponse(t RoundType) error {
 func (bft *ProtocolBFTCoSi) waitResponseVerification() (*Response, bool) {
 	log.Lvl3(bft.Name(), "Waiting for response verification:")
 	// wait the verification
-	verified := <-bft.verifyChan
+	if !<-bft.verifyChan {
+		return nil, false
+	}
 
 	// sanity check
 	if bft.IsLeaf() && len(bft.tempPrepareResponse) != 0 {
@@ -730,26 +724,12 @@ func (bft *ProtocolBFTCoSi) waitResponseVerification() (*Response, bool) {
 		return nil, false
 	}
 
-	if !verified {
-		// Add our exception
-		bft.tempExceptions = append(bft.tempExceptions, Exception{
-			Index:      bft.index,
-			Commitment: bft.prepare.GetCommitment(),
-		})
-		// Don't include our response!
-		resp = bft.Suite().Scalar().Set(resp).Sub(resp, bft.prepare.GetResponse())
-		log.Lvl3(bft.Name(), "Response verification: failed")
-	}
-
-	// if we didn't get all the responses, add them to the exception
-	// 1, find children that are not in tempPrepareResponsePublics
-	// 2, for the missing ones, find the global index and then add it to the exception
-	publicsMap := make(map[kyber.Point]bool)
-	for _, p := range bft.tempPrepareResponsePublics {
-		publicsMap[p] = true
-	}
+	// Create the exceptions for nodes that were not included in the first
+	// 2/3 of the responses. We do this in two steps. (1) Find children
+	// that are not in respondedNodesPrepare and (2) for the missing
+	// ones, find the global index and then add it to the exception.
 	for _, tn := range bft.Children() {
-		if !publicsMap[tn.ServerIdentity.Public] {
+		if _, ok := bft.respondedNodesPrepare[tn.ServerIdentity.Public]; !ok {
 			// We assume the server was also not available for the commitment
 			// so no need to subtract the commitment.
 			// Conversely, we cannot handle nodes which fail right
@@ -767,8 +747,8 @@ func (bft *ProtocolBFTCoSi) waitResponseVerification() (*Response, bool) {
 		Response:   resp,
 	}
 
-	log.Lvl3(bft.Name(), "Response verification:", verified)
-	return r, verified
+	log.Lvl3(bft.Name(), "Response verified")
+	return r, true
 }
 
 // nodeDone is either called by the end of EndProtocol or by the end of the
@@ -801,11 +781,11 @@ func (bft *ProtocolBFTCoSi) setClosing() {
 	bft.closingMutex.Unlock()
 }
 
-func (bft *ProtocolBFTCoSi) sendToChildren(msg interface{}) error {
-	// TODO send to only nodes that did reply
-	errs := bft.SendToChildrenInParallel(msg)
-	if len(errs) > bft.allowedExceptions {
-		return fmt.Errorf("sendToChildren failed with errors: %v", errs)
+func (bft *ProtocolBFTCoSi) multicast(msg interface{}, nodes map[kyber.Point]*onet.TreeNode) error {
+	for _, tn := range nodes {
+		if err := bft.SendTo(tn, msg); err != nil {
+			log.Error(err)
+		}
 	}
 	return nil
 }

--- a/bftcosi/bftcosi_test.go
+++ b/bftcosi/bftcosi_test.go
@@ -93,7 +93,7 @@ func TestThreshold(t *testing.T) {
 		node, err := local.CreateProtocol(TestProtocolName, tree)
 		log.ErrFatal(err)
 		bc := node.(*ProtocolBFTCoSi)
-		assert.Equal(t, thr, bc.allowedExceptions, "hosts was %d", hosts)
+		assert.Equal(t, thr, bc.AllowedExceptions, "hosts was %d", hosts)
 
 		// we need to wait a bit for the protocols to finish because
 		// some might not receive challenges and only exit after the

--- a/bftcosi/bftcosi_test.go
+++ b/bftcosi/bftcosi_test.go
@@ -117,7 +117,7 @@ func TestNodeFailure(t *testing.T) {
 
 	nbrHostsArr := []int{5, 7, 10}
 	for _, nbrHosts := range nbrHostsArr {
-		if err := runProtocolOnceGo(nbrHosts, TestProtocolName, 0, true, 1, nbrHosts-1); err != nil {
+		if err := runProtocolOnceGo(nbrHosts, TestProtocolName, 0, true, nbrHosts/3, nbrHosts-1); err != nil {
 			t.Fatalf("%d/%s/%d/%t: %s", nbrHosts, TestProtocolName, 0, true, err)
 		}
 	}

--- a/bftcosi/bftcosi_test.go
+++ b/bftcosi/bftcosi_test.go
@@ -57,7 +57,7 @@ func TestBftCoSi(t *testing.T) {
 
 	// Register test protocol using BFTCoSi
 	onet.GlobalProtocolRegister(TestProtocolName, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-		return NewBFTCoSiProtocol(n, verify, defaultTimeout)
+		return NewBFTCoSiProtocol(n, verify)
 	})
 
 	log.Lvl2("Simple count")
@@ -71,7 +71,7 @@ func TestThreshold(t *testing.T) {
 
 	// Register test protocol using BFTCoSi
 	onet.GlobalProtocolRegister(TestProtocolName, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-		return NewBFTCoSiProtocol(n, verify, defaultTimeout)
+		return NewBFTCoSiProtocol(n, verify)
 	})
 
 	tests := []struct{ h, t int }{
@@ -112,7 +112,7 @@ func TestNodeFailure(t *testing.T) {
 
 	// Register test protocol using BFTCoSi
 	onet.GlobalProtocolRegister(TestProtocolName, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-		return NewBFTCoSiProtocol(n, verify, defaultTimeout)
+		return NewBFTCoSiProtocol(n, verify)
 	})
 
 	nbrHostsArr := []int{5, 7, 10}
@@ -157,6 +157,7 @@ func runProtocolOnceGo(nbrHosts int, name string, refuseCount int, succeed bool,
 	// Register the function generating the protocol instance
 	var root *ProtocolBFTCoSi
 	root = node.(*ProtocolBFTCoSi)
+	root.Timeout = defaultTimeout
 	root.Msg = msg
 	cMux.Lock()
 	counter := &Counter{refuseCount: refuseCount}

--- a/bftcosi/packets.go
+++ b/bftcosi/packets.go
@@ -144,18 +144,19 @@ type ChallengePrepare struct {
 	Challenge kyber.Scalar
 }
 
-// ChallengeCommit  is the challenge used by BftCoSi during the "commit"
-// phase. It contains the basic challenge (out of the block we want to sign) +
-// the signature of the "prepare" round. It also contains the exception list
-// coming from the "prepare" phase. This exception list has been collected by
-// the root during the response of the "prepare" phase and broadcast it through
-// the challenge of the "commit". These are needed in order to verify the
-// signature and to see how many peers did not sign. It's not spoofable because
-// otherwise the signature verification will be wrong.
+// ChallengeCommit  is the challenge used by BftCoSi during the "commit" phase.
+// It contains the basic challenge (out of the block we want to sign) + the
+// signature of the "prepare" round. It also contains the exception list coming
+// from the "prepare" phase. This exception list has been collected by the root
+// during the response of the "prepare" phase and broadcast it through the
+// challenge of the "commit". These are needed in order to verify the signature
+// and to see how many peers did not sign. It's not spoofable because otherwise
+// the signature verification will be wrong.
 type ChallengeCommit struct {
 	// Challenge for the current round
 	Challenge kyber.Scalar
-	// Signature is the signature response generated at the previous round (prepare)
+	// Signature is the signature response generated at the previous round
+	// (prepare)
 	Signature *BFTSignature
 }
 
@@ -166,14 +167,15 @@ type challengePrepareChan struct {
 	ChallengePrepare
 }
 
-// challengeCommitChan is the type of the channel used to catch the response messages.
+// challengeCommitChan is the type of the channel used to catch the response
+// messages.
 type challengeCommitChan struct {
 	*onet.TreeNode
 	ChallengeCommit
 }
 
-// Response is the struct used by ByzCoin during the response. It
-// contains the response + the basic exception list.
+// Response is the struct used by ByzCoin during the response. It contains the
+// response + the basic exception list.
 type Response struct {
 	Response   kyber.Scalar
 	Exceptions []Exception
@@ -187,11 +189,9 @@ type responseChan struct {
 }
 
 // Exception represents the exception mechanism used in BFTCosi to indicate a
-// signer did not want to sign.
-// The index is the index of the public key of the cosigner that do not want to
-// sign.
-// The commit is needed in order to be able to
-// correctly verify the signature
+// signer did not want to sign.  The index is the index of the public key of
+// the cosigner that do not want to sign.  The commit is needed in order to be
+// able to correctly verify the signature.
 type Exception struct {
 	Index      int
 	Commitment kyber.Point

--- a/identity/api_test.go
+++ b/identity/api_test.go
@@ -354,6 +354,7 @@ func TestVerificationFunction(t *testing.T) {
 	services := l.GetServices(hosts, identityService)
 	s0 := services[0].(*Service)
 	defer l.CloseAll()
+
 	for _, s := range services {
 		log.Lvl3(s.(*Service).Storage.Identities)
 	}

--- a/identity/service.go
+++ b/identity/service.go
@@ -788,9 +788,5 @@ func newIdentityService(c *onet.Context) (onet.Service, error) {
 	s.tagsLimits = make(map[string]int8)
 	s.pointsLimits = make(map[string]int8)
 
-	// we do not support failure
-	scs := c.Service(skipchain.ServiceName).(*skipchain.Service)
-	scs.MustNotFail = true
-
 	return s, nil
 }

--- a/identity/service.go
+++ b/identity/service.go
@@ -12,13 +12,11 @@ collective signatures and be assured that the blockchain is valid.
 package identity
 
 import (
-	"reflect"
-	"sync"
-
 	"errors"
-
 	"fmt"
 	"math/big"
+	"reflect"
+	"sync"
 
 	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/messaging"
@@ -789,5 +787,10 @@ func newIdentityService(c *onet.Context) (onet.Service, error) {
 	skipchain.RegisterVerification(c, VerifyIdentity, s.VerifyBlock)
 	s.tagsLimits = make(map[string]int8)
 	s.pointsLimits = make(map[string]int8)
+
+	// we do not support failure
+	scs := c.Service(skipchain.ServiceName).(*skipchain.Service)
+	scs.MustNotFail = true
+
 	return s, nil
 }

--- a/messaging/propagate.go
+++ b/messaging/propagate.go
@@ -103,7 +103,11 @@ func NewPropagationFunc(c propagationContext, name string, f PropagationStore, t
 	log.Lvl3("Registering new propagation for", c.ServerIdentity(),
 		name, pid)
 	return func(el *onet.Roster, msg network.Message, to time.Duration) (int, error) {
-		tree := el.GenerateNaryTreeWithRoot(8, c.ServerIdentity())
+		bf := 8
+		if thresh != 0 && len(el.List) > 2 {
+			bf = len(el.List) - 1
+		}
+		tree := el.GenerateNaryTreeWithRoot(bf, c.ServerIdentity())
 		if tree == nil {
 			return 0, errors.New("Didn't find root in tree")
 		}
@@ -194,7 +198,14 @@ func (p *Propagate) Dispatch() error {
 					return err
 				}
 			}
-			// propagate to as many as we can
+			/*
+				if p.allowedFailures != 0 && !p.IsRoot() {
+					panic("when there are failures, only root should reach here")
+				}
+				if p.received == p.subtreeCount-p.allowedFailures {
+					process = false
+				}
+			*/
 			if p.received == p.subtreeCount {
 				process = false
 			}

--- a/messaging/propagate.go
+++ b/messaging/propagate.go
@@ -105,7 +105,7 @@ func NewPropagationFunc(c propagationContext, name string, f PropagationStore, t
 	return func(el *onet.Roster, msg network.Message, to time.Duration) (int, error) {
 		bf := 8
 		if thresh != 0 && len(el.List) > 2 {
-			bf = len(el.List) - 1
+			bf = len(el.List)
 		}
 		tree := el.GenerateNaryTreeWithRoot(bf, c.ServerIdentity())
 		if tree == nil {
@@ -198,15 +198,7 @@ func (p *Propagate) Dispatch() error {
 					return err
 				}
 			}
-			/*
-				if p.allowedFailures != 0 && !p.IsRoot() {
-					panic("when there are failures, only root should reach here")
-				}
-				if p.received == p.subtreeCount-p.allowedFailures {
-					process = false
-				}
-			*/
-			if p.received == p.subtreeCount {
+			if p.received >= p.subtreeCount-p.allowedFailures {
 				process = false
 			}
 		case <-time.After(timeout):

--- a/pop/service/service.go
+++ b/pop/service/service.go
@@ -970,10 +970,10 @@ func newService(c *onet.Context) (onet.Service, error) {
 	s.RegisterProcessorFunc(mergeConfigID, s.MergeConfig)
 	s.RegisterProcessorFunc(mergeConfigReplyID, s.MergeConfigReply)
 	s.ProtocolRegister(bftSignFinal, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-		return bftcosi.NewBFTCoSiProtocol(n, s.bftVerifyFinal)
+		return bftcosi.NewBFTCoSiProtocol(n, s.bftVerifyFinal, timeout/2)
 	})
 	s.ProtocolRegister(bftSignMerge, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-		return bftcosi.NewBFTCoSiProtocol(n, s.bftVerifyMerge)
+		return bftcosi.NewBFTCoSiProtocol(n, s.bftVerifyMerge, timeout/2)
 	})
 	return s, nil
 }

--- a/pop/service/service.go
+++ b/pop/service/service.go
@@ -708,7 +708,6 @@ func (s *Service) PropagateFinal(msg network.Message) {
 //signs FinalStatement with BFTCosi and Propagates signature to other nodes
 func (s *Service) signAndPropagate(final *FinalStatement, protoName string,
 	data []byte) error {
-
 	bf := 2
 	if len(final.Desc.Roster.List)-1 > 2 {
 		bf = len(final.Desc.Roster.List) - 1
@@ -732,6 +731,7 @@ func (s *Service) signAndPropagate(final *FinalStatement, protoName string,
 			"protocol instance is invalid")
 	}
 
+	root.Timeout = timeout / 2
 	// pop is not fault tolerant
 	root.AllowedExceptions = 0
 
@@ -978,10 +978,10 @@ func newService(c *onet.Context) (onet.Service, error) {
 	s.RegisterProcessorFunc(mergeConfigID, s.MergeConfig)
 	s.RegisterProcessorFunc(mergeConfigReplyID, s.MergeConfigReply)
 	s.ProtocolRegister(bftSignFinal, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-		return bftcosi.NewBFTCoSiProtocol(n, s.bftVerifyFinal, timeout/2)
+		return bftcosi.NewBFTCoSiProtocol(n, s.bftVerifyFinal)
 	})
 	s.ProtocolRegister(bftSignMerge, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-		return bftcosi.NewBFTCoSiProtocol(n, s.bftVerifyMerge, timeout/2)
+		return bftcosi.NewBFTCoSiProtocol(n, s.bftVerifyMerge)
 	})
 	return s, nil
 }

--- a/pop/service/service.go
+++ b/pop/service/service.go
@@ -708,7 +708,13 @@ func (s *Service) PropagateFinal(msg network.Message) {
 //signs FinalStatement with BFTCosi and Propagates signature to other nodes
 func (s *Service) signAndPropagate(final *FinalStatement, protoName string,
 	data []byte) error {
-	tree := final.Desc.Roster.GenerateNaryTreeWithRoot(2, s.ServerIdentity())
+
+	bf := 2
+	if len(final.Desc.Roster.List)-1 > 2 {
+		bf = len(final.Desc.Roster.List) - 1
+	}
+
+	tree := final.Desc.Roster.GenerateNaryTreeWithRoot(bf, s.ServerIdentity())
 	if tree == nil {
 		return errors.New(
 			"Root does not exist")
@@ -724,8 +730,10 @@ func (s *Service) signAndPropagate(final *FinalStatement, protoName string,
 	if !ok {
 		return errors.New(
 			"protocol instance is invalid")
-
 	}
+
+	// pop is not fault tolerant
+	root.AllowedExceptions = 0
 
 	root.Msg, err = final.Hash()
 	if err != nil {

--- a/pop/service/service_test.go
+++ b/pop/service/service_test.go
@@ -412,6 +412,7 @@ func TestService_MergeRequest(t *testing.T) {
 	log.Lvlf2("Group 1, Server: %s", srvcs[1].ServerIdentity())
 	log.Lvlf2("Group 2, Server: %s", srvcs[2].ServerIdentity())
 	log.Lvlf2("Group 2, Server: %s", srvcs[3].ServerIdentity())
+	// right signature
 	mr.ID = []byte(hash[0])
 	sg, err = schnorr.Sign(tSuite, priv[0], mr.ID)
 	log.ErrFatal(err)
@@ -436,7 +437,6 @@ func TestService_MergeRequest(t *testing.T) {
 			s.data.Finals[hash[i/2]].Verify() == nil,
 			fmt.Sprintf("Signature in node %d is not created", i))
 	}
-
 }
 
 func storeDesc(srvcs []onet.Service, el *onet.Roster, nbr int,

--- a/pop/service/service_test.go
+++ b/pop/service/service_test.go
@@ -412,7 +412,6 @@ func TestService_MergeRequest(t *testing.T) {
 	log.Lvlf2("Group 1, Server: %s", srvcs[1].ServerIdentity())
 	log.Lvlf2("Group 2, Server: %s", srvcs[2].ServerIdentity())
 	log.Lvlf2("Group 2, Server: %s", srvcs[3].ServerIdentity())
-	// right signature
 	mr.ID = []byte(hash[0])
 	sg, err = schnorr.Sign(tSuite, priv[0], mr.ID)
 	log.ErrFatal(err)

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -42,6 +42,9 @@ func init() {
 // Service handles adding new SkipBlocks
 type Service struct {
 	*onet.ServiceProcessor
+	// MustNotFail is a flag to determine whether failures are allowed in
+	// the bft protocol.
+	MustNotFail        bool
 	db                 *SkipBlockDB
 	propagate          messaging.PropagationFunc
 	verifiers          map[VerifierID]SkipBlockVerifier
@@ -52,7 +55,6 @@ type Service struct {
 	bftTimeout         time.Duration
 	propTimeout        time.Duration
 	chains             chainLocker
-	mustNotFail        bool
 }
 
 type chainLocker struct {
@@ -1156,7 +1158,7 @@ func (s *Service) startBFT(proto string, roster *onet.Roster, msg, data []byte) 
 	// Register the function generating the protocol instance
 	root.Msg = msg
 	root.Data = data
-	if s.mustNotFail {
+	if s.MustNotFail {
 		root.AllowedExceptions = 0
 	}
 

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -42,9 +42,6 @@ func init() {
 // Service handles adding new SkipBlocks
 type Service struct {
 	*onet.ServiceProcessor
-	// MustNotFail is a flag to determine whether failures are allowed in
-	// the bft protocol.
-	MustNotFail        bool
 	db                 *SkipBlockDB
 	propagate          messaging.PropagationFunc
 	verifiers          map[VerifierID]SkipBlockVerifier
@@ -1158,9 +1155,6 @@ func (s *Service) startBFT(proto string, roster *onet.Roster, msg, data []byte) 
 	// Register the function generating the protocol instance
 	root.Msg = msg
 	root.Data = data
-	if s.MustNotFail {
-		root.AllowedExceptions = 0
-	}
 
 	if s.bftTimeout != 0 {
 		root.Timeout = s.bftTimeout

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -416,7 +416,7 @@ func (s *Service) syncChain(roster *onet.Roster, latest SkipBlockID) error {
 // in the roster, in order to find an answer, even in the case that a few
 // nodes in the network are down.
 func (s *Service) getBlocks(roster *onet.Roster, id SkipBlockID, n int) ([]*SkipBlock, error) {
-	subCount := len(roster.List) - (len(roster.List)-1)/3
+	subCount := (len(roster.List)-1)/3 + 1
 	r := roster.RandomSubset(s.ServerIdentity(), subCount)
 	tr := r.GenerateStar()
 	pi, err := s.CreateProtocol(ProtocolGetBlocks, tr)
@@ -912,6 +912,9 @@ func (s *Service) bftVerifyFollowBlock(msg []byte, data []byte) bool {
 		}
 		target := s.db.GetByID(newest.BackLinkIDs[fs.TargetHeight])
 		if target == nil {
+			// we are synching twice, but usually it should not
+			// happen because if trySync is used above, then we
+			// should be up-to-date
 			if err = trySync(newest); err != nil {
 				return err
 			}

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -1158,7 +1158,9 @@ func (s *Service) startBFT(proto string, roster *onet.Roster, msg, data []byte) 
 	// Register the function generating the protocol instance
 	root.Msg = msg
 	root.Data = data
+	root.Timeout = defaultPropagateTimeout / 2
 
+	// give the option for tests to set the timeout
 	if s.bftTimeout != 0 {
 		root.Timeout = s.bftTimeout
 	}
@@ -1357,10 +1359,10 @@ func newSkipchainService(c *onet.Context) (onet.Service, error) {
 		return nil, err
 	}
 	s.ProtocolRegister(bftNewBlock, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-		return bftcosi.NewBFTCoSiProtocol(n, s.bftVerifyNewBlock, defaultPropagateTimeout/2)
+		return bftcosi.NewBFTCoSiProtocol(n, s.bftVerifyNewBlock)
 	})
 	s.ProtocolRegister(bftFollowBlock, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-		return bftcosi.NewBFTCoSiProtocol(n, s.bftVerifyFollowBlock, defaultPropagateTimeout/2)
+		return bftcosi.NewBFTCoSiProtocol(n, s.bftVerifyFollowBlock)
 	})
 	return s, nil
 }

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -56,10 +56,6 @@ func storeSkipBlock(t *testing.T, fail bool) {
 	// for us.
 	deadServer := servers[len(servers)-1]
 
-	if !fail {
-		service.MustNotFail = true
-	}
-
 	// Setting up root roster
 	sbRoot, err := makeGenesisRoster(service, el)
 	log.ErrFatal(err)
@@ -148,7 +144,6 @@ func TestService_GetUpdateChain(t *testing.T) {
 	sbCount := conodes - 1
 	servers, el, gs := local.MakeHELS(conodes, skipchainSID, cothority.Suite)
 	s := gs.(*Service)
-	s.MustNotFail = true
 
 	sbs := make([]*SkipBlock, sbCount)
 	var err error
@@ -321,7 +316,6 @@ func TestService_Verification(t *testing.T) {
 	sbLength := 4
 	_, el, genService := local.MakeHELS(sbLength, skipchainSID, cothority.Suite)
 	service := genService.(*Service)
-	service.MustNotFail = true
 
 	elRoot := onet.NewRoster(el.List[0:3])
 	sbRoot, err := makeGenesisRoster(service, elRoot)
@@ -566,7 +560,6 @@ func TestService_ParallelGenesis(t *testing.T) {
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	_, roster, s1 := makeHELS(local, 5)
-	s1.MustNotFail = true
 	sb0 := &SkipBlock{
 		SkipBlockFix: &SkipBlockFix{
 			MaximumHeight: 1,
@@ -617,7 +610,6 @@ func TestService_ParallelStoreBlock(t *testing.T) {
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	_, roster, s1 := makeHELS(local, 5)
-	s1.MustNotFail = true
 	ssb := &StoreSkipBlock{
 		NewBlock: &SkipBlock{
 			SkipBlockFix: &SkipBlockFix{
@@ -682,7 +674,6 @@ func TestService_Propagation(t *testing.T) {
 		services[i] = s.(*Service)
 	}
 	service := genService.(*Service)
-	service.MustNotFail = true
 
 	// longer timeout because we have a lot of nodes
 	service.propTimeout = 20 * time.Second
@@ -1149,7 +1140,4 @@ func nukeBlocksFrom(t *testing.T, db *SkipBlockDB, where SkipBlockID) {
 		}
 		where = sb.ForwardLink[0].Hash()
 	}
-}
-
-func delayedCloseAll(local *onet.LocalTest) {
 }

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -57,7 +57,7 @@ func storeSkipBlock(t *testing.T, fail bool) {
 	deadServer := servers[len(servers)-1]
 
 	if !fail {
-		service.mustNotFail = true
+		service.MustNotFail = true
 	}
 
 	// Setting up root roster
@@ -148,7 +148,7 @@ func TestService_GetUpdateChain(t *testing.T) {
 	sbCount := conodes - 1
 	servers, el, gs := local.MakeHELS(conodes, skipchainSID, cothority.Suite)
 	s := gs.(*Service)
-	s.mustNotFail = true
+	s.MustNotFail = true
 
 	sbs := make([]*SkipBlock, sbCount)
 	var err error
@@ -321,7 +321,7 @@ func TestService_Verification(t *testing.T) {
 	sbLength := 4
 	_, el, genService := local.MakeHELS(sbLength, skipchainSID, cothority.Suite)
 	service := genService.(*Service)
-	service.mustNotFail = true
+	service.MustNotFail = true
 
 	elRoot := onet.NewRoster(el.List[0:3])
 	sbRoot, err := makeGenesisRoster(service, elRoot)
@@ -566,7 +566,7 @@ func TestService_ParallelGenesis(t *testing.T) {
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	_, roster, s1 := makeHELS(local, 5)
-	s1.mustNotFail = true
+	s1.MustNotFail = true
 	sb0 := &SkipBlock{
 		SkipBlockFix: &SkipBlockFix{
 			MaximumHeight: 1,
@@ -617,7 +617,7 @@ func TestService_ParallelStoreBlock(t *testing.T) {
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 	_, roster, s1 := makeHELS(local, 5)
-	s1.mustNotFail = true
+	s1.MustNotFail = true
 	ssb := &StoreSkipBlock{
 		NewBlock: &SkipBlock{
 			SkipBlockFix: &SkipBlockFix{
@@ -682,7 +682,7 @@ func TestService_Propagation(t *testing.T) {
 		services[i] = s.(*Service)
 	}
 	service := genService.(*Service)
-	service.mustNotFail = true
+	service.MustNotFail = true
 
 	// longer timeout because we have a lot of nodes
 	service.propTimeout = 20 * time.Second
@@ -1100,28 +1100,23 @@ func TestService_LeaderCatchup(t *testing.T) {
 
 	// Write one more onto the leader: it will need to sync it's chain in
 	// order to handle this write.
-	log.Print("1")
 	ssbrep, err = leader.StoreSkipBlock(&StoreSkipBlock{LatestID: ssbrep.Latest.Hash,
 		NewBlock: sbRoot})
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.Print("2")
 
 	sb11 := leader.db.GetByID(ssbrep.Latest.Hash)
 	require.Equal(t, sb11.Index, 11)
 
-	log.Print("3")
 	// Simulate follower old backup.
 	nukeBlocksFrom(t, follower.db, third)
 
-	log.Print("4")
 	// Write onto leader; the follower will need to sync to be able to sign
 	// this.
 	ssbrep, err = leader.StoreSkipBlock(&StoreSkipBlock{
 		LatestID: ssbrep.Latest.Hash,
 		NewBlock: sbRoot})
-	log.Print("5")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -97,7 +97,6 @@ func storeSkipBlock(t *testing.T, fail bool) {
 	if id == nil {
 		t.Fatal("second block last id is nil")
 	}
-	log.Lvl3("Storing a new skipblock")
 	psbr2, err := service.StoreSkipBlock(&StoreSkipBlock{LatestID: id, NewBlock: next})
 	if err != nil {
 		t.Fatal("StoreSkipBlock:", err)
@@ -775,6 +774,11 @@ func TestService_AddFollow(t *testing.T) {
 	master2, err := services[1].StoreSkipBlock(ssb)
 	log.ErrFatal(err)
 	require.True(t, services[1].db.GetByID(master1.Latest.Hash).ForwardLink[0].Hash().Equal(master2.Latest.Hash))
+
+	// The propagation in skipchain might still be happening in the
+	// background because the root does not wait for all replies. So we
+	// wait a bit for it to finish.
+	time.Sleep(time.Second)
 }
 
 func TestService_CreateLinkPrivate(t *testing.T) {

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -19,8 +19,9 @@ import (
 	"gopkg.in/satori/go.uuid.v1"
 )
 
-// How long to wait before a timeout is generated in the propagation.
-const defaultPropagateTimeout = 15 * time.Second
+// How long to wait before a timeout is generated in the propagation. It is not
+// set to a constant because we'd like to change it in the test.
+var defaultPropagateTimeout = 15 * time.Second
 
 // SkipBlockID represents the Hash of the SkipBlock
 type SkipBlockID []byte
@@ -704,6 +705,14 @@ func (db *SkipBlockDB) VerifyLinks(sb *SkipBlock) error {
 		return errors.New("didn't find our block in forward-links")
 	}
 	return nil
+}
+
+func (db *SkipBlockDB) getLatestByID(genID SkipBlockID) (*SkipBlock, error) {
+	gen := db.GetByID(genID)
+	if gen == nil {
+		return nil, fmt.Errorf("cannot find genesis block %x", genID)
+	}
+	return db.GetLatest(gen)
 }
 
 // GetLatest searches for the latest available block for that skipblock.


### PR DESCRIPTION
This PR implements an optimised version of bftcosi where the root node does not wait for all replies from its children, it makes progress when 2/3rd of the replies arrive. This so that in an event of a failure, we do not need to wait for a long timeout.