### PR TITLE
don't return network.Message

### DIFF
--- a/cisc/Reference.md
+++ b/cisc/Reference.md
@@ -40,7 +40,11 @@ to work with. You can manage the connections with `cisc skipchain` followed by:
 	   * Public keys - no privacy, but no pop-party visit is required
   * Join - will ask the devices of the remote skipwchain to vote on the inclusion of this device in the skipchain
   * Leave - remove this device from an identity
-  * Roster - change the roster of an identity
+  * Roster - modify the roster of an identity
+    * Show - shows the current roster
+    * Set - sets the roster to a new roster
+    * Add - adds a new node to the roster
+    * Remove - removes a node from the roster
   * List - show all stored skipchains
   * QRCode - prints a QRCode on the terminal so a remote device can contact
 

--- a/cisc/commands.go
+++ b/cisc/commands.go
@@ -1,12 +1,22 @@
 package main
 
-import "gopkg.in/urfave/cli.v1"
+import cli "gopkg.in/urfave/cli.v1"
 
 /*
 This holds the cli-commands so the main-file is less cluttered.
 */
 
 func getCommands() cli.Commands {
+	tomlORIP := []cli.Flag{
+		cli.StringFlag{
+			Name:  "toml, t",
+			Usage: "give a toml file with the node to add",
+		},
+		cli.StringFlag{
+			Name:  "addr, a",
+			Usage: "give an ip:port pair to add to the roster",
+		},
+	}
 	return cli.Commands{
 		{
 			Name:    "link",
@@ -107,11 +117,40 @@ func getCommands() cli.Commands {
 					Action:    scQrcode,
 				},
 				{
-					Name:      "roster",
-					Aliases:   []string{"r"},
-					Usage:     "define a new roster for the skipchain",
-					ArgsUsage: "group.toml [skipchain-id]",
-					Action:    scRoster,
+					Name:    "roster",
+					Aliases: []string{"r"},
+					Usage:   "change the roster for the skipchain",
+					Subcommands: cli.Commands{
+						cli.Command{
+							Name:      "show",
+							Aliases:   []string{"s"},
+							Usage:     "shows the current roster of the skipchain",
+							ArgsUsage: "[skipchain-id]",
+							Action:    scRosterShow,
+						},
+						cli.Command{
+							Name:      "set",
+							Usage:     "set the current roster of the skipchain",
+							ArgsUsage: "group.toml [skipchain-id]",
+							Action:    scRosterSet,
+						},
+						cli.Command{
+							Name:      "add",
+							Aliases:   []string{"a"},
+							Usage:     "adds a node to the current roster of the skipchain",
+							ArgsUsage: "[skipchain-id]",
+							Action:    scRosterAdd,
+							Flags:     tomlORIP,
+						},
+						cli.Command{
+							Name:      "remove",
+							Aliases:   []string{"rm"},
+							Usage:     "removes a node from the current roster of the skipchain",
+							ArgsUsage: "[skipchain-id]",
+							Action:    scRosterRemove,
+							Flags:     tomlORIP,
+						},
+					},
 				},
 			},
 		},

--- a/cisc/lib.go
+++ b/cisc/lib.go
@@ -241,18 +241,27 @@ func getKeyConfig(c *cli.Context) string {
 	return configDir + "/admin_key.bin"
 }
 
-// Reads the group-file and returns it
 func getGroup(c *cli.Context) *app.Group {
-	gfile := c.Args().Get(0)
-	gr, err := os.Open(gfile)
+	g, err := getGroupString(c.Args().Get(0))
 	log.ErrFatal(err)
+	return g
+}
+
+// Reads the group-file and returns it
+func getGroupString(gfile string) (*app.Group, error) {
+	gr, err := os.Open(gfile)
+	if err != nil {
+		return nil, err
+	}
 	defer gr.Close()
 	groups, err := app.ReadGroupDescToml(gr)
-	log.ErrFatal(err)
-	if groups == nil || groups.Roster == nil || len(groups.Roster.List) == 0 {
-		log.Fatal("No servers found in roster from", gfile)
+	if err != nil {
+		return nil, err
 	}
-	return groups
+	if groups == nil || groups.Roster == nil || len(groups.Roster.List) == 0 {
+		return nil, errors.New("No servers found in roster from: " + gfile)
+	}
+	return groups, nil
 }
 
 // retrieves ssh-directory and ssh-config-name.

--- a/cisc/test.sh
+++ b/cisc/test.sh
@@ -51,7 +51,28 @@ main(){
   test Follow
   test SymLink
   test Revoke
+  test RosterEdit
   stopTest
+}
+
+testRosterEdit(){
+  runCoBG `seq 3`
+  runAddToken 3
+  runDbgCl 0 1 skipchain create -name client1 co1/public.toml
+  runGrepSed ID "s/.* //" runDbgCl 2 1 data list
+  ID=$SED
+  dbgOut "ID is" $ID
+  testGrep ${addr[1]} runDbgCl 1 1 skipchain roster show
+  testNGrep ${addr[2]} runDbgCl 1 1 skipchain roster show
+  testOK runCl 1 skipchain roster add --addr ${addr[2]}
+  testGrep ${addr[2]} runDbgCl 1 1 skipchain roster show
+  testFail runCl 1 skipchain roster remove --addr ${addr[3]}
+  testOK runCl 1 skipchain roster remove --addr ${addr[2]}
+  testNGrep ${addr[2]} runDbgCl 1 1 skipchain roster show
+  testOK runCl 1 skipchain roster add --toml co2/public.toml
+  testGrep ${addr[2]} runDbgCl 1 1 skipchain roster show
+  testOK runCl 1 skipchain roster set public.toml
+  testGrep ${addr[3]} runDbgCl 1 1 skipchain roster show
 }
 
 testRevoke(){
@@ -304,7 +325,7 @@ testDataRoster(){
   runAddPublic 3 $pub1
   testOK runCl 1 skipchain create co1/public.toml
   testNGrep 2004 runCl 1 data list
-  testOK runCl 1 skipchain roster public.toml
+  testOK runCl 1 skipchain roster set public.toml
   testGrep 2004 runCl 1 data list
   testOK runCl 1 kv add one two
 }

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -174,7 +174,7 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, er
 	// If TargetSkipChainID is not given, it is a genesis block.
 	if psbd.TargetSkipChainID.IsNull() {
 		// A new chain is created
-		log.Lvl3("Creating new skipchain with roster", psbd.NewBlock.Roster.List)
+		log.Lvl2("Creating new skipchain with roster", psbd.NewBlock.Roster.List)
 		prop.Height = prop.MaximumHeight
 		prop.ForwardLink = make([]*ForwardLink, 0)
 		// genesis block has a random back-link, so that two
@@ -203,7 +203,7 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, er
 	} else {
 
 		// We're appending a block to an existing chain.
-		log.Lvlf3("Adding block with roster %+v to %x",
+		log.Lvlf2("Adding block with roster %+v to %x",
 			psbd.NewBlock.Roster.List, psbd.TargetSkipChainID)
 
 		// At this point the TargetSkipChainID must have something in
@@ -365,7 +365,7 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, er
 // SkipBlock we know. The last block in the returned slice of blocks is
 // not guaranteed to have no forward links. It is up to the caller
 // to continue following forward links with the new roster if necessary.
-func (s *Service) GetUpdateChain(guc *GetUpdateChain) (network.Message, error) {
+func (s *Service) GetUpdateChain(guc *GetUpdateChain) (*GetUpdateChainReply, error) {
 	block := s.db.GetByID(guc.LatestID)
 	if block == nil {
 		return nil, errors.New("Couldn't find latest skipblock")

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -153,9 +153,8 @@ func TestService_SetChildrenSkipBlock(t *testing.T) {
 	for i, h := range hosts {
 		log.Lvlf2("%x", skipchainSID)
 		s := local.Services[h.ServerIdentity.ID][skipchainSID].(*Service)
-		m, err := s.GetUpdateChain(&GetUpdateChain{LatestID: sbRoot.Hash})
+		sb, err := s.GetUpdateChain(&GetUpdateChain{LatestID: sbRoot.Hash})
 		log.ErrFatal(err, "Failed in iteration="+strconv.Itoa(i)+":")
-		sb := m.(*GetUpdateChainReply)
 		log.Lvl2(s.Context)
 		if len(sb.Update) != 1 {
 			// we expect only the first block
@@ -177,8 +176,7 @@ func TestService_SetChildrenSkipBlock(t *testing.T) {
 	for _, h := range hosts {
 		s := local.Services[h.ServerIdentity.ID][skipchainSID].(*Service)
 
-		m, err := s.GetUpdateChain(&GetUpdateChain{LatestID: sbInter.Hash})
-		sb := m.(*GetUpdateChainReply)
+		sb, err := s.GetUpdateChain(&GetUpdateChain{LatestID: sbInter.Hash})
 
 		log.ErrFatal(err)
 		if len(sb.Update) != 1 {
@@ -889,7 +887,7 @@ func checkMLUpdate(service *Service, root, latest *SkipBlock, base, height int) 
 	if err != nil {
 		return err
 	}
-	updates := chain.(*GetUpdateChainReply).Update
+	updates := chain.Update
 	genesis := updates[0]
 	if len(genesis.ForwardLink) != height {
 		return errors.New("genesis-block doesn't have height " + strconv.Itoa(height))


### PR DESCRIPTION
Returning `network.Message` in services is evil - it should return the correct message.

This can only be merged into master once #1182 is merged into here.