### PR TITLE
merging onchain-secrets changes from byzgen_poc

### DIFF
--- a/ocs/darc/darc.go
+++ b/ocs/darc/darc.go
@@ -52,18 +52,29 @@ func NewDarc(owners *[]*Identity, users *[]*Identity, desc []byte) *Darc {
 func (d *Darc) Copy() *Darc {
 	dCopy := &Darc{
 		Version: d.Version,
-		BaseID:  d.BaseID,
+	}
+	if d.BaseID != nil {
+		bid := ID(make([]byte, len(*d.BaseID)))
+		copy(bid, *d.BaseID)
+		dCopy.BaseID = &bid
 	}
 	if d.Owners != nil {
-		owners := append([]*Identity{}, *d.Owners...)
+		owners := []*Identity{}
+		for _, o := range *d.Owners {
+			owners = append(owners, o.Copy())
+		}
 		dCopy.Owners = &owners
 	}
 	if d.Users != nil {
-		users := append([]*Identity{}, *d.Users...)
+		users := []*Identity{}
+		for _, u := range *d.Users {
+			users = append(users, u.Copy())
+		}
 		dCopy.Users = &users
 	}
 	if d.Description != nil {
-		desc := *(d.Description)
+		desc := make([]byte, len(*d.Description))
+		copy(desc, *d.Description)
 		dCopy.Description = &desc
 	}
 	return dCopy

--- a/ocs/darc/struct.go
+++ b/ocs/darc/struct.go
@@ -27,6 +27,21 @@ const (
 	User
 )
 
+// Copy creates a deep copy of the IdentityDarc.
+func (id *Identity) Copy() *Identity {
+	c := &Identity{}
+	if id.Darc != nil {
+		c.Darc = &IdentityDarc{make([]byte, len(id.Darc.ID))}
+		copy(c.Darc.ID, id.Darc.ID)
+	} else if id.Ed25519 != nil {
+		c.Ed25519 = &IdentityEd25519{id.Ed25519.Point.Clone()}
+	} else if id.X509EC != nil {
+		c.X509EC = &IdentityX509EC{make([]byte, len(id.X509EC.Public))}
+		copy(c.X509EC.Public, id.X509EC.Public)
+	}
+	return c
+}
+
 // PROTOSTART
 //
 // option java_package = "ch.epfl.dedis.proto";

--- a/ocs/service/api.go
+++ b/ocs/service/api.go
@@ -30,7 +30,7 @@ type Client struct {
 	sbc *skipchain.Client
 }
 
-// NewClient instantiates a new ocs.Client
+// NewClient instantiates a new Client
 func NewClient() *Client {
 	return &Client{
 		Client: onet.NewClient(cothority.Suite, ServiceName),

--- a/ocs/service/darcdb.go
+++ b/ocs/service/darcdb.go
@@ -1,0 +1,172 @@
+package service
+
+import (
+	"errors"
+	"time"
+
+	bolt "github.com/coreos/bbolt"
+	"github.com/dedis/cothority"
+	"github.com/dedis/cothority/ocs/darc"
+	"github.com/dedis/onet/log"
+	"github.com/dedis/onet/network"
+)
+
+// DarcDB holds the database to the darcs. It has the following
+// entries:
+//  - DarcID - the protobuffed darc
+//  - "latest" + DarcBaseID - the ID of the latest valid darc
+//    attached to that BaseID
+//  - "previous" + DarcID - the ID of the darc coming before
+//    the given darcID
+// Not added yet, but possible, would be "next" + DarcID.
+type DarcDB struct {
+	*bolt.DB
+	bucketName []byte
+}
+
+var latestKey = []byte("latest")
+var previousKey = []byte("previous")
+
+// NewDarcDB returns an initialized DarcDB structure.
+func NewDarcDB(db *bolt.DB, bn []byte) *DarcDB {
+	return &DarcDB{
+		DB:         db,
+		bucketName: bn,
+	}
+}
+
+// GetByID returns a new copy of the skip-block or nil if it doesn't exist
+func (db *DarcDB) GetByID(id darc.ID) *darc.Darc {
+	start := time.Now()
+	defer func() {
+		log.Lvl3("Time to get darc:", time.Since(start))
+	}()
+	var result *darc.Darc
+	err := db.View(func(tx *bolt.Tx) error {
+		sb, err := db.getFromTx(tx, id)
+		if err != nil {
+			return err
+		}
+		result = sb
+		return nil
+	})
+
+	if err != nil {
+		return nil
+	}
+	return result
+}
+
+// GetLatestDarc looks in the database for the latest darc
+// belonging to a darc-baseID.
+func (db *DarcDB) GetLatestDarc(baseID darc.ID) (d *darc.Darc, err error) {
+	err = db.View(func(tx *bolt.Tx) error {
+		latestKey := append(latestKey, baseID...)
+		latestID := tx.Bucket(db.bucketName).Get(latestKey)
+		if latestID == nil {
+			return nil
+		}
+		d, err = db.getFromTx(tx, latestID)
+		return err
+	})
+	return
+}
+
+// GetPathToLatest will search through the database to find
+// the list of darcs that came after the one requested.
+func (db *DarcDB) GetPathToLatest(start *darc.Darc) (path []*darc.Darc, err error) {
+	latest, err := db.GetLatestDarc(start.GetBaseID())
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	if latest == nil {
+		return nil, errors.New("didn't find latest")
+	}
+	if start.Version > latest.Version {
+		return nil, errors.New("don't have a version number this big")
+	}
+	size := latest.Version - start.Version
+	path = make([]*darc.Darc, size+1)
+	path[0] = start
+	if latest.Version > start.Version {
+		err = db.Update(func(tx *bolt.Tx) error {
+
+			for latest.Version > start.Version {
+				path[size] = latest
+				previousKey := append(previousKey, latest.GetID()...)
+				val := tx.Bucket(db.bucketName).Get(previousKey)
+				if val == nil {
+					return errors.New("didn't find previous")
+				}
+				latest, err = db.getFromTx(tx, val)
+				if err != nil {
+					return err
+				}
+				size--
+			}
+			return nil
+		})
+	}
+	return
+}
+
+// Store stores the given darc
+func (db *DarcDB) Store(d *darc.Darc) error {
+	return db.Update(func(tx *bolt.Tx) error {
+		previous, err := db.GetLatestDarc(d.GetBaseID())
+		if err == nil && previous != nil {
+			previousKey := append(previousKey, d.GetID()...)
+			if err := tx.Bucket(db.bucketName).Put(previousKey, previous.GetID()); err != nil {
+				return err
+			}
+		}
+		latestKey := append(latestKey, d.GetBaseID()...)
+		if err := tx.Bucket(db.bucketName).Put(latestKey, d.GetID()); err != nil {
+			return err
+		}
+		key := d.GetID()
+		val, err := network.Marshal(d)
+		if err != nil {
+			return err
+		}
+		return tx.Bucket(db.bucketName).Put(key, val)
+	})
+}
+
+// GetPrevious searches for the previous darc in the
+// signature and returns it
+func (db *DarcDB) GetPrevious(d *darc.Darc) (previous *darc.Darc, err error) {
+	if d.Signature != nil && d.Signature.SignaturePath.Darcs != nil {
+		darcs := *d.Signature.SignaturePath.Darcs
+		return (darcs)[len(darcs)-1], nil
+	}
+	err = db.Update(func(tx *bolt.Tx) error {
+		previousKey := append(previousKey, d.GetID()...)
+		val := tx.Bucket(db.bucketName).Get(previousKey)
+		if val == nil {
+			return errors.New("didn't find previous")
+		}
+		previous, err = db.getFromTx(tx, val)
+		return err
+	})
+	return
+}
+
+// getFromTx returns the darc identified by id.
+// nil is returned if the key does not exist.
+// An error is thrown if marshalling fails.
+// The caller must ensure that this function is called from within a valid transaction.
+func (db *DarcDB) getFromTx(tx *bolt.Tx, id darc.ID) (*darc.Darc, error) {
+	val := tx.Bucket(db.bucketName).Get(id)
+	if val == nil {
+		return nil, nil
+	}
+
+	_, dMsg, err := network.Unmarshal(val, cothority.Suite)
+	if err != nil {
+		return nil, err
+	}
+
+	return dMsg.(*darc.Darc).Copy(), nil
+}

--- a/ocs/service/service_test.go
+++ b/ocs/service/service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"sync"
 	"testing"
+	"time"
 
 	bolt "github.com/coreos/bbolt"
 	"github.com/dedis/cothority"
@@ -118,14 +119,13 @@ func TestService_GetDarcPath(t *testing.T) {
 	})
 	require.Nil(t, err)
 
+	log.Lvl1("Searching for wrong role")
 	request := &GetDarcPath{
 		OCS:        o.sc.OCS.SkipChainID(),
 		BaseDarcID: o.readers.GetID(),
 		Identity:   *wDarcID,
 		Role:       int(darc.Owner),
 	}
-
-	log.Lvl1("Searching for wrong role")
 	reply, err := o.service.GetDarcPath(request)
 	require.NotNil(t, err)
 
@@ -213,72 +213,175 @@ func TestStress(t *testing.T) {
 		t.Skip("Not stress-testing on travis")
 	}
 
-	nbrThreads := 30
-	nbrLoops := 10
+	nbrThreads := 20
+	nbrLoops := 20
 
 	o := createOCS(t)
 	defer o.local.CloseAll()
 
 	wg := &sync.WaitGroup{}
 	wg.Add(nbrThreads)
+	addDarc := sync.Mutex{}
+	latestReader := o.readers.Copy()
+	var newSigner *darc.Signer
+	doneChan := make(chan bool)
+	errChan := make(chan error)
+	done := make([]bool, nbrThreads)
+	mutex := sync.Mutex{}
+
+	// Bits: 0 - update darc; 1 - write; 2 - read; 3 - re-encrypt;
+	// 4 - getDarcPath
+	actions := 0x1f
+	count := 0
 	for thread := 0; thread < nbrThreads; thread++ {
 		go func(n int) {
 			for loop := 0; loop < nbrLoops; loop++ {
-				// Creating a write request
-				log.Lvlf1("Loop %d in thread %d: Write", loop, n)
-				encKey := []byte{1, 2, 3}
-				write := NewWrite(cothority.Suite, o.sc.OCS.Hash, o.sc.X, o.readers, encKey)
-				write.Data = []byte{}
-				sigPath := darc.NewSignaturePath([]*darc.Darc{o.readers}, *o.writerI, darc.User)
-				sig, err := darc.NewDarcSignature(write.Reader.GetID(), sigPath, o.writer)
-				require.Nil(t, err)
-				wr, err := o.service.WriteRequest(&WriteRequest{
-					OCS:       o.sc.OCS.Hash,
-					Write:     *write,
-					Signature: *sig,
-					Readers:   o.readers,
-				})
-				require.Nil(t, err)
-				require.NotNil(t, wr)
+				start := time.Now()
+				mutex.Lock()
+				log.Print("Run:", count)
+				count++
+				mutex.Unlock()
+				if actions&0x1 != 0 {
+					// Adding a new darc
+					for {
+						addDarc.Lock()
+						log.Lvlf1("Loop %d in thread %d: PrepareDarc", loop, n)
+						w := darc.NewSignerEd25519(nil, nil)
+						newReader := latestReader.Copy()
+						newReader.AddUser(w.Identity())
+						if newSigner != nil {
+							newReader.RemoveUser(newSigner.Identity())
+						}
+						err := newReader.SetEvolutionOnline(latestReader, o.writer)
+						if err != nil {
+							errChan <- err
+						}
 
-				// Making a read request
-				log.Lvlf1("Loop %d in thread %d: Read", loop, n)
-				sigRead, err := darc.NewDarcSignature(wr.SB.Hash, sigPath, o.writer)
-				require.Nil(t, err)
-				read := Read{
-					DataID:    wr.SB.Hash,
-					Signature: *sigRead,
+						log.Lvlf1("Loop %d in thread %d: UpdateDarc", loop, n)
+						_, err = o.service.UpdateDarc(&UpdateDarc{
+							OCS:  o.sc.OCS.SkipChainID(),
+							Darc: *newReader,
+						})
+						if err != nil {
+							log.Lvlf2("Couldn't store darc: %s - trying again", err.Error())
+						} else {
+							latestReader = newReader
+							newSigner = w
+							addDarc.Unlock()
+							break
+						}
+						addDarc.Unlock()
+					}
 				}
-				rr, err := o.service.ReadRequest(&ReadRequest{
-					OCS:  o.sc.OCS.Hash,
-					Read: read,
-				})
-				require.Nil(t, err)
 
-				// Decoding the file
-				log.Lvlf1("Loop %d in thread %d: DecryptKey", loop, n)
-				symEnc, err := o.service.DecryptKeyRequest(&DecryptKeyRequest{
-					Read: rr.SB.Hash,
-				})
-				require.Nil(t, err)
-				priv, err := o.writer.GetPrivate()
-				require.Nil(t, err)
-				sym, err2 := DecodeKey(cothority.Suite, o.sc.X, write.Cs, symEnc.XhatEnc, priv)
-				require.Nil(t, err2)
-				require.Equal(t, encKey, sym)
+				if actions&0x10 != 0 {
+					addDarc.Lock()
+					latestID := (*latestReader.Users)[len(*latestReader.Users)-1]
+					addDarc.Unlock()
+					log.Lvlf1("Loop %d in thread %d: GetDarcPath", loop, n)
+					_, err := o.service.GetDarcPath(&GetDarcPath{
+						OCS:        o.sc.OCS.SkipChainID(),
+						BaseDarcID: o.readers.GetID(),
+						Identity:   *latestID,
+						Role:       int(darc.User),
+					})
+					if err != nil {
+						errChan <- err
+					}
+				}
+
+				if actions&0x2 != 0 {
+					// Creating a write request
+					log.Lvlf1("Loop %d in thread %d: Write", loop, n)
+					encKey := []byte{1, 2, 3}
+					write := NewWrite(cothority.Suite, o.sc.OCS.Hash, o.sc.X, o.readers, encKey)
+					write.Data = []byte{}
+					sigPath := darc.NewSignaturePath([]*darc.Darc{o.readers}, *o.writerI, darc.User)
+					sig, err := darc.NewDarcSignature(write.Reader.GetID(), sigPath, o.writer)
+					if err != nil {
+						errChan <- err
+					}
+					wr, err := o.service.WriteRequest(&WriteRequest{
+						OCS:       o.sc.OCS.Hash,
+						Write:     *write,
+						Signature: *sig,
+						Readers:   o.readers,
+					})
+					if err != nil {
+						errChan <- err
+					}
+					require.NotNil(t, wr)
+
+					if actions&0x4 != 0 {
+						// Making a read request
+						log.Lvlf1("Loop %d in thread %d: Read", loop, n)
+						sigRead, err := darc.NewDarcSignature(wr.SB.Hash, sigPath, o.writer)
+						if err != nil {
+							errChan <- err
+						}
+						read := Read{
+							DataID:    wr.SB.Hash,
+							Signature: *sigRead,
+						}
+						rr, err := o.service.ReadRequest(&ReadRequest{
+							OCS:  o.sc.OCS.Hash,
+							Read: read,
+						})
+						if err != nil {
+							errChan <- err
+						}
+
+						if actions&0x8 != 0 {
+							// Decoding the file
+							log.Lvlf1("Loop %d in thread %d: DecryptKey", loop, n)
+							symEnc, err := o.service.DecryptKeyRequest(&DecryptKeyRequest{
+								Read: rr.SB.Hash,
+							})
+							if err != nil {
+								errChan <- err
+							}
+							priv, err := o.writer.GetPrivate()
+							if err != nil {
+								errChan <- err
+							}
+							sym, err2 := DecodeKey(cothority.Suite, o.sc.X, write.Cs, symEnc.XhatEnc, priv)
+							if err2 != nil {
+								errChan <- err2
+							}
+							require.Equal(t, encKey, sym)
+						}
+					}
+				}
+				log.LLvl5("Timing TestRun [ms]:", time.Since(start).Nanoseconds()/1e6/int64(nbrThreads))
 			}
 			wg.Done()
+			mutex.Lock()
+			done[n] = true
+			mutex.Unlock()
 		}(thread)
 	}
-	wg.Wait()
-	active := false
-	for _, s := range o.local.Servers {
-		for _, tn := range o.local.GetTreeNodeInstances(s.ServerIdentity.ID) {
-			log.Lvl1("Still active: ", tn.Info())
-			active = true
+	go func() {
+		wg.Wait()
+		doneChan <- true
+	}()
+	for {
+		select {
+		case <-doneChan:
+			log.Lvl1("Stress-test done")
+			return
+		case err := <-errChan:
+			log.Fatal("Error in stress-test:", err)
+		case <-time.After(10 * time.Second):
+			log.Lvl1("** Thread-list waiting:")
+			mutex.Lock()
+			for i := range done {
+				if !done[i] {
+					log.Lvl1("Thread", i, "still working")
+				}
+			}
+			mutex.Unlock()
 		}
 	}
-	require.False(t, active)
 }
 
 type ocsStruct struct {


### PR DESCRIPTION
Finally merging the changes to onchain-secrets from byzgen_poc. This includes:
- holding darcs in a database instead of a map
- use a SkipChain 10/10 for faster updating
- better stress-test
- improved darc deep copy
- ocs-reencryption failure handling