### PR TITLE
don't use skipchain.NewClient

### DIFF
--- a/cisc/Reference.md
+++ b/cisc/Reference.md
@@ -40,7 +40,11 @@ to work with. You can manage the connections with `cisc skipchain` followed by:
 	   * Public keys - no privacy, but no pop-party visit is required
   * Join - will ask the devices of the remote skipwchain to vote on the inclusion of this device in the skipchain
   * Leave - remove this device from an identity
-  * Roster - change the roster of an identity
+  * Roster - modify the roster of an identity
+    * Show - shows the current roster
+    * Set - sets the roster to a new roster
+    * Add - adds a new node to the roster
+    * Remove - removes a node from the roster
   * List - show all stored skipchains
   * QRCode - prints a QRCode on the terminal so a remote device can contact
 

--- a/cisc/commands.go
+++ b/cisc/commands.go
@@ -1,12 +1,22 @@
 package main
 
-import "gopkg.in/urfave/cli.v1"
+import cli "gopkg.in/urfave/cli.v1"
 
 /*
 This holds the cli-commands so the main-file is less cluttered.
 */
 
 func getCommands() cli.Commands {
+	tomlORIP := []cli.Flag{
+		cli.StringFlag{
+			Name:  "toml, t",
+			Usage: "give a toml file with the node to add",
+		},
+		cli.StringFlag{
+			Name:  "addr, a",
+			Usage: "give an ip:port pair to add to the roster",
+		},
+	}
 	return cli.Commands{
 		{
 			Name:    "link",
@@ -107,11 +117,40 @@ func getCommands() cli.Commands {
 					Action:    scQrcode,
 				},
 				{
-					Name:      "roster",
-					Aliases:   []string{"r"},
-					Usage:     "define a new roster for the skipchain",
-					ArgsUsage: "group.toml [skipchain-id]",
-					Action:    scRoster,
+					Name:    "roster",
+					Aliases: []string{"r"},
+					Usage:   "change the roster for the skipchain",
+					Subcommands: cli.Commands{
+						cli.Command{
+							Name:      "show",
+							Aliases:   []string{"s"},
+							Usage:     "shows the current roster of the skipchain",
+							ArgsUsage: "[skipchain-id]",
+							Action:    scRosterShow,
+						},
+						cli.Command{
+							Name:      "set",
+							Usage:     "set the current roster of the skipchain",
+							ArgsUsage: "group.toml [skipchain-id]",
+							Action:    scRosterSet,
+						},
+						cli.Command{
+							Name:      "add",
+							Aliases:   []string{"a"},
+							Usage:     "adds a node to the current roster of the skipchain",
+							ArgsUsage: "[skipchain-id]",
+							Action:    scRosterAdd,
+							Flags:     tomlORIP,
+						},
+						cli.Command{
+							Name:      "remove",
+							Aliases:   []string{"rm"},
+							Usage:     "removes a node from the current roster of the skipchain",
+							ArgsUsage: "[skipchain-id]",
+							Action:    scRosterRemove,
+							Flags:     tomlORIP,
+						},
+					},
 				},
 			},
 		},

--- a/cisc/lib.go
+++ b/cisc/lib.go
@@ -241,18 +241,27 @@ func getKeyConfig(c *cli.Context) string {
 	return configDir + "/admin_key.bin"
 }
 
-// Reads the group-file and returns it
 func getGroup(c *cli.Context) *app.Group {
-	gfile := c.Args().Get(0)
-	gr, err := os.Open(gfile)
+	g, err := getGroupString(c.Args().Get(0))
 	log.ErrFatal(err)
+	return g
+}
+
+// Reads the group-file and returns it
+func getGroupString(gfile string) (*app.Group, error) {
+	gr, err := os.Open(gfile)
+	if err != nil {
+		return nil, err
+	}
 	defer gr.Close()
 	groups, err := app.ReadGroupDescToml(gr)
-	log.ErrFatal(err)
-	if groups == nil || groups.Roster == nil || len(groups.Roster.List) == 0 {
-		log.Fatal("No servers found in roster from", gfile)
+	if err != nil {
+		return nil, err
 	}
-	return groups
+	if groups == nil || groups.Roster == nil || len(groups.Roster.List) == 0 {
+		return nil, errors.New("No servers found in roster from: " + gfile)
+	}
+	return groups, nil
 }
 
 // retrieves ssh-directory and ssh-config-name.

--- a/cisc/test.sh
+++ b/cisc/test.sh
@@ -29,29 +29,50 @@ main(){
   createFinal 2 > /dev/null
   createToken 2
 
-  test Build
-  test Link
-  test Final
-  test ClientSetup
-  test ScCreate
-  test ScCreate2
-  test ScCreate3
-  test DataList
-  test DataVote
-  test DataRoster
-  test IdConnect
-  test IdLeave
-  test KeyAdd
-  test KeyFile
-  test KeyAdd2
-  test KeyAddWeb
-  test KeyDel
-  test SSHAdd
-  test SSHDel
-  test Follow
-  test SymLink
-  test Revoke
+  # test Build
+  # test Link
+  # test Final
+  # test ClientSetup
+  # test ScCreate
+  # test ScCreate2
+  # test ScCreate3
+  # test DataList
+  # test DataVote
+  # test DataRoster
+  # test IdConnect
+  # test IdLeave
+  # test KeyAdd
+  # test KeyFile
+  # test KeyAdd2
+  # test KeyAddWeb
+  # test KeyDel
+  # test SSHAdd
+  # test SSHDel
+  # test Follow
+  # test SymLink
+  # test Revoke
+  test RosterEdit
   stopTest
+}
+
+testRosterEdit(){
+  runCoBG `seq 3`
+  runAddToken 3
+  runDbgCl 0 1 skipchain create -name client1 co1/public.toml
+  runGrepSed ID "s/.* //" runDbgCl 2 1 data list
+  ID=$SED
+  dbgOut "ID is" $ID
+  testGrep ${addr[1]} runDbgCl 1 1 skipchain roster show
+  testNGrep ${addr[2]} runDbgCl 1 1 skipchain roster show
+  testOK runCl 1 skipchain roster add --addr ${addr[2]}
+  testGrep ${addr[2]} runDbgCl 1 1 skipchain roster show
+  testFail runCl 1 skipchain roster remove --addr ${addr[3]}
+  testOK runCl 1 skipchain roster remove --addr ${addr[2]}
+  testNGrep ${addr[2]} runDbgCl 1 1 skipchain roster show
+  testOK runCl 1 skipchain roster add --toml co2/public.toml
+  testGrep ${addr[2]} runDbgCl 1 1 skipchain roster show
+  testOK runCl 1 skipchain roster set public.toml
+  testGrep ${addr[3]} runDbgCl 1 1 skipchain roster show
 }
 
 testRevoke(){
@@ -304,7 +325,7 @@ testDataRoster(){
   runAddPublic 3 $pub1
   testOK runCl 1 skipchain create co1/public.toml
   testNGrep 2004 runCl 1 data list
-  testOK runCl 1 skipchain roster public.toml
+  testOK runCl 1 skipchain roster set public.toml
   testGrep 2004 runCl 1 data list
   testOK runCl 1 kv add one two
 }


### PR DESCRIPTION
Continuing cleaning up of `skipchain.NewClient` occurrences. Changing my mind on cross-service calls which seem to be OK now.

This can only be merged into #1181 once #1179 is merged into here.