### PR TITLE
Contracts should not be able to write into the collection

### DIFF
--- a/eventlog/buckets.go
+++ b/eventlog/buckets.go
@@ -3,7 +3,6 @@ package eventlog
 import (
 	"errors"
 
-	"github.com/dedis/cothority/omniledger/collection"
 	omniledger "github.com/dedis/cothority/omniledger/service"
 	"github.com/dedis/protobuf"
 )
@@ -57,7 +56,7 @@ func (b *bucket) newLink(oldID, newID, eventID []byte) (omniledger.StateChanges,
 	}, &newBucket, nil
 }
 
-func getLatestBucket(coll collection.Collection) ([]byte, *bucket, error) {
+func getLatestBucket(coll omniledger.CollectionView) ([]byte, *bucket, error) {
 	bucketID, err := getIndexValue(coll)
 	if err != nil {
 		return nil, nil, err
@@ -72,7 +71,7 @@ func getLatestBucket(coll collection.Collection) ([]byte, *bucket, error) {
 	return bucketID, b, nil
 }
 
-func getBucketByID(coll collection.Collection, objID []byte) (*bucket, error) {
+func getBucketByID(coll omniledger.CollectionView, objID []byte) (*bucket, error) {
 	r, err := coll.Get(objID).Record()
 	if err != nil {
 		return nil, err
@@ -92,7 +91,7 @@ func getBucketByID(coll collection.Collection, objID []byte) (*bucket, error) {
 	return &b, nil
 }
 
-func getIndexValue(coll collection.Collection) ([]byte, error) {
+func getIndexValue(coll omniledger.CollectionView) ([]byte, error) {
 	r, err := coll.Get(indexKey.Slice()).Record()
 	if err != nil {
 		return nil, err

--- a/eventlog/service.go
+++ b/eventlog/service.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/dedis/cothority/omniledger/collection"
 	omniledger "github.com/dedis/cothority/omniledger/service"
 	"github.com/dedis/cothority/skipchain"
 	"github.com/dedis/onet"
@@ -122,7 +121,7 @@ func (s *Service) GetEvent(req *GetEventRequest) (*GetEventResponse, error) {
 
 const contractName = "eventlog"
 
-func (s *Service) decodeAndCheckEvent(coll collection.Collection, eventBuf []byte) (*Event, error) {
+func (s *Service) decodeAndCheckEvent(coll omniledger.CollectionView, eventBuf []byte) (*Event, error) {
 	// Check the timestamp of the event: it should never be in the future,
 	// and it should not be more than 10 blocks in the past. (Why 10?
 	// Because it works.  But it would be nice to have a better way to hold
@@ -152,7 +151,7 @@ func (s *Service) decodeAndCheckEvent(coll collection.Collection, eventBuf []byt
 
 // contractFunction is the function that runs to process a transaction of
 // type "eventlog"
-func (s *Service) contractFunction(coll collection.Collection, tx omniledger.Instruction, c []omniledger.Coin) ([]omniledger.StateChange, []omniledger.Coin, error) {
+func (s *Service) contractFunction(coll omniledger.CollectionView, tx omniledger.Instruction, c []omniledger.Coin) ([]omniledger.StateChange, []omniledger.Coin, error) {
 	if tx.Delete != nil {
 		return nil, nil, errors.New("delete tx not allowed")
 	}

--- a/omniledger/service/contracts.go
+++ b/omniledger/service/contracts.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/dedis/cothority/omniledger/collection"
 	"github.com/dedis/cothority/omniledger/darc"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/protobuf"
@@ -47,7 +46,7 @@ type Config struct {
 }
 
 // LoadConfigFromColl loads the configuration data from the collections.
-func LoadConfigFromColl(coll collection.Collection) (*Config, error) {
+func LoadConfigFromColl(coll CollectionView) (*Config, error) {
 	// Find the genesis-darc ID.
 	val, contract, err := getValueContract(coll, GenesisReferenceID.Slice())
 	if err != nil {
@@ -80,7 +79,7 @@ func LoadConfigFromColl(coll collection.Collection) (*Config, error) {
 }
 
 // LoadBlockIntervalFromColl loads the block interval from the collections.
-func LoadBlockIntervalFromColl(coll collection.Collection) (time.Duration, error) {
+func LoadBlockIntervalFromColl(coll CollectionView) (time.Duration, error) {
 	config, err := LoadConfigFromColl(coll)
 	if err != nil {
 		return defaultInterval, err
@@ -90,7 +89,7 @@ func LoadBlockIntervalFromColl(coll collection.Collection) (time.Duration, error
 
 // ContractConfig can only be instantiated once per skipchain, and only for
 // the genesis block.
-func (s *Service) ContractConfig(cdb collection.Collection, tx Instruction, coins []Coin) (sc []StateChange, c []Coin, err error) {
+func (s *Service) ContractConfig(cdb CollectionView, tx Instruction, coins []Coin) (sc []StateChange, c []Coin, err error) {
 	if tx.Spawn == nil {
 		return nil, nil, errors.New("Config can only be spawned")
 	}
@@ -139,6 +138,6 @@ func (s *Service) ContractConfig(cdb collection.Collection, tx Instruction, coin
 // ContractDarc accepts the following instructions:
 //   - Spawn - creates a new darc
 //   - Invoke.Evolve - evolves an existing darc
-func (s *Service) ContractDarc(cdb collection.Collection, tx Instruction, coins []Coin) (sc []StateChange, c []Coin, err error) {
+func (s *Service) ContractDarc(cdb CollectionView, tx Instruction, coins []Coin) (sc []StateChange, c []Coin, err error) {
 	return nil, nil, errors.New("Not yet implemented")
 }

--- a/omniledger/service/service_test.go
+++ b/omniledger/service/service_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dedis/cothority/omniledger/collection"
 	"github.com/dedis/cothority/omniledger/darc"
 	"github.com/dedis/cothority/skipchain"
 	"github.com/dedis/kyber/suites"
@@ -277,7 +276,7 @@ func TestService_StateChange(t *testing.T) {
 	defer closeQueues(s.local)
 
 	var latest int64
-	f := func(cdb collection.Collection, tx Instruction, c []Coin) ([]StateChange, []Coin, error) {
+	f := func(cdb CollectionView, tx Instruction, c []Coin) ([]StateChange, []Coin, error) {
 		cid, _, err := tx.GetContractState(cdb)
 		if err != nil {
 			return nil, nil, err
@@ -442,15 +441,15 @@ func closeQueues(local *onet.LocalTest) {
 	}
 }
 
-func invalidContractFunc(cdb collection.Collection, tx Instruction, c []Coin) ([]StateChange, []Coin, error) {
+func invalidContractFunc(cdb CollectionView, tx Instruction, c []Coin) ([]StateChange, []Coin, error) {
 	return nil, nil, errors.New("this invalid contract always returns an error")
 }
 
-func panicContractFunc(cdb collection.Collection, tx Instruction, c []Coin) ([]StateChange, []Coin, error) {
+func panicContractFunc(cdb CollectionView, tx Instruction, c []Coin) ([]StateChange, []Coin, error) {
 	panic("this contract panics")
 }
 
-func dummyContractFunc(cdb collection.Collection, tx Instruction, c []Coin) ([]StateChange, []Coin, error) {
+func dummyContractFunc(cdb CollectionView, tx Instruction, c []Coin) ([]StateChange, []Coin, error) {
 	args := tx.Spawn.Args[0].Value
 	cid, _, err := tx.GetContractState(cdb)
 	if err != nil {

--- a/omniledger/service/transaction.go
+++ b/omniledger/service/transaction.go
@@ -150,7 +150,7 @@ func (instr Instruction) Hash() []byte {
 
 // GetContractState searches for the contract kind of this instruction and the
 // attached state to it. It needs the collection to do so.
-func (instr Instruction) GetContractState(coll collection.Collection) (contractID string, state []byte, err error) {
+func (instr Instruction) GetContractState(coll CollectionView) (contractID string, state []byte, err error) {
 	// Getting the kind is different for instructions that create a key
 	// and for instructions that send a call to an existing key.
 	if instr.Spawn != nil {


### PR DESCRIPTION
Give the contract a form of the collection that only has
Get operations, not Store operations, so that packages which
implment contracts cannot write into the collection except
by returning StateChanges.