### PR TITLE
Make evolve and sign action names configurable

### DIFF
--- a/eventlog/service_test.go
+++ b/eventlog/service_test.go
@@ -59,8 +59,8 @@ func TestService_Log(t *testing.T) {
 
 func (s *ser) init(t *testing.T) (skipchain.SkipBlockID, darc.Darc, []*darc.Signer) {
 	owner := darc.NewSignerEd25519(nil, nil)
-	rules := darc.InitRules([]*darc.Identity{owner.Identity()}, []*darc.Identity{})
-	d1 := darc.NewDarc(AddWriter(rules, nil), []byte("eventlog writer"))
+	d1 := darc.NewDarc([]*darc.Identity{owner.Identity()}, []*darc.Identity{}, "_evolve", "_sign", []byte("eventlog writer"))
+	require.Nil(t, d1.AddRule("Spawn_eventlog", d1.GetEvolutionExpr()))
 
 	reply, err := s.services[0].Init(&InitRequest{
 		Roster:        *s.roster,

--- a/external/java/src/main/java/ch/epfl/dedis/lib/eventlog/EventLog.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/eventlog/EventLog.java
@@ -37,10 +37,9 @@ public class EventLog {
         for (Signer signer : signers) {
             identities.add(signer.getIdentity());
         }
-        Map<String, byte[]> rules = Darc.initRules(identities, new ArrayList<>());
-        rules.put("Spawn_eventlog", rules.get("_evolve"));
 
-        Darc darc = new Darc(rules, "eventlog owner".getBytes());
+        Darc darc = new Darc(identities, new ArrayList<>(), "_evolve", "_sign", "eventlog genesis darc".getBytes());
+        darc.setExpr("Spawn_eventlog", darc.getEvolveExpr());
         byte[] genesisBuf  = this.init(roster, darc, blockInterval);
 
         this.genesis = new SkipblockId(genesisBuf);

--- a/external/java/src/main/java/ch/epfl/dedis/proto/DarcProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/proto/DarcProto.java
@@ -37,8 +37,8 @@ public final class DarcProto {
 
     /**
      * <pre>
-     * Description is a free-form field that can hold any data as required by the user.
-     * Darc itself will never depend on any of the data in here.
+     * Description is a free-form field that can hold any data as required by the
+     * user.  Darc itself will never depend on any of the data in here.
      * </pre>
      *
      * <code>required bytes description = 2;</code>
@@ -46,8 +46,8 @@ public final class DarcProto {
     boolean hasDescription();
     /**
      * <pre>
-     * Description is a free-form field that can hold any data as required by the user.
-     * Darc itself will never depend on any of the data in here.
+     * Description is a free-form field that can hold any data as required by the
+     * user.  Darc itself will never depend on any of the data in here.
      * </pre>
      *
      * <code>required bytes description = 2;</code>
@@ -90,26 +90,84 @@ public final class DarcProto {
 
     /**
      * <pre>
-     * Rules map an action to an expression.
-     * An action is a string that should be associated with an expression. The
-     * application typically will define the action but there are two actions that
-     * are in all the darcs, "_evolve" and "_sign". The application can modify
-     * these actions but should not change the semantics of these actions.
+     * EvolveName is the name for the evolution action, which must exist and is
+     * responsible for managing the rules for evolving a darc.  This field should
+     * not be changed after initialisation.
      * </pre>
      *
-     * <code>map&lt;string, bytes&gt; rules = 5;</code>
+     * <code>required string evolvename = 5;</code>
+     */
+    boolean hasEvolvename();
+    /**
+     * <pre>
+     * EvolveName is the name for the evolution action, which must exist and is
+     * responsible for managing the rules for evolving a darc.  This field should
+     * not be changed after initialisation.
+     * </pre>
+     *
+     * <code>required string evolvename = 5;</code>
+     */
+    java.lang.String getEvolvename();
+    /**
+     * <pre>
+     * EvolveName is the name for the evolution action, which must exist and is
+     * responsible for managing the rules for evolving a darc.  This field should
+     * not be changed after initialisation.
+     * </pre>
+     *
+     * <code>required string evolvename = 5;</code>
+     */
+    com.google.protobuf.ByteString
+        getEvolvenameBytes();
+
+    /**
+     * <pre>
+     * SignName is the name of the sign action, which must exist and is
+     * responsible for giving other identities to sign on behalf of this darc.
+     * This field should not be changed after initialisation.
+     * </pre>
+     *
+     * <code>required string signname = 6;</code>
+     */
+    boolean hasSignname();
+    /**
+     * <pre>
+     * SignName is the name of the sign action, which must exist and is
+     * responsible for giving other identities to sign on behalf of this darc.
+     * This field should not be changed after initialisation.
+     * </pre>
+     *
+     * <code>required string signname = 6;</code>
+     */
+    java.lang.String getSignname();
+    /**
+     * <pre>
+     * SignName is the name of the sign action, which must exist and is
+     * responsible for giving other identities to sign on behalf of this darc.
+     * This field should not be changed after initialisation.
+     * </pre>
+     *
+     * <code>required string signname = 6;</code>
+     */
+    com.google.protobuf.ByteString
+        getSignnameBytes();
+
+    /**
+     * <pre>
+     * Rules map an action to an expression. The evolve action and the sign
+     * action must exist, but they may be empty.
+     * </pre>
+     *
+     * <code>map&lt;string, bytes&gt; rules = 7;</code>
      */
     int getRulesCount();
     /**
      * <pre>
-     * Rules map an action to an expression.
-     * An action is a string that should be associated with an expression. The
-     * application typically will define the action but there are two actions that
-     * are in all the darcs, "_evolve" and "_sign". The application can modify
-     * these actions but should not change the semantics of these actions.
+     * Rules map an action to an expression. The evolve action and the sign
+     * action must exist, but they may be empty.
      * </pre>
      *
-     * <code>map&lt;string, bytes&gt; rules = 5;</code>
+     * <code>map&lt;string, bytes&gt; rules = 7;</code>
      */
     boolean containsRules(
         java.lang.String key);
@@ -121,27 +179,21 @@ public final class DarcProto {
     getRules();
     /**
      * <pre>
-     * Rules map an action to an expression.
-     * An action is a string that should be associated with an expression. The
-     * application typically will define the action but there are two actions that
-     * are in all the darcs, "_evolve" and "_sign". The application can modify
-     * these actions but should not change the semantics of these actions.
+     * Rules map an action to an expression. The evolve action and the sign
+     * action must exist, but they may be empty.
      * </pre>
      *
-     * <code>map&lt;string, bytes&gt; rules = 5;</code>
+     * <code>map&lt;string, bytes&gt; rules = 7;</code>
      */
     java.util.Map<java.lang.String, com.google.protobuf.ByteString>
     getRulesMap();
     /**
      * <pre>
-     * Rules map an action to an expression.
-     * An action is a string that should be associated with an expression. The
-     * application typically will define the action but there are two actions that
-     * are in all the darcs, "_evolve" and "_sign". The application can modify
-     * these actions but should not change the semantics of these actions.
+     * Rules map an action to an expression. The evolve action and the sign
+     * action must exist, but they may be empty.
      * </pre>
      *
-     * <code>map&lt;string, bytes&gt; rules = 5;</code>
+     * <code>map&lt;string, bytes&gt; rules = 7;</code>
      */
 
     com.google.protobuf.ByteString getRulesOrDefault(
@@ -149,14 +201,11 @@ public final class DarcProto {
         com.google.protobuf.ByteString defaultValue);
     /**
      * <pre>
-     * Rules map an action to an expression.
-     * An action is a string that should be associated with an expression. The
-     * application typically will define the action but there are two actions that
-     * are in all the darcs, "_evolve" and "_sign". The application can modify
-     * these actions but should not change the semantics of these actions.
+     * Rules map an action to an expression. The evolve action and the sign
+     * action must exist, but they may be empty.
      * </pre>
      *
-     * <code>map&lt;string, bytes&gt; rules = 5;</code>
+     * <code>map&lt;string, bytes&gt; rules = 7;</code>
      */
 
     com.google.protobuf.ByteString getRulesOrThrow(
@@ -164,116 +213,117 @@ public final class DarcProto {
 
     /**
      * <pre>
-     * Signature is calculated on the Request-representation of the darc.
-     * It needs to be created by identities that have the "_evolve" action
-     * from the previous valid Darc.
+     * Signature is calculated on the Request-representation of the darc.  It
+     * needs to be created by identities that have the "_evolve" action from the
+     * previous valid Darc.
      * </pre>
      *
-     * <code>repeated .Signature signatures = 6;</code>
+     * <code>repeated .Signature signatures = 8;</code>
      */
     java.util.List<ch.epfl.dedis.proto.DarcProto.Signature> 
         getSignaturesList();
     /**
      * <pre>
-     * Signature is calculated on the Request-representation of the darc.
-     * It needs to be created by identities that have the "_evolve" action
-     * from the previous valid Darc.
+     * Signature is calculated on the Request-representation of the darc.  It
+     * needs to be created by identities that have the "_evolve" action from the
+     * previous valid Darc.
      * </pre>
      *
-     * <code>repeated .Signature signatures = 6;</code>
+     * <code>repeated .Signature signatures = 8;</code>
      */
     ch.epfl.dedis.proto.DarcProto.Signature getSignatures(int index);
     /**
      * <pre>
-     * Signature is calculated on the Request-representation of the darc.
-     * It needs to be created by identities that have the "_evolve" action
-     * from the previous valid Darc.
+     * Signature is calculated on the Request-representation of the darc.  It
+     * needs to be created by identities that have the "_evolve" action from the
+     * previous valid Darc.
      * </pre>
      *
-     * <code>repeated .Signature signatures = 6;</code>
+     * <code>repeated .Signature signatures = 8;</code>
      */
     int getSignaturesCount();
     /**
      * <pre>
-     * Signature is calculated on the Request-representation of the darc.
-     * It needs to be created by identities that have the "_evolve" action
-     * from the previous valid Darc.
+     * Signature is calculated on the Request-representation of the darc.  It
+     * needs to be created by identities that have the "_evolve" action from the
+     * previous valid Darc.
      * </pre>
      *
-     * <code>repeated .Signature signatures = 6;</code>
+     * <code>repeated .Signature signatures = 8;</code>
      */
     java.util.List<? extends ch.epfl.dedis.proto.DarcProto.SignatureOrBuilder> 
         getSignaturesOrBuilderList();
     /**
      * <pre>
-     * Signature is calculated on the Request-representation of the darc.
-     * It needs to be created by identities that have the "_evolve" action
-     * from the previous valid Darc.
+     * Signature is calculated on the Request-representation of the darc.  It
+     * needs to be created by identities that have the "_evolve" action from the
+     * previous valid Darc.
      * </pre>
      *
-     * <code>repeated .Signature signatures = 6;</code>
+     * <code>repeated .Signature signatures = 8;</code>
      */
     ch.epfl.dedis.proto.DarcProto.SignatureOrBuilder getSignaturesOrBuilder(
         int index);
 
     /**
      * <pre>
-     * VerificationDarcs are a list of darcs that the verifier needs to
-     * verify this darc. It is not needed in online verification where the
-     * verifier stores all darcs.
+     * VerificationDarcs are a list of darcs that the verifier needs to verify
+     * this darc. It is not needed in online verification where the verifier
+     * stores all darcs.
      * </pre>
      *
-     * <code>repeated .Darc verificationdarcs = 7;</code>
+     * <code>repeated .Darc verificationdarcs = 9;</code>
      */
     java.util.List<ch.epfl.dedis.proto.DarcProto.Darc> 
         getVerificationdarcsList();
     /**
      * <pre>
-     * VerificationDarcs are a list of darcs that the verifier needs to
-     * verify this darc. It is not needed in online verification where the
-     * verifier stores all darcs.
+     * VerificationDarcs are a list of darcs that the verifier needs to verify
+     * this darc. It is not needed in online verification where the verifier
+     * stores all darcs.
      * </pre>
      *
-     * <code>repeated .Darc verificationdarcs = 7;</code>
+     * <code>repeated .Darc verificationdarcs = 9;</code>
      */
     ch.epfl.dedis.proto.DarcProto.Darc getVerificationdarcs(int index);
     /**
      * <pre>
-     * VerificationDarcs are a list of darcs that the verifier needs to
-     * verify this darc. It is not needed in online verification where the
-     * verifier stores all darcs.
+     * VerificationDarcs are a list of darcs that the verifier needs to verify
+     * this darc. It is not needed in online verification where the verifier
+     * stores all darcs.
      * </pre>
      *
-     * <code>repeated .Darc verificationdarcs = 7;</code>
+     * <code>repeated .Darc verificationdarcs = 9;</code>
      */
     int getVerificationdarcsCount();
     /**
      * <pre>
-     * VerificationDarcs are a list of darcs that the verifier needs to
-     * verify this darc. It is not needed in online verification where the
-     * verifier stores all darcs.
+     * VerificationDarcs are a list of darcs that the verifier needs to verify
+     * this darc. It is not needed in online verification where the verifier
+     * stores all darcs.
      * </pre>
      *
-     * <code>repeated .Darc verificationdarcs = 7;</code>
+     * <code>repeated .Darc verificationdarcs = 9;</code>
      */
     java.util.List<? extends ch.epfl.dedis.proto.DarcProto.DarcOrBuilder> 
         getVerificationdarcsOrBuilderList();
     /**
      * <pre>
-     * VerificationDarcs are a list of darcs that the verifier needs to
-     * verify this darc. It is not needed in online verification where the
-     * verifier stores all darcs.
+     * VerificationDarcs are a list of darcs that the verifier needs to verify
+     * this darc. It is not needed in online verification where the verifier
+     * stores all darcs.
      * </pre>
      *
-     * <code>repeated .Darc verificationdarcs = 7;</code>
+     * <code>repeated .Darc verificationdarcs = 9;</code>
      */
     ch.epfl.dedis.proto.DarcProto.DarcOrBuilder getVerificationdarcsOrBuilder(
         int index);
   }
   /**
    * <pre>
-   * Darc is the basic structure representing an access control. A Darc can evolve in the way that
-   * a new Darc points to the previous one and is signed by the owner(s) of the previous Darc.
+   * Darc is the basic structure representing an access control. A Darc can
+   * evolve in the way that a new Darc points to the previous one and is signed
+   * by the owner(s) of the previous Darc.
    * </pre>
    *
    * Protobuf type {@code Darc}
@@ -292,6 +342,8 @@ public final class DarcProto {
       description_ = com.google.protobuf.ByteString.EMPTY;
       baseid_ = com.google.protobuf.ByteString.EMPTY;
       previd_ = com.google.protobuf.ByteString.EMPTY;
+      evolvename_ = "";
+      signname_ = "";
       signatures_ = java.util.Collections.emptyList();
       verificationdarcs_ = java.util.Collections.emptyList();
     }
@@ -348,10 +400,22 @@ public final class DarcProto {
               break;
             }
             case 42: {
-              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000010;
+              evolvename_ = bs;
+              break;
+            }
+            case 50: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000020;
+              signname_ = bs;
+              break;
+            }
+            case 58: {
+              if (!((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
                 rules_ = com.google.protobuf.MapField.newMapField(
                     RulesDefaultEntryHolder.defaultEntry);
-                mutable_bitField0_ |= 0x00000010;
+                mutable_bitField0_ |= 0x00000040;
               }
               com.google.protobuf.MapEntry<java.lang.String, com.google.protobuf.ByteString>
               rules__ = input.readMessage(
@@ -360,19 +424,19 @@ public final class DarcProto {
                   rules__.getKey(), rules__.getValue());
               break;
             }
-            case 50: {
-              if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+            case 66: {
+              if (!((mutable_bitField0_ & 0x00000080) == 0x00000080)) {
                 signatures_ = new java.util.ArrayList<ch.epfl.dedis.proto.DarcProto.Signature>();
-                mutable_bitField0_ |= 0x00000020;
+                mutable_bitField0_ |= 0x00000080;
               }
               signatures_.add(
                   input.readMessage(ch.epfl.dedis.proto.DarcProto.Signature.PARSER, extensionRegistry));
               break;
             }
-            case 58: {
-              if (!((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
+            case 74: {
+              if (!((mutable_bitField0_ & 0x00000100) == 0x00000100)) {
                 verificationdarcs_ = new java.util.ArrayList<ch.epfl.dedis.proto.DarcProto.Darc>();
-                mutable_bitField0_ |= 0x00000040;
+                mutable_bitField0_ |= 0x00000100;
               }
               verificationdarcs_.add(
                   input.readMessage(ch.epfl.dedis.proto.DarcProto.Darc.PARSER, extensionRegistry));
@@ -386,10 +450,10 @@ public final class DarcProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+        if (((mutable_bitField0_ & 0x00000080) == 0x00000080)) {
           signatures_ = java.util.Collections.unmodifiableList(signatures_);
         }
-        if (((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
+        if (((mutable_bitField0_ & 0x00000100) == 0x00000100)) {
           verificationdarcs_ = java.util.Collections.unmodifiableList(verificationdarcs_);
         }
         this.unknownFields = unknownFields.build();
@@ -405,7 +469,7 @@ public final class DarcProto {
     protected com.google.protobuf.MapField internalGetMapField(
         int number) {
       switch (number) {
-        case 5:
+        case 7:
           return internalGetRules();
         default:
           throw new RuntimeException(
@@ -447,8 +511,8 @@ public final class DarcProto {
     private com.google.protobuf.ByteString description_;
     /**
      * <pre>
-     * Description is a free-form field that can hold any data as required by the user.
-     * Darc itself will never depend on any of the data in here.
+     * Description is a free-form field that can hold any data as required by the
+     * user.  Darc itself will never depend on any of the data in here.
      * </pre>
      *
      * <code>required bytes description = 2;</code>
@@ -458,8 +522,8 @@ public final class DarcProto {
     }
     /**
      * <pre>
-     * Description is a free-form field that can hold any data as required by the user.
-     * Darc itself will never depend on any of the data in here.
+     * Description is a free-form field that can hold any data as required by the
+     * user.  Darc itself will never depend on any of the data in here.
      * </pre>
      *
      * <code>required bytes description = 2;</code>
@@ -514,7 +578,127 @@ public final class DarcProto {
       return previd_;
     }
 
-    public static final int RULES_FIELD_NUMBER = 5;
+    public static final int EVOLVENAME_FIELD_NUMBER = 5;
+    private volatile java.lang.Object evolvename_;
+    /**
+     * <pre>
+     * EvolveName is the name for the evolution action, which must exist and is
+     * responsible for managing the rules for evolving a darc.  This field should
+     * not be changed after initialisation.
+     * </pre>
+     *
+     * <code>required string evolvename = 5;</code>
+     */
+    public boolean hasEvolvename() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <pre>
+     * EvolveName is the name for the evolution action, which must exist and is
+     * responsible for managing the rules for evolving a darc.  This field should
+     * not be changed after initialisation.
+     * </pre>
+     *
+     * <code>required string evolvename = 5;</code>
+     */
+    public java.lang.String getEvolvename() {
+      java.lang.Object ref = evolvename_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          evolvename_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * EvolveName is the name for the evolution action, which must exist and is
+     * responsible for managing the rules for evolving a darc.  This field should
+     * not be changed after initialisation.
+     * </pre>
+     *
+     * <code>required string evolvename = 5;</code>
+     */
+    public com.google.protobuf.ByteString
+        getEvolvenameBytes() {
+      java.lang.Object ref = evolvename_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        evolvename_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int SIGNNAME_FIELD_NUMBER = 6;
+    private volatile java.lang.Object signname_;
+    /**
+     * <pre>
+     * SignName is the name of the sign action, which must exist and is
+     * responsible for giving other identities to sign on behalf of this darc.
+     * This field should not be changed after initialisation.
+     * </pre>
+     *
+     * <code>required string signname = 6;</code>
+     */
+    public boolean hasSignname() {
+      return ((bitField0_ & 0x00000020) == 0x00000020);
+    }
+    /**
+     * <pre>
+     * SignName is the name of the sign action, which must exist and is
+     * responsible for giving other identities to sign on behalf of this darc.
+     * This field should not be changed after initialisation.
+     * </pre>
+     *
+     * <code>required string signname = 6;</code>
+     */
+    public java.lang.String getSignname() {
+      java.lang.Object ref = signname_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          signname_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * SignName is the name of the sign action, which must exist and is
+     * responsible for giving other identities to sign on behalf of this darc.
+     * This field should not be changed after initialisation.
+     * </pre>
+     *
+     * <code>required string signname = 6;</code>
+     */
+    public com.google.protobuf.ByteString
+        getSignnameBytes() {
+      java.lang.Object ref = signname_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        signname_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int RULES_FIELD_NUMBER = 7;
     private static final class RulesDefaultEntryHolder {
       static final com.google.protobuf.MapEntry<
           java.lang.String, com.google.protobuf.ByteString> defaultEntry =
@@ -542,14 +726,11 @@ public final class DarcProto {
     }
     /**
      * <pre>
-     * Rules map an action to an expression.
-     * An action is a string that should be associated with an expression. The
-     * application typically will define the action but there are two actions that
-     * are in all the darcs, "_evolve" and "_sign". The application can modify
-     * these actions but should not change the semantics of these actions.
+     * Rules map an action to an expression. The evolve action and the sign
+     * action must exist, but they may be empty.
      * </pre>
      *
-     * <code>map&lt;string, bytes&gt; rules = 5;</code>
+     * <code>map&lt;string, bytes&gt; rules = 7;</code>
      */
 
     public boolean containsRules(
@@ -566,14 +747,11 @@ public final class DarcProto {
     }
     /**
      * <pre>
-     * Rules map an action to an expression.
-     * An action is a string that should be associated with an expression. The
-     * application typically will define the action but there are two actions that
-     * are in all the darcs, "_evolve" and "_sign". The application can modify
-     * these actions but should not change the semantics of these actions.
+     * Rules map an action to an expression. The evolve action and the sign
+     * action must exist, but they may be empty.
      * </pre>
      *
-     * <code>map&lt;string, bytes&gt; rules = 5;</code>
+     * <code>map&lt;string, bytes&gt; rules = 7;</code>
      */
 
     public java.util.Map<java.lang.String, com.google.protobuf.ByteString> getRulesMap() {
@@ -581,14 +759,11 @@ public final class DarcProto {
     }
     /**
      * <pre>
-     * Rules map an action to an expression.
-     * An action is a string that should be associated with an expression. The
-     * application typically will define the action but there are two actions that
-     * are in all the darcs, "_evolve" and "_sign". The application can modify
-     * these actions but should not change the semantics of these actions.
+     * Rules map an action to an expression. The evolve action and the sign
+     * action must exist, but they may be empty.
      * </pre>
      *
-     * <code>map&lt;string, bytes&gt; rules = 5;</code>
+     * <code>map&lt;string, bytes&gt; rules = 7;</code>
      */
 
     public com.google.protobuf.ByteString getRulesOrDefault(
@@ -601,14 +776,11 @@ public final class DarcProto {
     }
     /**
      * <pre>
-     * Rules map an action to an expression.
-     * An action is a string that should be associated with an expression. The
-     * application typically will define the action but there are two actions that
-     * are in all the darcs, "_evolve" and "_sign". The application can modify
-     * these actions but should not change the semantics of these actions.
+     * Rules map an action to an expression. The evolve action and the sign
+     * action must exist, but they may be empty.
      * </pre>
      *
-     * <code>map&lt;string, bytes&gt; rules = 5;</code>
+     * <code>map&lt;string, bytes&gt; rules = 7;</code>
      */
 
     public com.google.protobuf.ByteString getRulesOrThrow(
@@ -622,28 +794,28 @@ public final class DarcProto {
       return map.get(key);
     }
 
-    public static final int SIGNATURES_FIELD_NUMBER = 6;
+    public static final int SIGNATURES_FIELD_NUMBER = 8;
     private java.util.List<ch.epfl.dedis.proto.DarcProto.Signature> signatures_;
     /**
      * <pre>
-     * Signature is calculated on the Request-representation of the darc.
-     * It needs to be created by identities that have the "_evolve" action
-     * from the previous valid Darc.
+     * Signature is calculated on the Request-representation of the darc.  It
+     * needs to be created by identities that have the "_evolve" action from the
+     * previous valid Darc.
      * </pre>
      *
-     * <code>repeated .Signature signatures = 6;</code>
+     * <code>repeated .Signature signatures = 8;</code>
      */
     public java.util.List<ch.epfl.dedis.proto.DarcProto.Signature> getSignaturesList() {
       return signatures_;
     }
     /**
      * <pre>
-     * Signature is calculated on the Request-representation of the darc.
-     * It needs to be created by identities that have the "_evolve" action
-     * from the previous valid Darc.
+     * Signature is calculated on the Request-representation of the darc.  It
+     * needs to be created by identities that have the "_evolve" action from the
+     * previous valid Darc.
      * </pre>
      *
-     * <code>repeated .Signature signatures = 6;</code>
+     * <code>repeated .Signature signatures = 8;</code>
      */
     public java.util.List<? extends ch.epfl.dedis.proto.DarcProto.SignatureOrBuilder> 
         getSignaturesOrBuilderList() {
@@ -651,64 +823,64 @@ public final class DarcProto {
     }
     /**
      * <pre>
-     * Signature is calculated on the Request-representation of the darc.
-     * It needs to be created by identities that have the "_evolve" action
-     * from the previous valid Darc.
+     * Signature is calculated on the Request-representation of the darc.  It
+     * needs to be created by identities that have the "_evolve" action from the
+     * previous valid Darc.
      * </pre>
      *
-     * <code>repeated .Signature signatures = 6;</code>
+     * <code>repeated .Signature signatures = 8;</code>
      */
     public int getSignaturesCount() {
       return signatures_.size();
     }
     /**
      * <pre>
-     * Signature is calculated on the Request-representation of the darc.
-     * It needs to be created by identities that have the "_evolve" action
-     * from the previous valid Darc.
+     * Signature is calculated on the Request-representation of the darc.  It
+     * needs to be created by identities that have the "_evolve" action from the
+     * previous valid Darc.
      * </pre>
      *
-     * <code>repeated .Signature signatures = 6;</code>
+     * <code>repeated .Signature signatures = 8;</code>
      */
     public ch.epfl.dedis.proto.DarcProto.Signature getSignatures(int index) {
       return signatures_.get(index);
     }
     /**
      * <pre>
-     * Signature is calculated on the Request-representation of the darc.
-     * It needs to be created by identities that have the "_evolve" action
-     * from the previous valid Darc.
+     * Signature is calculated on the Request-representation of the darc.  It
+     * needs to be created by identities that have the "_evolve" action from the
+     * previous valid Darc.
      * </pre>
      *
-     * <code>repeated .Signature signatures = 6;</code>
+     * <code>repeated .Signature signatures = 8;</code>
      */
     public ch.epfl.dedis.proto.DarcProto.SignatureOrBuilder getSignaturesOrBuilder(
         int index) {
       return signatures_.get(index);
     }
 
-    public static final int VERIFICATIONDARCS_FIELD_NUMBER = 7;
+    public static final int VERIFICATIONDARCS_FIELD_NUMBER = 9;
     private java.util.List<ch.epfl.dedis.proto.DarcProto.Darc> verificationdarcs_;
     /**
      * <pre>
-     * VerificationDarcs are a list of darcs that the verifier needs to
-     * verify this darc. It is not needed in online verification where the
-     * verifier stores all darcs.
+     * VerificationDarcs are a list of darcs that the verifier needs to verify
+     * this darc. It is not needed in online verification where the verifier
+     * stores all darcs.
      * </pre>
      *
-     * <code>repeated .Darc verificationdarcs = 7;</code>
+     * <code>repeated .Darc verificationdarcs = 9;</code>
      */
     public java.util.List<ch.epfl.dedis.proto.DarcProto.Darc> getVerificationdarcsList() {
       return verificationdarcs_;
     }
     /**
      * <pre>
-     * VerificationDarcs are a list of darcs that the verifier needs to
-     * verify this darc. It is not needed in online verification where the
-     * verifier stores all darcs.
+     * VerificationDarcs are a list of darcs that the verifier needs to verify
+     * this darc. It is not needed in online verification where the verifier
+     * stores all darcs.
      * </pre>
      *
-     * <code>repeated .Darc verificationdarcs = 7;</code>
+     * <code>repeated .Darc verificationdarcs = 9;</code>
      */
     public java.util.List<? extends ch.epfl.dedis.proto.DarcProto.DarcOrBuilder> 
         getVerificationdarcsOrBuilderList() {
@@ -716,36 +888,36 @@ public final class DarcProto {
     }
     /**
      * <pre>
-     * VerificationDarcs are a list of darcs that the verifier needs to
-     * verify this darc. It is not needed in online verification where the
-     * verifier stores all darcs.
+     * VerificationDarcs are a list of darcs that the verifier needs to verify
+     * this darc. It is not needed in online verification where the verifier
+     * stores all darcs.
      * </pre>
      *
-     * <code>repeated .Darc verificationdarcs = 7;</code>
+     * <code>repeated .Darc verificationdarcs = 9;</code>
      */
     public int getVerificationdarcsCount() {
       return verificationdarcs_.size();
     }
     /**
      * <pre>
-     * VerificationDarcs are a list of darcs that the verifier needs to
-     * verify this darc. It is not needed in online verification where the
-     * verifier stores all darcs.
+     * VerificationDarcs are a list of darcs that the verifier needs to verify
+     * this darc. It is not needed in online verification where the verifier
+     * stores all darcs.
      * </pre>
      *
-     * <code>repeated .Darc verificationdarcs = 7;</code>
+     * <code>repeated .Darc verificationdarcs = 9;</code>
      */
     public ch.epfl.dedis.proto.DarcProto.Darc getVerificationdarcs(int index) {
       return verificationdarcs_.get(index);
     }
     /**
      * <pre>
-     * VerificationDarcs are a list of darcs that the verifier needs to
-     * verify this darc. It is not needed in online verification where the
-     * verifier stores all darcs.
+     * VerificationDarcs are a list of darcs that the verifier needs to verify
+     * this darc. It is not needed in online verification where the verifier
+     * stores all darcs.
      * </pre>
      *
-     * <code>repeated .Darc verificationdarcs = 7;</code>
+     * <code>repeated .Darc verificationdarcs = 9;</code>
      */
     public ch.epfl.dedis.proto.DarcProto.DarcOrBuilder getVerificationdarcsOrBuilder(
         int index) {
@@ -767,6 +939,14 @@ public final class DarcProto {
         return false;
       }
       if (!hasPrevid()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasEvolvename()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasSignname()) {
         memoizedIsInitialized = 0;
         return false;
       }
@@ -800,17 +980,23 @@ public final class DarcProto {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeBytes(4, previd_);
       }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 5, evolvename_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 6, signname_);
+      }
       com.google.protobuf.GeneratedMessageV3
         .serializeStringMapTo(
           output,
           internalGetRules(),
           RulesDefaultEntryHolder.defaultEntry,
-          5);
+          7);
       for (int i = 0; i < signatures_.size(); i++) {
-        output.writeMessage(6, signatures_.get(i));
+        output.writeMessage(8, signatures_.get(i));
       }
       for (int i = 0; i < verificationdarcs_.size(); i++) {
-        output.writeMessage(7, verificationdarcs_.get(i));
+        output.writeMessage(9, verificationdarcs_.get(i));
       }
       unknownFields.writeTo(output);
     }
@@ -836,6 +1022,12 @@ public final class DarcProto {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(4, previd_);
       }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, evolvename_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, signname_);
+      }
       for (java.util.Map.Entry<java.lang.String, com.google.protobuf.ByteString> entry
            : internalGetRules().getMap().entrySet()) {
         com.google.protobuf.MapEntry<java.lang.String, com.google.protobuf.ByteString>
@@ -844,15 +1036,15 @@ public final class DarcProto {
             .setValue(entry.getValue())
             .build();
         size += com.google.protobuf.CodedOutputStream
-            .computeMessageSize(5, rules__);
+            .computeMessageSize(7, rules__);
       }
       for (int i = 0; i < signatures_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(6, signatures_.get(i));
+          .computeMessageSize(8, signatures_.get(i));
       }
       for (int i = 0; i < verificationdarcs_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(7, verificationdarcs_.get(i));
+          .computeMessageSize(9, verificationdarcs_.get(i));
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -890,6 +1082,16 @@ public final class DarcProto {
         result = result && getPrevid()
             .equals(other.getPrevid());
       }
+      result = result && (hasEvolvename() == other.hasEvolvename());
+      if (hasEvolvename()) {
+        result = result && getEvolvename()
+            .equals(other.getEvolvename());
+      }
+      result = result && (hasSignname() == other.hasSignname());
+      if (hasSignname()) {
+        result = result && getSignname()
+            .equals(other.getSignname());
+      }
       result = result && internalGetRules().equals(
           other.internalGetRules());
       result = result && getSignaturesList()
@@ -923,6 +1125,14 @@ public final class DarcProto {
       if (hasPrevid()) {
         hash = (37 * hash) + PREVID_FIELD_NUMBER;
         hash = (53 * hash) + getPrevid().hashCode();
+      }
+      if (hasEvolvename()) {
+        hash = (37 * hash) + EVOLVENAME_FIELD_NUMBER;
+        hash = (53 * hash) + getEvolvename().hashCode();
+      }
+      if (hasSignname()) {
+        hash = (37 * hash) + SIGNNAME_FIELD_NUMBER;
+        hash = (53 * hash) + getSignname().hashCode();
       }
       if (!internalGetRules().getMap().isEmpty()) {
         hash = (37 * hash) + RULES_FIELD_NUMBER;
@@ -1031,8 +1241,9 @@ public final class DarcProto {
     }
     /**
      * <pre>
-     * Darc is the basic structure representing an access control. A Darc can evolve in the way that
-     * a new Darc points to the previous one and is signed by the owner(s) of the previous Darc.
+     * Darc is the basic structure representing an access control. A Darc can
+     * evolve in the way that a new Darc points to the previous one and is signed
+     * by the owner(s) of the previous Darc.
      * </pre>
      *
      * Protobuf type {@code Darc}
@@ -1050,7 +1261,7 @@ public final class DarcProto {
       protected com.google.protobuf.MapField internalGetMapField(
           int number) {
         switch (number) {
-          case 5:
+          case 7:
             return internalGetRules();
           default:
             throw new RuntimeException(
@@ -1061,7 +1272,7 @@ public final class DarcProto {
       protected com.google.protobuf.MapField internalGetMutableMapField(
           int number) {
         switch (number) {
-          case 5:
+          case 7:
             return internalGetMutableRules();
           default:
             throw new RuntimeException(
@@ -1102,16 +1313,20 @@ public final class DarcProto {
         bitField0_ = (bitField0_ & ~0x00000004);
         previd_ = com.google.protobuf.ByteString.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000008);
+        evolvename_ = "";
+        bitField0_ = (bitField0_ & ~0x00000010);
+        signname_ = "";
+        bitField0_ = (bitField0_ & ~0x00000020);
         internalGetMutableRules().clear();
         if (signaturesBuilder_ == null) {
           signatures_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000020);
+          bitField0_ = (bitField0_ & ~0x00000080);
         } else {
           signaturesBuilder_.clear();
         }
         if (verificationdarcsBuilder_ == null) {
           verificationdarcs_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000040);
+          bitField0_ = (bitField0_ & ~0x00000100);
         } else {
           verificationdarcsBuilder_.clear();
         }
@@ -1155,21 +1370,29 @@ public final class DarcProto {
           to_bitField0_ |= 0x00000008;
         }
         result.previd_ = previd_;
+        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        result.evolvename_ = evolvename_;
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000020;
+        }
+        result.signname_ = signname_;
         result.rules_ = internalGetRules();
         result.rules_.makeImmutable();
         if (signaturesBuilder_ == null) {
-          if (((bitField0_ & 0x00000020) == 0x00000020)) {
+          if (((bitField0_ & 0x00000080) == 0x00000080)) {
             signatures_ = java.util.Collections.unmodifiableList(signatures_);
-            bitField0_ = (bitField0_ & ~0x00000020);
+            bitField0_ = (bitField0_ & ~0x00000080);
           }
           result.signatures_ = signatures_;
         } else {
           result.signatures_ = signaturesBuilder_.build();
         }
         if (verificationdarcsBuilder_ == null) {
-          if (((bitField0_ & 0x00000040) == 0x00000040)) {
+          if (((bitField0_ & 0x00000100) == 0x00000100)) {
             verificationdarcs_ = java.util.Collections.unmodifiableList(verificationdarcs_);
-            bitField0_ = (bitField0_ & ~0x00000040);
+            bitField0_ = (bitField0_ & ~0x00000100);
           }
           result.verificationdarcs_ = verificationdarcs_;
         } else {
@@ -1229,13 +1452,23 @@ public final class DarcProto {
         if (other.hasPrevid()) {
           setPrevid(other.getPrevid());
         }
+        if (other.hasEvolvename()) {
+          bitField0_ |= 0x00000010;
+          evolvename_ = other.evolvename_;
+          onChanged();
+        }
+        if (other.hasSignname()) {
+          bitField0_ |= 0x00000020;
+          signname_ = other.signname_;
+          onChanged();
+        }
         internalGetMutableRules().mergeFrom(
             other.internalGetRules());
         if (signaturesBuilder_ == null) {
           if (!other.signatures_.isEmpty()) {
             if (signatures_.isEmpty()) {
               signatures_ = other.signatures_;
-              bitField0_ = (bitField0_ & ~0x00000020);
+              bitField0_ = (bitField0_ & ~0x00000080);
             } else {
               ensureSignaturesIsMutable();
               signatures_.addAll(other.signatures_);
@@ -1248,7 +1481,7 @@ public final class DarcProto {
               signaturesBuilder_.dispose();
               signaturesBuilder_ = null;
               signatures_ = other.signatures_;
-              bitField0_ = (bitField0_ & ~0x00000020);
+              bitField0_ = (bitField0_ & ~0x00000080);
               signaturesBuilder_ = 
                 com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                    getSignaturesFieldBuilder() : null;
@@ -1261,7 +1494,7 @@ public final class DarcProto {
           if (!other.verificationdarcs_.isEmpty()) {
             if (verificationdarcs_.isEmpty()) {
               verificationdarcs_ = other.verificationdarcs_;
-              bitField0_ = (bitField0_ & ~0x00000040);
+              bitField0_ = (bitField0_ & ~0x00000100);
             } else {
               ensureVerificationdarcsIsMutable();
               verificationdarcs_.addAll(other.verificationdarcs_);
@@ -1274,7 +1507,7 @@ public final class DarcProto {
               verificationdarcsBuilder_.dispose();
               verificationdarcsBuilder_ = null;
               verificationdarcs_ = other.verificationdarcs_;
-              bitField0_ = (bitField0_ & ~0x00000040);
+              bitField0_ = (bitField0_ & ~0x00000100);
               verificationdarcsBuilder_ = 
                 com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                    getVerificationdarcsFieldBuilder() : null;
@@ -1296,6 +1529,12 @@ public final class DarcProto {
           return false;
         }
         if (!hasPrevid()) {
+          return false;
+        }
+        if (!hasEvolvename()) {
+          return false;
+        }
+        if (!hasSignname()) {
           return false;
         }
         for (int i = 0; i < getSignaturesCount(); i++) {
@@ -1381,8 +1620,8 @@ public final class DarcProto {
       private com.google.protobuf.ByteString description_ = com.google.protobuf.ByteString.EMPTY;
       /**
        * <pre>
-       * Description is a free-form field that can hold any data as required by the user.
-       * Darc itself will never depend on any of the data in here.
+       * Description is a free-form field that can hold any data as required by the
+       * user.  Darc itself will never depend on any of the data in here.
        * </pre>
        *
        * <code>required bytes description = 2;</code>
@@ -1392,8 +1631,8 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Description is a free-form field that can hold any data as required by the user.
-       * Darc itself will never depend on any of the data in here.
+       * Description is a free-form field that can hold any data as required by the
+       * user.  Darc itself will never depend on any of the data in here.
        * </pre>
        *
        * <code>required bytes description = 2;</code>
@@ -1403,8 +1642,8 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Description is a free-form field that can hold any data as required by the user.
-       * Darc itself will never depend on any of the data in here.
+       * Description is a free-form field that can hold any data as required by the
+       * user.  Darc itself will never depend on any of the data in here.
        * </pre>
        *
        * <code>required bytes description = 2;</code>
@@ -1420,8 +1659,8 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Description is a free-form field that can hold any data as required by the user.
-       * Darc itself will never depend on any of the data in here.
+       * Description is a free-form field that can hold any data as required by the
+       * user.  Darc itself will never depend on any of the data in here.
        * </pre>
        *
        * <code>required bytes description = 2;</code>
@@ -1535,6 +1774,230 @@ public final class DarcProto {
         return this;
       }
 
+      private java.lang.Object evolvename_ = "";
+      /**
+       * <pre>
+       * EvolveName is the name for the evolution action, which must exist and is
+       * responsible for managing the rules for evolving a darc.  This field should
+       * not be changed after initialisation.
+       * </pre>
+       *
+       * <code>required string evolvename = 5;</code>
+       */
+      public boolean hasEvolvename() {
+        return ((bitField0_ & 0x00000010) == 0x00000010);
+      }
+      /**
+       * <pre>
+       * EvolveName is the name for the evolution action, which must exist and is
+       * responsible for managing the rules for evolving a darc.  This field should
+       * not be changed after initialisation.
+       * </pre>
+       *
+       * <code>required string evolvename = 5;</code>
+       */
+      public java.lang.String getEvolvename() {
+        java.lang.Object ref = evolvename_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            evolvename_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * EvolveName is the name for the evolution action, which must exist and is
+       * responsible for managing the rules for evolving a darc.  This field should
+       * not be changed after initialisation.
+       * </pre>
+       *
+       * <code>required string evolvename = 5;</code>
+       */
+      public com.google.protobuf.ByteString
+          getEvolvenameBytes() {
+        java.lang.Object ref = evolvename_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          evolvename_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * EvolveName is the name for the evolution action, which must exist and is
+       * responsible for managing the rules for evolving a darc.  This field should
+       * not be changed after initialisation.
+       * </pre>
+       *
+       * <code>required string evolvename = 5;</code>
+       */
+      public Builder setEvolvename(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
+        evolvename_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * EvolveName is the name for the evolution action, which must exist and is
+       * responsible for managing the rules for evolving a darc.  This field should
+       * not be changed after initialisation.
+       * </pre>
+       *
+       * <code>required string evolvename = 5;</code>
+       */
+      public Builder clearEvolvename() {
+        bitField0_ = (bitField0_ & ~0x00000010);
+        evolvename_ = getDefaultInstance().getEvolvename();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * EvolveName is the name for the evolution action, which must exist and is
+       * responsible for managing the rules for evolving a darc.  This field should
+       * not be changed after initialisation.
+       * </pre>
+       *
+       * <code>required string evolvename = 5;</code>
+       */
+      public Builder setEvolvenameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
+        evolvename_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object signname_ = "";
+      /**
+       * <pre>
+       * SignName is the name of the sign action, which must exist and is
+       * responsible for giving other identities to sign on behalf of this darc.
+       * This field should not be changed after initialisation.
+       * </pre>
+       *
+       * <code>required string signname = 6;</code>
+       */
+      public boolean hasSignname() {
+        return ((bitField0_ & 0x00000020) == 0x00000020);
+      }
+      /**
+       * <pre>
+       * SignName is the name of the sign action, which must exist and is
+       * responsible for giving other identities to sign on behalf of this darc.
+       * This field should not be changed after initialisation.
+       * </pre>
+       *
+       * <code>required string signname = 6;</code>
+       */
+      public java.lang.String getSignname() {
+        java.lang.Object ref = signname_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            signname_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * SignName is the name of the sign action, which must exist and is
+       * responsible for giving other identities to sign on behalf of this darc.
+       * This field should not be changed after initialisation.
+       * </pre>
+       *
+       * <code>required string signname = 6;</code>
+       */
+      public com.google.protobuf.ByteString
+          getSignnameBytes() {
+        java.lang.Object ref = signname_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          signname_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * SignName is the name of the sign action, which must exist and is
+       * responsible for giving other identities to sign on behalf of this darc.
+       * This field should not be changed after initialisation.
+       * </pre>
+       *
+       * <code>required string signname = 6;</code>
+       */
+      public Builder setSignname(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000020;
+        signname_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * SignName is the name of the sign action, which must exist and is
+       * responsible for giving other identities to sign on behalf of this darc.
+       * This field should not be changed after initialisation.
+       * </pre>
+       *
+       * <code>required string signname = 6;</code>
+       */
+      public Builder clearSignname() {
+        bitField0_ = (bitField0_ & ~0x00000020);
+        signname_ = getDefaultInstance().getSignname();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * SignName is the name of the sign action, which must exist and is
+       * responsible for giving other identities to sign on behalf of this darc.
+       * This field should not be changed after initialisation.
+       * </pre>
+       *
+       * <code>required string signname = 6;</code>
+       */
+      public Builder setSignnameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000020;
+        signname_ = value;
+        onChanged();
+        return this;
+      }
+
       private com.google.protobuf.MapField<
           java.lang.String, com.google.protobuf.ByteString> rules_;
       private com.google.protobuf.MapField<java.lang.String, com.google.protobuf.ByteString>
@@ -1563,14 +2026,11 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Rules map an action to an expression.
-       * An action is a string that should be associated with an expression. The
-       * application typically will define the action but there are two actions that
-       * are in all the darcs, "_evolve" and "_sign". The application can modify
-       * these actions but should not change the semantics of these actions.
+       * Rules map an action to an expression. The evolve action and the sign
+       * action must exist, but they may be empty.
        * </pre>
        *
-       * <code>map&lt;string, bytes&gt; rules = 5;</code>
+       * <code>map&lt;string, bytes&gt; rules = 7;</code>
        */
 
       public boolean containsRules(
@@ -1587,14 +2047,11 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Rules map an action to an expression.
-       * An action is a string that should be associated with an expression. The
-       * application typically will define the action but there are two actions that
-       * are in all the darcs, "_evolve" and "_sign". The application can modify
-       * these actions but should not change the semantics of these actions.
+       * Rules map an action to an expression. The evolve action and the sign
+       * action must exist, but they may be empty.
        * </pre>
        *
-       * <code>map&lt;string, bytes&gt; rules = 5;</code>
+       * <code>map&lt;string, bytes&gt; rules = 7;</code>
        */
 
       public java.util.Map<java.lang.String, com.google.protobuf.ByteString> getRulesMap() {
@@ -1602,14 +2059,11 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Rules map an action to an expression.
-       * An action is a string that should be associated with an expression. The
-       * application typically will define the action but there are two actions that
-       * are in all the darcs, "_evolve" and "_sign". The application can modify
-       * these actions but should not change the semantics of these actions.
+       * Rules map an action to an expression. The evolve action and the sign
+       * action must exist, but they may be empty.
        * </pre>
        *
-       * <code>map&lt;string, bytes&gt; rules = 5;</code>
+       * <code>map&lt;string, bytes&gt; rules = 7;</code>
        */
 
       public com.google.protobuf.ByteString getRulesOrDefault(
@@ -1622,14 +2076,11 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Rules map an action to an expression.
-       * An action is a string that should be associated with an expression. The
-       * application typically will define the action but there are two actions that
-       * are in all the darcs, "_evolve" and "_sign". The application can modify
-       * these actions but should not change the semantics of these actions.
+       * Rules map an action to an expression. The evolve action and the sign
+       * action must exist, but they may be empty.
        * </pre>
        *
-       * <code>map&lt;string, bytes&gt; rules = 5;</code>
+       * <code>map&lt;string, bytes&gt; rules = 7;</code>
        */
 
       public com.google.protobuf.ByteString getRulesOrThrow(
@@ -1650,14 +2101,11 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Rules map an action to an expression.
-       * An action is a string that should be associated with an expression. The
-       * application typically will define the action but there are two actions that
-       * are in all the darcs, "_evolve" and "_sign". The application can modify
-       * these actions but should not change the semantics of these actions.
+       * Rules map an action to an expression. The evolve action and the sign
+       * action must exist, but they may be empty.
        * </pre>
        *
-       * <code>map&lt;string, bytes&gt; rules = 5;</code>
+       * <code>map&lt;string, bytes&gt; rules = 7;</code>
        */
 
       public Builder removeRules(
@@ -1677,14 +2125,11 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Rules map an action to an expression.
-       * An action is a string that should be associated with an expression. The
-       * application typically will define the action but there are two actions that
-       * are in all the darcs, "_evolve" and "_sign". The application can modify
-       * these actions but should not change the semantics of these actions.
+       * Rules map an action to an expression. The evolve action and the sign
+       * action must exist, but they may be empty.
        * </pre>
        *
-       * <code>map&lt;string, bytes&gt; rules = 5;</code>
+       * <code>map&lt;string, bytes&gt; rules = 7;</code>
        */
       public Builder putRules(
           java.lang.String key,
@@ -1697,14 +2142,11 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Rules map an action to an expression.
-       * An action is a string that should be associated with an expression. The
-       * application typically will define the action but there are two actions that
-       * are in all the darcs, "_evolve" and "_sign". The application can modify
-       * these actions but should not change the semantics of these actions.
+       * Rules map an action to an expression. The evolve action and the sign
+       * action must exist, but they may be empty.
        * </pre>
        *
-       * <code>map&lt;string, bytes&gt; rules = 5;</code>
+       * <code>map&lt;string, bytes&gt; rules = 7;</code>
        */
 
       public Builder putAllRules(
@@ -1717,9 +2159,9 @@ public final class DarcProto {
       private java.util.List<ch.epfl.dedis.proto.DarcProto.Signature> signatures_ =
         java.util.Collections.emptyList();
       private void ensureSignaturesIsMutable() {
-        if (!((bitField0_ & 0x00000020) == 0x00000020)) {
+        if (!((bitField0_ & 0x00000080) == 0x00000080)) {
           signatures_ = new java.util.ArrayList<ch.epfl.dedis.proto.DarcProto.Signature>(signatures_);
-          bitField0_ |= 0x00000020;
+          bitField0_ |= 0x00000080;
          }
       }
 
@@ -1728,12 +2170,12 @@ public final class DarcProto {
 
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public java.util.List<ch.epfl.dedis.proto.DarcProto.Signature> getSignaturesList() {
         if (signaturesBuilder_ == null) {
@@ -1744,12 +2186,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public int getSignaturesCount() {
         if (signaturesBuilder_ == null) {
@@ -1760,12 +2202,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public ch.epfl.dedis.proto.DarcProto.Signature getSignatures(int index) {
         if (signaturesBuilder_ == null) {
@@ -1776,12 +2218,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public Builder setSignatures(
           int index, ch.epfl.dedis.proto.DarcProto.Signature value) {
@@ -1799,12 +2241,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public Builder setSignatures(
           int index, ch.epfl.dedis.proto.DarcProto.Signature.Builder builderForValue) {
@@ -1819,12 +2261,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public Builder addSignatures(ch.epfl.dedis.proto.DarcProto.Signature value) {
         if (signaturesBuilder_ == null) {
@@ -1841,12 +2283,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public Builder addSignatures(
           int index, ch.epfl.dedis.proto.DarcProto.Signature value) {
@@ -1864,12 +2306,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public Builder addSignatures(
           ch.epfl.dedis.proto.DarcProto.Signature.Builder builderForValue) {
@@ -1884,12 +2326,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public Builder addSignatures(
           int index, ch.epfl.dedis.proto.DarcProto.Signature.Builder builderForValue) {
@@ -1904,12 +2346,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public Builder addAllSignatures(
           java.lang.Iterable<? extends ch.epfl.dedis.proto.DarcProto.Signature> values) {
@@ -1925,17 +2367,17 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public Builder clearSignatures() {
         if (signaturesBuilder_ == null) {
           signatures_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000020);
+          bitField0_ = (bitField0_ & ~0x00000080);
           onChanged();
         } else {
           signaturesBuilder_.clear();
@@ -1944,12 +2386,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public Builder removeSignatures(int index) {
         if (signaturesBuilder_ == null) {
@@ -1963,12 +2405,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public ch.epfl.dedis.proto.DarcProto.Signature.Builder getSignaturesBuilder(
           int index) {
@@ -1976,12 +2418,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public ch.epfl.dedis.proto.DarcProto.SignatureOrBuilder getSignaturesOrBuilder(
           int index) {
@@ -1992,12 +2434,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public java.util.List<? extends ch.epfl.dedis.proto.DarcProto.SignatureOrBuilder> 
            getSignaturesOrBuilderList() {
@@ -2009,12 +2451,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public ch.epfl.dedis.proto.DarcProto.Signature.Builder addSignaturesBuilder() {
         return getSignaturesFieldBuilder().addBuilder(
@@ -2022,12 +2464,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public ch.epfl.dedis.proto.DarcProto.Signature.Builder addSignaturesBuilder(
           int index) {
@@ -2036,12 +2478,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * Signature is calculated on the Request-representation of the darc.
-       * It needs to be created by identities that have the "_evolve" action
-       * from the previous valid Darc.
+       * Signature is calculated on the Request-representation of the darc.  It
+       * needs to be created by identities that have the "_evolve" action from the
+       * previous valid Darc.
        * </pre>
        *
-       * <code>repeated .Signature signatures = 6;</code>
+       * <code>repeated .Signature signatures = 8;</code>
        */
       public java.util.List<ch.epfl.dedis.proto.DarcProto.Signature.Builder> 
            getSignaturesBuilderList() {
@@ -2054,7 +2496,7 @@ public final class DarcProto {
           signaturesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.proto.DarcProto.Signature, ch.epfl.dedis.proto.DarcProto.Signature.Builder, ch.epfl.dedis.proto.DarcProto.SignatureOrBuilder>(
                   signatures_,
-                  ((bitField0_ & 0x00000020) == 0x00000020),
+                  ((bitField0_ & 0x00000080) == 0x00000080),
                   getParentForChildren(),
                   isClean());
           signatures_ = null;
@@ -2065,9 +2507,9 @@ public final class DarcProto {
       private java.util.List<ch.epfl.dedis.proto.DarcProto.Darc> verificationdarcs_ =
         java.util.Collections.emptyList();
       private void ensureVerificationdarcsIsMutable() {
-        if (!((bitField0_ & 0x00000040) == 0x00000040)) {
+        if (!((bitField0_ & 0x00000100) == 0x00000100)) {
           verificationdarcs_ = new java.util.ArrayList<ch.epfl.dedis.proto.DarcProto.Darc>(verificationdarcs_);
-          bitField0_ |= 0x00000040;
+          bitField0_ |= 0x00000100;
          }
       }
 
@@ -2076,12 +2518,12 @@ public final class DarcProto {
 
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public java.util.List<ch.epfl.dedis.proto.DarcProto.Darc> getVerificationdarcsList() {
         if (verificationdarcsBuilder_ == null) {
@@ -2092,12 +2534,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public int getVerificationdarcsCount() {
         if (verificationdarcsBuilder_ == null) {
@@ -2108,12 +2550,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public ch.epfl.dedis.proto.DarcProto.Darc getVerificationdarcs(int index) {
         if (verificationdarcsBuilder_ == null) {
@@ -2124,12 +2566,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public Builder setVerificationdarcs(
           int index, ch.epfl.dedis.proto.DarcProto.Darc value) {
@@ -2147,12 +2589,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public Builder setVerificationdarcs(
           int index, ch.epfl.dedis.proto.DarcProto.Darc.Builder builderForValue) {
@@ -2167,12 +2609,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public Builder addVerificationdarcs(ch.epfl.dedis.proto.DarcProto.Darc value) {
         if (verificationdarcsBuilder_ == null) {
@@ -2189,12 +2631,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public Builder addVerificationdarcs(
           int index, ch.epfl.dedis.proto.DarcProto.Darc value) {
@@ -2212,12 +2654,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public Builder addVerificationdarcs(
           ch.epfl.dedis.proto.DarcProto.Darc.Builder builderForValue) {
@@ -2232,12 +2674,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public Builder addVerificationdarcs(
           int index, ch.epfl.dedis.proto.DarcProto.Darc.Builder builderForValue) {
@@ -2252,12 +2694,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public Builder addAllVerificationdarcs(
           java.lang.Iterable<? extends ch.epfl.dedis.proto.DarcProto.Darc> values) {
@@ -2273,17 +2715,17 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public Builder clearVerificationdarcs() {
         if (verificationdarcsBuilder_ == null) {
           verificationdarcs_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000040);
+          bitField0_ = (bitField0_ & ~0x00000100);
           onChanged();
         } else {
           verificationdarcsBuilder_.clear();
@@ -2292,12 +2734,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public Builder removeVerificationdarcs(int index) {
         if (verificationdarcsBuilder_ == null) {
@@ -2311,12 +2753,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public ch.epfl.dedis.proto.DarcProto.Darc.Builder getVerificationdarcsBuilder(
           int index) {
@@ -2324,12 +2766,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public ch.epfl.dedis.proto.DarcProto.DarcOrBuilder getVerificationdarcsOrBuilder(
           int index) {
@@ -2340,12 +2782,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public java.util.List<? extends ch.epfl.dedis.proto.DarcProto.DarcOrBuilder> 
            getVerificationdarcsOrBuilderList() {
@@ -2357,12 +2799,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public ch.epfl.dedis.proto.DarcProto.Darc.Builder addVerificationdarcsBuilder() {
         return getVerificationdarcsFieldBuilder().addBuilder(
@@ -2370,12 +2812,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public ch.epfl.dedis.proto.DarcProto.Darc.Builder addVerificationdarcsBuilder(
           int index) {
@@ -2384,12 +2826,12 @@ public final class DarcProto {
       }
       /**
        * <pre>
-       * VerificationDarcs are a list of darcs that the verifier needs to
-       * verify this darc. It is not needed in online verification where the
-       * verifier stores all darcs.
+       * VerificationDarcs are a list of darcs that the verifier needs to verify
+       * this darc. It is not needed in online verification where the verifier
+       * stores all darcs.
        * </pre>
        *
-       * <code>repeated .Darc verificationdarcs = 7;</code>
+       * <code>repeated .Darc verificationdarcs = 9;</code>
        */
       public java.util.List<ch.epfl.dedis.proto.DarcProto.Darc.Builder> 
            getVerificationdarcsBuilderList() {
@@ -2402,7 +2844,7 @@ public final class DarcProto {
           verificationdarcsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.proto.DarcProto.Darc, ch.epfl.dedis.proto.DarcProto.Darc.Builder, ch.epfl.dedis.proto.DarcProto.DarcOrBuilder>(
                   verificationdarcs_,
-                  ((bitField0_ & 0x00000040) == 0x00000040),
+                  ((bitField0_ & 0x00000100) == 0x00000100),
                   getParentForChildren(),
                   isClean());
           verificationdarcs_ = null;
@@ -9380,27 +9822,28 @@ public final class DarcProto {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\ndarc.proto\"\335\001\n\004Darc\022\017\n\007version\030\001 \002(\004\022\023" +
+      "\n\ndarc.proto\"\203\002\n\004Darc\022\017\n\007version\030\001 \002(\004\022\023" +
       "\n\013description\030\002 \002(\014\022\016\n\006baseid\030\003 \001(\014\022\016\n\006p" +
-      "revid\030\004 \002(\014\022\037\n\005rules\030\005 \003(\0132\020.Darc.RulesE" +
-      "ntry\022\036\n\nsignatures\030\006 \003(\0132\n.Signature\022 \n\021" +
-      "verificationdarcs\030\007 \003(\0132\005.Darc\032,\n\nRulesE" +
-      "ntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\014:\0028\001\"k\n\010" +
-      "Identity\022\033\n\004darc\030\001 \001(\0132\r.IdentityDarc\022!\n" +
-      "\007ed25519\030\002 \001(\0132\020.IdentityEd25519\022\037\n\006x509" +
-      "ec\030\003 \001(\0132\017.IdentityX509EC\" \n\017IdentityEd2" +
-      "5519\022\r\n\005point\030\001 \002(\014\" \n\016IdentityX509EC\022\016\n" +
-      "\006public\030\001 \002(\014\"\032\n\014IdentityDarc\022\n\n\002id\030\001 \002(" +
-      "\014\"9\n\tSignature\022\021\n\tsignature\030\001 \002(\014\022\031\n\006sig" +
-      "ner\030\002 \002(\0132\t.Identity\"H\n\006Signer\022\037\n\007ed2551" +
-      "9\030\001 \001(\0132\016.SignerEd25519\022\035\n\006x509ec\030\002 \001(\0132" +
-      "\r.SignerX509EC\".\n\rSignerEd25519\022\r\n\005point" +
-      "\030\001 \002(\014\022\016\n\006secret\030\002 \002(\014\"-\n\014SignerX509EC\022\r" +
-      "\n\005point\030\001 \002(\014\022\016\n\006secret\030\002 \002(\014\"i\n\007Request" +
-      "\022\016\n\006baseid\030\001 \002(\014\022\016\n\006action\030\002 \002(\t\022\013\n\003msg\030" +
-      "\003 \002(\014\022\035\n\nidentities\030\004 \003(\0132\t.Identity\022\022\n\n" +
-      "signatures\030\005 \003(\014B \n\023ch.epfl.dedis.protoB" +
-      "\tDarcProto"
+      "revid\030\004 \002(\014\022\022\n\nevolvename\030\005 \002(\t\022\020\n\010signn" +
+      "ame\030\006 \002(\t\022\037\n\005rules\030\007 \003(\0132\020.Darc.RulesEnt" +
+      "ry\022\036\n\nsignatures\030\010 \003(\0132\n.Signature\022 \n\021ve" +
+      "rificationdarcs\030\t \003(\0132\005.Darc\032,\n\nRulesEnt" +
+      "ry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\014:\0028\001\"k\n\010Id" +
+      "entity\022\033\n\004darc\030\001 \001(\0132\r.IdentityDarc\022!\n\007e" +
+      "d25519\030\002 \001(\0132\020.IdentityEd25519\022\037\n\006x509ec" +
+      "\030\003 \001(\0132\017.IdentityX509EC\" \n\017IdentityEd255" +
+      "19\022\r\n\005point\030\001 \002(\014\" \n\016IdentityX509EC\022\016\n\006p" +
+      "ublic\030\001 \002(\014\"\032\n\014IdentityDarc\022\n\n\002id\030\001 \002(\014\"" +
+      "9\n\tSignature\022\021\n\tsignature\030\001 \002(\014\022\031\n\006signe" +
+      "r\030\002 \002(\0132\t.Identity\"H\n\006Signer\022\037\n\007ed25519\030" +
+      "\001 \001(\0132\016.SignerEd25519\022\035\n\006x509ec\030\002 \001(\0132\r." +
+      "SignerX509EC\".\n\rSignerEd25519\022\r\n\005point\030\001" +
+      " \002(\014\022\016\n\006secret\030\002 \002(\014\"-\n\014SignerX509EC\022\r\n\005" +
+      "point\030\001 \002(\014\022\016\n\006secret\030\002 \002(\014\"i\n\007Request\022\016" +
+      "\n\006baseid\030\001 \002(\014\022\016\n\006action\030\002 \002(\t\022\013\n\003msg\030\003 " +
+      "\002(\014\022\035\n\nidentities\030\004 \003(\0132\t.Identity\022\022\n\nsi" +
+      "gnatures\030\005 \003(\014B \n\023ch.epfl.dedis.protoB\tD" +
+      "arcProto"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -9419,7 +9862,7 @@ public final class DarcProto {
     internal_static_Darc_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_Darc_descriptor,
-        new java.lang.String[] { "Version", "Description", "Baseid", "Previd", "Rules", "Signatures", "Verificationdarcs", });
+        new java.lang.String[] { "Version", "Description", "Baseid", "Previd", "Evolvename", "Signname", "Rules", "Signatures", "Verificationdarcs", });
     internal_static_Darc_RulesEntry_descriptor =
       internal_static_Darc_descriptor.getNestedTypes().get(0);
     internal_static_Darc_RulesEntry_fieldAccessorTable = new

--- a/external/proto/darc.proto
+++ b/external/proto/darc.proto
@@ -7,32 +7,38 @@ option java_outer_classname = "DarcProto";
 // These are the messages used in the API-calls
 // ***
 
-// Darc is the basic structure representing an access control. A Darc can evolve in the way that
-// a new Darc points to the previous one and is signed by the owner(s) of the previous Darc.
+// Darc is the basic structure representing an access control. A Darc can
+// evolve in the way that a new Darc points to the previous one and is signed
+// by the owner(s) of the previous Darc.
 message Darc {
   // Version should be monotonically increasing over the evolution of a Darc.
   required uint64 version = 1;
-  // Description is a free-form field that can hold any data as required by the user.
-  // Darc itself will never depend on any of the data in here.
+  // Description is a free-form field that can hold any data as required by the
+  // user.  Darc itself will never depend on any of the data in here.
   required bytes description = 2;
   // BaseID is the ID of the first darc of this Series
   optional bytes baseid = 3;
   // PrevID is the previous darc ID in the chain of evolution.
   required bytes previd = 4;
-  // Rules map an action to an expression.
-  // An action is a string that should be associated with an expression. The
-  // application typically will define the action but there are two actions that
-  // are in all the darcs, "_evolve" and "_sign". The application can modify
-  // these actions but should not change the semantics of these actions.
-  map<string, bytes> rules = 5;
-  // Signature is calculated on the Request-representation of the darc.
-  // It needs to be created by identities that have the "_evolve" action
-  // from the previous valid Darc.
-  repeated Signature signatures = 6;
-  // VerificationDarcs are a list of darcs that the verifier needs to
-  // verify this darc. It is not needed in online verification where the
-  // verifier stores all darcs.
-  repeated Darc verificationdarcs = 7;
+  // EvolveName is the name for the evolution action, which must exist and is
+  // responsible for managing the rules for evolving a darc.  This field should
+  // not be changed after initialisation.
+  required string evolvename = 5;
+  // SignName is the name of the sign action, which must exist and is
+  // responsible for giving other identities to sign on behalf of this darc.
+  // This field should not be changed after initialisation.
+  required string signname = 6;
+  // Rules map an action to an expression. The evolve action and the sign
+  // action must exist, but they may be empty.
+  map<string, bytes> rules = 7;
+  // Signature is calculated on the Request-representation of the darc.  It
+  // needs to be created by identities that have the "_evolve" action from the
+  // previous valid Darc.
+  repeated Signature signatures = 8;
+  // VerificationDarcs are a list of darcs that the verifier needs to verify
+  // this darc. It is not needed in online verification where the verifier
+  // stores all darcs.
+  repeated Darc verificationdarcs = 9;
 }
 
 // Identity is a generic structure can be either an Ed25519 public key, a Darc

--- a/omniledger/darc/darc.go
+++ b/omniledger/darc/darc.go
@@ -35,28 +35,16 @@ package darc
 
 import (
 	"bytes"
-	"crypto/ecdsa"
 	"crypto/sha256"
-	"crypto/sha512"
-	"crypto/x509"
-	"encoding/asn1"
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"math/big"
 	"sort"
 	"strings"
 
-	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/omniledger/darc/expression"
-	"github.com/dedis/kyber"
-	"github.com/dedis/kyber/sign/schnorr"
-	"github.com/dedis/kyber/util/key"
 	"github.com/dedis/protobuf"
 )
-
-const evolve = "_evolve"
-const sign = "_sign"
 
 // GetDarc is a callback function that we expect the user of this library to
 // supply in some of our methods. The user is free to choose how he/she wants
@@ -71,36 +59,21 @@ const sign = "_sign"
 // nil if no match is found.
 type GetDarc func(s string, latest bool) *Darc
 
-// InitRules initialise a set of rules with the default actions "_evolve" and
-// "_sign". Signers are joined with logical-Or, owners are joined with
-// logical-AND. If other expressions are needed, please set the rules manually.
-func InitRules(owners []*Identity, signers []*Identity) Rules {
-	rs := make(Rules)
-
-	ownerIDs := make([]string, len(owners))
-	for i, o := range owners {
-		ownerIDs[i] = o.String()
-	}
-	rs[evolve] = expression.InitAndExpr(ownerIDs...)
-
-	signerIDs := make([]string, len(signers))
-	for i, s := range signers {
-		signerIDs[i] = s.String()
-	}
-	rs[sign] = expression.InitOrExpr(signerIDs...)
-	return rs
-}
-
 // NewDarc initialises a darc-structure given its owners and users. Note that
 // the BaseID is empty if the Version is 0, it must be computed using
-// GetBaseID.
-func NewDarc(rules Rules, desc []byte) *Darc {
+// GetBaseID. It sets the initial set of rules with owners and signers. Signers
+// are joined with logical-Or, owners (identities that are allowed to evolve
+// the darc) are joined with logical-AND. If other expressions are needed,
+// please set the rules manually.
+func NewDarc(owners []*Identity, signers []*Identity, evolveName, signName Action, desc []byte) *Darc {
 	zeroSha := sha256.Sum256([]byte{})
 	return &Darc{
 		Version:     0,
 		Description: desc,
+		EvolveName:  evolveName,
+		SignName:    signName,
 		Signatures:  []*Signature{},
-		Rules:       rules,
+		Rules:       initRules(owners, signers, evolveName, signName),
 		PrevID:      zeroSha[:],
 	}
 }
@@ -112,16 +85,14 @@ func (d *Darc) Copy() *Darc {
 		Description: copyBytes(d.Description),
 		BaseID:      copyBytes(d.BaseID),
 		PrevID:      copyBytes(d.PrevID),
+		EvolveName:  d.EvolveName,
+		SignName:    d.SignName,
 	}
 	dCopy.VerificationDarcs = make([]*Darc, len(d.VerificationDarcs))
 	for i := range d.VerificationDarcs {
 		dCopy.VerificationDarcs[i] = d.VerificationDarcs[i]
 	}
-	newRules := make(Rules)
-	for k, v := range d.Rules {
-		newRules[k] = v
-	}
-	dCopy.Rules = newRules
+	dCopy.Rules = d.Rules.copyRules()
 	return dCopy
 }
 
@@ -166,6 +137,8 @@ func (d Darc) GetID() ID {
 	h.Write(d.Description)
 	h.Write(d.BaseID)
 	h.Write(d.PrevID)
+	h.Write([]byte(d.EvolveName))
+	h.Write([]byte(d.SignName))
 
 	actions := make([]string, len(d.Rules))
 	var i int
@@ -196,77 +169,100 @@ func (d Darc) GetBaseID() ID {
 }
 
 // AddRule adds a new action expression-pair, the action must not exist.
-func (r Rules) AddRule(a Action, expr expression.Expr) error {
-	if _, ok := r[a]; ok {
+func (d *Darc) AddRule(a Action, expr expression.Expr) error {
+	if _, ok := d.Rules[a]; ok {
 		return errors.New("action already exists")
 	}
-	r[a] = expr
+	d.Rules[a] = expr
 	return nil
 }
 
 // UpdateRule updates an existing action-expression pair, it cannot be the
 // evolve or sign action.
-func (r Rules) UpdateRule(a Action, expr expression.Expr) error {
-	if isDefault(a) {
+func (d *Darc) UpdateRule(a Action, expr expression.Expr) error {
+	if d.isDefault(a) {
 		return fmt.Errorf("cannot update action %s", a)
 	}
-	return r.updateRule(a, expr)
-}
-
-// DeleteRules deletes an action, it cannot delete the evolve or sign action.
-func (r Rules) DeleteRules(a Action) error {
-	if isDefault(a) {
-		return fmt.Errorf("cannot delete action %s", a)
+	r, err := d.Rules.updateRule(a, expr)
+	if err != nil {
+		return err
 	}
-	if _, ok := r[a]; !ok {
-		return fmt.Errorf("DeleteRules: action '%v' does not exist", a)
-	}
-	delete(r, a)
+	d.Rules = r
 	return nil
 }
 
-// Contains checks if the action a is in the rules.
-func (r Rules) Contains(a Action) bool {
-	_, ok := r[a]
+// DeleteRules deletes an action, it cannot delete the evolve or sign action.
+func (d *Darc) DeleteRules(a Action) error {
+	if d.isDefault(a) {
+		return fmt.Errorf("cannot delete action %s", a)
+	}
+	if _, ok := d.Rules[a]; !ok {
+		return fmt.Errorf("DeleteRules: action '%v' does not exist", a)
+	}
+	delete(d.Rules, a)
+	return nil
+}
+
+// ContainsAction checks if the action a is in the rules.
+func (d Darc) ContainsAction(a Action) bool {
+	_, ok := d.Rules[a]
 	return ok
 }
 
 // GetEvolutionExpr returns the expression that describes the evolution action.
-func (r Rules) GetEvolutionExpr() expression.Expr {
-	return r[evolve]
+func (d Darc) GetEvolutionExpr() expression.Expr {
+	return d.Rules[d.EvolveName]
 }
 
 // GetSignExpr returns the expression that describes the sign action.
-func (r Rules) GetSignExpr() expression.Expr {
-	return r[sign]
+func (d Darc) GetSignExpr() expression.Expr {
+	return d.Rules[d.SignName]
 }
 
-// UpdateEvolution will update the "_evolve" action, which allows identities
+// UpdateEvolution will update the evolve action, which allows identities
 // that satisfies the expression to evolve the Darc. Take extreme care when
 // using this function.
-func (r Rules) UpdateEvolution(expr expression.Expr) error {
-	return r.updateRule(evolve, expr)
+func (d *Darc) UpdateEvolution(expr expression.Expr) error {
+	r, err := d.Rules.updateRule(d.EvolveName, expr)
+	if err != nil {
+		return err
+	}
+	d.Rules = r
+	return nil
 }
 
 // UpdateSign will update the "_sign" action, which allows identities that
 // satisfies the expression to sign on behalf of another darc.
-func (r Rules) UpdateSign(expr expression.Expr) error {
-	return r.updateRule(sign, expr)
-}
-
-func (r Rules) updateRule(a Action, expr expression.Expr) error {
-	if _, ok := r[a]; !ok {
-		return fmt.Errorf("updateRule: action '%v' does not exist", a)
+func (d *Darc) UpdateSign(expr expression.Expr) error {
+	r, err := d.Rules.updateRule(d.SignName, expr)
+	if err != nil {
+		return err
 	}
-	r[a] = expr
+	d.Rules = r
 	return nil
 }
 
-func isDefault(action Action) bool {
-	if action == evolve || action == sign {
+func (d Darc) isDefault(action Action) bool {
+	if action == d.EvolveName || action == d.SignName {
 		return true
 	}
 	return false
+}
+
+func (r Rules) updateRule(a Action, expr expression.Expr) (Rules, error) {
+	if _, ok := r[a]; !ok {
+		return r, fmt.Errorf("updateRule: action '%v' does not exist", a)
+	}
+	r[a] = expr
+	return r, nil
+}
+
+func (r Rules) copyRules() Rules {
+	newRules := make(Rules)
+	for k, v := range r {
+		newRules[k] = v
+	}
+	return newRules
 }
 
 // EvolveFrom sets the fields of d such that it is a valid evolution from the
@@ -279,6 +275,8 @@ func (d *Darc) EvolveFrom(prev *Darc) error {
 	d.Version = prev.Version + 1
 	d.BaseID = prev.GetBaseID()
 	d.PrevID = prev.GetID()
+	d.EvolveName = prev.EvolveName
+	d.SignName = prev.SignName
 	return nil
 }
 
@@ -304,7 +302,7 @@ func (d *Darc) MakeEvolveRequest(prevSigners ...*Signer) (*Request, []byte, erro
 	}
 	inner := innerRequest{
 		BaseID:     d.GetBaseID(),
-		Action:     evolve,
+		Action:     d.EvolveName,
 		Msg:        d.GetID(),
 		Identities: signerIDs,
 	}
@@ -326,11 +324,6 @@ func (d *Darc) MakeEvolveRequest(prevSigners ...*Signer) (*Request, []byte, erro
 		inner,
 		tmpSigs,
 	}, darcBuf, nil
-}
-
-// IncrementVersion updates the version number of the Darc
-func (d *Darc) IncrementVersion() {
-	d.Version++
 }
 
 // Verify will check that the darc is correct, an error is returned if
@@ -393,7 +386,7 @@ func (r *Request) VerifyWithCB(d *Darc, getDarc GetDarc) error {
 	if !d.GetBaseID().Equal(r.BaseID) {
 		return fmt.Errorf("base id mismatch")
 	}
-	if !d.Rules.Contains(r.Action) {
+	if !d.ContainsAction(r.Action) {
 		return fmt.Errorf("VerifyWithCB: action '%v' does not exist", r.Action)
 	}
 	digest := r.Hash()
@@ -413,6 +406,7 @@ func (r *Request) VerifyWithCB(d *Darc, getDarc GetDarc) error {
 // String returns a human-readable string representation of the darc.
 func (d Darc) String() string {
 	s := fmt.Sprintf("ID:\t%x\nBase:\t%x\nPrev:\t%x\nVer:\t%d\nRules:", d.GetID(), d.GetBaseID(), d.PrevID, d.Version)
+	s += fmt.Sprintf("\nEvolveName:\t%s\nSignName:\t%s", d.EvolveName, d.SignName)
 	for k, v := range d.Rules {
 		s += fmt.Sprintf("\n\t%s - \"%s\"", k, v)
 	}
@@ -469,6 +463,23 @@ func DarcsToGetDarcs(darcs []*Darc) GetDarc {
 	}
 }
 
+func initRules(owners []*Identity, signers []*Identity, evolveName, signName Action) Rules {
+	rs := make(Rules)
+
+	ownerIDs := make([]string, len(owners))
+	for i, o := range owners {
+		ownerIDs[i] = o.String()
+	}
+	rs[evolveName] = expression.InitAndExpr(ownerIDs...)
+
+	signerIDs := make([]string, len(signers))
+	for i, s := range signers {
+		signerIDs[i] = s.String()
+	}
+	rs[signName] = expression.InitOrExpr(signerIDs...)
+	return rs
+}
+
 // verifyOneEvolution verifies that one evolution is performed correctly. That
 // is, there exists a signature in the newDarc that is signed by one of the
 // identities with the evolve permission in the oldDarc. The message that
@@ -490,7 +501,7 @@ func verifyOneEvolution(newDarc, prevDarc *Darc, getDarc func(string, bool) *Dar
 
 	// check that signers have the permission
 	if err := evalExprWithSigs(
-		prevDarc.Rules.GetEvolutionExpr(),
+		prevDarc.GetEvolutionExpr(),
 		getDarc,
 		newDarc.Signatures...); err != nil {
 		return err
@@ -503,7 +514,7 @@ func verifyOneEvolution(newDarc, prevDarc *Darc, getDarc func(string, bool) *Dar
 	}
 	inner := innerRequest{
 		BaseID:     newDarc.GetBaseID(),
-		Action:     evolve,
+		Action:     newDarc.EvolveName,
 		Msg:        newDarc.GetID(),
 		Identities: signerIDs,
 	}
@@ -547,12 +558,12 @@ func evalExpr(expr expression.Expr, getDarc GetDarc, ids ...string) error {
 			// because it may have revoked some rules in earlier
 			// darcs. We do this recursively because there may be
 			// further delegations.
-			if !d.Rules.Contains(sign) {
+			if !d.ContainsAction(d.SignName) {
 				return false
 			}
 			// Recursively evaluate the sign expression until we
 			// find the final signer with a ed25519 key.
-			if err := evalExpr(d.Rules[sign], getDarc, ids...); err != nil {
+			if err := evalExpr(d.GetSignExpr(), getDarc, ids...); err != nil {
 				return false
 			}
 			return true
@@ -572,337 +583,6 @@ func evalExpr(expr expression.Expr, getDarc GetDarc, ids ...string) error {
 		return fmt.Errorf("expression '%s' evaluated to false", expr)
 	}
 	return nil
-}
-
-// Type returns an integer representing the type of key held in the signer.
-// It is compatible with Identity.Type. For an empty signer, -1 is returned.
-func (s *Signer) Type() int {
-	switch {
-	case s.Ed25519 != nil:
-		return 1
-	case s.X509EC != nil:
-		return 2
-	default:
-		return -1
-	}
-}
-
-// Identity returns an identity struct with the pre initialised fields
-// for the appropriate signer.
-func (s *Signer) Identity() *Identity {
-	switch s.Type() {
-	case 1:
-		return &Identity{Ed25519: &IdentityEd25519{Point: s.Ed25519.Point}}
-	case 2:
-		return &Identity{X509EC: &IdentityX509EC{Public: s.X509EC.Point}}
-	default:
-		return nil
-	}
-}
-
-// Sign returns a signature in bytes for a given messages by the signer
-func (s *Signer) Sign(msg []byte) ([]byte, error) {
-	if msg == nil {
-		return nil, errors.New("nothing to sign, message is empty")
-	}
-	switch s.Type() {
-	case 0:
-		return nil, errors.New("cannot sign with a darc")
-	case 1:
-		return s.Ed25519.Sign(msg)
-	case 2:
-		return s.X509EC.Sign(msg)
-	default:
-		return nil, errors.New("unknown signer type")
-	}
-}
-
-// GetPrivate returns the private key, if one exists.
-func (s *Signer) GetPrivate() (kyber.Scalar, error) {
-	switch s.Type() {
-	case 1:
-		return s.Ed25519.Secret, nil
-	case 0, 2:
-		return nil, errors.New("signer lacks a private key")
-	default:
-		return nil, errors.New("signer is of unknown type")
-	}
-}
-
-// Equal first checks the type of the two identities, and if they match,
-// it returns if their data is the same.
-func (id *Identity) Equal(id2 *Identity) bool {
-	if id.Type() != id2.Type() {
-		return false
-	}
-	switch id.Type() {
-	case 0:
-		return id.Darc.Equal(id2.Darc)
-	case 1:
-		return id.Ed25519.Equal(id2.Ed25519)
-	case 2:
-		return id.X509EC.Equal(id2.X509EC)
-	}
-	return false
-}
-
-// Type returns an int indicating what type of identity this is. If all
-// identities are nil, it returns -1.
-func (id *Identity) Type() int {
-	switch {
-	case id.Darc != nil:
-		return 0
-	case id.Ed25519 != nil:
-		return 1
-	case id.X509EC != nil:
-		return 2
-	}
-	return -1
-}
-
-// TypeString returns the string of the type of the identity.
-func (id *Identity) TypeString() string {
-	switch id.Type() {
-	case 0:
-		return "darc"
-	case 1:
-		return "ed25519"
-	case 2:
-		return "x509ec"
-	default:
-		return "No identity"
-	}
-}
-
-// String returns the string representation of the identity
-func (id *Identity) String() string {
-	switch id.Type() {
-	case 0:
-		return fmt.Sprintf("%s:%x", id.TypeString(), id.Darc.ID)
-	case 1:
-		return fmt.Sprintf("%s:%s", id.TypeString(), id.Ed25519.Point.String())
-	case 2:
-		return fmt.Sprintf("%s:%x", id.TypeString(), id.X509EC.Public)
-	default:
-		return "No identity"
-	}
-}
-
-// Verify returns nil if the signature is correct, or an error if something
-// went wrong.
-func (id *Identity) Verify(msg, sig []byte) error {
-	switch id.Type() {
-	case 0:
-		return errors.New("cannot verify a darc-signature")
-	case 1:
-		return id.Ed25519.Verify(msg, sig)
-	case 2:
-		return id.X509EC.Verify(msg, sig)
-	default:
-		return errors.New("unknown identity")
-	}
-}
-
-// NewIdentityDarc creates a new darc identity struct given a darcid
-func NewIdentityDarc(id ID) *Identity {
-	return &Identity{
-		Darc: &IdentityDarc{
-			ID: id,
-		},
-	}
-}
-
-// Equal returns true if both IdentityDarcs point to the same data.
-func (idd *IdentityDarc) Equal(idd2 *IdentityDarc) bool {
-	return bytes.Equal(idd.ID, idd2.ID)
-}
-
-// NewIdentityEd25519 creates a new Ed25519 identity struct given a point
-func NewIdentityEd25519(point kyber.Point) *Identity {
-	return &Identity{
-		Ed25519: &IdentityEd25519{
-			Point: point,
-		},
-	}
-}
-
-// Equal returns true if both IdentityEd25519 point to the same data.
-func (ide *IdentityEd25519) Equal(ide2 *IdentityEd25519) bool {
-	return ide.Point.Equal(ide2.Point)
-}
-
-// Verify returns nil if the signature is correct, or an error if something
-// fails.
-func (ide *IdentityEd25519) Verify(msg, sig []byte) error {
-	return schnorr.Verify(cothority.Suite, ide.Point, msg, sig)
-}
-
-// NewIdentityX509EC creates a new X509EC identity struct given a point
-func NewIdentityX509EC(public []byte) *Identity {
-	return &Identity{
-		X509EC: &IdentityX509EC{
-			Public: public,
-		},
-	}
-}
-
-// Equal returns true if both IdentityX509EC point to the same data.
-func (idkc *IdentityX509EC) Equal(idkc2 *IdentityX509EC) bool {
-	return bytes.Compare(idkc.Public, idkc2.Public) == 0
-}
-
-type sigRS struct {
-	R *big.Int
-	S *big.Int
-}
-
-// Verify returns nil if the signature is correct, or an error if something
-// fails.
-func (idkc *IdentityX509EC) Verify(msg, s []byte) error {
-	public, err := x509.ParsePKIXPublicKey(idkc.Public)
-	if err != nil {
-		return err
-	}
-	digest := sha512.Sum384(msg)
-	sig := &sigRS{}
-	_, err = asn1.Unmarshal(s, sig)
-	if err != nil {
-		return err
-	}
-	if ecdsa.Verify(public.(*ecdsa.PublicKey), digest[:], sig.R, sig.S) {
-		return nil
-	}
-	return errors.New("Wrong signature")
-}
-
-// NewSignerEd25519 initializes a new SignerEd25519 given a public and private keys.
-// If any of the given values is nil or both are nil, then a new key pair is generated.
-// It returns a signer.
-func NewSignerEd25519(point kyber.Point, secret kyber.Scalar) *Signer {
-	if point == nil || secret == nil {
-		kp := key.NewKeyPair(cothority.Suite)
-		point, secret = kp.Public, kp.Private
-	}
-	return &Signer{Ed25519: &SignerEd25519{
-		Point:  point,
-		Secret: secret,
-	}}
-}
-
-// Sign creates a schnorr signautre on the message
-func (eds *SignerEd25519) Sign(msg []byte) ([]byte, error) {
-	return schnorr.Sign(cothority.Suite, eds.Secret, msg)
-}
-
-// Hash computes the digest of the request, the identities and signatures are
-// not included.
-func (r *Request) Hash() []byte {
-	return r.innerRequest.Hash()
-}
-
-func (r innerRequest) Hash() []byte {
-	h := sha256.New()
-	h.Write(r.BaseID)
-	h.Write([]byte(r.Action))
-	h.Write(r.Msg)
-	for _, i := range r.Identities {
-		h.Write([]byte(i.String()))
-	}
-	return h.Sum(nil)
-}
-
-// GetIdentityStrings returns a slice of identity strings, this is useful for
-// creating a parser.
-func (r *Request) GetIdentityStrings() []string {
-	res := make([]string, len(r.Identities))
-	for i, id := range r.Identities {
-		res[i] = id.String()
-	}
-	return res
-}
-
-// MsgToDarc attempts to return a darc given the matching darcBuf. This
-// function should *not* be used as a way to verify the darc, it only checks
-// that darcBuf can be decoded and matches with the Msg part of the request.
-func (r *Request) MsgToDarc(darcBuf []byte) (*Darc, error) {
-	d, err := NewDarcFromProto(darcBuf)
-	if err != nil {
-		return nil, err
-	}
-
-	if !d.GetID().Equal(r.Msg) {
-		return nil, errors.New("darc IDs are not equal")
-	}
-
-	if len(r.Signatures) != len(r.Identities) {
-		return nil, errors.New("signature and identitity length mismatch")
-	}
-	darcSigs := make([]*Signature, len(r.Signatures))
-	for i := range r.Signatures {
-		darcSigs[i] = &Signature{
-			Signature: r.Signatures[i],
-			Signer:    *r.Identities[i],
-		}
-	}
-	d.Signatures = darcSigs
-
-	return d, nil
-}
-
-// InitRequest initialises a request, the caller must provide all the fields of
-// the request. There is no guarantee that this request is valid, please see
-// InitAndSignRequest is a valid request needs to be created.
-func InitRequest(baseID ID, action Action, msg []byte, ids []*Identity, sigs [][]byte) Request {
-	inner := innerRequest{
-		BaseID:     baseID,
-		Action:     action,
-		Msg:        msg,
-		Identities: ids,
-	}
-	return Request{
-		inner,
-		sigs,
-	}
-}
-
-// InitAndSignRequest creates a new request which can be verified by a Darc.
-func InitAndSignRequest(baseID ID, action Action, msg []byte, signers ...*Signer) (*Request, error) {
-	if len(signers) == 0 {
-		return nil, errors.New("there are no signers")
-	}
-	signerIDs := make([]*Identity, len(signers))
-	for i, s := range signers {
-		signerIDs[i] = s.Identity()
-	}
-	inner := innerRequest{
-		BaseID:     baseID,
-		Action:     action,
-		Msg:        msg,
-		Identities: signerIDs,
-	}
-	digest := inner.Hash()
-	sigs := make([][]byte, len(signers))
-	for i, s := range signers {
-		var err error
-		sigs[i], err = s.Sign(digest)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return &Request{
-		inner,
-		sigs,
-	}, nil
-}
-
-// NewSignerX509EC creates a new SignerX509EC - mostly for tests
-func NewSignerX509EC() *Signer {
-	return nil
-}
-
-// Sign creates a RSA signature on the message
-func (kcs *SignerX509EC) Sign(msg []byte) ([]byte, error) {
-	return nil, errors.New("not yet implemented")
 }
 
 func copyBytes(a []byte) []byte {

--- a/omniledger/darc/darc_example_test.go
+++ b/omniledger/darc/darc_example_test.go
@@ -9,20 +9,21 @@ import (
 )
 
 func Example() {
+	evolve := darc.Action("evolve")
+	sign := darc.Action("sign")
 	// Consider a client-server configuration. Where the client holds the
 	// credentials and wants the server to check for requests or evolve
 	// darcs. We begin by creating a darc on the server.
 	// We can create a new darc like so.
 	owner1 := darc.NewSignerEd25519(nil, nil)
-	rules1 := darc.InitRules([]*darc.Identity{owner1.Identity()}, []*darc.Identity{})
-	d1 := darc.NewDarc(rules1, []byte("example darc"))
+	d1 := darc.NewDarc([]*darc.Identity{owner1.Identity()}, []*darc.Identity{},
+		evolve, sign, []byte("example darc"))
 	fmt.Println(d1.Verify())
 
 	// Now the client wants to evolve the darc (change the owner), so it
 	// creates a request and then sends it to the server.
 	owner2 := darc.NewSignerEd25519(nil, nil)
-	rules2 := darc.InitRules([]*darc.Identity{owner2.Identity()}, []*darc.Identity{})
-	d2 := darc.NewDarc(rules2, []byte("example darc 2"))
+	d2 := darc.NewDarc([]*darc.Identity{owner2.Identity()}, []*darc.Identity{}, evolve, sign, []byte("example darc 2"))
 	d2.EvolveFrom(d1)
 	r, d2Buf, err := d2.MakeEvolveRequest(owner1)
 	fmt.Println(err)
@@ -60,7 +61,7 @@ func Example() {
 		owner2.Identity().String(),
 		owner3.Identity().String())
 	d3 := d1.Copy()
-	d3.Rules.AddRule(action3, expr3)
+	d3.AddRule(action3, expr3)
 
 	// Typically the Msg part of the request is a digest of the actual
 	// message. For simplicity in this example, we put the actual message

--- a/omniledger/darc/identitiy.go
+++ b/omniledger/darc/identitiy.go
@@ -1,0 +1,247 @@
+package darc
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/sha512"
+	"crypto/x509"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/dedis/cothority"
+	"github.com/dedis/kyber"
+	"github.com/dedis/kyber/sign/schnorr"
+	"github.com/dedis/kyber/util/key"
+)
+
+// Type returns an integer representing the type of key held in the signer.
+// It is compatible with Identity.Type. For an empty signer, -1 is returned.
+func (s *Signer) Type() int {
+	switch {
+	case s.Ed25519 != nil:
+		return 1
+	case s.X509EC != nil:
+		return 2
+	default:
+		return -1
+	}
+}
+
+// Identity returns an identity struct with the pre initialised fields
+// for the appropriate signer.
+func (s *Signer) Identity() *Identity {
+	switch s.Type() {
+	case 1:
+		return &Identity{Ed25519: &IdentityEd25519{Point: s.Ed25519.Point}}
+	case 2:
+		return &Identity{X509EC: &IdentityX509EC{Public: s.X509EC.Point}}
+	default:
+		return nil
+	}
+}
+
+// Sign returns a signature in bytes for a given messages by the signer
+func (s *Signer) Sign(msg []byte) ([]byte, error) {
+	if msg == nil {
+		return nil, errors.New("nothing to sign, message is empty")
+	}
+	switch s.Type() {
+	case 0:
+		return nil, errors.New("cannot sign with a darc")
+	case 1:
+		return s.Ed25519.Sign(msg)
+	case 2:
+		return s.X509EC.Sign(msg)
+	default:
+		return nil, errors.New("unknown signer type")
+	}
+}
+
+// GetPrivate returns the private key, if one exists.
+func (s *Signer) GetPrivate() (kyber.Scalar, error) {
+	switch s.Type() {
+	case 1:
+		return s.Ed25519.Secret, nil
+	case 0, 2:
+		return nil, errors.New("signer lacks a private key")
+	default:
+		return nil, errors.New("signer is of unknown type")
+	}
+}
+
+// Equal first checks the type of the two identities, and if they match,
+// it returns if their data is the same.
+func (id *Identity) Equal(id2 *Identity) bool {
+	if id.Type() != id2.Type() {
+		return false
+	}
+	switch id.Type() {
+	case 0:
+		return id.Darc.Equal(id2.Darc)
+	case 1:
+		return id.Ed25519.Equal(id2.Ed25519)
+	case 2:
+		return id.X509EC.Equal(id2.X509EC)
+	}
+	return false
+}
+
+// Type returns an int indicating what type of identity this is. If all
+// identities are nil, it returns -1.
+func (id *Identity) Type() int {
+	switch {
+	case id.Darc != nil:
+		return 0
+	case id.Ed25519 != nil:
+		return 1
+	case id.X509EC != nil:
+		return 2
+	}
+	return -1
+}
+
+// TypeString returns the string of the type of the identity.
+func (id *Identity) TypeString() string {
+	switch id.Type() {
+	case 0:
+		return "darc"
+	case 1:
+		return "ed25519"
+	case 2:
+		return "x509ec"
+	default:
+		return "No identity"
+	}
+}
+
+// String returns the string representation of the identity
+func (id *Identity) String() string {
+	switch id.Type() {
+	case 0:
+		return fmt.Sprintf("%s:%x", id.TypeString(), id.Darc.ID)
+	case 1:
+		return fmt.Sprintf("%s:%s", id.TypeString(), id.Ed25519.Point.String())
+	case 2:
+		return fmt.Sprintf("%s:%x", id.TypeString(), id.X509EC.Public)
+	default:
+		return "No identity"
+	}
+}
+
+// Verify returns nil if the signature is correct, or an error if something
+// went wrong.
+func (id *Identity) Verify(msg, sig []byte) error {
+	switch id.Type() {
+	case 0:
+		return errors.New("cannot verify a darc-signature")
+	case 1:
+		return id.Ed25519.Verify(msg, sig)
+	case 2:
+		return id.X509EC.Verify(msg, sig)
+	default:
+		return errors.New("unknown identity")
+	}
+}
+
+// NewIdentityDarc creates a new darc identity struct given a darcid
+func NewIdentityDarc(id ID) *Identity {
+	return &Identity{
+		Darc: &IdentityDarc{
+			ID: id,
+		},
+	}
+}
+
+// Equal returns true if both IdentityDarcs point to the same data.
+func (idd *IdentityDarc) Equal(idd2 *IdentityDarc) bool {
+	return bytes.Equal(idd.ID, idd2.ID)
+}
+
+// NewIdentityEd25519 creates a new Ed25519 identity struct given a point
+func NewIdentityEd25519(point kyber.Point) *Identity {
+	return &Identity{
+		Ed25519: &IdentityEd25519{
+			Point: point,
+		},
+	}
+}
+
+// Equal returns true if both IdentityEd25519 point to the same data.
+func (ide *IdentityEd25519) Equal(ide2 *IdentityEd25519) bool {
+	return ide.Point.Equal(ide2.Point)
+}
+
+// Verify returns nil if the signature is correct, or an error if something
+// fails.
+func (ide *IdentityEd25519) Verify(msg, sig []byte) error {
+	return schnorr.Verify(cothority.Suite, ide.Point, msg, sig)
+}
+
+// NewIdentityX509EC creates a new X509EC identity struct given a point
+func NewIdentityX509EC(public []byte) *Identity {
+	return &Identity{
+		X509EC: &IdentityX509EC{
+			Public: public,
+		},
+	}
+}
+
+// Equal returns true if both IdentityX509EC point to the same data.
+func (idkc *IdentityX509EC) Equal(idkc2 *IdentityX509EC) bool {
+	return bytes.Compare(idkc.Public, idkc2.Public) == 0
+}
+
+type sigRS struct {
+	R *big.Int
+	S *big.Int
+}
+
+// Verify returns nil if the signature is correct, or an error if something
+// fails.
+func (idkc *IdentityX509EC) Verify(msg, s []byte) error {
+	public, err := x509.ParsePKIXPublicKey(idkc.Public)
+	if err != nil {
+		return err
+	}
+	digest := sha512.Sum384(msg)
+	sig := &sigRS{}
+	_, err = asn1.Unmarshal(s, sig)
+	if err != nil {
+		return err
+	}
+	if ecdsa.Verify(public.(*ecdsa.PublicKey), digest[:], sig.R, sig.S) {
+		return nil
+	}
+	return errors.New("Wrong signature")
+}
+
+// NewSignerEd25519 initializes a new SignerEd25519 given a public and private keys.
+// If any of the given values is nil or both are nil, then a new key pair is generated.
+// It returns a signer.
+func NewSignerEd25519(point kyber.Point, secret kyber.Scalar) *Signer {
+	if point == nil || secret == nil {
+		kp := key.NewKeyPair(cothority.Suite)
+		point, secret = kp.Public, kp.Private
+	}
+	return &Signer{Ed25519: &SignerEd25519{
+		Point:  point,
+		Secret: secret,
+	}}
+}
+
+// Sign creates a schnorr signautre on the message
+func (eds *SignerEd25519) Sign(msg []byte) ([]byte, error) {
+	return schnorr.Sign(cothority.Suite, eds.Secret, msg)
+}
+
+// NewSignerX509EC creates a new SignerX509EC - mostly for tests
+func NewSignerX509EC() *Signer {
+	return nil
+}
+
+// Sign creates a RSA signature on the message
+func (kcs *SignerX509EC) Sign(msg []byte) ([]byte, error) {
+	return nil, errors.New("not yet implemented")
+}

--- a/omniledger/darc/request.go
+++ b/omniledger/darc/request.go
@@ -1,0 +1,107 @@
+package darc
+
+import (
+	"crypto/sha256"
+	"errors"
+)
+
+// Hash computes the digest of the request, the identities and signatures are
+// not included.
+func (r *Request) Hash() []byte {
+	return r.innerRequest.Hash()
+}
+
+func (r innerRequest) Hash() []byte {
+	h := sha256.New()
+	h.Write(r.BaseID)
+	h.Write([]byte(r.Action))
+	h.Write(r.Msg)
+	for _, i := range r.Identities {
+		h.Write([]byte(i.String()))
+	}
+	return h.Sum(nil)
+}
+
+// GetIdentityStrings returns a slice of identity strings, this is useful for
+// creating a parser.
+func (r *Request) GetIdentityStrings() []string {
+	res := make([]string, len(r.Identities))
+	for i, id := range r.Identities {
+		res[i] = id.String()
+	}
+	return res
+}
+
+// MsgToDarc attempts to return a darc given the matching darcBuf. This
+// function should *not* be used as a way to verify the darc, it only checks
+// that darcBuf can be decoded and matches with the Msg part of the request.
+func (r *Request) MsgToDarc(darcBuf []byte) (*Darc, error) {
+	d, err := NewDarcFromProto(darcBuf)
+	if err != nil {
+		return nil, err
+	}
+
+	if !d.GetID().Equal(r.Msg) {
+		return nil, errors.New("darc IDs are not equal")
+	}
+
+	if len(r.Signatures) != len(r.Identities) {
+		return nil, errors.New("signature and identitity length mismatch")
+	}
+	darcSigs := make([]*Signature, len(r.Signatures))
+	for i := range r.Signatures {
+		darcSigs[i] = &Signature{
+			Signature: r.Signatures[i],
+			Signer:    *r.Identities[i],
+		}
+	}
+	d.Signatures = darcSigs
+
+	return d, nil
+}
+
+// InitRequest initialises a request, the caller must provide all the fields of
+// the request. There is no guarantee that this request is valid, please see
+// InitAndSignRequest is a valid request needs to be created.
+func InitRequest(baseID ID, action Action, msg []byte, ids []*Identity, sigs [][]byte) Request {
+	inner := innerRequest{
+		BaseID:     baseID,
+		Action:     action,
+		Msg:        msg,
+		Identities: ids,
+	}
+	return Request{
+		inner,
+		sigs,
+	}
+}
+
+// InitAndSignRequest creates a new request which can be verified by a Darc.
+func InitAndSignRequest(baseID ID, action Action, msg []byte, signers ...*Signer) (*Request, error) {
+	if len(signers) == 0 {
+		return nil, errors.New("there are no signers")
+	}
+	signerIDs := make([]*Identity, len(signers))
+	for i, s := range signers {
+		signerIDs[i] = s.Identity()
+	}
+	inner := innerRequest{
+		BaseID:     baseID,
+		Action:     action,
+		Msg:        msg,
+		Identities: signerIDs,
+	}
+	digest := inner.Hash()
+	sigs := make([][]byte, len(signers))
+	for i, s := range signers {
+		var err error
+		sigs[i], err = s.Sign(digest)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &Request{
+		inner,
+		sigs,
+	}, nil
+}

--- a/omniledger/darc/struct.go
+++ b/omniledger/darc/struct.go
@@ -43,7 +43,16 @@ type Darc struct {
 	BaseID ID
 	// PrevID is the previous darc ID in the chain of evolution.
 	PrevID ID
-	// Rules map an action to an expression.
+	// EvolveName is the name for the evolution action, which must
+	// exist and is responsible for managing the rules for evolving a darc.
+	// This field should not be changed after initialisation.
+	EvolveName Action
+	// SignName is the name of the sign action, which must exist and
+	// is responsible for giving other identities to sign on behalf of this
+	// darc. This field should not be changed after initialisation.
+	SignName Action
+	// Rules map an action to an expression. The evolve action and the sign
+	// action must exist, but they may be empty.
 	Rules Rules
 	// Signature is calculated on the Request-representation of the darc.
 	// It needs to be created by identities that have the "_evolve" action
@@ -57,8 +66,9 @@ type Darc struct {
 
 // Action is a string that should be associated with an expression. The
 // application typically will define the action but there are two actions that
-// are in all the darcs, "_evolve" and "_sign". The application can modify
-// these actions but should not change the semantics of these actions.
+// must be set in all darcs, evolve and sign. After initialisation, the
+// application can modify the expressions under these actions but should not
+// change the semantics or the name.
 type Action string
 
 // Rules are action-expression associations.
@@ -88,7 +98,6 @@ type IdentityX509EC struct {
 // IdentityDarc is a structure that points to a Darc with a given ID on a
 // skipchain. The signer should belong to the Darc.
 type IdentityDarc struct {
-	// Signer SignerEd25519
 	ID ID
 }
 

--- a/omniledger/service/api.go
+++ b/omniledger/service/api.go
@@ -77,9 +77,9 @@ func DefaultGenesisMsg(v Version, r *onet.Roster, rules []string, ids ...*darc.I
 	if len(ids) == 0 {
 		return nil, errors.New("no identities ")
 	}
-	d := darc.NewDarc(darc.InitRules(ids, ids), []byte("genesis darc"))
+	d := darc.NewDarc(ids, ids, "_evolve", "_sign", []byte("genesis darc"))
 	for _, r := range rules {
-		d.Rules.AddRule(darc.Action(r), d.Rules.GetSignExpr())
+		d.AddRule(darc.Action(r), d.GetSignExpr())
 	}
 
 	m := CreateGenesisBlock{

--- a/omniledger/service/transaction.go
+++ b/omniledger/service/transaction.go
@@ -182,7 +182,7 @@ func (instr Instruction) Action() string {
 	a := "invalid"
 	switch {
 	case instr.Spawn != nil:
-		a = fmt.Sprintf("Spawn_%s", instr.Spawn.ContractID)
+		a = "Spawn_" + instr.Spawn.ContractID
 	case instr.Invoke != nil:
 		a = "Invoke_" + instr.Invoke.Command
 	case instr.Delete != nil:

--- a/omniledger/service/transaction_test.go
+++ b/omniledger/service/transaction_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var testEvolveName = darc.Action("_evolve")
+var testSignName = darc.Action("_sign")
+
 func nonceStr(s string) (n Nonce) {
 	copy(n[:], s)
 	return n
@@ -94,8 +97,8 @@ func TestSortTransactions(t *testing.T) {
 func TestTransaction_Signing(t *testing.T) {
 	signer := darc.NewSignerEd25519(nil, nil)
 	ids := []*darc.Identity{signer.Identity()}
-	d := darc.NewDarc(darc.InitRules(ids, ids), []byte("genesis darc"))
-	d.Rules.AddRule("Spawn_dummy_kind", d.Rules.GetSignExpr())
+	d := darc.NewDarc(ids, ids, testEvolveName, testSignName, []byte("genesis darc"))
+	d.AddRule("Spawn_dummy_kind", d.GetSignExpr())
 	require.Nil(t, d.Verify())
 
 	instr, err := createInstr(d.GetBaseID(), "dummy_kind", []byte("dummy_value"), signer)


### PR DESCRIPTION
We make this change because the service using darcs may have its own
naming scheme for these actions. The implementation simply adds two
additional fields for these names, which must be set on initialisation.