### PR TITLE
Responds empty commit when verification fail

### DIFF
--- a/evoting/service/service_test.go
+++ b/evoting/service/service_test.go
@@ -107,22 +107,20 @@ func TestService(t *testing.T) {
 	})
 	require.Equal(t, err, errOnlyLeader)
 
-	// Commented out due to issue #1167.
-	//
 	// // Try to cast a vote for another person. (i.e. t.User != t.Ballot.User)
-	// ballot = &lib.Ballot{
-	// 	User:  idUser2,
-	// 	Alpha: k,
-	// 	Beta:  c,
-	// }
-	// _, err = s0.Cast(&evoting.Cast{
-	// 	ID:        replyOpen.ID,
-	// 	Ballot:    ballot,
-	// 	User:      idUser1,
-	// 	Signature: sig,
-	// })
-	// // expect a failure
-	// require.NotNil(t, err)
+	ballot = &lib.Ballot{
+		User:  idUser2,
+		Alpha: k,
+		Beta:  c,
+	}
+	_, err = s0.Cast(&evoting.Cast{
+		ID:        replyOpen.ID,
+		Ballot:    ballot,
+		User:      idUser1,
+		Signature: sig,
+	})
+	// expect a failure
+	require.NotNil(t, err)
 
 	// Prepare a helper for testing voting.
 	vote := func(user uint32, bufCand []byte) *evoting.CastReply {

--- a/ftcosi/protocol/helper_functions.go
+++ b/ftcosi/protocol/helper_functions.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/dedis/kyber"
@@ -13,7 +14,7 @@ import (
 // generateCommitmentAndAggregate generates a personal secret and commitment
 // and returns respectively the secret, an aggregated commitment and an aggregated mask
 func generateCommitmentAndAggregate(s cosi.Suite, t *onet.TreeNodeInstance, publics []kyber.Point,
-	structCommitments []StructCommitment) (kyber.Scalar, kyber.Point, *cosi.Mask, error) {
+	structCommitments []StructCommitment, ok bool) (kyber.Scalar, kyber.Point, *cosi.Mask, error) {
 
 	if t == nil {
 		return nil, nil, nil, fmt.Errorf("TreeNodeInstance should not be nil, but is")
@@ -33,12 +34,27 @@ func generateCommitmentAndAggregate(s cosi.Suite, t *onet.TreeNodeInstance, publ
 
 	//generate personal secret and commitment
 	secret, commitment := cosi.Commit(s)
+	if !ok {
+		commitment = s.Point().Null()
+	}
 	commitments = append(commitments, commitment)
 
 	//generate personal mask
 	personalMask, err := cosi.NewMask(s, publics, t.Public())
 	if err != nil {
 		return nil, nil, nil, err
+	}
+	if !ok {
+		var found bool
+		for i, p := range publics {
+			if p.Equal(t.Public()) {
+				personalMask.SetBit(i, false)
+				found = true
+			}
+		}
+		if !found {
+			return nil, nil, nil, errors.New("failed to find own public key")
+		}
 	}
 	masks = append(masks, personalMask.Mask())
 
@@ -65,7 +81,7 @@ func generateCommitmentAndAggregate(s cosi.Suite, t *onet.TreeNodeInstance, publ
 // generateResponse generates a personal response based on the secret
 // and returns the aggregated response of all children and the node
 func generateResponse(s cosi.Suite, t *onet.TreeNodeInstance, structResponses []StructResponse,
-	secret kyber.Scalar, challenge kyber.Scalar) (kyber.Scalar, error) {
+	secret kyber.Scalar, challenge kyber.Scalar, ok bool) (kyber.Scalar, error) {
 
 	if t == nil {
 		return nil, fmt.Errorf("TreeNodeInstance should not be nil, but is")
@@ -87,6 +103,9 @@ func generateResponse(s cosi.Suite, t *onet.TreeNodeInstance, structResponses []
 	personalResponse, err := cosi.Response(s, t.Private(), secret, challenge)
 	if err != nil {
 		return nil, err
+	}
+	if !ok {
+		personalResponse = s.Scalar().Zero()
 	}
 	responses = append(responses, personalResponse)
 	log.Lvl3(t.ServerIdentity().Address, "Verification successful")

--- a/ftcosi/protocol/protocol_test.go
+++ b/ftcosi/protocol/protocol_test.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,8 +14,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const FailureProtocolName = "FailureProtocol"
+const FailureSubProtocolName = "FailureSubProtocol"
+
+const RefuseOneProtocolName = "RefuseOneProtocol"
+const RefuseOneSubProtocolName = "RefuseOneSubProtocol"
+
 func init() {
 	GlobalRegisterDefaultProtocols()
+	onet.GlobalProtocolRegister(FailureProtocolName, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
+		vf := func(a, b []byte) bool { return true }
+		return NewFtCosi(n, vf, FailureSubProtocolName, cothority.Suite)
+	})
+	onet.GlobalProtocolRegister(FailureSubProtocolName, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
+		vf := func(a, b []byte) bool { return false }
+		return NewSubFtCosi(n, vf, cothority.Suite)
+	})
+	onet.GlobalProtocolRegister(RefuseOneProtocolName, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
+		vf := func(a, b []byte) bool { return true }
+		return NewFtCosi(n, vf, RefuseOneSubProtocolName, cothority.Suite)
+	})
+	onet.GlobalProtocolRegister(RefuseOneSubProtocolName, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
+		return NewSubFtCosi(n, refuse, cothority.Suite)
+	})
 }
 
 var testSuite = cothority.Suite
@@ -266,10 +288,150 @@ func TestProtocolErrors(t *testing.T) {
 	}
 }
 
+func TestProtocolRefusalAll(t *testing.T) {
+	nodes := []int{4, 5, 13}
+	subtrees := []int{1, 2, 5, 9}
+	proposal := []byte{0xFF}
+
+	for _, nNodes := range nodes {
+		for _, nSubtrees := range subtrees {
+			log.Lvl2("test asking for", nNodes, "nodes and", nSubtrees, "subtrees")
+
+			local := onet.NewLocalTest(testSuite)
+			_, _, tree := local.GenTree(nNodes, false)
+
+			// get public keys
+			publics := make([]kyber.Point, tree.Size())
+			for i, node := range tree.List() {
+				publics[i] = node.ServerIdentity.Public
+			}
+
+			pi, err := local.CreateProtocol(FailureProtocolName, tree)
+			if err != nil {
+				local.CloseAll()
+				t.Fatal("Error in creation of protocol:", err)
+			}
+			cosiProtocol := pi.(*FtCosi)
+			cosiProtocol.CreateProtocol = local.CreateProtocol
+			cosiProtocol.Msg = proposal
+			cosiProtocol.NSubtrees = nSubtrees
+			cosiProtocol.Timeout = defaultTimeout
+
+			err = cosiProtocol.Start()
+			if err != nil {
+				local.CloseAll()
+				t.Fatal(err)
+			}
+
+			// only the leader agrees, the verification should only pass with a threshold of 1
+			// the rest, including using the complete policy should fail
+			var signature []byte
+			select {
+			case signature = <-cosiProtocol.FinalSignature:
+				log.Lvl3("Instance is done")
+			case <-time.After(defaultTimeout * 2):
+				// wait a bit longer than the protocol timeout
+				local.CloseAll()
+				t.Fatal("didn't get commitment in time")
+			}
+
+			err = verifySignature(signature, publics, proposal, cosi.CompletePolicy{})
+			if err == nil {
+				local.CloseAll()
+				t.Fatal("verification should fail")
+			}
+
+			err = verifySignature(signature, publics, proposal, cosi.NewThresholdPolicy(2))
+			if err == nil {
+				local.CloseAll()
+				t.Fatal("verification should fail")
+			}
+
+			err = verifySignature(signature, publics, proposal, cosi.NewThresholdPolicy(1))
+			if err != nil {
+				local.CloseAll()
+				t.Fatal(err)
+			}
+
+			local.CloseAll()
+		}
+	}
+}
+
+func TestProtocolRefuseOne(t *testing.T) {
+	nodes := []int{4, 5, 13}
+	subtrees := []int{1, 2, 5, 9}
+	proposal := []byte{0xFF}
+
+	for _, nNodes := range nodes {
+		for _, nSubtrees := range subtrees {
+			for refuseIdx := 0; refuseIdx < nNodes-1; refuseIdx++ {
+				log.Lvl2("test asking for", nNodes, "nodes and", nSubtrees, "subtrees")
+				counter = &Counter{refuseIdx: refuseIdx}
+
+				local := onet.NewLocalTest(testSuite)
+				_, _, tree := local.GenTree(nNodes, false)
+
+				// get public keys
+				publics := make([]kyber.Point, tree.Size())
+				for i, node := range tree.List() {
+					publics[i] = node.ServerIdentity.Public
+				}
+
+				pi, err := local.CreateProtocol(RefuseOneProtocolName, tree)
+				if err != nil {
+					local.CloseAll()
+					t.Fatal("Error in creation of protocol:", err)
+				}
+				cosiProtocol := pi.(*FtCosi)
+				cosiProtocol.CreateProtocol = local.CreateProtocol
+				cosiProtocol.Msg = proposal
+				cosiProtocol.NSubtrees = nSubtrees
+				cosiProtocol.Timeout = defaultTimeout
+
+				err = cosiProtocol.Start()
+				if err != nil {
+					local.CloseAll()
+					t.Fatal(err)
+				}
+
+				// only the leader agrees, the verification should only pass with a threshold of 1
+				// the rest, including using the complete policy should fail
+				var signature []byte
+				select {
+				case signature = <-cosiProtocol.FinalSignature:
+					log.Lvl3("Instance is done")
+				case <-time.After(defaultTimeout * 2):
+					// wait a bit longer than the protocol timeout
+					local.CloseAll()
+					t.Fatal("didn't get commitment in time")
+				}
+
+				err = verifySignature(signature, publics, proposal, cosi.CompletePolicy{})
+				if err == nil {
+					local.CloseAll()
+					t.Fatalf("verification should fail, refused index: %d", refuseIdx)
+				}
+
+				err = verifySignature(signature, publics, proposal, cosi.NewThresholdPolicy(nNodes-1))
+				if err != nil {
+					local.CloseAll()
+					t.Fatal(err)
+				}
+				local.CloseAll()
+
+				counter.Lock()
+				if counter.veriCount != nNodes-1 {
+					counter.Unlock()
+					t.Fatalf("not enough verified count, need %d but got %d", counter.veriCount, nNodes-1)
+				}
+			}
+		}
+	}
+}
+
 func getAndVerifySignature(cosiProtocol *FtCosi, publics []kyber.Point,
 	proposal []byte, policy cosi.Policy) error {
-
-	// get response
 	var signature []byte
 	select {
 	case signature = <-cosiProtocol.FinalSignature:
@@ -279,6 +441,11 @@ func getAndVerifySignature(cosiProtocol *FtCosi, publics []kyber.Point,
 		return fmt.Errorf("didn't get commitment in time")
 	}
 
+	return verifySignature(signature, publics, proposal, policy)
+}
+
+func verifySignature(signature []byte, publics []kyber.Point,
+	proposal []byte, policy cosi.Policy) error {
 	// verify signature
 	err := cosi.Verify(testSuite, publics, proposal, signature, policy)
 	if err != nil {
@@ -286,4 +453,22 @@ func getAndVerifySignature(cosiProtocol *FtCosi, publics []kyber.Point,
 	}
 	log.Lvl2("Signature correctly verified!")
 	return nil
+}
+
+type Counter struct {
+	veriCount int
+	refuseIdx int
+	sync.Mutex
+}
+
+var counter = &Counter{}
+
+func refuse(msg, data []byte) bool {
+	counter.Lock()
+	defer counter.Unlock()
+	defer func() { counter.veriCount++ }()
+	if counter.veriCount == counter.refuseIdx {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
Initially, the sub protocol would return an error immediately if the
verification function returns false and exit the protocol. As a result,
the sub-leader and the leader must wait for a timeout before they
proceed to the next step in the protocol. This commit brings an
exception handling mechanism inspired from bftcosi. The difference is
that instead of returning exceptions, the nodes return the commitment
without their own share and with their part of the mask set to false.

The performance improvement is evident from a byzcoinx test.
```
tsf-444-wpa-1-068:byzcoinx cong$ git co -
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
tsf-444-wpa-1-068:byzcoinx cong$ go test  -count=1 -run TestBftCoSiRefuse
PASS
ok  	github.com/dedis/cothority/byzcoinx	2.898s
tsf-444-wpa-1-068:byzcoinx cong$ git co -
Switched to branch 'ftcosi_exceptions'
tsf-444-wpa-1-068:byzcoinx cong$ go test  -count=1 -run TestBftCoSiRefuse
PASS
ok  	github.com/dedis/cothority/byzcoinx	0.366s
```

fixes #1167 - removed the comments and ran the service tests about 5 times and saw no non-determinism. 