### PR TITLE
Making skipchain more robust

### DIFF
--- a/skipchain/msgs.go
+++ b/skipchain/msgs.go
@@ -122,6 +122,9 @@ type ForwardSignature struct {
 	Previous SkipBlockID
 	// Newest is the newest skipblock, signed by previous
 	Newest *SkipBlock
+	// Links holds the forwardlinks to prove that 'Newest' is valid. For
+	// the level-0 forwardlink, this is empty.
+	Links []*ForwardLink
 }
 
 // GetSingleBlock asks for a single block.


### PR DESCRIPTION
The current implementation of skipchains made assumptions that are not always true when evolving the roster and when some nodes are down. Also rogue nodes could request to insert invalid skipblocks. This PR fixes some of these shortcomings:
- before new skipblocks are stored in the database, an existing block needs to have a valid forwardlink to this new block
- when asking non-0 level forwardlinks, a proof starting at the genesis block is given to prove that the new block is valid
- for any forwardlink, all necessary blocks are transmitted, so that out-of-date nodes or nodes that were offline can correctly verify the new block is valid

**Message incompatibility**

This PR changes the `ForwardSignature` structure that is used when requesting new forwardlinks. Unfortunately this is a non-compatible change. The alternative would be to start by propagating all necessary blocks to all nodes, and only then request the forward-signature. But this would increase the storage needed for nodes that are not in the roster anymore.

Closes #1252 