### PR TITLE
evoting: handle failures while finalizing

### DIFF
--- a/evoting/lib/container.go
+++ b/evoting/lib/container.go
@@ -43,7 +43,9 @@ type Mix struct {
 	Ballots []*Ballot // Ballots are permuted and re-encrypted.
 	Proof   []byte    // Proof of the shuffle.
 
-	Node string // Node signifies the creator of the mix.
+	Node      string      // Node signifies the creator of the mix.
+	PublicKey kyber.Point // Public key of the node generating the mix
+	Signature []byte      // Signature of the public key
 }
 
 // Partial contains the partially decrypted ballots.

--- a/evoting/lib/container.go
+++ b/evoting/lib/container.go
@@ -52,8 +52,9 @@ type Mix struct {
 type Partial struct {
 	Points []kyber.Point // Points are the partially decrypted plaintexts.
 
-	Flag bool   // Flag signals if the mixes could not be verified.
-	Node string // Node signifies the creator of this partial decryption.
+	Node      string      // Node signifies the creator of this partial decryption.
+	PublicKey kyber.Point // Public key of the node generating a partial decryption
+	Signature []byte      // Signature of the public key
 }
 
 // genPartials generates partial decryptions for a given list of shared secrets.

--- a/evoting/lib/container.go
+++ b/evoting/lib/container.go
@@ -55,6 +55,7 @@ type Partial struct {
 	Node      string      // Node signifies the creator of this partial decryption.
 	PublicKey kyber.Point // Public key of the node generating a partial decryption
 	Signature []byte      // Signature of the public key
+	Index     int         // Index of the node in the roster
 }
 
 // genPartials generates partial decryptions for a given list of shared secrets.

--- a/evoting/lib/election.go
+++ b/evoting/lib/election.go
@@ -124,6 +124,9 @@ func (e *Election) setStage(s *skipchain.Service) error {
 		return errors.New("error getting latest skipblock")
 	}
 	transaction := UnmarshalTransaction(latest.Data)
+	if transaction == nil {
+		return errors.New("invalid transaction")
+	}
 
 	if transaction.Partial != nil {
 		e.Stage = Decrypted

--- a/evoting/protocol/decrypt.go
+++ b/evoting/protocol/decrypt.go
@@ -1,7 +1,12 @@
 package protocol
 
 import (
+	"errors"
+	"sync"
+
+	"github.com/dedis/cothority"
 	"github.com/dedis/kyber"
+	"github.com/dedis/kyber/sign/schnorr"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/network"
 
@@ -38,7 +43,10 @@ type Decrypt struct {
 	Secret   *lib.SharedSecret // Secret is the private key share from the DKG.
 	Election *lib.Election     // Election to be decrypted.
 
-	Finished chan bool // Flag to signal protocol termination.
+	Finished           chan bool // Flag to signal protocol termination.
+	LeaderParticipates bool      // LeaderParticipates is a flag to denote if leader should calculate the partial.
+	successReplies     int
+	mutex              sync.Mutex
 
 	Skipchain *skipchain.Service
 }
@@ -63,64 +71,78 @@ func (d *Decrypt) Start() error {
 // HandlePrompt retrieves the mixes, verifies them and performs a partial decryption
 // on the last mix before appending it to the election skipchain.
 func (d *Decrypt) HandlePrompt(prompt MessagePromptDecrypt) error {
-	if !d.IsRoot() {
-		defer d.finish()
-	}
-
-	box, err := d.Election.Box(d.Skipchain)
-	if err != nil {
-		return err
-	}
 	mixes, err := d.Election.Mixes(d.Skipchain)
 	if err != nil {
 		return err
 	}
-
-	last := mixes[len(mixes)-1].Ballots
-	points := make([]kyber.Point, len(box.Ballots))
-	for i := range points {
-		points[i] = lib.Decrypt(d.Secret.V, last[i].Alpha, last[i].Beta)
+	target := 2 * len(d.Election.Roster.List) / 3
+	if len(mixes) <= target {
+		return errors.New("Not enough mixes")
 	}
-
-	flag := Verify(d.Election.Key, box, mixes)
-	partial := &lib.Partial{Points: points, Flag: flag, Node: d.Name()}
-	transaction := lib.NewTransaction(partial, d.User, d.Signature)
-	if err = lib.StoreUsingWebsocket(d.Election.ID, d.Election.Roster, transaction); err != nil {
-		return err
-	}
-
-	if d.IsLeaf() {
+	partials, err := d.Election.Partials(d.Skipchain)
+	delegate := func() error {
+		if d.IsRoot() {
+			d.successReplies = len(partials)
+			if d.LeaderParticipates {
+				d.successReplies++
+			}
+			d.Broadcast(&PromptDecrypt{})
+			return nil
+		}
+		// report to root
+		defer d.Done()
 		return d.SendTo(d.Root(), &TerminateDecrypt{})
 	}
-	return d.SendToChildren(&PromptDecrypt{})
+	if d.IsRoot() && !d.LeaderParticipates {
+		return delegate()
+	}
+
+	mix := mixes[len(mixes)-1]
+	points := make([]kyber.Point, len(mix.Ballots))
+	for i := range points {
+		points[i] = lib.Decrypt(d.Secret.V, mix.Ballots[i].Alpha, mix.Ballots[i].Beta)
+	}
+
+	partial := &lib.Partial{
+		Points:    points,
+		Node:      d.Name(),
+		PublicKey: d.Public(),
+	}
+	data, err := partial.PublicKey.MarshalBinary()
+	if err != nil {
+		return d.SendTo(d.Root(), &TerminateDecrypt{Error: err.Error()})
+	}
+	sig, err := schnorr.Sign(cothority.Suite, d.Private(), data)
+	if err != nil {
+		return d.SendTo(d.Root(), &TerminateDecrypt{Error: err.Error()})
+	}
+	partial.Signature = sig
+	transaction := lib.NewTransaction(partial, d.User, d.Signature)
+	if err = lib.StoreUsingWebsocket(d.Election.ID, d.Election.Roster, transaction); err != nil {
+		return d.SendTo(d.Root(), &TerminateDecrypt{Error: err.Error()})
+	}
+	return delegate()
 }
 
 // finish terminates the protocol within onet.
-func (d *Decrypt) finish() {
-	d.Done()
-	d.Finished <- true
+func (d *Decrypt) finish(err error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	if err == nil {
+		d.successReplies++
+	}
+	if d.successReplies > 2*len(d.Election.Roster.List)/3 {
+		d.Done()
+		d.Finished <- true
+	}
 }
 
 // HandleTerminate concludes to the protocol.
 func (d *Decrypt) HandleTerminate(terminate MessageTerminateDecrypt) error {
-	d.finish()
+	if terminate.Error != "" {
+		d.finish(errors.New(terminate.Error))
+	} else {
+		d.finish(nil)
+	}
 	return nil
-}
-
-// Verify iteratively checks the integrity of each mix.
-func Verify(key kyber.Point, box *lib.Box, mixes []*lib.Mix) bool {
-	x, y := lib.Split(box.Ballots)
-	v, w := lib.Split(mixes[0].Ballots)
-	if lib.Verify(mixes[0].Proof, key, x, y, v, w) != nil {
-		return false
-	}
-
-	for i := 0; i < len(mixes)-1; i++ {
-		x, y = lib.Split(mixes[i].Ballots)
-		v, w = lib.Split(mixes[i+1].Ballots)
-		if lib.Verify(mixes[i+1].Proof, key, x, y, v, w) != nil {
-			return false
-		}
-	}
-	return true
 }

--- a/evoting/protocol/decrypt_struct.go
+++ b/evoting/protocol/decrypt_struct.go
@@ -16,7 +16,9 @@ type MessagePromptDecrypt struct {
 
 // TerminateDecrypt is sent by the leaf node to the root node upon completion of
 // the last partial decryption, which terminates the protocol.
-type TerminateDecrypt struct{}
+type TerminateDecrypt struct {
+	Error string
+}
 
 // MessageTerminateDecrypt is a wrapper around TerminateDecrypt.
 type MessageTerminateDecrypt struct {

--- a/evoting/protocol/decrypt_test.go
+++ b/evoting/protocol/decrypt_test.go
@@ -217,8 +217,10 @@ func TestDecryptNodeFailure(t *testing.T) {
 			Points:    points,
 			Node:      "",
 			PublicKey: nodes[i].ServerIdentity.Public,
+			Index:     i,
 		}
 		data, _ := partial.PublicKey.MarshalBinary()
+		data = append(data, byte(partial.Index))
 		sig, _ := schnorr.Sign(cothority.Suite, local.GetPrivate(nodes[i]), data)
 		partial.Signature = sig
 		transaction := lib.NewTransaction(partial, election.Creator, []byte{})

--- a/evoting/protocol/decrypt_test.go
+++ b/evoting/protocol/decrypt_test.go
@@ -5,11 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/proof"
 	"github.com/dedis/kyber/shuffle"
 	"github.com/dedis/kyber/sign/schnorr"
 	"github.com/dedis/kyber/util/random"
 	"github.com/dedis/onet"
+	"github.com/dedis/onet/log"
+	"github.com/dedis/onet/network"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -100,7 +103,8 @@ func runDecrypt(t *testing.T, n int) {
 		a, b := lib.Encrypt(key, []byte{byte(i)})
 		ballots[i] = &lib.Ballot{User: uint32(i), Alpha: a, Beta: b}
 		tx = lib.NewTransaction(ballots[i], election.Creator, []byte{})
-		lib.StoreUsingWebsocket(election.ID, election.Roster, tx)
+		err := lib.StoreUsingWebsocket(election.ID, election.Roster, tx)
+		require.Nil(t, err)
 	}
 
 	mixes := make([]*lib.Mix, n)
@@ -113,7 +117,8 @@ func runDecrypt(t *testing.T, n int) {
 		sig, _ := schnorr.Sign(cothority.Suite, local.GetPrivate(nodes[i]), data)
 		mix := &lib.Mix{Ballots: lib.Combine(v, w), Proof: proof, Node: string(i), PublicKey: public, Signature: sig}
 		tx = lib.NewTransaction(mix, election.Creator, []byte{})
-		lib.StoreUsingWebsocket(election.ID, election.Roster, tx)
+		err := lib.StoreUsingWebsocket(election.ID, election.Roster, tx)
+		require.Nil(t, err)
 		x, y = v, w
 	}
 
@@ -124,16 +129,127 @@ func runDecrypt(t *testing.T, n int) {
 	decrypt.Signature = []byte{}
 	decrypt.Election = election
 	decrypt.Skipchain = services[0].(*decryptService).skipchain
+	decrypt.LeaderParticipates = true
 	decrypt.Start()
 
 	select {
 	case <-decrypt.Finished:
 		partials, _ := election.Partials(services[0].(*decryptService).skipchain)
-		require.Equal(t, n, len(partials))
-		for _, partial := range partials {
-			require.True(t, partial.Flag)
-		}
-	case <-time.After(60 * time.Second):
+		require.True(t, 2*n/3 < len(partials))
+	case <-time.After(180 * time.Second):
 		assert.True(t, false)
 	}
+
+	// The decrypt protocol tries to stop early as soon as 2n/3 + 1 nodes store a partial.
+	// However, since the leader sends a broadcast to all the n nodes initially we
+	// want the servers to be up until the goroutines terminate or the test framework complains
+	// about zombie goroutines. The call to time.Sleep ensures we dont end up with
+	// zombie goroutines
+	time.Sleep(2 * time.Second)
+}
+
+func TestDecryptNodeFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping", t.Name(), " in short mode")
+	}
+	local := onet.NewLocalTest(cothority.Suite)
+	defer local.CloseAll()
+
+	nodes, roster, tree := local.GenBigTree(7, 7, 1, true)
+	services := local.GetServices(nodes, decryptServiceID)
+
+	dkgs, _ := lib.DKGSimulate(7, 6)
+	shared, _ := lib.NewSharedSecret(dkgs[0])
+	key := shared.X
+
+	chain, _ := lib.NewSkipchain(services[0].(*decryptService).skipchain, roster, skipchain.VerificationStandard)
+	election := &lib.Election{
+		ID:      chain.Hash,
+		Roster:  roster,
+		Key:     key,
+		Creator: 0,
+		Users:   []uint32{0, 1, 2},
+	}
+	for i := range services {
+		services[i].(*decryptService).secret, _ = lib.NewSharedSecret(dkgs[i])
+		services[i].(*decryptService).election = election
+		services[i].(*decryptService).user = 0
+		services[i].(*decryptService).signature = []byte{}
+	}
+
+	tx := lib.NewTransaction(election, election.Creator, []byte{})
+	lib.StoreUsingWebsocket(election.ID, election.Roster, tx)
+
+	ballots := make([]*lib.Ballot, 3)
+	for i := 0; i < 3; i++ {
+		a, b := lib.Encrypt(key, []byte{byte(i)})
+		ballots[i] = &lib.Ballot{User: uint32(i), Alpha: a, Beta: b}
+		tx = lib.NewTransaction(ballots[i], election.Creator, []byte{})
+		lib.StoreUsingWebsocket(election.ID, election.Roster, tx)
+	}
+
+	mixes := make([]*lib.Mix, 7)
+	x, y := lib.Split(ballots)
+	for i := range mixes {
+		v, w, prover := shuffle.Shuffle(cothority.Suite, nil, key, x, y, random.New())
+		proof, _ := proof.HashProve(cothority.Suite, "", prover)
+		public := roster.Get(i).Public
+		data, _ := public.MarshalBinary()
+		sig, _ := schnorr.Sign(cothority.Suite, local.GetPrivate(nodes[i]), data)
+		mix := &lib.Mix{Ballots: lib.Combine(v, w), Proof: proof, Node: string(i), PublicKey: public, Signature: sig}
+		mixes[i] = mix
+		tx = lib.NewTransaction(mix, election.Creator, []byte{})
+		err := lib.StoreUsingWebsocket(election.ID, election.Roster, tx)
+		require.Nil(t, err)
+		x, y = v, w
+	}
+
+	// we're trying to simulate a decryption that failed previously
+	for i := 0; i < 2; i++ {
+		mix := mixes[len(mixes)-1]
+		points := make([]kyber.Point, len(mix.Ballots))
+		for i := range points {
+			secret, _ := lib.NewSharedSecret(dkgs[i])
+			points[i] = lib.Decrypt(secret.V, mix.Ballots[i].Alpha, mix.Ballots[i].Beta)
+		}
+
+		partial := &lib.Partial{
+			Points:    points,
+			Node:      "",
+			PublicKey: nodes[i].ServerIdentity.Public,
+		}
+		data, _ := partial.PublicKey.MarshalBinary()
+		sig, _ := schnorr.Sign(cothority.Suite, local.GetPrivate(nodes[i]), data)
+		partial.Signature = sig
+		transaction := lib.NewTransaction(partial, election.Creator, []byte{})
+		lib.StoreUsingWebsocket(election.ID, election.Roster, transaction)
+	}
+
+	rooted := onet.NewRoster(append([]*network.ServerIdentity{tree.Roster.List[0]}, tree.Roster.List[2:]...))
+	protocolTree := rooted.GenerateNaryTree(1)
+	instance, _ := services[0].(*decryptService).CreateProtocol(NameDecrypt, protocolTree)
+	decrypt := instance.(*Decrypt)
+	decrypt.Secret, _ = lib.NewSharedSecret(dkgs[0])
+	decrypt.User = 0
+	decrypt.Signature = []byte{}
+	decrypt.Election = election
+	decrypt.Skipchain = services[0].(*decryptService).skipchain
+	decrypt.LeaderParticipates = false
+	log.Lvl1("Starting the decrypt protocol")
+	decrypt.Start()
+
+	select {
+	case <-decrypt.Finished:
+		partials, _ := election.Partials(services[0].(*decryptService).skipchain)
+		require.True(t, len(partials) == 5)
+	case <-time.After(300 * time.Second):
+		assert.True(t, false)
+	}
+
+	// The decrypt protocol tries to stop early as soon as 2n/3 + 1 nodes store a partial.
+	// However, since the leader sends a broadcast to all the n nodes initially we
+	// want the servers to be up until the goroutines terminate or the test framework complains
+	// about zombie goroutines. The call to time.Sleep ensures we dont end up with
+	// zombie goroutines
+	time.Sleep(2 * time.Second)
 }

--- a/evoting/protocol/shuffle.go
+++ b/evoting/protocol/shuffle.go
@@ -87,8 +87,9 @@ func (s *Shuffle) HandlePrompt(prompt MessagePrompt) error {
 	// base condition
 	target := 2 * len(s.Election.Roster.List) / 3
 
+	added := 0
 	continueProtocol := func() error {
-		if len(s.Children()) > 0 && len(mixes)+1 <= target {
+		if len(s.Children()) > 0 && len(mixes)+added <= target {
 			child := s.Children()[0]
 			for {
 				// err here only checks for network errors while trying to
@@ -152,6 +153,7 @@ func (s *Shuffle) HandlePrompt(prompt MessagePrompt) error {
 	if err != nil {
 		return err
 	}
+	added = 1
 	return nil
 }
 

--- a/evoting/protocol/shuffle.go
+++ b/evoting/protocol/shuffle.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dedis/cothority"
 	"github.com/dedis/kyber/proof"
 	"github.com/dedis/kyber/shuffle"
+	"github.com/dedis/kyber/sign/schnorr"
 	"github.com/dedis/kyber/util/random"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/network"
@@ -42,9 +43,10 @@ type Shuffle struct {
 	Signature []byte
 	Election  *lib.Election // Election to be shuffled.
 
-	Finished chan bool // Flag to signal protocol termination.
+	Finished chan error // Flag to signal protocol termination.
 
-	Skipchain *skipchain.Service
+	Skipchain          *skipchain.Service
+	LeaderParticipates bool // LeaderParticipates is a flag that denotes if leader should participate in the shuffle
 }
 
 func init() {
@@ -54,7 +56,7 @@ func init() {
 
 // NewShuffle initializes the protocol object and registers all the handlers.
 func NewShuffle(node *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-	shuffle := &Shuffle{TreeNodeInstance: node, Finished: make(chan bool, 1)}
+	shuffle := &Shuffle{TreeNodeInstance: node, Finished: make(chan error, 1)}
 	shuffle.RegisterHandlers(shuffle.HandlePrompt, shuffle.HandleTerminate)
 	return shuffle, nil
 }
@@ -67,24 +69,61 @@ func (s *Shuffle) Start() error {
 // HandlePrompt retrieves, shuffles and stores the mix back on the skipchain.
 func (s *Shuffle) HandlePrompt(prompt MessagePrompt) error {
 	var ballots []*lib.Ballot
-	if s.IsRoot() {
+	mixes, err := s.Election.Mixes(s.Skipchain)
+	if !s.IsRoot() {
+		defer s.Done()
+	}
+
+	if len(mixes) == 0 {
 		box, err := s.Election.Box(s.Skipchain)
 		if err != nil {
 			return err
 		}
 		ballots = box.Ballots
 	} else {
-		mixes, err := s.Election.Mixes(s.Skipchain)
-		if err != nil {
-			return err
-		}
 		ballots = mixes[len(mixes)-1].Ballots
-		defer s.finish()
+	}
+
+	// base condition
+	target := 2 * len(s.Election.Roster.List) / 3
+
+	continueProtocol := func() error {
+		if len(s.Children()) > 0 && len(mixes)+1 <= target {
+			child := s.Children()[0]
+			for {
+				// err here only checks for network errors while trying to
+				// send a message to the child
+				err = s.SendTo(child, &PromptShuffle{})
+				if err != nil {
+					// retry with next one
+					if len(child.Children) > 0 {
+						child = child.Children[0]
+					} else {
+						errString := "shuffle error: retried all nodes, couldn't shuffle required number of times"
+						return s.SendTo(s.Root(), &TerminateShuffle{Error: errString})
+					}
+				} else {
+					return nil
+				}
+			}
+		}
+		return s.SendTo(s.Root(), &TerminateShuffle{})
+	}
+
+	defer continueProtocol()
+
+	if len(mixes) > target {
+		return s.SendTo(s.Root(), &TerminateShuffle{})
 	}
 
 	if len(ballots) < 2 {
-		return errors.New("not enough (> 2) ballots to shuffle")
+		return s.SendTo(s.Root(), &TerminateShuffle{
+			Error: "shuffle error: not enough (> 2) ballots to shuffle",
+		})
+	}
 
+	if s.IsRoot() && !s.LeaderParticipates {
+		return nil
 	}
 
 	a, b := lib.Split(ballots)
@@ -93,26 +132,41 @@ func (s *Shuffle) HandlePrompt(prompt MessagePrompt) error {
 	if err != nil {
 		return err
 	}
-	mix := &lib.Mix{Ballots: lib.Combine(g, d), Proof: proof, Node: s.Name()}
-	transaction := lib.NewTransaction(mix, s.User, s.Signature)
-	if err := lib.StoreUsingWebsocket(s.Election.ID, s.Election.Roster, transaction); err != nil {
+	mix := &lib.Mix{
+		Ballots:   lib.Combine(g, d),
+		Proof:     proof,
+		Node:      s.Name(),
+		PublicKey: s.ServerIdentity().Public,
+	}
+	data, err := mix.PublicKey.MarshalBinary()
+	if err != nil {
 		return err
 	}
-
-	if s.IsLeaf() {
-		return s.SendTo(s.Root(), &TerminateShuffle{})
+	sig, err := schnorr.Sign(cothority.Suite, s.Private(), data)
+	if err != nil {
+		return err
 	}
-	return s.SendToChildren(&PromptShuffle{})
+	mix.Signature = sig
+	transaction := lib.NewTransaction(mix, s.User, s.Signature)
+	err = lib.StoreUsingWebsocket(s.Election.ID, s.Election.Roster, transaction)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // finish terminates the protocol within onet.
-func (s *Shuffle) finish() {
+func (s *Shuffle) finish(err error) {
 	s.Done()
-	s.Finished <- true
+	s.Finished <- err
 }
 
 // HandleTerminate concludes the protocol.
 func (s *Shuffle) HandleTerminate(terminate MessageTerminate) error {
-	s.finish()
+	if terminate.Error != "" {
+		s.finish(errors.New(terminate.Error))
+	} else {
+		s.finish(nil)
+	}
 	return nil
 }

--- a/evoting/protocol/shuffle_struct.go
+++ b/evoting/protocol/shuffle_struct.go
@@ -16,7 +16,9 @@ type MessagePrompt struct {
 
 // TerminateShuffle is sent by the leaf node to the root node upon completion of
 // the last shuffle, which terminates the protocol.
-type TerminateShuffle struct{}
+type TerminateShuffle struct {
+	Error string // Protobuf doesn't support error type
+}
 
 // MessageTerminate is a wrapper around TerminateShuffle.
 type MessageTerminate struct {

--- a/evoting/protocol/shuffle_test.go
+++ b/evoting/protocol/shuffle_test.go
@@ -57,6 +57,72 @@ func TestShuffleProtocol(t *testing.T) {
 	}
 }
 
+func TestShuffleNodeFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping", t.Name(), " in short mode")
+	}
+	local := onet.NewLocalTest(cothority.Suite)
+	defer local.CloseAll()
+
+	nodes, roster, tree := local.GenBigTree(5, 5, 1, true)
+
+	services := local.GetServices(nodes, shuffleServiceID)
+
+	dkgs, _ := lib.DKGSimulate(5, 4)
+	shared, _ := lib.NewSharedSecret(dkgs[0])
+	key := shared.X
+
+	chain, _ := lib.NewSkipchain(services[0].(*shuffleService).skipchain, roster, skipchain.VerificationStandard)
+	election := &lib.Election{
+		ID:      chain.Hash,
+		Roster:  roster,
+		Key:     key,
+		Creator: 0,
+		Users:   []uint32{0, 1, 2},
+	}
+	for i := range services {
+		services[i].(*shuffleService).election = election
+		services[i].(*shuffleService).user = 0
+		services[i].(*shuffleService).signature = []byte{}
+	}
+
+	tx := lib.NewTransaction(election, election.Creator, []byte{})
+	lib.Store(services[0].(*shuffleService).skipchain, election.ID, tx)
+
+	for i := 0; i < 3; i++ {
+		a, b := lib.Encrypt(key, []byte{byte(i)})
+		ballot := &lib.Ballot{User: uint32(i), Alpha: a, Beta: b}
+		tx = lib.NewTransaction(ballot, election.Creator, []byte{})
+		lib.Store(services[0].(*shuffleService).skipchain, election.ID, tx)
+	}
+	nodes[3].Stop()
+
+	instance, _ := services[0].(*shuffleService).CreateProtocol(NameShuffle, tree)
+	shuffle := instance.(*Shuffle)
+	shuffle.User = 0
+	shuffle.Signature = []byte{}
+	shuffle.Election = election
+	shuffle.Skipchain = services[0].(*shuffleService).skipchain
+	shuffle.LeaderParticipates = true
+	shuffle.Start()
+
+	select {
+	case <-shuffle.Finished:
+		box, _ := election.Box(services[0].(*shuffleService).skipchain)
+		mixes, _ := election.Mixes(services[0].(*shuffleService).skipchain)
+
+		require.Equal(t, 4, len(mixes))
+		in1, in2 := lib.Split(box.Ballots)
+		for i := range mixes {
+			out1, out2 := lib.Split(mixes[i].Ballots)
+			require.Nil(t, lib.Verify(mixes[i].Proof, election.Key, in1, in2, out1, out2))
+			in1, in2 = out1, out2
+		}
+	case <-time.After(180 * time.Second):
+		t.Fatal("Protocol timeout")
+	}
+
+}
 func runShuffle(t *testing.T, n int) {
 	local := onet.NewLocalTest(cothority.Suite)
 	defer local.CloseAll()
@@ -98,14 +164,16 @@ func runShuffle(t *testing.T, n int) {
 	shuffle.Signature = []byte{}
 	shuffle.Election = election
 	shuffle.Skipchain = services[0].(*shuffleService).skipchain
+	shuffle.LeaderParticipates = true
 	shuffle.Start()
 
 	select {
-	case <-shuffle.Finished:
+	case err := <-shuffle.Finished:
+		require.Nil(t, err)
 		box, _ := election.Box(services[0].(*shuffleService).skipchain)
 		mixes, _ := election.Mixes(services[0].(*shuffleService).skipchain)
 
-		require.Equal(t, n, len(mixes))
+		require.Equal(t, 2*n/3+1, len(mixes))
 		in1, in2 := lib.Split(box.Ballots)
 		for i := range mixes {
 			out1, out2 := lib.Split(mixes[i].Ballots)

--- a/evoting/service/service.go
+++ b/evoting/service/service.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 // timeout for protocol termination.
-const timeout = 90 * time.Second
+const timeout = 120 * time.Second
 
 // serviceID is the onet identifier.
 var serviceID onet.ServiceID
@@ -541,11 +541,15 @@ func (s *Service) Reconstruct(req *evoting.Reconstruct) (*evoting.ReconstructRep
 	n := len(election.Roster.List)
 	for i := 0; i < len(partials[0].Points); i++ {
 		shares := make([]*share.PubShare, n)
-		for j, partial := range partials {
+		for _, partial := range partials {
+			j := partial.Index
 			shares[j] = &share.PubShare{I: j, V: partial.Points[i]}
 		}
 
-		message, _ := share.RecoverCommit(cothority.Suite, shares, 2*n/3+1, n)
+		message, err := share.RecoverCommit(cothority.Suite, shares, 2*n/3+1, n)
+		if err != nil {
+			return nil, err
+		}
 		points = append(points, message)
 	}
 
@@ -710,8 +714,6 @@ func new(context *onet.Context) (onet.Service, error) {
 		},
 		skipchain: context.Service(skipchain.ServiceName).(*skipchain.Service),
 	}
-	log.Lvl1("Setting skipchain propagation timeout to 5s")
-	service.skipchain.SetPropTimeout(5 * time.Second)
 
 	service.RegisterHandlers(
 		service.Ping,

--- a/evoting/service/service.go
+++ b/evoting/service/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -37,7 +38,7 @@ func init() {
 }
 
 // timeout for protocol termination.
-const timeout = 60 * time.Second
+const timeout = 90 * time.Second
 
 // serviceID is the onet identifier.
 var serviceID onet.ServiceID
@@ -51,8 +52,9 @@ type Service struct {
 
 	skipchain *skipchain.Service
 
-	mutex   sync.Mutex
-	storage *storage
+	mutex         sync.Mutex
+	finalizeMutex sync.Mutex // used for protecting shuffle and decrypt operations
+	storage       *storage
 
 	pin string // pin is the current service number.
 }
@@ -368,6 +370,8 @@ func (s *Service) GetPartials(req *evoting.GetPartials) (*evoting.GetPartialsRep
 
 // Shuffle message handler. Initiate shuffle protocol.
 func (s *Service) Shuffle(req *evoting.Shuffle) (*evoting.ShuffleReply, error) {
+	s.finalizeMutex.Lock()
+	defer s.finalizeMutex.Unlock()
 	if !s.leader() {
 		return nil, errOnlyLeader
 	}
@@ -377,18 +381,48 @@ func (s *Service) Shuffle(req *evoting.Shuffle) (*evoting.ShuffleReply, error) {
 		return nil, err
 	}
 
-	rooted := election.Roster.NewRosterWithRoot(s.ServerIdentity())
+	// create a roster excluding nodes that have already participated
+	mixes, err := election.Mixes(s.skipchain)
+	if len(mixes) > 2*len(election.Roster.List)/3 {
+		return &evoting.ShuffleReply{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	participated := make(map[string]bool)
+	for _, mix := range mixes {
+		participated[mix.PublicKey.String()] = true
+	}
+	filtered := []*network.ServerIdentity{}
+	for _, node := range election.Roster.List[1:] {
+		if _, ok := participated[node.Public.String()]; !ok {
+			filtered = append(filtered, node)
+		}
+	}
+
+	// shuffle the filtered list using Fischer-Yates
+	// rand.Shuffle is introduced in Go 1.10
+	for i := len(filtered) - 1; i > 0; i-- {
+		j := rand.Intn(i)
+		filtered[i], filtered[j] = filtered[j], filtered[i]
+	}
+
+	// add the leader to the front of the list
+	filtered = append([]*network.ServerIdentity{election.Roster.List[0]}, filtered...)
+	rooted := onet.NewRoster(filtered)
 	tree := rooted.GenerateNaryTree(1)
 	if tree == nil {
 		return nil, errors.New("failed to generate tree")
 	}
 
+	hasParticipated, _ := participated[election.Roster.List[0].Public.String()]
 	instance, _ := s.CreateProtocol(protocol.NameShuffle, tree)
 	protocol := instance.(*protocol.Shuffle)
 	protocol.User = req.User
 	protocol.Signature = req.Signature
 	protocol.Election = election
 	protocol.Skipchain = s.skipchain
+	protocol.LeaderParticipates = !hasParticipated
 
 	config, _ := network.Marshal(&synchronizer{
 		ID:        req.ID,
@@ -400,8 +434,8 @@ func (s *Service) Shuffle(req *evoting.Shuffle) (*evoting.ShuffleReply, error) {
 		return nil, err
 	}
 	select {
-	case <-protocol.Finished:
-		return &evoting.ShuffleReply{}, nil
+	case err := <-protocol.Finished:
+		return &evoting.ShuffleReply{}, err
 	case <-time.After(timeout):
 		return nil, errors.New("shuffle error, protocol timeout")
 	}
@@ -640,6 +674,8 @@ func new(context *onet.Context) (onet.Service, error) {
 		},
 		skipchain: context.Service(skipchain.ServiceName).(*skipchain.Service),
 	}
+	log.Lvl1("Setting skipchain propagation timeout to 5s")
+	service.skipchain.SetPropTimeout(5 * time.Second)
 
 	service.RegisterHandlers(
 		service.Ping,

--- a/evoting/service/service_test.go
+++ b/evoting/service/service_test.go
@@ -313,7 +313,6 @@ func TestEvolveRoster(t *testing.T) {
 		Admins:    []uint32{idAdmin, idAdmin2},
 	})
 	require.Nil(t, err)
-	log.Lvl2("Wrote 2nd roster")
 
 	// Run an election on the new set of conodes, the new nodeKP, and the new
 	// election admin.
@@ -321,6 +320,13 @@ func TestEvolveRoster(t *testing.T) {
 
 	// There was a test here before to try to replace the leader.
 	// It didn't work. For the time being, that is not supported.
+
+	// The decrypt protocol tries to stop early as soon as 2n/3 + 1 nodes store a partial.
+	// However, since the leader sends a broadcast to all the n nodes initially we
+	// want the servers to be up until the goroutines terminate or the test framework complains
+	// about zombie goroutines. The call to time.Sleep ensures we dont end up with
+	// zombie goroutines
+	time.Sleep(5 * time.Second)
 }
 
 func setupElection(t *testing.T, s0 *Service, rl *evoting.LinkReply, nodeKP *key.Pair) skipchain.SkipBlockID {
@@ -484,4 +490,119 @@ func TestShuffleCatastrophicNodeFailure(t *testing.T) {
 		Signature: adminSig,
 	})
 	require.Nil(t, err)
+}
+
+func TestDecryptBenignNodeFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping", t.Name(), " in short mode")
+	}
+	local := onet.NewLocalTest(cothority.Suite)
+	defer local.CloseAll()
+
+	nodeKP := key.NewKeyPair(cothority.Suite)
+	nodes, roster, _ := local.GenBigTree(7, 7, 1, true)
+	s0 := local.GetServices(nodes, serviceID)[0].(*Service)
+
+	// Create the master skipchain
+	ro := onet.NewRoster(roster.List)
+	rl, err := s0.Link(&evoting.Link{
+		Pin:    s0.pin,
+		Roster: ro,
+		Key:    nodeKP.Public,
+		Admins: []uint32{idAdmin},
+	})
+	require.Nil(t, err)
+	log.Lvl2("Wrote the roster")
+
+	electionID := setupElection(t, s0, rl, nodeKP)
+	adminSig := generateSignature(nodeKP.Private, rl.ID, idAdmin)
+
+	// Shuffle all votes
+	_, err = s0.Shuffle(&evoting.Shuffle{
+		ID:        electionID,
+		User:      idAdmin,
+		Signature: adminSig,
+	})
+	require.Nil(t, err)
+
+	// Close 2 Nodes
+	nodes[2].Close()
+	nodes[5].Close()
+
+	// Try to decrypt
+	_, err = s0.Decrypt(&evoting.Decrypt{
+		ID:        electionID,
+		User:      idAdmin,
+		Signature: adminSig,
+	})
+	require.Nil(t, err)
+}
+
+func TestDecryptCatastrophicNodeFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping", t.Name(), " in short mode")
+	}
+	local := onet.NewLocalTest(cothority.Suite)
+	defer local.CloseAll()
+
+	nodeKP := key.NewKeyPair(cothority.Suite)
+	nodes, roster, _ := local.GenBigTree(7, 7, 1, true)
+	s0 := local.GetServices(nodes, serviceID)[0].(*Service)
+
+	// Create the master skipchain
+	ro := onet.NewRoster(roster.List)
+	rl, err := s0.Link(&evoting.Link{
+		Pin:    s0.pin,
+		Roster: ro,
+		Key:    nodeKP.Public,
+		Admins: []uint32{idAdmin},
+	})
+	require.Nil(t, err)
+	log.Lvl2("Wrote the roster")
+
+	electionID := setupElection(t, s0, rl, nodeKP)
+	adminSig := generateSignature(nodeKP.Private, rl.ID, idAdmin)
+
+	// Shuffle all votes
+	_, err = s0.Shuffle(&evoting.Shuffle{
+		ID:        electionID,
+		User:      idAdmin,
+		Signature: adminSig,
+	})
+	require.Nil(t, err)
+
+	// Fail 3 nodes
+	nodes[2].Pause()
+	nodes[4].Pause()
+	nodes[5].Pause()
+
+	// Try a decrypt now. It should timeout because no blocks can be stored
+	_, err = s0.Decrypt(&evoting.Decrypt{
+		ID:        electionID,
+		User:      idAdmin,
+		Signature: adminSig,
+	})
+	require.NotNil(t, err)
+
+	log.Lvl2("Decrypt timed out on 3 nodes failing")
+
+	// Unpause the nodes
+	nodes[2].Unpause()
+	nodes[4].Unpause()
+	nodes[5].Unpause()
+
+	// Try a decrypt now. It should succeed
+	_, err = s0.Decrypt(&evoting.Decrypt{
+		ID:        electionID,
+		User:      idAdmin,
+		Signature: adminSig,
+	})
+	require.Nil(t, err)
+
+	// The decrypt protocol tries to stop early as soon as 2n/3 + 1 nodes store a partial.
+	// However, since the leader sends a broadcast to all the n nodes initially we
+	// want the servers to be up until the goroutines terminate or the test framework complains
+	// about zombie goroutines. The call to time.Sleep ensures we dont end up with
+	// zombie goroutines
+	time.Sleep(5 * time.Second)
 }

--- a/evoting/service/service_test.go
+++ b/evoting/service/service_test.go
@@ -7,15 +7,20 @@ import (
 
 	"github.com/dedis/cothority"
 	"github.com/dedis/kyber"
+	"github.com/dedis/kyber/proof"
+	"github.com/dedis/kyber/shuffle"
 	"github.com/dedis/kyber/sign/schnorr"
 	"github.com/dedis/kyber/util/key"
+	"github.com/dedis/kyber/util/random"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
+	"github.com/dedis/onet/network"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/dedis/cothority/evoting"
 	"github.com/dedis/cothority/evoting/lib"
+	"github.com/dedis/cothority/skipchain"
 )
 
 func TestMain(m *testing.M) {
@@ -316,4 +321,167 @@ func TestEvolveRoster(t *testing.T) {
 
 	// There was a test here before to try to replace the leader.
 	// It didn't work. For the time being, that is not supported.
+}
+
+func setupElection(t *testing.T, s0 *Service, rl *evoting.LinkReply, nodeKP *key.Pair) skipchain.SkipBlockID {
+	adminSig := generateSignature(nodeKP.Private, rl.ID, idAdmin)
+
+	replyOpen, err := s0.Open(&evoting.Open{
+		ID: rl.ID,
+		Election: &lib.Election{
+			Creator: idAdmin,
+			Users:   []uint32{idUser1, idUser2, idUser3, idAdmin},
+			End:     time.Now().Unix() + 86400,
+		},
+		User:      idAdmin,
+		Signature: adminSig,
+	})
+	require.Nil(t, err)
+
+	// Prepare a helper for testing voting.
+	vote := func(user uint32, bufCand []byte) *evoting.CastReply {
+		k, c := lib.Encrypt(replyOpen.Key, bufCand)
+		ballot := &lib.Ballot{
+			User:  user,
+			Alpha: k,
+			Beta:  c,
+		}
+		cast, err := s0.Cast(&evoting.Cast{
+			ID:        replyOpen.ID,
+			Ballot:    ballot,
+			User:      user,
+			Signature: generateSignature(nodeKP.Private, rl.ID, user),
+		})
+		require.Nil(t, err)
+		return cast
+	}
+
+	// User votes
+	vote(idUser1, bufCand1)
+	vote(idUser2, bufCand1)
+	vote(idUser3, bufCand2)
+
+	return replyOpen.ID
+}
+
+func TestShuffleBenignNodeFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping", t.Name(), " in short mode")
+	}
+	local := onet.NewLocalTest(cothority.Suite)
+	defer local.CloseAll()
+
+	nodeKP := key.NewKeyPair(cothority.Suite)
+	nodes, roster, _ := local.GenBigTree(7, 7, 1, true)
+	s0 := local.GetServices(nodes, serviceID)[0].(*Service)
+
+	// Create the master skipchain
+	ro := onet.NewRoster(roster.List)
+	rl, err := s0.Link(&evoting.Link{
+		Pin:    s0.pin,
+		Roster: ro,
+		Key:    nodeKP.Public,
+		Admins: []uint32{idAdmin},
+	})
+	require.Nil(t, err)
+	log.Lvl2("Wrote the roster")
+
+	electionID := setupElection(t, s0, rl, nodeKP)
+	adminSig := generateSignature(nodeKP.Private, rl.ID, idAdmin)
+
+	// Pause 2 nodes
+	nodes[5].Close()
+	nodes[6].Close()
+
+	// Shuffle all votes
+	_, err = s0.Shuffle(&evoting.Shuffle{
+		ID:        electionID,
+		User:      idAdmin,
+		Signature: adminSig,
+	})
+	require.Nil(t, err)
+}
+
+func TestShuffleCatastrophicNodeFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping", t.Name(), " in short mode")
+	}
+	local := onet.NewLocalTest(cothority.Suite)
+	defer local.CloseAll()
+
+	nodeKP := key.NewKeyPair(cothority.Suite)
+	nodes, roster, _ := local.GenBigTree(7, 7, 1, true)
+	s0 := local.GetServices(nodes, serviceID)[0].(*Service)
+
+	// Create the master skipchain
+	ro := onet.NewRoster(roster.List)
+	rl, err := s0.Link(&evoting.Link{
+		Pin:    s0.pin,
+		Roster: ro,
+		Key:    nodeKP.Public,
+		Admins: []uint32{idAdmin},
+	})
+	require.Nil(t, err)
+	log.Lvl2("Wrote the roster")
+
+	electionID := setupElection(t, s0, rl, nodeKP)
+	adminSig := generateSignature(nodeKP.Private, rl.ID, idAdmin)
+
+	// Append two Mixes manually to simulate a shuffle gone bad
+	election, err := lib.GetElection(s0.skipchain, electionID, false, 0)
+	require.Nil(t, err)
+
+	genMix := func(ballots []*lib.Ballot, election *lib.Election, serverIdentity *network.ServerIdentity, private kyber.Scalar) *lib.Mix {
+		a, b := lib.Split(ballots)
+		g, d, prov := shuffle.Shuffle(cothority.Suite, nil, election.Key, a, b, random.New())
+		proof, err := proof.HashProve(cothority.Suite, "", prov)
+		require.Nil(t, err)
+		mix := &lib.Mix{
+			Ballots:   lib.Combine(g, d),
+			Proof:     proof,
+			Node:      "",
+			PublicKey: serverIdentity.Public,
+		}
+		data, err := mix.PublicKey.MarshalBinary()
+		require.Nil(t, err)
+		sig, err := schnorr.Sign(cothority.Suite, private, data)
+		require.Nil(t, err)
+		mix.Signature = sig
+		return mix
+	}
+
+	box, err := election.Box(s0.skipchain)
+	mix := genMix(box.Ballots, election, roster.Get(0), local.GetPrivate(nodes[0]))
+	tx := lib.NewTransaction(mix, idAdmin, adminSig)
+	_, err = lib.Store(s0.skipchain, election.ID, tx)
+	require.Nil(t, err)
+	mix2 := genMix(mix.Ballots, election, roster.Get(1), local.GetPrivate(nodes[1]))
+	tx = lib.NewTransaction(mix2, idAdmin, adminSig)
+	_, err = lib.Store(s0.skipchain, election.ID, tx)
+	require.Nil(t, err)
+
+	// Fail 3 nodes. New blocks cannot be added now because consensus cannot be reached.
+	nodes[2].Pause()
+	nodes[5].Pause()
+	nodes[6].Pause()
+
+	// Shuffle all votes
+	_, err = s0.Shuffle(&evoting.Shuffle{
+		ID:        electionID,
+		User:      idAdmin,
+		Signature: adminSig,
+	})
+	require.NotNil(t, err)
+
+	// Unpause the nodes and retry shuffling
+	nodes[2].Unpause()
+	nodes[5].Unpause()
+	nodes[6].Unpause()
+
+	_, err = s0.Shuffle(&evoting.Shuffle{
+		ID:        electionID,
+		User:      idAdmin,
+		Signature: adminSig,
+	})
+	require.Nil(t, err)
 }

--- a/external/js/cothority/package-lock.json
+++ b/external/js/cothority/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedis/cothority",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedis/cothority",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "module for interacting with cothority nodes",
   "main": "dist/bundle.node.min.js",
   "browser": "dist/bundle.min.js",

--- a/external/js/cothority/webpack.config.js
+++ b/external/js/cothority/webpack.config.js
@@ -18,8 +18,8 @@ const nodeConfig = {
         use: {
           loader: "babel-loader",
           options: {
-            presets: ["env"],
-	    plugins: [ require("babel-plugin-transform-object-rest-spread") ],
+            presets: [["env", { targets: { node: 8 } }]],
+            plugins: [require("babel-plugin-transform-object-rest-spread")]
           }
         }
       }
@@ -50,8 +50,10 @@ const browserConfig = {
         use: {
           loader: "babel-loader",
           options: {
-            presets: ["env"],
-	    plugins: [ require("babel-plugin-transform-object-rest-spread") ],
+            presets: [
+              ["env", { targets: { browsers: [">1%"] }, useBuiltIns: true }]
+            ],
+            plugins: [require("babel-plugin-transform-object-rest-spread")]
           }
         }
       }

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -779,6 +779,11 @@ func (s *Service) SetBFTTimeout(t time.Duration) {
 	s.bftTimeout = t
 }
 
+// SetPropTimeout is used to set the propagation timeout
+func (s *Service) SetPropTimeout(t time.Duration) {
+	s.propTimeout = t
+}
+
 func (s *Service) verifySigs(msg, sig []byte) bool {
 	// If there are no clients, all signatures verify.
 	if len(s.Storage.Clients) == 0 {


### PR DESCRIPTION
This PR contains modifications to the shuffle protocol to recover from failure during shuffling. The shuffle protocol is a chain protocol where each node in the protocol tries to perform a shuffle on the last `Mix` transaction (or `Box` in case of the leader). The node then propagates the message further down the chain. In case of a network error, the node tries to contact the next node in chain. If a node fails for any reason during the shuffle, the protocol would time out for the leader. From the administrator's perspective, restarting a protocol would first look at existing `Mix` transactions in the skipchain and the protocol will be re-initiated with the left over nodes.

Edit:

Updated the PR to handle decrypt resilience as well. The Decrypt protocol now sends a broadcast to all nodes and exits as soon as it gets 2n/3+1 replies. In case the protocol is resumed from a previously failed attempt, the leader first tries to figure out the list of nodes that have not participated in decryption before and then reinitiates the protocol.