### PR TITLE
Correctly create backward links and verify update chain

### DIFF
--- a/skipchain/api_test.go
+++ b/skipchain/api_test.go
@@ -124,7 +124,7 @@ func TestClient_GetUpdateChain(t *testing.T) {
 	sbs := make([]*SkipBlock, sbCount)
 	var err error
 	sbs[0], err = makeGenesisRosterArgs(s, onet.NewRoster(roster.List[0:2]),
-		nil, VerificationNone, 1, 1)
+		nil, VerificationNone, 2, 3)
 	log.ErrFatal(err)
 
 	log.Lvl1("Initialize skipchain.")

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -44,6 +44,8 @@ func TestService_StoreSkipBlock(t *testing.T) {
 }
 
 func storeSkipBlock(t *testing.T, nbrServers int, fail bool) {
+	defaultPropagateTimeout = time.Second
+
 	// First create a roster to attach the data to it
 	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
@@ -81,7 +83,7 @@ func storeSkipBlock(t *testing.T, nbrServers int, fail bool) {
 
 	// kill one node and it should still work
 	if fail {
-		log.Lvl3("Pausing server", deadServer.Address())
+		log.Lvl2("Pausing server", deadServer.Address())
 		deadServer.Pause()
 	}
 

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -22,7 +22,7 @@ import (
 )
 
 // How long to wait before a timeout is generated in the propagation.
-const defaultPropagateTimeout = 15 * time.Second
+var defaultPropagateTimeout = 15 * time.Second
 
 // SkipBlockID represents the Hash of the SkipBlock
 type SkipBlockID []byte


### PR DESCRIPTION
- StoreSkipBlock: Fetch missing blocks when creating backward links
- api.GetUpdateChain: Fix error when verifying whether the update chain
is correct