### PR TITLE
Cothority-js should not bury error strings

### DIFF
--- a/external/js/cothority/lib/net/net.js
+++ b/external/js/cothority/lib/net/net.js
@@ -177,6 +177,7 @@ class LeaderSocket {
     // maximum 3 times and returns on the first successful attempt
     const that = this;
     const fn = co.wrap(function*() {
+      var lastErr
       for (let i = 0; i < 3; i++) {
         try {
           const socket = new Socket(
@@ -187,10 +188,11 @@ class LeaderSocket {
           return Promise.resolve(reply);
         } catch (e) {
           console.error("error sending request: ", e.message);
+	  lastErr = e
         }
       }
       return Promise.reject(
-        new Error("couldn't send request after 3 attempts")
+        new Error("couldn't send request after 3 attempts: "+lastErr.message)
       );
     });
     return fn();

--- a/external/js/cothority/package-lock.json
+++ b/external/js/cothority/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedis/cothority",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedis/cothority",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "module for interacting with cothority nodes",
   "main": "dist/bundle.node.min.js",
   "browser": "dist/bundle.min.js",

--- a/external/js/cothority/test/net/net.js
+++ b/external/js/cothority/test/net/net.js
@@ -184,7 +184,7 @@ describe("leader socket", () => {
     // create the socket and see if we have any messages back
     const socket = new network.LeaderSocket(roster, "test");
     socket.send("Request", "ServerIdentity", {}).catch(e => {
-      expect(e.message).to.equal("couldn't send request after 3 attempts");
+      expect(e.message).to.include("couldn't send request after 3 attempts");
       done();
     });
   });


### PR DESCRIPTION
When the retry 3 times code was added, it had the side effect of
hiding the true reason for the error. Expose the last known
error message again.