### PR TITLE
Making e-voting resilient to out of sync chains

### DIFF
--- a/evoting/lib/elgamal.go
+++ b/evoting/lib/elgamal.go
@@ -1,6 +1,8 @@
 package lib
 
 import (
+	"errors"
+
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/proof"
 	"github.com/dedis/kyber/shuffle"
@@ -30,6 +32,9 @@ func Decrypt(private kyber.Scalar, K, C kyber.Point) kyber.Point {
 
 // Verify performs verifies the proof of a Neff shuffle.
 func Verify(tag []byte, public kyber.Point, x, y, v, w []kyber.Point) error {
+	if len(x) < 2 || len(y) < 2 || len(v) < 2 || len(w) < 2 {
+		return errors.New("cannot verify less than 2 points")
+	}
 	verifier := shuffle.Verifier(cothority.Suite, nil, public, x, y, v, w)
 	return proof.HashVerify(cothority.Suite, "", verifier, tag)
 }

--- a/evoting/lib/transaction.go
+++ b/evoting/lib/transaction.go
@@ -199,6 +199,7 @@ func (t *Transaction) Verify(genesis skipchain.SkipBlockID, s *skipchain.Service
 		if err != nil {
 			return err
 		}
+
 		err = schnorr.Verify(cothority.Suite, election.MasterKey, digest, t.Signature)
 		if err != nil {
 			return err

--- a/evoting/protocol/shuffle.go
+++ b/evoting/protocol/shuffle.go
@@ -127,6 +127,9 @@ func (s *Shuffle) HandlePrompt(prompt MessagePrompt) error {
 		return nil
 	}
 
+	if len(ballots) < 2 {
+		return errors.New("cannot shuffle less than 2 ballots")
+	}
 	a, b := lib.Split(ballots)
 	g, d, prov := shuffle.Shuffle(cothority.Suite, nil, s.Election.Key, a, b, random.New())
 	proof, err := proof.HashProve(cothority.Suite, "", prov)

--- a/evoting/service/service_test.go
+++ b/evoting/service/service_test.go
@@ -649,3 +649,77 @@ func TestDecryptCatastrophicNodeFailure(t *testing.T) {
 	})
 	require.Nil(t, err)
 }
+
+func TestCastNodeFailureShuffleAllOk(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping", t.Name(), " in short mode")
+	}
+	local := onet.NewLocalTest(cothority.Suite)
+	defer local.CloseAll()
+
+	nodeKP := key.NewKeyPair(cothority.Suite)
+	nodes, roster, _ := local.GenBigTree(7, 7, 1, true)
+	s0 := local.GetServices(nodes, serviceID)[0].(*Service)
+	sc0 := local.GetServices(nodes, onet.ServiceFactory.ServiceID(skipchain.ServiceName))[0].(*skipchain.Service)
+	// Set a lower timeout for the tests
+	sc0.SetPropTimeout(5 * time.Second)
+
+	// Create the master skipchain
+	ro := onet.NewRoster(roster.List)
+	rl, err := s0.Link(&evoting.Link{
+		Pin:    s0.pin,
+		Roster: ro,
+		Key:    nodeKP.Public,
+		Admins: []uint32{idAdmin},
+	})
+	require.Nil(t, err)
+	log.Lvl2("Wrote the roster")
+
+	adminSig := generateSignature(nodeKP.Private, rl.ID, idAdmin)
+
+	replyOpen, err := s0.Open(&evoting.Open{
+		ID: rl.ID,
+		Election: &lib.Election{
+			Creator: idAdmin,
+			Users:   []uint32{idUser1, idUser2, idUser3, idAdmin},
+			End:     time.Now().Unix() + 86400,
+		},
+		User:      idAdmin,
+		Signature: adminSig,
+	})
+	require.Nil(t, err)
+
+	// Prepare a helper for testing voting.
+	vote := func(user uint32, bufCand []byte) *evoting.CastReply {
+		k, c := lib.Encrypt(replyOpen.Key, bufCand)
+		ballot := &lib.Ballot{
+			User:  user,
+			Alpha: k,
+			Beta:  c,
+		}
+		cast, err := s0.Cast(&evoting.Cast{
+			ID:        replyOpen.ID,
+			Ballot:    ballot,
+			User:      user,
+			Signature: generateSignature(nodeKP.Private, rl.ID, user),
+		})
+		require.Nil(t, err)
+		return cast
+	}
+
+	vote(idUser1, bufCand1)
+	nodes[5].Pause()
+	vote(idUser2, bufCand1)
+	nodes[5].Unpause()
+
+	electionID := replyOpen.ID
+
+	// Shuffle all votes
+	adminSig = generateSignature(nodeKP.Private, rl.ID, idAdmin)
+	_, err = s0.Shuffle(&evoting.Shuffle{
+		ID:        electionID,
+		User:      idAdmin,
+		Signature: adminSig,
+	})
+	require.Nil(t, err)
+}


### PR DESCRIPTION
The underlying problem comes from issue #1244. The consequence of
that issue is that when a node that was down during some part of the
election fetches all ballots in order to try to verify the first shuffle
proposed by the leader, we end up with fewer ballots than the leader saw.
Having fewer ballots is no big deal, it just means we will refuse to sign
the forward link. Other conodes, which have the full chain, will sign it,
achieving a quorum.

If the election had only 2 ballots, we might trigger panics in the
shuffle library, and this change prevents that from happening.