### PR TITLE
cothorityjs: check event code on websocket close event

### DIFF
--- a/external/js/cothority/lib/net/net.js
+++ b/external/js/cothority/lib/net/net.js
@@ -84,7 +84,9 @@ function Socket(addr, service) {
       };
 
       ws.onclose = event => {
-        if (!event.wasClean) reject(new Error(event.reason));
+        if (!event.wasClean || event.code === 4000) {
+          reject(new Error(event.reason));
+        }
       };
 
       ws.onerror = error => {


### PR DESCRIPTION
The Conode websocket API returns an event code with value 4000
whenever the underlying service returns an error. This PR updates
the onclose handler to reject the promise if the event code is 4000

Fixes #1084