### PR TITLE
Changing storage-structure

### DIFF
--- a/identity/api_test.go
+++ b/identity/api_test.go
@@ -34,18 +34,18 @@ func TestIdentity_PinRequest(t *testing.T) {
 	defer local.CloseAll()
 	servers := local.GenServers(1)
 	srvc := local.GetServices(servers, identityService)[0].(*Service)
-	require.Equal(t, 0, len(srvc.Storage.Auth.pins))
+	require.Equal(t, 0, len(srvc.Storage.Auth.Pins))
 	pub := tSuite.Point().Pick(tSuite.XOF([]byte("test")))
 	_, err := srvc.PinRequest(&PinRequest{"", pub})
 	require.NotNil(t, err)
-	require.NotEqual(t, 0, len(srvc.Storage.Auth.pins))
+	require.NotEqual(t, 0, len(srvc.Storage.Auth.Pins))
 	pin := ""
-	for t := range srvc.Storage.Auth.pins {
+	for t := range srvc.Storage.Auth.Pins {
 		pin = t
 	}
 	_, err = srvc.PinRequest(&PinRequest{pin, pub})
 	log.Error(err)
-	require.Equal(t, pub, srvc.Storage.Auth.adminKeys[0])
+	require.Equal(t, pub, srvc.Storage.Auth.AdminKeys[0])
 }
 
 func suiteSkip(t *testing.T) {
@@ -106,13 +106,13 @@ func TestIdentity_StoreKeys(t *testing.T) {
 	// here we assume the mask is 1 byte long, hence the line below turns
 	// a cosi signature into an eddsa signature
 	final.Signature = final.Signature[0 : len(final.Signature)-1]
-	srvc.Storage.Auth.adminKeys = append(srvc.Storage.Auth.adminKeys, keypairAdmin.Public)
+	srvc.Storage.Auth.AdminKeys = append(srvc.Storage.Auth.AdminKeys, keypairAdmin.Public)
 
 	sig, err := schnorr.Sign(tSuite, keypairAdmin.Private, hash)
 	require.Nil(t, err)
 	_, err = srvc.StoreKeys(&StoreKeys{PoPAuth, final, nil, sig})
 	require.Nil(t, err)
-	require.Equal(t, 1, len(srvc.Storage.Auth.sets))
+	require.Equal(t, 1, len(srvc.Storage.Auth.Sets))
 }
 
 func TestIdentity_StoreKeys2(t *testing.T) {
@@ -135,12 +135,12 @@ func TestIdentity_StoreKeys2(t *testing.T) {
 	}
 	hash := h.Sum(nil)
 
-	srvc.Storage.Auth.adminKeys = append(srvc.Storage.Auth.adminKeys, keypairAdmin.Public)
+	srvc.Storage.Auth.AdminKeys = append(srvc.Storage.Auth.AdminKeys, keypairAdmin.Public)
 	sig, err := schnorr.Sign(tSuite, keypairAdmin.Private, hash)
 	log.ErrFatal(err)
 	_, err = srvc.StoreKeys(&StoreKeys{PublicAuth, nil, pubs, sig})
 	require.Nil(t, err)
-	require.Equal(t, N, len(srvc.Storage.Auth.keys))
+	require.Equal(t, N, len(srvc.Storage.Auth.Keys))
 }
 
 func TestIdentity_DataNewCheck(t *testing.T) {
@@ -219,7 +219,7 @@ func TestIdentity_Authenticate(t *testing.T) {
 	defer l.CloseAll()
 	au := &Authenticate{[]byte{}, []byte{}}
 	s.Authenticate(au)
-	require.Equal(t, 1, len(s.Storage.Auth.nonces))
+	require.Equal(t, 1, len(s.Storage.Auth.Nonces))
 }
 
 func TestIdentity_CreateIdentity(t *testing.T) {
@@ -323,7 +323,7 @@ func TestCrashAfterRevocation(t *testing.T) {
 	for _, srvc := range services {
 		s := srvc.(*Service)
 		log.Lvl3(s.Storage.Identities)
-		s.Storage.Auth.sets = append(s.Storage.Auth.sets, set)
+		s.Storage.Auth.Sets = append(s.Storage.Auth.Sets, anonSet{Set: set})
 	}
 
 	c1 := NewIdentity(roster, 2, "one", kp1)
@@ -437,7 +437,7 @@ func createIdentity(l *onet.LocalTest, services []onet.Service, roster *onet.Ros
 	set := anon.Set([]kyber.Point{kp1.Public, kp2.Public})
 	for _, srvc := range services {
 		s := srvc.(*Service)
-		s.Storage.Auth.sets = append(s.Storage.Auth.sets, set)
+		s.Storage.Auth.Sets = append(s.Storage.Auth.Sets, anonSet{Set: set})
 	}
 
 	c := NewTestIdentity(roster, 50, name, l, kp1)

--- a/identity/service_test.go
+++ b/identity/service_test.go
@@ -26,7 +26,7 @@ func TestService_CreateIdentity2(t *testing.T) {
 	kp := key.NewKeyPair(tSuite)
 	kp2 := key.NewKeyPair(tSuite)
 	set := anon.Set([]kyber.Point{kp.Public, kp2.Public})
-	service.Storage.Auth.sets = append(service.Storage.Auth.sets, set)
+	service.Storage.Auth.Sets = append(service.Storage.Auth.Sets, anonSet{Set: set})
 
 	da := NewData(ro, 50, kp.Public, "one")
 	ci := &CreateIdentity{}
@@ -34,7 +34,7 @@ func TestService_CreateIdentity2(t *testing.T) {
 	ci.Data = da
 	ci.Nonce = make([]byte, nonceSize)
 	random.Bytes(ci.Nonce, random.New())
-	service.Storage.Auth.nonces[string(ci.Nonce)] = struct{}{}
+	service.Storage.Auth.Nonces[string(ci.Nonce)] = true
 	ctx := []byte(ServiceName + service.ServerIdentity().String())
 
 	ci.Sig = anon.Sign(tSuite, ci.Nonce,
@@ -55,7 +55,7 @@ func TestService_CreateIdentity3(t *testing.T) {
 	service := s.(*Service)
 
 	kp := key.NewKeyPair(tSuite)
-	service.Storage.Auth.keys = append(service.Storage.Auth.keys, kp.Public)
+	service.Storage.Auth.Keys = append(service.Storage.Auth.Keys, kp.Public)
 
 	da := NewData(ro, 50, kp.Public, "one")
 	ci := &CreateIdentity{}
@@ -63,7 +63,7 @@ func TestService_CreateIdentity3(t *testing.T) {
 	ci.Data = da
 	ci.Nonce = make([]byte, nonceSize)
 	random.Bytes(ci.Nonce, tSuite.RandomStream())
-	service.Storage.Auth.nonces[string(ci.Nonce)] = struct{}{}
+	service.Storage.Auth.Nonces[string(ci.Nonce)] = true
 	var err error
 	ssig, err := schnorr.Sign(tSuite, kp.Private, ci.Nonce)
 	ci.SchnSig = &ssig


### PR DESCRIPTION
The fields of the storage structure were private and as such not stored
on disk.
This commit fixes that by making them public and fixing the use of
[]anon.Set that protobuf couldn't marshal