### PR TITLE
cothorityjs: verify protobuf message before sending request

### DIFF
--- a/external/js/cothority/lib/net/net.js
+++ b/external/js/cothority/lib/net/net.js
@@ -60,6 +60,10 @@ function Socket(addr, service) {
       }
 
       ws.onopen = () => {
+        const errMsg = requestModel.verify(data);
+        if (errMsg) {
+          reject(new Error(errMsg));
+        }
         const message = requestModel.create(data);
         const marshal = requestModel.encode(message).finish();
         ws.send(marshal);


### PR DESCRIPTION
Protobufjs includes a verification function for ensuring the data
types in the javascript object are compatible with those mentioned
in the protobuf file. This PR uses the verifier before initiating
the websocket request and rejects the promise in case of an error.