### PR TITLE
evoting: reintroduce Election Stage

### DIFF
--- a/evoting/service/service.go
+++ b/evoting/service/service.go
@@ -245,8 +245,12 @@ func (s *Service) GetElections(req *evoting.GetElections) (*evoting.GetElections
 		if err != nil {
 			return nil, err
 		}
+		// Check if user is a voter or election creator.
 		if election.IsUser(req.User) || election.IsCreator(req.User) {
-			elections = append(elections, election)
+			// Filter the election by Stage. 0 denotes no filtering.
+			if req.Stage == 0 || req.Stage == election.Stage {
+				elections = append(elections, election)
+			}
 		}
 	}
 	return &evoting.GetElectionsReply{Elections: elections}, nil

--- a/evoting/struct.go
+++ b/evoting/struct.go
@@ -106,6 +106,7 @@ type DecryptReply struct{}
 type GetElections struct {
 	User   uint32                // User identifier.
 	Master skipchain.SkipBlockID // Master skipchain ID.
+	Stage  lib.ElectionState     // Election Stage filter. 0 for all elections.
 }
 
 // GetElectionsReply message.


### PR DESCRIPTION
The frontend requires a way to filter out elections based on their
current stage to enable/disable buttons and render the elections
at an appropriate position. This commit caches the current phase
of the election in the Stage field.

Another alternative would've been to expose methods on the service that allow checking the phase for every election but that would be quite expensive.