### PR TITLE
add evoting Dockerfile

### DIFF
--- a/conode/experimental.go
+++ b/conode/experimental.go
@@ -1,0 +1,8 @@
+package main
+
+/*
+This imports the experimental services that will not be used in the
+stable branch.
+*/
+
+import _ "github.com/dedis/cothority/evoting/service"

--- a/stable/remove_files
+++ b/stable/remove_files
@@ -1,0 +1,1 @@
+conode/experimental.go


### PR DESCRIPTION
Created a new Dockerfile which adds the evoting service to conode.go
before the build.

The resulting image can be pushed to Dockerhub. `dedis/conode:evoting` perhaps?