### PR TITLE
Adding Protobuf messages to share PoP Party config through a conode

### DIFF
--- a/external/protobuf/pop/config.proto
+++ b/external/protobuf/pop/config.proto
@@ -36,3 +36,33 @@ message StoreConfig {
 message StoreConfigReply {
     required bytes id = 1;
 }
+
+// Contains the informations on the proposed party,
+// with the list of the current accepted conodes
+message ProposeParty {
+    required PopDesc desc = 1;
+}
+
+// Used to ask for the current state of the configuration
+// of the party
+message GetPropose {
+    required string name = 1;
+}
+
+// Used as a join proposal for a speciic party
+message ProposeJoin {
+    required string name = 1;
+    required ServerIdentity conode = 2;
+}
+
+// Used to ask for the list of current unconfirmed conodes
+// that want to join the party
+message ProposePoll {
+    required string name = 1;
+}
+
+// Contains the list of the unconfirmed conodes that want to
+// join the party
+message ProposePollReply {
+    repeated ServerIdentity newConodes = 2;
+}


### PR DESCRIPTION
This is a proposal of messages that could be used to easily share a PoP Party Configuration file. 

Here is an example of a possible procedure (see below for a detailed explanation) : 
![pop_config_flow](https://user-images.githubusercontent.com/1623687/38419439-c7953ca2-39a0-11e8-97ed-9d771994c483.png)

1. **Org 1** links to **conode 1**, creates the party config and sends **“ProposeParty”**
2. **Org 1** adds a new organizer
3. **Org 1** presents a QR Code containing **[Conode 1 + Party name]**
4. **Org 2** links to **conode 2**
5. **Org 2** scans the QR Code, contacts **conode 1** and sends **“GetPropose”** to get the party infos
6. **Org 2** sends **“ProposeJoin”** to **conode 1** 
7. **Org 1** ask for new conodes by polling using **“ProposePoll”**
8. **Co 1** sends the new conodes waiting for approbations using **“ProposePollReply”**
9. **Org 1** accepts **Org 2** using **“ProposeParty”**
10.  Each organizer get the final description using **“GetPropose”** and issue a **“StoreConfig”** to their cononde