### PR TITLE
insert defers into protocols to correctly clean up

### DIFF
--- a/byzcoinx/byzcoinx.go
+++ b/byzcoinx/byzcoinx.go
@@ -131,6 +131,7 @@ func (bft *ByzCoinX) initCosiProtocol(phase phase) (*protocol.FtCosi, error) {
 // 4, wait for the commit phase to finish
 // 5, send the final signature
 func (bft *ByzCoinX) Dispatch() error {
+	defer bft.Done()
 
 	if !bft.IsRoot() {
 		return fmt.Errorf("non-root should not start this protocol")

--- a/ftcosi/protocol/protocol.go
+++ b/ftcosi/protocol/protocol.go
@@ -101,6 +101,7 @@ func (p *FtCosi) Shutdown() error {
 // Dispatch is the main method of the protocol, defining the root node behaviour
 // and sequential handling of subprotocols.
 func (p *FtCosi) Dispatch() error {
+	defer p.Done()
 	if !p.IsRoot() {
 		return nil
 	}

--- a/ftcosi/protocol/sub_protocol.go
+++ b/ftcosi/protocol/sub_protocol.go
@@ -95,6 +95,7 @@ func (p *SubFtCosi) Shutdown() error {
 
 // Dispatch is the main method of the subprotocol, running on each node and handling the messages in order
 func (p *SubFtCosi) Dispatch() error {
+	defer p.Done()
 
 	// ----- Announcement -----
 	announcement, channelOpen := <-p.ChannelAnnouncement

--- a/messaging/propagate.go
+++ b/messaging/propagate.go
@@ -154,6 +154,7 @@ func (p *Propagate) Start() error {
 func (p *Propagate) Dispatch() error {
 	process := true
 	log.Lvl4(p.ServerIdentity(), "Start dispatch")
+	defer p.Done()
 	for process {
 		p.Lock()
 		timeout := p.sd.Timeout
@@ -217,7 +218,6 @@ func (p *Propagate) Dispatch() error {
 			p.onDoneCb(p.received + 1)
 		}
 	}
-	p.Done()
 	return nil
 }
 

--- a/ocs/protocol/dkg.go
+++ b/ocs/protocol/dkg.go
@@ -31,9 +31,9 @@ type SetupDKG struct {
 	keypair *key.Pair
 	publics []kyber.Point
 	// Whether we started the `DKG.SecretCommits`
-	commit bool
-	Wait   bool
-	Done   chan bool
+	commit    bool
+	Wait      bool
+	SetupDone chan bool
 
 	structStartDeal    chan structStartDeal
 	structDeal         chan structDeal
@@ -48,7 +48,7 @@ func NewSetupDKG(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
 	o := &SetupDKG{
 		TreeNodeInstance: n,
 		keypair:          key.NewKeyPair(cothority.Suite),
-		Done:             make(chan bool, 1),
+		SetupDone:        make(chan bool, 1),
 		Threshold:        uint32(len(n.Roster().List) - (len(n.Roster().List)-1)/3),
 		nodes:            n.List(),
 	}
@@ -79,6 +79,7 @@ func (o *SetupDKG) Start() error {
 
 // Dispatch takes care for channel-messages that need to be treated in the correct order.
 func (o *SetupDKG) Dispatch() error {
+	defer o.Done()
 	err := o.allStartDeal(<-o.structStartDeal)
 	if err != nil {
 		return err
@@ -116,7 +117,7 @@ func (o *SetupDKG) Dispatch() error {
 	}
 
 	if o.DKG.Finished() {
-		o.Done <- true
+		o.SetupDone <- true
 		return nil
 	}
 	err = errors.New("protocol is finished but dkg is not")

--- a/ocs/protocol/dkg_test.go
+++ b/ocs/protocol/dkg_test.go
@@ -50,7 +50,7 @@ func setupDKG(t *testing.T, nbrNodes int) {
 	log.ErrFatal(pi.Start())
 	timeout := network.WaitRetry * time.Duration(network.MaxRetryConnect*nbrNodes*2) * time.Millisecond
 	select {
-	case <-protocol.Done:
+	case <-protocol.SetupDone:
 		log.Lvl2("root-node is Done")
 		require.NotNil(t, protocol.DKG)
 	case <-time.After(timeout):

--- a/ocs/protocol/ocs.go
+++ b/ocs/protocol/ocs.go
@@ -93,6 +93,7 @@ func (o *OCS) Start() error {
 // Reencrypt is received by every node to give his part of
 // the share
 func (o *OCS) reencrypt(r structReencrypt) error {
+	defer o.Done()
 	log.Lvl3(o.Name() + ": starting reencrypt")
 	ui, err := o.getUI(r.U, r.Xc)
 	if err != nil {

--- a/ocs/service/service.go
+++ b/ocs/service/service.go
@@ -138,7 +138,7 @@ func (s *Service) CreateSkipchains(req *CreateSkipchainsRequest) (reply *CreateS
 	}
 	log.Lvl3("Started DKG-protocol - waiting for done", len(req.Roster.List))
 	select {
-	case <-setupDKG.Done:
+	case <-setupDKG.SetupDone:
 		shared, err := setupDKG.SharedSecret()
 		if err != nil {
 			return nil, err
@@ -519,7 +519,7 @@ func (s *Service) NewProtocol(tn *onet.TreeNodeInstance, conf *onet.GenericConfi
 		}
 		setupDKG := pi.(*protocol.SetupDKG)
 		go func(conf *onet.GenericConfig) {
-			<-setupDKG.Done
+			<-setupDKG.SetupDone
 			shared, err := setupDKG.SharedSecret()
 			if err != nil {
 				log.Error(err)

--- a/ocs/service/service_test.go
+++ b/ocs/service/service_test.go
@@ -271,6 +271,14 @@ func TestStress(t *testing.T) {
 		}(thread)
 	}
 	wg.Wait()
+	active := false
+	for _, s := range o.local.Servers {
+		for _, tn := range o.local.GetTreeNodeInstances(s.ServerIdentity.ID) {
+			log.Lvl1("Still active: ", tn.Info())
+			active = true
+		}
+	}
+	require.False(t, active)
 }
 
 type ocsStruct struct {


### PR DESCRIPTION
Different protocols were not calling `Done` to terminate it, making a memory-leak.