### PR TITLE
Do not wait for impossible responses

### DIFF
--- a/messaging/propagate_test.go
+++ b/messaging/propagate_test.go
@@ -27,7 +27,7 @@ func TestPropagation(t *testing.T) {
 }
 
 // Tests an n-node system
-func propagate(t *testing.T, nbrNodes []int, nbrFailures []int) {
+func propagate(t *testing.T, nbrNodes, nbrFailures []int) {
 	for i, n := range nbrNodes {
 		local := onet.NewLocalTest(tSuite)
 		servers, el, _ := local.GenTree(n, true)


### PR DESCRIPTION
Propagation may fail when a child is down. But the old code will wait
for responses dead children anyway. This commit removes this sub-optimal
functionality and node now only wait for the number of children that
successfully received the initial propagation message.

Tests show improvements in timing.
Before:
```
--- PASS: TestPropagation (5.37s)
PASS
ok  	github.com/dedis/cothority/messaging	5.760s
```
After:
```
--- PASS: TestPropagation (2.39s)
PASS
ok  	github.com/dedis/cothority/messaging	2.782s
```