### PR TITLE
Capitalizing service endpoints

### DIFF
--- a/pop/service/api.go
+++ b/pop/service/api.go
@@ -49,7 +49,7 @@ func (c *Client) StoreConfig(dst network.Address, p *PopDesc, priv kyber.Scalar)
 	if err != nil {
 		return err
 	}
-	err = c.SendProtobuf(si, &storeConfig{p, sg}, nil)
+	err = c.SendProtobuf(si, &StoreConfig{p, sg}, nil)
 	if err != nil {
 		return err
 	}
@@ -60,8 +60,8 @@ func (c *Client) StoreConfig(dst network.Address, p *PopDesc, priv kyber.Scalar)
 func (c *Client) FetchFinal(dst network.Address, hash []byte) (
 	*FinalStatement, error) {
 	si := &network.ServerIdentity{Address: dst}
-	res := &finalizeResponse{}
-	err := c.SendProtobuf(si, &fetchRequest{hash}, res)
+	res := &FinalizeResponse{}
+	err := c.SendProtobuf(si, &FetchRequest{hash}, res)
 	if err != nil {
 		return nil, err
 	}
@@ -77,14 +77,14 @@ func (c *Client) FetchFinal(dst network.Address, hash []byte) (
 func (c *Client) Finalize(dst network.Address, p *PopDesc, attendees []kyber.Point,
 	priv kyber.Scalar) (*FinalStatement, error) {
 	si := &network.ServerIdentity{Address: dst}
-	req := &finalizeRequest{}
+	req := &FinalizeRequest{}
 	req.DescID = p.Hash()
 	req.Attendees = attendees
 	hash, err := req.hash()
 	if err != nil {
 		return nil, err
 	}
-	res := &finalizeResponse{}
+	res := &FinalizeResponse{}
 	sg, err := schnorr.Sign(cothority.Suite, priv, hash)
 	if err != nil {
 		return nil, err
@@ -103,14 +103,14 @@ func (c *Client) Finalize(dst network.Address, p *PopDesc, attendees []kyber.Poi
 func (c *Client) Merge(dst network.Address, p *PopDesc, priv kyber.Scalar) (
 	*FinalStatement, error) {
 	si := &network.ServerIdentity{Address: dst}
-	res := &finalizeResponse{}
+	res := &FinalizeResponse{}
 	hash := p.Hash()
 	sg, err := schnorr.Sign(cothority.Suite, priv, hash)
 	if err != nil {
 		return nil, err
 	}
 
-	e := c.SendProtobuf(si, &mergeRequest{hash, sg}, res)
+	e := c.SendProtobuf(si, &MergeRequest{hash, sg}, res)
 	if e != nil {
 		return nil, e
 	}

--- a/pop/service/struct.go
+++ b/pop/service/struct.go
@@ -13,8 +13,8 @@ import (
 // We need to register all messages so the network knows how to handle them.
 func init() {
 	for _, msg := range []interface{}{
-		checkConfig{}, checkConfigReply{},
-		PinRequest{}, fetchRequest{}, mergeRequest{},
+		CheckConfig{}, CheckConfigReply{},
+		PinRequest{}, FetchRequest{}, MergeRequest{},
 	} {
 		network.RegisterMessage(msg)
 	}
@@ -33,32 +33,32 @@ const (
 	PopStatusOK
 )
 
-// checkConfig asks whether the pop-config and the attendees are available.
-type checkConfig struct {
+// CheckConfig asks whether the pop-config and the attendees are available.
+type CheckConfig struct {
 	PopHash   []byte
 	Attendees []kyber.Point
 }
 
-// checkConfigReply sends back an integer for the Pop. 0 means no config yet,
+// CheckConfigReply sends back an integer for the Pop. 0 means no config yet,
 // other values are defined as constants.
 // If PopStatus == PopStatusOK, then the Attendees will be the common attendees between
 // the two nodes.
-type checkConfigReply struct {
+type CheckConfigReply struct {
 	PopStatus int
 	PopHash   []byte
 	Attendees []kyber.Point
 }
 
-// mergeConfig asks if party is ready to merge
-type mergeConfig struct {
+// MergeConfig asks if party is ready to merge
+type MergeConfig struct {
 	// FinalStatement of current party
 	Final *FinalStatement
 	// Hash of PopDesc party to merge with
 	ID []byte
 }
 
-// mergeConfigReply responds with info of asked party
-type mergeConfigReply struct {
+// MergeConfigReply responds with info of asked party
+type MergeConfigReply struct {
 	// status of merging process
 	PopStatus int
 	// hash of party was asking to merge
@@ -75,27 +75,27 @@ type PinRequest struct {
 	Public kyber.Point
 }
 
-// storeConfig presents a config to store
-type storeConfig struct {
+// StoreConfig presents a config to store
+type StoreConfig struct {
 	Desc      *PopDesc
 	Signature []byte
 }
 
-// storeConfigReply gives back the hash.
-// TODO: storeConfigReply will give in a later version a handler that can be used to
+// StoreConfigReply gives back the hash.
+// TODO: StoreConfigReply will give in a later version a handler that can be used to
 // identify that config.
-type storeConfigReply struct {
+type StoreConfigReply struct {
 	ID []byte
 }
 
-// finalizeRequest asks to finalize on the given descid-popconfig.
-type finalizeRequest struct {
+// FinalizeRequest asks to finalize on the given descid-popconfig.
+type FinalizeRequest struct {
 	DescID    []byte
 	Attendees []kyber.Point
 	Signature []byte
 }
 
-func (fr *finalizeRequest) hash() ([]byte, error) {
+func (fr *FinalizeRequest) hash() ([]byte, error) {
 	h := cothority.Suite.Hash()
 	_, err := h.Write(fr.DescID)
 	if err != nil {
@@ -114,20 +114,20 @@ func (fr *finalizeRequest) hash() ([]byte, error) {
 	return h.Sum(nil), nil
 }
 
-// finalizeResponse returns the FinalStatement if all conodes already received
+// FinalizeResponse returns the FinalStatement if all conodes already received
 // a PopDesc and signed off. The FinalStatement holds the updated PopDesc, the
 // pruned attendees-public-key-list and the collective signature.
-type finalizeResponse struct {
+type FinalizeResponse struct {
 	Final *FinalStatement
 }
 
-// fetchRequest asks to get FinalStatement
-type fetchRequest struct {
+// FetchRequest asks to get FinalStatement
+type FetchRequest struct {
 	ID []byte
 }
 
-// mergeRequest asks to start merging process for given Party
-type mergeRequest struct {
+// MergeRequest asks to start merging process for given Party
+type MergeRequest struct {
 	ID        []byte
 	Signature []byte
 }


### PR DESCRIPTION
Some of the struct-definitions used lowercase letters which made the websocket-endpoint to be lowercase, too. But all other endpoints start with an uppercase, so fix this.