### PR TITLE
Conode: Show dev version and remove vgo

### DIFF
--- a/conode/.gitignore
+++ b/conode/.gitignore
@@ -1,5 +1,1 @@
 conode_data
-
-# This might be left from a failed "make docker", and we never want
-# to check it in, so list it here.
-.netrc

--- a/conode/Dockerfile
+++ b/conode/Dockerfile
@@ -1,9 +1,9 @@
 FROM golang:1.10 as builder
+ARG BUILDFLAG="-s -w -X main.gitTag=unknown github.com/dedis/onet.gitTag=unknown"
 RUN apt-get update && apt-get install -y clang
-RUN go get golang.org/x/vgo
 RUN go get github.com/dedis/cothority
-COPY .netrc /root
-RUN cd /go/src/github.com/dedis/cothority/conode && GOOS=linux vgo install
+RUN cd /go/src/github.com/dedis/cothority/conode && go get -u ./...
+RUN cd /go/src/github.com/dedis/cothority/conode && go install -ldflags="$BUILDFLAG" .
 
 FROM debian:stretch-slim
 WORKDIR /root/

--- a/conode/Makefile
+++ b/conode/Makefile
@@ -39,6 +39,12 @@ docker_clean:
 
 TAG=$(shell git describe --tags)
 OUTPUT_DIR=conode-$(TAG)
+# dev is the master branch, which will get automatic date tagging for
+# distribution files.
+ifeq ($(TAG),dev)
+	TAG := $(TAG)-$(shell date +%y%m%d)
+endif
+
 # -s -w are for smaller binaries
 # -X compiles the git tag into the binary
 flags=-ldflags="-s -w -X main.gitTag=$(TAG) -X github.com/dedis/onet.gitTag=$(TAG)"
@@ -55,7 +61,7 @@ bindist:
 	GOOS=windows GOARCH=386 vgo build $(flags) -o $(OUTPUT_DIR)/conode.exe
 	echo "#!/bin/sh" > $(OUTPUT_DIR)/conode
 	echo "./conode.\`uname -s\`.\`uname -m\` \$$*" >> $(OUTPUT_DIR)/conode
-	chmod +x $(OUTPUT_DIR)/conode	
+	chmod +x $(OUTPUT_DIR)/conode
 	LANG=C tar zcf $(OUTPUT_DIR).tar.gz $(OUTPUT_DIR)
 	rm -rf $(OUTPUT_DIR)
 

--- a/conode/Makefile
+++ b/conode/Makefile
@@ -1,23 +1,36 @@
 CONTAINER = conode
 IMAGE_NAME = dedis/$(CONTAINER)
-GITCOMMIT := $(shell git rev-parse --short HEAD)
+DATA_DIR = $(shell pwd)/conode_data
+TAG=$(shell git describe --tags)
+OUTPUT_DIR=conode-$(TAG)
+# dev is the master branch, which will get automatic date tagging for
+# distribution files.
+ifeq ($(TAG),dev)
+	TAG := $(TAG)-$(shell date +%y%m%d)
+endif
+VERSION := $(TAG)
 GITUNTRACKEDCHANGES := $(shell git status --porcelain --untracked-files=no)
 ifneq ($(GITUNTRACKEDCHANGES),)
-	GITCOMMIT := $(GITCOMMIT)-dirty
+	VERSION := $(VERSION)-dirty
 endif
-VERSION = $(GITCOMMIT)
-DATA_DIR = $(shell pwd)/conode_data
+
+# -s -w are for smaller binaries
+# -X compiles the git tag into the binary
+ldflags=-s -w -X main.gitTag=$(TAG) -X github.com/dedis/onet.gitTag=$(TAG)
+flags=-ldflags="$(ldflags)"
 
 all: docker
 
 docker: Dockerfile
-	[ -f $(HOME)/.netrc ] && cp $(HOME)/.netrc .
-	docker build -t $(IMAGE_NAME):$(VERSION) .
-	rm -f .netrc
+	BUILDFLAG=$(flags)
+	docker build -t $(IMAGE_NAME):$(VERSION) --build-arg BUILDFLAG="$(ldflags)" .
 
-push:
+docker_push: docker
 	@[ -n "$(GITUNTRACKEDCHANGES)" ] && echo "Pushing dirty images not allowed." && exit 1 || true
 	docker push $(IMAGE_NAME):$(VERSION)
+
+docker_push_latest: docker_push
+	docker tag $(IMAGE_NAME):$(VERSION) $(IMAGE_NAME):latest
 
 docker_setup:
 	mkdir -p $(DATA_DIR)
@@ -37,28 +50,16 @@ docker_clean:
 	docker kill $(CONTAINER) || echo nothing to stop
 	docker image ls $(IMAGE_NAME) -q | xargs docker rmi -f || echo done
 
-TAG=$(shell git describe --tags)
-OUTPUT_DIR=conode-$(TAG)
-# dev is the master branch, which will get automatic date tagging for
-# distribution files.
-ifeq ($(TAG),dev)
-	TAG := $(TAG)-$(shell date +%y%m%d)
-endif
-
-# -s -w are for smaller binaries
-# -X compiles the git tag into the binary
-flags=-ldflags="-s -w -X main.gitTag=$(TAG) -X github.com/dedis/onet.gitTag=$(TAG)"
-
 # The suffix on conode exe is the result from: echo `uname -s`.`uname -m`
 # so that we can find the right one in the wrapper script.
 bindist:
 	vgo verify
 	rm -rf $(OUTPUT_DIR)
 	mkdir $(OUTPUT_DIR)
-	GOOS=linux GOARCH=amd64 vgo build $(flags) -o $(OUTPUT_DIR)/conode.Linux.x86_64
-	GOOS=linux  GOARCH=arm vgo build $(flags) -o $(OUTPUT_DIR)/conode.Linux.armv7l
-	GOOS=freebsd GOARCH=amd64 vgo build $(flags) -o $(OUTPUT_DIR)/conode.FreeBSD.amd64
-	GOOS=windows GOARCH=386 vgo build $(flags) -o $(OUTPUT_DIR)/conode.exe
+	GOOS=linux GOARCH=amd64 go build $(flags) -o $(OUTPUT_DIR)/conode.Linux.x86_64
+	GOOS=linux  GOARCH=arm go build $(flags) -o $(OUTPUT_DIR)/conode.Linux.armv7l
+	GOOS=freebsd GOARCH=amd64 go build $(flags) -o $(OUTPUT_DIR)/conode.FreeBSD.amd64
+	GOOS=windows GOARCH=386 go build $(flags) -o $(OUTPUT_DIR)/conode.exe
 	echo "#!/bin/sh" > $(OUTPUT_DIR)/conode
 	echo "./conode.\`uname -s\`.\`uname -m\` \$$*" >> $(OUTPUT_DIR)/conode
 	chmod +x $(OUTPUT_DIR)/conode


### PR DESCRIPTION
This PR removes the `vgo` building from the Makefile, as the usage of `.netrc` is not nice for users who simply want to create a docker image.

It also adds the `-dev-YYMMDD` tag to the master-branch, so that the nodes can be easily recognized on status.dedis.ch.