### PR TITLE
Remove the "GetSingleBlock id == -1" hack

### DIFF
--- a/evoting/lib/master.go
+++ b/evoting/lib/master.go
@@ -37,11 +37,11 @@ func GetMaster(s *skipchain.Service, id skipchain.SkipBlockID) (*Master, error) 
 	// Search backwards from the end of the chain, unmarshalling each block until
 	// we find the first Master transaction. (There are Link transactions mixed in
 	// with the Masters.)
-
-	block, err := s.GetSingleBlockByIndex(
-		&skipchain.GetSingleBlockByIndex{Genesis: id, Index: -1},
-	)
-	// Cannot even find this chain?
+	gb := s.GetDB().GetByID(id)
+	if gb == nil {
+		return nil, errors.New("No such genesis-block")
+	}
+	block, err := s.GetDB().GetLatest(gb)
 	if err != nil {
 		return nil, err
 	}

--- a/skipchain/api_test.go
+++ b/skipchain/api_test.go
@@ -261,13 +261,8 @@ func TestClient_GetSingleBlockByIndex(t *testing.T) {
 	reply2, err := c.StoreSkipBlock(sb1, roster, nil)
 	log.ErrFatal(err)
 
-	// look for latest via id == -1
-	search, err := c.GetSingleBlockByIndex(roster, sb1.Hash, -1)
-	log.ErrFatal(err)
-	require.True(t, reply2.Latest.Equal(search))
-
 	// 0
-	search, err = c.GetSingleBlockByIndex(roster, sb1.Hash, 0)
+	search, err := c.GetSingleBlockByIndex(roster, sb1.Hash, 0)
 	log.ErrFatal(err)
 	require.True(t, sb1.Equal(search))
 

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -508,15 +508,11 @@ func (s *Service) GetSingleBlock(id *GetSingleBlock) (*SkipBlock, error) {
 }
 
 // GetSingleBlockByIndex searches for the given block and returns it. If no such block is
-// found, a nil is returned. An index of -1 means "the latest block on the skipchain".
+// found, a nil is returned.
 func (s *Service) GetSingleBlockByIndex(id *GetSingleBlockByIndex) (*SkipBlock, error) {
 	sb := s.db.GetByID(id.Genesis)
 	if sb == nil {
 		return nil, errors.New("No such genesis-block")
-
-	}
-	if id.Index == -1 {
-		return s.GetDB().GetLatest(sb)
 	}
 	if sb.Index == id.Index {
 		return sb, nil


### PR DESCRIPTION
I added this while working on evoting's GetMaster, but it is a bad
idea, and not needed. Removing it.