### PR TITLE
cothorityjs: fix variable name conflicts in RosterSocket.send

### DIFF
--- a/external/js/cothority/lib/net/net.js
+++ b/external/js/cothority/lib/net/net.js
@@ -115,33 +115,30 @@ class RosterSocket {
    * @returns {Promise} holds the returned data in case of success.
    */
   send(request, response, data) {
-    const socket = this;
-    const fn = co.wrap(function*(req, resp, data, socket) {
-      request = req;
-      response = resp;
-      data = data;
-      var addresses = socket.addresses;
-      var service = socket.service;
+    const that = this;
+    const fn = co.wrap(function*() {
+      const addresses = that.addresses;
+      const service = that.service;
       shuffle(addresses);
       // try first the last good server we know
-      if (socket.lastGoodServer) addresses.unshift(socket.lastGoodServer);
+      if (that.lastGoodServer) addresses.unshift(that.lastGoodServer);
 
-      for (var i = 0; i < addresses.length; i++) {
-        var addr = addresses[i];
+      for (let i = 0; i < addresses.length; i++) {
+        const addr = addresses[i];
         try {
-          var socket = new Socket(addr, service);
+          const socket = new Socket(addr, service);
           console.log("RosterSocket: trying out " + addr + "/" + service);
-          var data = yield socket.send(request, response, data);
-          socket.lastGoodServer = addr;
-          return Promise.resolve(data);
+          const socketResponse = yield socket.send(request, response, data);
+          that.lastGoodServer = addr;
+          return Promise.resolve(socketResponse);
         } catch (err) {
-          console.log("rostersocket: " + err);
+          console.error("rostersocket: " + err);
           continue;
         }
       }
-      return Promise.reject("no conodes are available");
+      return Promise.reject(new Error("no conodes are available"));
     });
-    return fn(request, response, data, socket);
+    return fn();
   }
 }
 

--- a/external/js/cothority/package-lock.json
+++ b/external/js/cothority/package-lock.json
@@ -1,7 +1,8 @@
 {
   "name": "@dedis/cothority",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@dedis/kyber-js": {
       "version": "0.0.7",

--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedis/cothority",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "module for interacting with cothority nodes",
   "main": "dist/bundle.node.min.js",
   "browser": "dist/bundle.min.js",


### PR DESCRIPTION
RosterSocket.send has socket redeclared in the try block which
results in lastGoodServer not being cached in the RosterSocket
object. This PR uses a different name for shadowing the "this"
variable and prevents the conflict. Also removed unneeded arguments
in the generator.