### PR TITLE
Add support for Safari 10 on CothorityJS

### DIFF
--- a/external/js/cothority/webpack.config.js
+++ b/external/js/cothority/webpack.config.js
@@ -26,7 +26,15 @@ const nodeConfig = {
     ]
   },
   externals: [nodeExternals()],
-  plugins: [new UglifyJsPlugin()]
+  plugins: [
+    new UglifyJsPlugin({
+      uglifyOptions: {
+        mangle: {
+          safari10: true
+        }
+      }
+    })
+  ]
 };
 
 const browserConfig = {
@@ -60,7 +68,15 @@ const browserConfig = {
     ]
   },
   externals: ["bufferutil", "utf-8-validate"],
-  plugins: [new UglifyJsPlugin()]
+  plugins: [
+    new UglifyJsPlugin({
+      uglifyOptions: {
+        mangle: {
+          safari10: true
+        }
+      }
+    })
+  ]
 };
 
 module.exports = [nodeConfig, browserConfig];


### PR DESCRIPTION
Cothorithy JS suffers from a bug on Safari 10 where the variable scoping is not correctly handled, thus preventing the module from being loaded (see here for more informations : https://github.com/mishoo/UglifyJS2/issues/1753). These flags allow Uglify JS to handle Safari 10 by correctly mangling the file according to this bug.