### PR TITLE
evoting: use skipchain service in protocol

### DIFF
--- a/evoting/lib/chains.go
+++ b/evoting/lib/chains.go
@@ -36,12 +36,10 @@ func StoreUsingWebsocket(id skipchain.SkipBlockID, roster *onet.Roster, transact
 	if err != nil {
 		return err
 	}
-
 	enc, err := protobuf.Encode(transaction)
 	if err != nil {
 		return err
 	}
-
 	_, err = client.StoreSkipBlock(reply.Update[len(reply.Update)-1], nil, enc)
 	if err != nil {
 		return err

--- a/evoting/lib/transaction.go
+++ b/evoting/lib/transaction.go
@@ -203,7 +203,7 @@ func (t *Transaction) Verify(genesis skipchain.SkipBlockID, s *skipchain.Service
 			return err
 		}
 
-		mixes, err := election.Mixes()
+		mixes, err := election.Mixes(s)
 		if err != nil {
 			return err
 		} else if len(mixes) == len(roster.List) {
@@ -223,14 +223,14 @@ func (t *Transaction) Verify(genesis skipchain.SkipBlockID, s *skipchain.Service
 			return err
 		}
 
-		mixes, err := election.Mixes()
+		mixes, err := election.Mixes(s)
 		if err != nil {
 			return err
 		} else if len(mixes) != len(roster.List) {
 			return errors.New("decrypt error, election not shuffled yet")
 		}
 
-		partials, err := election.Partials()
+		partials, err := election.Partials(s)
 		if err != nil {
 			return err
 		} else if len(partials) == len(roster.List) {

--- a/evoting/protocol/decrypt.go
+++ b/evoting/protocol/decrypt.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dedis/onet/network"
 
 	"github.com/dedis/cothority/evoting/lib"
+	"github.com/dedis/cothority/skipchain"
 )
 
 /*
@@ -38,6 +39,8 @@ type Decrypt struct {
 	Election *lib.Election     // Election to be decrypted.
 
 	Finished chan bool // Flag to signal protocol termination.
+
+	Skipchain *skipchain.Service
 }
 
 func init() {
@@ -64,11 +67,11 @@ func (d *Decrypt) HandlePrompt(prompt MessagePromptDecrypt) error {
 		defer d.finish()
 	}
 
-	box, err := d.Election.Box()
+	box, err := d.Election.Box(d.Skipchain)
 	if err != nil {
 		return err
 	}
-	mixes, err := d.Election.Mixes()
+	mixes, err := d.Election.Mixes(d.Skipchain)
 	if err != nil {
 		return err
 	}

--- a/evoting/protocol/decrypt_test.go
+++ b/evoting/protocol/decrypt_test.go
@@ -52,6 +52,7 @@ func (s *decryptService) NewProtocol(node *onet.TreeNodeInstance, conf *onet.Gen
 		decrypt.Signature = s.signature
 		decrypt.Secret = s.secret
 		decrypt.Election = s.election
+		decrypt.Skipchain = s.skipchain
 		return decrypt, nil
 	default:
 		return nil, errors.New("Unknown protocol")
@@ -118,11 +119,13 @@ func runDecrypt(t *testing.T, n int) {
 	decrypt.User = 0
 	decrypt.Signature = []byte{}
 	decrypt.Election = election
+	decrypt.Skipchain = services[0].(*decryptService).skipchain
 	decrypt.Start()
 
 	select {
 	case <-decrypt.Finished:
-		partials, _ := election.Partials()
+		partials, _ := election.Partials(services[0].(*decryptService).skipchain)
+		require.Equal(t, n, len(partials))
 		for _, partial := range partials {
 			require.True(t, partial.Flag)
 		}

--- a/evoting/protocol/shuffle.go
+++ b/evoting/protocol/shuffle.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dedis/onet/network"
 
 	"github.com/dedis/cothority/evoting/lib"
+	"github.com/dedis/cothority/skipchain"
 )
 
 /*
@@ -42,6 +43,8 @@ type Shuffle struct {
 	Election  *lib.Election // Election to be shuffled.
 
 	Finished chan bool // Flag to signal protocol termination.
+
+	Skipchain *skipchain.Service
 }
 
 func init() {
@@ -65,13 +68,13 @@ func (s *Shuffle) Start() error {
 func (s *Shuffle) HandlePrompt(prompt MessagePrompt) error {
 	var ballots []*lib.Ballot
 	if s.IsRoot() {
-		box, err := s.Election.Box()
+		box, err := s.Election.Box(s.Skipchain)
 		if err != nil {
 			return err
 		}
 		ballots = box.Ballots
 	} else {
-		mixes, err := s.Election.Mixes()
+		mixes, err := s.Election.Mixes(s.Skipchain)
 		if err != nil {
 			return err
 		}

--- a/evoting/protocol/shuffle_test.go
+++ b/evoting/protocol/shuffle_test.go
@@ -44,6 +44,7 @@ func (s *shuffleService) NewProtocol(n *onet.TreeNodeInstance, c *onet.GenericCo
 		shuffle.User = s.user
 		shuffle.Signature = s.signature
 		shuffle.Election = s.election
+		shuffle.Skipchain = s.skipchain
 		return shuffle, nil
 	default:
 		return nil, errors.New("Unknown protocol")
@@ -96,13 +97,15 @@ func runShuffle(t *testing.T, n int) {
 	shuffle.User = 0
 	shuffle.Signature = []byte{}
 	shuffle.Election = election
+	shuffle.Skipchain = services[0].(*shuffleService).skipchain
 	shuffle.Start()
 
 	select {
 	case <-shuffle.Finished:
-		box, _ := election.Box()
-		mixes, _ := election.Mixes()
+		box, _ := election.Box(services[0].(*shuffleService).skipchain)
+		mixes, _ := election.Mixes(services[0].(*shuffleService).skipchain)
 
+		require.Equal(t, n, len(mixes))
 		in1, in2 := lib.Split(box.Ballots)
 		for i := range mixes {
 			out1, out2 := lib.Split(mixes[i].Ballots)

--- a/evoting/service/service.go
+++ b/evoting/service/service.go
@@ -331,7 +331,7 @@ func (s *Service) GetBox(req *evoting.GetBox) (*evoting.GetBoxReply, error) {
 		return nil, err
 	}
 
-	box, err := election.Box()
+	box, err := election.Box(s.skipchain)
 	if err != nil {
 		return nil, err
 	}
@@ -345,7 +345,7 @@ func (s *Service) GetMixes(req *evoting.GetMixes) (*evoting.GetMixesReply, error
 		return nil, err
 	}
 
-	mixes, err := election.Mixes()
+	mixes, err := election.Mixes(s.skipchain)
 	if err != nil {
 		return nil, err
 	}
@@ -359,7 +359,7 @@ func (s *Service) GetPartials(req *evoting.GetPartials) (*evoting.GetPartialsRep
 		return nil, err
 	}
 
-	partials, err := election.Partials()
+	partials, err := election.Partials(s.skipchain)
 	if err != nil {
 		return nil, err
 	}
@@ -388,6 +388,7 @@ func (s *Service) Shuffle(req *evoting.Shuffle) (*evoting.ShuffleReply, error) {
 	protocol.User = req.User
 	protocol.Signature = req.Signature
 	protocol.Election = election
+	protocol.Skipchain = s.skipchain
 
 	config, _ := network.Marshal(&synchronizer{
 		ID:        req.ID,
@@ -428,6 +429,7 @@ func (s *Service) Decrypt(req *evoting.Decrypt) (*evoting.DecryptReply, error) {
 	protocol.Signature = req.Signature
 	protocol.Secret = s.secret(election.ID)
 	protocol.Election = election
+	protocol.Skipchain = s.skipchain
 
 	config, _ := network.Marshal(&synchronizer{
 		ID:        req.ID,
@@ -457,7 +459,7 @@ func (s *Service) Reconstruct(req *evoting.Reconstruct) (*evoting.ReconstructRep
 		return nil, err
 	}
 
-	partials, err := election.Partials()
+	partials, err := election.Partials(s.skipchain)
 	if err != nil {
 		return nil, err
 	} else if len(partials) != len(s.roster().List) {
@@ -511,6 +513,7 @@ func (s *Service) NewProtocol(node *onet.TreeNodeInstance, conf *onet.GenericCon
 		protocol.User = sync.User
 		protocol.Signature = sync.Signature
 		protocol.Election = election
+		protocol.Skipchain = s.skipchain
 
 		config, _ := network.Marshal(&synchronizer{
 			ID:        sync.ID,
@@ -532,6 +535,7 @@ func (s *Service) NewProtocol(node *onet.TreeNodeInstance, conf *onet.GenericCon
 		protocol.User = sync.User
 		protocol.Signature = sync.Signature
 		protocol.Election = election
+		protocol.Skipchain = s.skipchain
 
 		config, _ := network.Marshal(&synchronizer{
 			ID:        sync.ID,


### PR DESCRIPTION
Optimisations for Mix and Partial operations used within shuffle and decrypt protocol. They now use the skipchain service to get the blocks. The iterations are also performed from the end to search for the Mix or Partial transactions since they're always at the end of the chain in case of a finished election.