### PR TITLE
evoting: use skipchain service for creating new skipchains and appending blocks

### DIFF
--- a/evoting/lib/chains.go
+++ b/evoting/lib/chains.go
@@ -1,6 +1,8 @@
 package lib
 
 import (
+	"errors"
+
 	"github.com/dedis/onet"
 	"github.com/dedis/protobuf"
 
@@ -8,14 +10,27 @@ import (
 )
 
 // NewSkipchain creates a new skipchain for a given roster and verification function.
-func NewSkipchain(roster *onet.Roster, verifier []skipchain.VerifierID, data interface{}) (
+func NewSkipchain(s *skipchain.Service, roster *onet.Roster, verifier []skipchain.VerifierID) (
 	*skipchain.SkipBlock, error) {
-	client := skipchain.NewClient()
-	return client.CreateGenesis(roster, 8, 4, verifier, data, nil)
+	block := skipchain.NewSkipBlock()
+	block.Roster = roster
+	block.BaseHeight = 8
+	block.MaximumHeight = 4
+	block.VerifierIDs = verifier
+	block.Data = []byte{}
+
+	reply, err := s.StoreSkipBlock(&skipchain.StoreSkipBlock{
+		NewBlock: block,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return reply.Latest, nil
 }
 
-// Store appends a new block holding data to an existing skipchain.
-func Store(id skipchain.SkipBlockID, roster *onet.Roster, transaction *Transaction) error {
+// StoreUsingWebsocket appends a new block holding data to an existing skipchain
+// using websockets. Used for storing a block while executing a protocol.
+func StoreUsingWebsocket(id skipchain.SkipBlockID, roster *onet.Roster, transaction *Transaction) error {
 	client := skipchain.NewClient()
 	reply, err := client.GetUpdateChain(roster, id)
 	if err != nil {
@@ -28,6 +43,36 @@ func Store(id skipchain.SkipBlockID, roster *onet.Roster, transaction *Transacti
 	}
 
 	_, err = client.StoreSkipBlock(reply.Update[len(reply.Update)-1], nil, enc)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Store appends a new block holding data to an existing skipchain using the
+// skipchain service
+func Store(s *skipchain.Service, ID skipchain.SkipBlockID, transaction *Transaction) error {
+	db := s.GetDB()
+	latest, err := db.GetLatest(db.GetByID(ID))
+	if err != nil {
+		return errors.New("couldn't find latest block: " + err.Error())
+	}
+
+	enc, err := protobuf.Encode(transaction)
+	if err != nil {
+		return err
+	}
+
+	block := latest.Copy()
+	block.Data = enc
+	block.GenesisID = block.SkipChainID()
+	block.Index++
+	// Using an unset LatestID with block.GenesisID set is to ensure concurrent
+	// append.
+	_, err = s.StoreSkipBlock(&skipchain.StoreSkipBlock{
+		NewBlock:          block,
+		TargetSkipChainID: latest.SkipChainID(),
+	})
 	if err != nil {
 		return err
 	}

--- a/evoting/lib/master.go
+++ b/evoting/lib/master.go
@@ -33,10 +33,10 @@ type Link struct {
 }
 
 // GetMaster retrieves the master object from its skipchain.
-func GetMaster(roster *onet.Roster, id skipchain.SkipBlockID) (*Master, error) {
-	client := skipchain.NewClient()
-
-	block, err := client.GetSingleBlockByIndex(roster, id, 1)
+func GetMaster(s *skipchain.Service, id skipchain.SkipBlockID) (*Master, error) {
+	block, err := s.GetSingleBlockByIndex(
+		&skipchain.GetSingleBlockByIndex{Genesis: id, Index: 1},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -49,10 +49,10 @@ func GetMaster(roster *onet.Roster, id skipchain.SkipBlockID) (*Master, error) {
 }
 
 // Links returns all the links appended to the master skipchain.
-func (m *Master) Links() ([]*Link, error) {
-	client := skipchain.NewClient()
-
-	block, err := client.GetSingleBlockByIndex(m.Roster, m.ID, 0)
+func (m *Master) Links(s *skipchain.Service) ([]*Link, error) {
+	block, err := s.GetSingleBlockByIndex(
+		&skipchain.GetSingleBlockByIndex{Genesis: m.ID, Index: 0},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,9 @@ func (m *Master) Links() ([]*Link, error) {
 		if len(block.ForwardLink) <= 0 {
 			break
 		}
-		block, _ = client.GetSingleBlock(m.Roster, block.ForwardLink[0].To)
+		block, _ = s.GetSingleBlock(
+			&skipchain.GetSingleBlock{ID: block.ForwardLink[0].To},
+		)
 	}
 	return links, nil
 }

--- a/evoting/protocol/decrypt.go
+++ b/evoting/protocol/decrypt.go
@@ -82,7 +82,7 @@ func (d *Decrypt) HandlePrompt(prompt MessagePromptDecrypt) error {
 	flag := Verify(d.Election.Key, box, mixes)
 	partial := &lib.Partial{Points: points, Flag: flag, Node: d.Name()}
 	transaction := lib.NewTransaction(partial, d.User, d.Signature)
-	if err = lib.Store(d.Election.ID, d.Election.Roster, transaction); err != nil {
+	if err = lib.StoreUsingWebsocket(d.Election.ID, d.Election.Roster, transaction); err != nil {
 		return err
 	}
 

--- a/evoting/protocol/shuffle.go
+++ b/evoting/protocol/shuffle.go
@@ -92,7 +92,7 @@ func (s *Shuffle) HandlePrompt(prompt MessagePrompt) error {
 	}
 	mix := &lib.Mix{Ballots: lib.Combine(g, d), Proof: proof, Node: s.Name()}
 	transaction := lib.NewTransaction(mix, s.User, s.Signature)
-	if err := lib.Store(s.Election.ID, s.Election.Roster, transaction); err != nil {
+	if err := lib.StoreUsingWebsocket(s.Election.ID, s.Election.Roster, transaction); err != nil {
 		return err
 	}
 

--- a/evoting/service/service.go
+++ b/evoting/service/service.go
@@ -49,6 +49,8 @@ var storageKey = []byte("storage")
 type Service struct {
 	*onet.ServiceProcessor
 
+	skipchain *skipchain.Service
+
 	mutex   sync.Mutex
 	storage *storage
 
@@ -80,7 +82,7 @@ func (s *Service) Link(req *evoting.Link) (*evoting.LinkReply, error) {
 		return nil, errors.New("link error: invalid pin")
 	}
 
-	genesis, err := lib.NewSkipchain(req.Roster, lib.TransactionVerifiers, nil)
+	genesis, err := lib.NewSkipchain(s.skipchain, req.Roster, lib.TransactionVerifiers)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +94,8 @@ func (s *Service) Link(req *evoting.Link) (*evoting.LinkReply, error) {
 		Key:    req.Key,
 	}
 	transaction := lib.NewTransaction(master, 0, []byte{})
-	if err := lib.Store(master.ID, master.Roster, transaction); err != nil {
+
+	if err := lib.Store(s.skipchain, master.ID, transaction); err != nil {
 		return nil, err
 	}
 
@@ -107,7 +110,7 @@ func (s *Service) Link(req *evoting.Link) (*evoting.LinkReply, error) {
 
 // Open message hander. Create a new election with accompanying skipchain.
 func (s *Service) Open(req *evoting.Open) (*evoting.OpenReply, error) {
-	master, err := lib.GetMaster(s.roster(), req.ID)
+	master, err := lib.GetMaster(s.skipchain, req.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +119,7 @@ func (s *Service) Open(req *evoting.Open) (*evoting.OpenReply, error) {
 		return nil, errOnlyLeader
 	}
 
-	genesis, err := lib.NewSkipchain(master.Roster, lib.TransactionVerifiers, nil)
+	genesis, err := lib.NewSkipchain(s.skipchain, master.Roster, lib.TransactionVerifiers)
 	if err != nil {
 		return nil, err
 	}
@@ -153,13 +156,13 @@ func (s *Service) Open(req *evoting.Open) (*evoting.OpenReply, error) {
 		req.Election.Creator = req.User
 
 		transaction := lib.NewTransaction(req.Election, req.User, req.Signature)
-		if err = lib.Store(req.Election.ID, master.Roster, transaction); err != nil {
+		if err := lib.Store(s.skipchain, req.Election.ID, transaction); err != nil {
 			return nil, err
 		}
 
 		link := &lib.Link{ID: genesis.Hash}
 		transaction = lib.NewTransaction(link, req.User, req.Signature)
-		if err = lib.Store(master.ID, master.Roster, transaction); err != nil {
+		if err := lib.Store(s.skipchain, master.ID, transaction); err != nil {
 			return nil, err
 		}
 
@@ -242,7 +245,7 @@ func (s *Service) Cast(req *evoting.Cast) (*evoting.CastReply, error) {
 		return nil, errOnlyLeader
 	}
 	transaction := lib.NewTransaction(req.Ballot, req.User, req.Signature)
-	if err := lib.Store(req.ID, s.roster(), transaction); err != nil {
+	if err := lib.Store(s.skipchain, req.ID, transaction); err != nil {
 		return nil, err
 	}
 	return &evoting.CastReply{}, nil
@@ -250,12 +253,12 @@ func (s *Service) Cast(req *evoting.Cast) (*evoting.CastReply, error) {
 
 // GetElections message handler. Return all elections in which the given user participates.
 func (s *Service) GetElections(req *evoting.GetElections) (*evoting.GetElectionsReply, error) {
-	master, err := lib.GetMaster(s.roster(), req.Master)
+	master, err := lib.GetMaster(s.skipchain, req.Master)
 	if err != nil {
 		return nil, err
 	}
 
-	links, err := master.Links()
+	links, err := master.Links(s.skipchain)
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +281,7 @@ func (s *Service) GetElections(req *evoting.GetElections) (*evoting.GetElections
 
 	elections := make([]*lib.Election, 0)
 	for _, l := range links {
-		election, err := lib.GetElection(s.roster(), l.ID)
+		election, err := lib.GetElection(s.skipchain, l.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -295,7 +298,7 @@ func (s *Service) GetElections(req *evoting.GetElections) (*evoting.GetElections
 
 // GetBox message handler to retrieve the casted ballot in an election.
 func (s *Service) GetBox(req *evoting.GetBox) (*evoting.GetBoxReply, error) {
-	election, err := lib.GetElection(s.roster(), req.ID)
+	election, err := lib.GetElection(s.skipchain, req.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +312,7 @@ func (s *Service) GetBox(req *evoting.GetBox) (*evoting.GetBoxReply, error) {
 
 // GetMixes message handler. Vet all created mixes.
 func (s *Service) GetMixes(req *evoting.GetMixes) (*evoting.GetMixesReply, error) {
-	election, err := lib.GetElection(s.roster(), req.ID)
+	election, err := lib.GetElection(s.skipchain, req.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +326,7 @@ func (s *Service) GetMixes(req *evoting.GetMixes) (*evoting.GetMixesReply, error
 
 // GetPartials message handler. Vet all created partial decryptions.
 func (s *Service) GetPartials(req *evoting.GetPartials) (*evoting.GetPartialsReply, error) {
-	election, err := lib.GetElection(s.roster(), req.ID)
+	election, err := lib.GetElection(s.skipchain, req.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +344,7 @@ func (s *Service) Shuffle(req *evoting.Shuffle) (*evoting.ShuffleReply, error) {
 		return nil, errOnlyLeader
 	}
 
-	election, err := lib.GetElection(s.roster(), req.ID)
+	election, err := lib.GetElection(s.skipchain, req.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -381,7 +384,7 @@ func (s *Service) Decrypt(req *evoting.Decrypt) (*evoting.DecryptReply, error) {
 		return nil, errOnlyLeader
 	}
 
-	election, err := lib.GetElection(s.roster(), req.ID)
+	election, err := lib.GetElection(s.skipchain, req.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -421,7 +424,7 @@ func (s *Service) Reconstruct(req *evoting.Reconstruct) (*evoting.ReconstructRep
 		return nil, errOnlyLeader
 	}
 
-	election, err := lib.GetElection(s.roster(), req.ID)
+	election, err := lib.GetElection(s.skipchain, req.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -470,7 +473,7 @@ func (s *Service) NewProtocol(node *onet.TreeNodeInstance, conf *onet.GenericCon
 		}()
 		return protocol, nil
 	case protocol.NameShuffle:
-		election, err := lib.GetElection(s.roster(), sync.ID)
+		election, err := lib.GetElection(s.skipchain, sync.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -490,7 +493,7 @@ func (s *Service) NewProtocol(node *onet.TreeNodeInstance, conf *onet.GenericCon
 
 		return protocol, nil
 	case protocol.NameDecrypt:
-		election, err := lib.GetElection(s.roster(), sync.ID)
+		election, err := lib.GetElection(s.skipchain, sync.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -521,7 +524,7 @@ func (s *Service) verify(id []byte, skipblock *skipchain.SkipBlock) bool {
 		return false
 	}
 
-	err := transaction.Verify(skipblock.GenesisID, skipblock.Roster)
+	err := transaction.Verify(skipblock.GenesisID, s.skipchain)
 	if err != nil {
 		log.Lvl2("verify failed:", err)
 		return false
@@ -587,6 +590,10 @@ func (s *Service) load() error {
 	return nil
 }
 
+func (s *Service) db() *skipchain.SkipBlockDB {
+	return s.skipchain.GetDB()
+}
+
 // new initializes the service and registers all the message handlers.
 func new(context *onet.Context) (onet.Service, error) {
 	service := &Service{
@@ -594,6 +601,7 @@ func new(context *onet.Context) (onet.Service, error) {
 		storage: &storage{
 			Secrets: make(map[string]*lib.SharedSecret),
 		},
+		skipchain: context.Service(skipchain.ServiceName).(*skipchain.Service),
 	}
 
 	service.RegisterHandlers(


### PR DESCRIPTION
Changes the evoting service to use the skipchain service to create new skipchains and append new blocks.

Blocks appended during the execution of a protocol (Shuffle, Decrypt) still make use of the websocket API since they need to communicate with the leader.

Also updated setStage method to use the skipchain service to retrieve the latest block. This should be considerably faster than iterating over all blocks one at a time.