### PR TITLE
changing 'docker run -P' to 'docker run -p 6879-6880:6879-6880'

### DIFF
--- a/conode/Makefile
+++ b/conode/Makefile
@@ -44,7 +44,7 @@ docker_push_latest: docker_push
 
 docker_setup:
 	mkdir -p $(DATA_DIR)
-	docker run -it --rm -P --name $(CONTAINER) -v $(DATA_DIR):/conode_data \
+	docker run -it --rm -p 6879-6880:6879-6880 --name $(CONTAINER) -v $(DATA_DIR):/conode_data \
 	    $(IMAGE_NAME) ./conode setup
 
 docker_run:


### PR DESCRIPTION
using `-P` in `docker run` will create a link to a random port on the host, but we need to link to exactly those ports.