### PR TITLE
GetAllSkipchains fixes

### DIFF
--- a/scmgr/app.go
+++ b/scmgr/app.go
@@ -452,7 +452,7 @@ func dnsList(c *cli.Context) error {
 		short := !c.Bool("long")
 		log.Info(g.Sprint(short))
 		sub := sbli{}
-		sbs, err := cfg.Db.GetSkipchains()
+		sbs, err := cfg.Db.GetAll()
 		if err != nil {
 			return err
 		}
@@ -541,7 +541,7 @@ func dnsUpdate(c *cli.Context) error {
 	var sisNew []*network.ServerIdentity
 
 	// Get ServerIdentities from all skipblocks
-	sbs, err := cfg.Db.GetSkipchains()
+	sbs, err := cfg.Db.GetAll()
 	if err != nil {
 		return err
 	}
@@ -756,15 +756,13 @@ func (cfg *config) save(c *cli.Context) error {
 
 func (cfg *config) getSortedGenesis() []*skipchain.SkipBlock {
 	genesis := sbl{}
-	sbs, err := cfg.Db.GetSkipchains()
+	sbs, err := cfg.Db.GetAllSkipchains()
 	if err != nil {
 		log.Error(err)
 		return nil
 	}
 	for _, sb := range sbs {
-		if sb.Index == 0 {
-			genesis = append(genesis, sb)
-		}
+		genesis = append(genesis, sb)
 	}
 	sort.Sort(genesis)
 	return genesis

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -703,11 +703,11 @@ func TestService_AddFollow(t *testing.T) {
 	sig, err = schnorr.Sign(cothority.Suite, priv1, ssb.NewBlock.CalculateHash())
 	log.ErrFatal(err)
 	ssb.Signature = &sig
-	sbs, err := service.db.getAll()
-	log.ErrFatal(err)
-	for _, sb := range sbs {
-		services[1].db.Store(sb)
-	}
+	// sbs, err := service.db.getAll()
+	// log.ErrFatal(err)
+	// for _, sb := range sbs {
+	// 	services[1].db.Store(sb)
+	// }
 	master2, err := services[1].StoreSkipBlock(ssb)
 	log.ErrFatal(err)
 	require.True(t, services[1].db.GetByID(master1.Latest.Hash).ForwardLink[0].To.Equal(master2.Latest.Hash))

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -895,10 +895,7 @@ func (db *SkipBlockDB) getFromTx(tx *bolt.Tx, sbID SkipBlockID) (*SkipBlock, err
 	return sbMsg.(*SkipBlock).Copy(), nil
 }
 
-// getAll returns all the data in the database as a map
-// This function performs a single transaction,
-// the caller should not perform operations that may requires a view of the
-// database that is consistent at the time of the function call.
+// getAll returns all the data in the database as a map of (block id -> block)
 func (db *SkipBlockDB) getAll() (map[string]*SkipBlock, error) {
 	data := map[string]*SkipBlock{}
 	err := db.View(func(tx *bolt.Tx) error {


### PR DESCRIPTION
GetAllSkipchains now correctly returns only the latest block of each skipchain instead of all blocks.

It is also available to apps like scmgr that need to run it on a local database.