### PR TITLE
merging skipchain changes from byzgen_poc

### DIFF
--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -251,7 +251,9 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, er
 		// Synchronisation should only be done when we are locked
 		// because it modifies the database.
 		if needSync {
-			latest := s.findLatest(prev)
+			// Ignoring error as we might have a not up-to-date chain, but syncChain
+			// will take care of that.
+			latest, _ := s.db.GetLatest(prev)
 			log.Lvlf2("Catching up chain %x from index %v", prev.SkipChainID(), latest.Index)
 			err := s.syncChain(latest.Roster, latest.Hash)
 			if err != nil {
@@ -263,8 +265,11 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, er
 		// Once we have the lock on this skipchain, refresh
 		// prev in case someone else added a block to it while
 		// we were waiting for the lock.
-		prev = s.db.GetByID(prev.Hash)
-		prev = s.findLatest(prev)
+		var err error
+		prev, err = s.db.GetLatestByID(prev.Hash)
+		if err != nil {
+			return nil, err
+		}
 
 		if len(prev.ForwardLink) > 0 {
 			return nil, errors.New(
@@ -397,21 +402,6 @@ func (s *Service) GetUpdateChain(guc *GetUpdateChain) (*GetUpdateChainReply, err
 	reply := &GetUpdateChainReply{Update: blocks}
 
 	return reply, nil
-}
-
-// Search the local DB starting at bl and finding the latest block we know.
-func (s *Service) findLatest(bl *SkipBlock) *SkipBlock {
-	for {
-		if len(bl.ForwardLink) == 0 {
-			return bl
-		}
-		next := bl.ForwardLink[len(bl.ForwardLink)-1].To
-		nextBl := s.db.GetByID(next)
-		if nextBl == nil {
-			return bl
-		}
-		bl = nextBl
-	}
 }
 
 // syncChain communicates with conodes in the Roster via getBlocks

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	bolt "github.com/coreos/bbolt"
@@ -21,7 +22,8 @@ import (
 	"gopkg.in/satori/go.uuid.v1"
 )
 
-// How long to wait before a timeout is generated in the propagation.
+// How long to wait before a timeout is generated in the propagation. It is not
+// set to a constant because we'd like to change it in the test.
 var defaultPropagateTimeout = 15 * time.Second
 
 // SkipBlockID represents the Hash of the SkipBlock
@@ -531,13 +533,17 @@ func (fl *ForwardLink) Verify(suite cosi.Suite, pubs []kyber.Point) error {
 type SkipBlockDB struct {
 	*bolt.DB
 	bucketName []byte
+	// latestBlocks is used as a simple caching mechanism
+	latestBlocks map[string]SkipBlockID
+	latestMutex  sync.Mutex
 }
 
 // NewSkipBlockDB returns an initialized SkipBlockDB structure.
 func NewSkipBlockDB(db *bolt.DB, bn []byte) *SkipBlockDB {
 	return &SkipBlockDB{
-		DB:         db,
-		bucketName: bn,
+		DB:           db,
+		bucketName:   bn,
+		latestBlocks: map[string]SkipBlockID{},
 	}
 }
 
@@ -605,6 +611,7 @@ func (db *SkipBlockDB) Store(sb *SkipBlock) SkipBlockID {
 			if err != nil {
 				return err
 			}
+			db.latestUpdate(sb)
 		}
 		result = sb.Hash
 		return nil
@@ -618,7 +625,23 @@ func (db *SkipBlockDB) Store(sb *SkipBlock) SkipBlockID {
 	return result
 }
 
-// Length returns how many skip blocks there are in this SkipBlockDB.
+func (db *SkipBlockDB) latestUpdate(sb *SkipBlock) {
+	db.latestMutex.Lock()
+	defer db.latestMutex.Unlock()
+	idStr := string(sb.SkipChainID())
+	latest, exists := db.latestBlocks[idStr]
+	if !exists {
+		db.latestBlocks[idStr] = sb.Hash
+	} else {
+		old := db.GetByID(latest)
+		if old == nil || old.Index < sb.Index {
+			log.Lvlf3("updating sc %x: storing index %d", idStr, sb.Index)
+			db.latestBlocks[idStr] = sb.Hash
+		}
+	}
+}
+
+// Length returns the actual length using mutexes
 func (db *SkipBlockDB) Length() int {
 	var i int
 	db.View(func(tx *bolt.Tx) error {
@@ -708,25 +731,51 @@ func (db *SkipBlockDB) VerifyLinks(sb *SkipBlock) error {
 	if err := sbBack.VerifyForwardSignatures(); err != nil {
 		return err
 	}
-	if !sbBack.GetForward(0).To.Equal(sb.Hash) {
+	if !sbBack.GetForward(0).Hash().Equal(sb.Hash) {
 		return errors.New("didn't find our block in forward-links")
 	}
 	return nil
 }
 
+// GetLatestByID returns the latest skipblock of a skipchain
+// given its ID.
+func (db *SkipBlockDB) GetLatestByID(genID SkipBlockID) (*SkipBlock, error) {
+	gen := db.GetByID(genID)
+	if gen == nil {
+		return nil, fmt.Errorf("cannot find genesis block %x", genID)
+	}
+	return db.GetLatest(gen)
+}
+
 // GetLatest searches for the latest available block for that skipblock.
 func (db *SkipBlockDB) GetLatest(sb *SkipBlock) (*SkipBlock, error) {
+	start := time.Now()
+	defer func() {
+		log.Lvl3("Time to get latest:", time.Since(start))
+	}()
 	if sb == nil {
 		return nil, errors.New("got nil skipblock")
 	}
 	latest := sb
-	// TODO this can be optimised by using multiple bucket.Get in a single transaction
-	for latest.GetForwardLen() > 0 {
-		latest = db.GetByID(latest.GetForward(latest.GetForwardLen() - 1).To)
+	db.latestMutex.Lock()
+	latestID, exists := db.latestBlocks[string(sb.SkipChainID())]
+	if exists {
+		latest = db.GetByID(latestID)
 		if latest == nil {
-			return nil, errors.New("missing block")
+			latest = sb
 		}
 	}
+	db.latestMutex.Unlock()
+
+	// TODO this can be optimised by using multiple bucket.Get in a single transaction
+	for latest.GetForwardLen() > 0 {
+		next := db.GetByID(latest.GetForward(latest.GetForwardLen() - 1).To)
+		if next == nil {
+			return latest, errors.New("missing block")
+		}
+		latest = next
+	}
+	db.latestUpdate(latest)
 	return latest, nil
 }
 

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -215,5 +215,5 @@ func setupSkipBlockDB(t *testing.T) (*SkipBlockDB, string) {
 	})
 	require.Nil(t, err)
 
-	return &SkipBlockDB{db, []byte("skipblock-test")}, fname
+	return NewSkipBlockDB(db, []byte("skipblock-test")), fname
 }


### PR DESCRIPTION
Finally merge the changes from byzgen_poc. I didn't keep all the timing-measurements in there. It:
- replaces `findLatest` with `GetLatest`
- adds an optimization by keeping the latest skipblock of a skipchain