### PR TITLE
minimal changes to get the timeouts correct

### DIFF
--- a/bftcosi/bftcosi.go
+++ b/bftcosi/bftcosi.go
@@ -18,7 +18,6 @@ package bftcosi
 import (
 	"crypto/sha512"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -807,9 +806,11 @@ func (bft *ProtocolBFTCoSi) setClosing() {
 
 func (bft *ProtocolBFTCoSi) sendToChildren(msg interface{}) error {
 	// TODO send to only nodes that did reply
-	errs := bft.SendToChildrenInParallel(msg)
-	if len(errs) > bft.allowedExceptions {
-		return fmt.Errorf("sendToChildren failed with errors: %v", errs)
-	}
+	go func() {
+		errs := bft.SendToChildrenInParallel(msg)
+		if len(errs) > bft.allowedExceptions {
+			log.Errorf("sendToChildren failed with errors: %v", errs)
+		}
+	}()
 	return nil
 }

--- a/byzcoinx/byzcoinx.go
+++ b/byzcoinx/byzcoinx.go
@@ -89,7 +89,7 @@ func (bft *ByzCoinX) Start() error {
 		select {
 		case tmpSig := <-prepProto.FinalSignature:
 			bft.prepSigChan <- tmpSig
-		case <-time.After(time.Duration(bft.nSubtrees) * bft.Timeout):
+		case <-time.After(bft.Timeout):
 			log.Error(bft.ServerIdentity().Address, "timeout while waiting for signature")
 			bft.prepSigChan <- nil
 		}
@@ -117,7 +117,8 @@ func (bft *ByzCoinX) initCosiProtocol(phase phase) (*protocol.FtCosi, error) {
 	cosiProto.NSubtrees = bft.nSubtrees
 	cosiProto.Msg = bft.Msg
 	cosiProto.Data = bft.Data
-	cosiProto.Timeout = bft.Timeout
+	// For each of the prepare and commit phase we get half of the time.
+	cosiProto.Timeout = bft.Timeout / 2
 
 	return cosiProto, nil
 }
@@ -164,7 +165,7 @@ func (bft *ByzCoinX) Dispatch() error {
 	select {
 	case commitSig = <-commitProto.FinalSignature:
 		log.Lvl3("Finished commit phase")
-	case <-time.After(time.Duration(bft.nSubtrees) * bft.Timeout):
+	case <-time.After(bft.Timeout):
 		log.Error(bft.ServerIdentity().Address, "timeout while waiting for signature")
 	}
 

--- a/byzcoinx/byzcoinx.go
+++ b/byzcoinx/byzcoinx.go
@@ -90,7 +90,9 @@ func (bft *ByzCoinX) Start() error {
 		case tmpSig := <-prepProto.FinalSignature:
 			bft.prepSigChan <- tmpSig
 		case <-time.After(bft.Timeout):
-			log.Error(bft.ServerIdentity().Address, "timeout while waiting for signature")
+			// Waiting for bft.Timeout is too long here but used as a safeguard in
+			// case the prepProto does not return in time.
+			log.Error(bft.ServerIdentity().Address, "timeout should not happen while waiting for signature")
 			bft.prepSigChan <- nil
 		}
 	}()
@@ -166,7 +168,9 @@ func (bft *ByzCoinX) Dispatch() error {
 	case commitSig = <-commitProto.FinalSignature:
 		log.Lvl3("Finished commit phase")
 	case <-time.After(bft.Timeout):
-		log.Error(bft.ServerIdentity().Address, "timeout while waiting for signature")
+		// Waiting for bft.Timeout is too long here but used as a safeguard in
+		// case the commitProto does not return in time.
+		log.Error(bft.ServerIdentity().Address, "timeout should not happen while waiting for signature")
 	}
 
 	bft.FinalSignatureChan <- FinalSignature{bft.Msg, commitSig}

--- a/byzcoinx/byzcoinx_test.go
+++ b/byzcoinx/byzcoinx_test.go
@@ -2,6 +2,7 @@ package byzcoinx
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"math"
 	"strconv"
@@ -17,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var defaultTimeout = time.Second * 4
+var defaultTimeout = 5 * time.Second
 var testSuite = cothority.Suite
 
 type Counter struct {
@@ -106,6 +107,10 @@ func ack(a, b []byte) bool {
 }
 
 func TestMain(m *testing.M) {
+	flag.Parse()
+	if testing.Short() {
+		defaultTimeout = 20 * time.Second
+	}
 	log.MainTest(m)
 }
 

--- a/byzcoinx/byzcoinx_test.go
+++ b/byzcoinx/byzcoinx_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var defaultTimeout = time.Second * 2
+var defaultTimeout = time.Second * 4
 var testSuite = cothority.Suite
 
 type Counter struct {

--- a/byzcoinx/byzcoinx_test.go
+++ b/byzcoinx/byzcoinx_test.go
@@ -106,7 +106,7 @@ func ack(a, b []byte) bool {
 }
 
 func TestMain(m *testing.M) {
-	log.MainTest(m, 3)
+	log.MainTest(m)
 }
 
 func TestBftCoSi(t *testing.T) {
@@ -199,7 +199,7 @@ func runProtocol(t *testing.T, nbrHosts int, nbrFault int, refuseIndex int, prot
 	if nbrFault == 0 {
 		policy = nil
 	} else {
-		policy = cosi.NewThresholdPolicy(nbrFault)
+		policy = cosi.NewThresholdPolicy(nbrHosts - nbrFault)
 	}
 	err = getAndVerifySignature(bftCosiProto.FinalSignatureChan, publics, proposal, policy)
 	require.Nil(t, err)

--- a/evoting/service/service.go
+++ b/evoting/service/service.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 // timeout for protocol termination.
-const timeout = 120 * time.Second
+var timeout = 120 * time.Second
 
 // serviceID is the onet identifier.
 var serviceID onet.ServiceID

--- a/evoting/service/service_test.go
+++ b/evoting/service/service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"flag"
 	"strconv"
 	"testing"
 	"time"
@@ -23,7 +24,13 @@ import (
 	"github.com/dedis/cothority/skipchain"
 )
 
+var defaultTimeout = 5 * time.Second
+
 func TestMain(m *testing.M) {
+	flag.Parse()
+	if testing.Short() {
+		defaultTimeout = 20 * time.Second
+	}
 	log.MainTest(m)
 }
 
@@ -394,7 +401,7 @@ func TestShuffleBenignNodeFailure(t *testing.T) {
 	s0 := local.GetServices(nodes, serviceID)[0].(*Service)
 	sc0 := local.GetServices(nodes, onet.ServiceFactory.ServiceID(skipchain.ServiceName))[0].(*skipchain.Service)
 	// Set a lower timeout for the tests
-	sc0.SetPropTimeout(5 * time.Second)
+	sc0.SetPropTimeout(defaultTimeout)
 
 	// Create the master skipchain
 	ro := onet.NewRoster(roster.List)
@@ -435,7 +442,7 @@ func TestShuffleCatastrophicNodeFailure(t *testing.T) {
 	s0 := local.GetServices(nodes, serviceID)[0].(*Service)
 	sc0 := local.GetServices(nodes, onet.ServiceFactory.ServiceID(skipchain.ServiceName))[0].(*skipchain.Service)
 	// Set a lower timeout for the tests
-	sc0.SetPropTimeout(5 * time.Second)
+	sc0.SetPropTimeout(defaultTimeout)
 
 	// Create the master skipchain
 	ro := onet.NewRoster(roster.List)
@@ -521,7 +528,7 @@ func TestDecryptBenignNodeFailure(t *testing.T) {
 	s0 := local.GetServices(nodes, serviceID)[0].(*Service)
 	sc0 := local.GetServices(nodes, onet.ServiceFactory.ServiceID(skipchain.ServiceName))[0].(*skipchain.Service)
 	// Set a lower timeout for the tests
-	sc0.SetPropTimeout(5 * time.Second)
+	sc0.SetPropTimeout(defaultTimeout)
 
 	// Create the master skipchain
 	ro := onet.NewRoster(roster.List)
@@ -570,7 +577,7 @@ func TestDecryptCatastrophicNodeFailure(t *testing.T) {
 	s0 := local.GetServices(nodes, serviceID)[0].(*Service)
 	sc0 := local.GetServices(nodes, onet.ServiceFactory.ServiceID(skipchain.ServiceName))[0].(*skipchain.Service)
 	// Set a lower timeout for the tests
-	sc0.SetPropTimeout(5 * time.Second)
+	sc0.SetPropTimeout(defaultTimeout)
 
 	// Create the master skipchain
 	ro := onet.NewRoster(roster.List)

--- a/ftcosi/protocol/gen_tree_test.go
+++ b/ftcosi/protocol/gen_tree_test.go
@@ -10,13 +10,8 @@ import (
 	"testing"
 
 	"github.com/dedis/onet"
-	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
 )
-
-func TestMain(m *testing.M) {
-	log.MainTest(m)
-}
 
 // tests the root of the trees
 func TestGenTreesRoot(t *testing.T) {

--- a/ftcosi/protocol/protocol.go
+++ b/ftcosi/protocol/protocol.go
@@ -350,8 +350,8 @@ func (p *FtCosi) startSubProtocol(tree *onet.Tree) (*SubFtCosi, error) {
 	cosiSubProtocol.Msg = p.Msg
 	cosiSubProtocol.Data = p.Data
 	// We allow for one subleader failure during the commit phase, and thus
-	// only allocate half of the ftcosi budget to the subprotocol.
-	cosiSubProtocol.Timeout = p.Timeout / 2
+	// only allocate one third of the ftcosi budget to the subprotocol.
+	cosiSubProtocol.Timeout = p.Timeout / 3
 
 	err = cosiSubProtocol.Start()
 	if err != nil {

--- a/ftcosi/protocol/protocol_test.go
+++ b/ftcosi/protocol/protocol_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"flag"
 	"fmt"
 	"sync"
 	"testing"
@@ -40,7 +41,15 @@ func init() {
 }
 
 var testSuite = cothority.Suite
-var defaultTimeout = time.Second * 5
+var defaultTimeout = 5 * time.Second
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if testing.Short() {
+		defaultTimeout = 20 * time.Second
+	}
+	log.MainTest(m)
+}
 
 // Tests various trees configurations
 func TestProtocol(t *testing.T) {

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -1050,7 +1050,7 @@ func (s *Service) startBFT(proto string, roster *onet.Roster, msg, data []byte) 
 	root.Data = data
 	root.CreateProtocol = s.CreateProtocol
 	root.FinalSignatureChan = make(chan byzcoinx.FinalSignature, 1)
-	root.Timeout = s.propTimeout / 2
+	root.Timeout = s.propTimeout
 	if s.bftTimeout != 0 {
 		root.Timeout = s.bftTimeout
 	}

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -426,7 +426,8 @@ func (s *Service) syncChain(roster *onet.Roster, latest SkipBlockID) error {
 // in the roster, in order to find an answer, even in the case that a few
 // nodes in the network are down.
 func (s *Service) getBlocks(roster *onet.Roster, id SkipBlockID, n int) ([]*SkipBlock, error) {
-	subCount := (len(roster.List)-1)/3 + 1
+	// Only take half of the nodes to not spam the whole network.
+	subCount := len(roster.List) / 2
 	r := roster.RandomSubset(s.ServerIdentity(), subCount)
 	tr := r.GenerateStar()
 	pi, err := s.CreateProtocol(ProtocolGetBlocks, tr)


### PR DESCRIPTION
OK - the previous PR got too intrusive and never worked. Time to start fresh...

This puts the timeouts into a much nicer way, supposing that we're mostly network bound, the timeouts are spread out evenly between the leader, the subleaders and the nodes.

Also includes putting `SendToChildren` in go-routines, so that we don't wait for children accepting the connection but not replying.

Finally some logging changes for nicer and more useful outputs.

Depends on dedis/onet#417