### PR TITLE
removing some of the skipblocks propagations that were not needed

### DIFF
--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -169,7 +169,6 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, er
 		}
 	}
 	var prev *SkipBlock
-	var changed []*SkipBlock
 
 	// If TargetSkipChainID is not given, it is a genesis block.
 	if psbd.TargetSkipChainID.IsNull() {
@@ -189,6 +188,7 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, er
 			return nil, err
 		}
 
+		var changed []*SkipBlock
 		if !prop.ParentBlockID.IsNull() {
 			parent := s.db.GetByID(prop.ParentBlockID)
 			if parent == nil {
@@ -199,89 +199,76 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, er
 			changed = append(changed, parent)
 		}
 		changed = append(changed, prop)
-
+		log.Lvlf3("Propagate %d blocks", len(changed))
+		if err := s.startPropagation(changed); err != nil {
+			return nil, errors.New(
+				"Couldn't propagate new blocks: " + err.Error())
+		}
 	} else {
 
 		// We're appending a block to an existing chain.
 		log.Lvlf2("Adding block with roster %+v to %x",
 			psbd.NewBlock.Roster.List, psbd.TargetSkipChainID)
 
+		// Check if we really want to take this block with regard to our
+		// authorization lists.
+		if !s.blockIsFriendly(psbd.NewBlock) {
+			log.Lvlf2("%s: block is not friendly: %x",
+				s.ServerIdentity(), psbd.NewBlock.Hash)
+			return nil, errors.New("chain not followed")
+		}
+
 		// At this point the TargetSkipChainID must have something in
 		// it, so we look for the correct skipchain identified by it.
 		// For backward compatibility, TargetSkipChainID does not need
 		// to be a genesis block, it can also be a block on one of the
 		// chains.
-		if b := s.db.GetByID(psbd.TargetSkipChainID); b != nil {
-			// Ignore error here because even if prev ends up
-			// nil, we'll handle it in the next step.
-			prev, _ = s.db.GetLatest(b)
+		// This makes sure we have the genesis block and get the correct
+		// ID.
+		scID := psbd.TargetSkipChainID
+		sb := s.db.GetByID(psbd.TargetSkipChainID)
+		if sb == nil {
+			err := s.syncChain(psbd.NewBlock.Roster, scID)
+			if err != nil {
+				return nil, errors.New("didn't find block to attach to")
+			}
+			sb = s.db.GetByID(scID)
+		}
+		if !sb.SkipChainID().Equal(scID) {
+			scID = sb.SkipChainID()
 		}
 
-		var needSync bool
+		// From now on we have everything we need and lock the adding of new blocks
+		// from this leader to this skipchain.
+		s.chains.lock(scID)
+		defer s.chains.unlock(scID)
 
-		// If we cannot find the latest block, try to set it to the
-		// genesis and then update it later.
-		if prev == nil {
-			if !s.blockIsFriendly(psbd.NewBlock) {
-				log.Lvlf2("%s: block is not friendly: %x",
-					s.ServerIdentity(), psbd.NewBlock.Hash)
-				return nil, errors.New("chain not followed")
-			}
-
-			prev = s.db.GetByID(psbd.NewBlock.SkipChainID())
-			if prev == nil {
-				return nil, errors.New("unknown latest block, unknown chain-id")
-			}
-			needSync = true
+		var err error
+		prev, err = s.db.GetLatestByID(scID)
+		if err != nil {
+			return nil, errors.New("error while getting latest block: " + err.Error())
 		}
 
-		// Check the roster.
+		// Check the roster of the previous block - for the protocols to work
+		// correctly, we need to be in the roster of the latest block.
 		if i, _ := prev.Roster.Search(s.ServerIdentity().ID); i < 0 {
 			return nil, errors.New("this node is not in the previous roster")
 		}
 
-		// Now that we are sure we are responsible for this chain,
-		// make sure that concurrent requests to us to append to
-		// it can not happen.
-		chainID := prev.SkipChainID()
-		s.chains.lock(chainID)
-		defer s.chains.unlock(chainID)
-
-		// Try to find the latest block if the flag is set.
-		// Synchronisation should only be done when we are locked
-		// because it modifies the database.
-		if needSync {
-			// Ignoring error as we might have a not up-to-date chain, but syncChain
-			// will take care of that.
-			latest, _ := s.db.GetLatest(prev)
-			log.Lvlf2("Catching up chain %x from index %v", prev.SkipChainID(), latest.Index)
-			err := s.syncChain(latest.Roster, latest.Hash)
-			if err != nil {
-				return nil, errors.New("failed to catch up with error: " + err.Error())
-			}
-			prev = latest
-		}
-
-		// Once we have the lock on this skipchain, refresh
-		// prev in case someone else added a block to it while
-		// we were waiting for the lock.
-		var err error
-		prev, err = s.db.GetLatestByID(prev.Hash)
-		if err != nil {
-			return nil, err
-		}
-
+		// Check if the previous block already has a forward link.
 		if len(prev.ForwardLink) > 0 {
 			return nil, errors.New(
 				"the latest block already has a follower")
 		}
 
+		// Copy the block-header to a new block.
 		prop.MaximumHeight = prev.MaximumHeight
 		prop.BaseHeight = prev.BaseHeight
 		prop.ParentBlockID = nil
 		prop.VerifierIDs = prev.VerifierIDs
 		prop.Index = prev.Index + 1
-		prop.GenesisID = chainID
+		prop.GenesisID = scID
+		// And calculate the height of that block.
 		index := prop.Index
 		for prop.Height = 1; index%prop.BaseHeight == 0; prop.Height++ {
 			index /= prop.BaseHeight
@@ -291,13 +278,17 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, er
 		}
 		log.Lvl4("Found height", prop.Height, "for index", prop.Index,
 			"and maxHeight", prop.MaximumHeight, "and base", prop.BaseHeight)
+
+		// Add backlinks to the block.
 		prop.BackLinkIDs = make([]SkipBlockID, prop.Height)
 		pointer := prev
 		for h := range prop.BackLinkIDs {
-			for pointer.Height < h+1 {
-				prevPointer := s.db.GetByID(pointer.BackLinkIDs[0])
+			// For every height, we pass the skiplist backwards at the lower height,
+			// till we find a block with the desired height.
+			for pointer.Height <= h {
+				prevPointer := s.db.GetByID(pointer.BackLinkIDs[h-1])
 				if prevPointer == nil {
-					pp, err := s.getBlocks(pointer.Roster, pointer.BackLinkIDs[0], 1)
+					pp, err := s.getBlocks(pointer.Roster, pointer.BackLinkIDs[h-1], 1)
 					if err != nil {
 						return nil, errors.New("couldn't fetch missing block: " + err.Error())
 					}
@@ -326,11 +317,20 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, er
 			}
 		}
 
+		// Create first forward link. The first forward link is crucial, as it's the
+		// one where all the nodes will verify that the block is valid. Higher level
+		// forward links can depend on this forward link.
+		// After creating the forward link, it will propagate it to all nodes.
+		// TODO: we could optimize this by not sending around all the blocks again,
+		// but merely sending the ForwardLinks. But this would change the messages
+		// between conodes, and thus is kept for later versions.
 		if err := s.forwardLinkLevel0(prev, prop); err != nil {
 			return nil, errors.New(
 				"Couldn't get forward signature on block: " + err.Error())
 		}
-		changed = append(changed, prev, prop)
+
+		// Now create all further forward links. Again, after creation of each
+		// forward-link, it will propagate them to all nodes.
 		log.Lvl3("Asking forward-links from all linked blocks")
 		for i, bl := range prop.BackLinkIDs[1:] {
 			back := s.db.GetByID(bl)
@@ -350,12 +350,6 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, er
 				log.Lvl1("Couldn't get old block to sign: " + err.Error())
 			}
 		}
-	}
-	log.Lvlf3("Propagate %d blocks", len(changed))
-	if err := s.startPropagation(changed); err != nil {
-		return nil, errors.New(
-			"Couldn't propagate new blocks: " + err.Error())
-
 	}
 	reply := &StoreSkipBlockReply{
 		Previous: prev,
@@ -837,7 +831,7 @@ func (s *Service) forwardLinkLevel0(src, dst *SkipBlock) error {
 	if err = src.VerifyForwardSignatures(); err != nil {
 		return errors.New("Wrong BFT-signature: " + err.Error())
 	}
-	s.startPropagation([]*SkipBlock{src})
+	s.startPropagation([]*SkipBlock{src, dst})
 	return nil
 }
 
@@ -949,7 +943,7 @@ func (s *Service) forwardLink(fs *ForwardSignature) error {
 		fl.NewRoster = fs.Newest.Roster
 	}
 	from.AddForward(fl)
-	s.startPropagation([]*SkipBlock{from})
+	s.startPropagation([]*SkipBlock{from, fs.Newest})
 	return nil
 }
 

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -989,7 +989,7 @@ func TestService_LeaderCatchup(t *testing.T) {
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
 
-	hosts := local.GenServers(2)
+	hosts := local.GenServers(3)
 	roster := local.GenRosterFromHost(hosts...)
 	leader := local.Services[hosts[0].ServerIdentity.ID][skipchainSID].(*Service)
 	follower := local.Services[hosts[1].ServerIdentity.ID][skipchainSID].(*Service)
@@ -1004,15 +1004,13 @@ func TestService_LeaderCatchup(t *testing.T) {
 		},
 	}
 	ssbrep, err := leader.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: []byte{}, NewBlock: sbRoot})
-	log.ErrFatal(err)
+	require.Nil(t, err)
 
 	var third SkipBlockID
 	for i := 0; i < 10; i++ {
 		ssbrep, err = leader.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: ssbrep.Latest.Hash,
 			NewBlock: sbRoot})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(t, err)
 		if i == 3 {
 			third = ssbrep.Latest.Hash
 		}
@@ -1027,9 +1025,7 @@ func TestService_LeaderCatchup(t *testing.T) {
 	// to handle this write.
 	ssbrep, err = leader.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: ssbrep.Latest.Hash,
 		NewBlock: sbRoot})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 
 	sb11 := leader.db.GetByID(ssbrep.Latest.Hash)
 	require.Equal(t, sb11.Index, 11)
@@ -1040,9 +1036,7 @@ func TestService_LeaderCatchup(t *testing.T) {
 	// Write onto leader; the follower will need to sync to be able to sign this.
 	ssbrep, err = leader.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: ssbrep.Latest.Hash,
 		NewBlock: sbRoot})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 }
 
 func nukeBlocksFrom(t *testing.T, db *SkipBlockDB, where SkipBlockID) {


### PR DESCRIPTION
When creating a new skipblock, a copy of the new block and the older blocks have been sent around excessively:
- once in `createForwardLink0`, once in `createForwardLink` and once at the end of `StoreSkipBlock`
- `createForwardLink0` did not sent the latest block, which led to an incoherent state in the db, because the latest block was stored including the forward-link, but this one was pointing towards nothing

Also added some comments and cleaned up the way we prepare for the new block.