### PR TITLE
making testing of bft easier

### DIFF
--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -778,6 +778,12 @@ func (s *Service) AddClientKey(pub kyber.Point) {
 	s.save()
 }
 
+// SetBFTTimeout can be used in tests to change the timeout passed
+// to BFTCoSi.
+func (s *Service) SetBFTTimeout(t time.Duration) {
+	s.bftTimeout = t
+}
+
 func (s *Service) verifySigs(msg, sig []byte) bool {
 	// If there are no clients, all signatures verify.
 	if len(s.Storage.Clients) == 0 {


### PR DESCRIPTION
Correctly fail BFTCoSi if the server is stopped.
Also cleans up correctly by not calling `Shutdown` itself.