### PR TITLE
Add contract for darc evolution

### DIFF
--- a/eventlog/el/main.go
+++ b/eventlog/el/main.go
@@ -26,7 +26,7 @@ type config struct {
 	Name   string
 	ID     skipchain.SkipBlockID
 	Roster *onet.Roster
-	Owner  *darc.Signer
+	Owner  darc.Signer
 	Darc   *darc.Darc
 }
 
@@ -198,7 +198,7 @@ func doLog(c *cli.Context) error {
 	// TODO: It should be possible to send logs, signing them with a different
 	// key. But first, we need to implement something like "el grant" to grant write
 	// privs to a given private/public key.
-	cl.Signers = []*darc.Signer{cfgs[cfg].Owner}
+	cl.Signers = []darc.Signer{cfgs[cfg].Owner}
 	// TODO: It is too bad that we need to store the Darc in config. It
 	// seems like the server should know this for us...
 	cl.Darc = cfgs[cfg].Darc

--- a/eventlog/service_test.go
+++ b/eventlog/service_test.go
@@ -57,9 +57,9 @@ func TestService_Log(t *testing.T) {
 	})
 }
 
-func (s *ser) init(t *testing.T) (skipchain.SkipBlockID, darc.Darc, []*darc.Signer) {
+func (s *ser) init(t *testing.T) (skipchain.SkipBlockID, darc.Darc, []darc.Signer) {
 	owner := darc.NewSignerEd25519(nil, nil)
-	rules := darc.InitRules([]*darc.Identity{owner.Identity()}, []*darc.Identity{})
+	rules := darc.InitRules([]darc.Identity{owner.Identity()}, []darc.Identity{})
 	d1 := darc.NewDarc(AddWriter(rules, nil), []byte("eventlog writer"))
 
 	reply, err := s.services[0].Init(&InitRequest{
@@ -71,7 +71,7 @@ func (s *ser) init(t *testing.T) (skipchain.SkipBlockID, darc.Darc, []*darc.Sign
 	require.NotNil(t, reply.ID)
 	require.False(t, reply.ID.IsNull())
 
-	return reply.ID, *d1, []*darc.Signer{owner}
+	return reply.ID, *d1, []darc.Signer{owner}
 }
 
 type ser struct {

--- a/omniledger/darc/darc_example_test.go
+++ b/omniledger/darc/darc_example_test.go
@@ -14,14 +14,14 @@ func Example() {
 	// darcs. We begin by creating a darc on the server.
 	// We can create a new darc like so.
 	owner1 := darc.NewSignerEd25519(nil, nil)
-	rules1 := darc.InitRules([]*darc.Identity{owner1.Identity()}, []*darc.Identity{})
+	rules1 := darc.InitRules([]darc.Identity{owner1.Identity()}, []darc.Identity{})
 	d1 := darc.NewDarc(rules1, []byte("example darc"))
-	fmt.Println(d1.Verify())
+	fmt.Println(d1.Verify(true))
 
 	// Now the client wants to evolve the darc (change the owner), so it
 	// creates a request and then sends it to the server.
 	owner2 := darc.NewSignerEd25519(nil, nil)
-	rules2 := darc.InitRules([]*darc.Identity{owner2.Identity()}, []*darc.Identity{})
+	rules2 := darc.InitRules([]darc.Identity{owner2.Identity()}, []darc.Identity{})
 	d2 := darc.NewDarc(rules2, []byte("example darc 2"))
 	d2.EvolveFrom(d1)
 	r, d2Buf, err := d2.MakeEvolveRequest(owner1)
@@ -47,7 +47,7 @@ func Example() {
 			return d1
 		}
 		return nil
-	}))
+	}, true))
 
 	// The above illustrates the basic use of darcs, in the following
 	// examples, we show how to create custom rules to enforce custom

--- a/omniledger/darc/struct.go
+++ b/omniledger/darc/struct.go
@@ -48,7 +48,7 @@ type Darc struct {
 	// Signature is calculated on the Request-representation of the darc.
 	// It needs to be created by identities that have the "_evolve" action
 	// from the previous valid Darc.
-	Signatures []*Signature
+	Signatures []Signature
 	// VerificationDarcs are a list of darcs that the verifier needs to
 	// verify this darc. It is not needed in online verification where the
 	// verifier stores all darcs.
@@ -124,7 +124,7 @@ type innerRequest struct {
 	BaseID     ID
 	Action     Action
 	Msg        []byte
-	Identities []*Identity
+	Identities []Identity
 }
 
 // Request is the structure that the client must provide to be verified

--- a/omniledger/service/api.go
+++ b/omniledger/service/api.go
@@ -73,7 +73,7 @@ func (c *Client) GetProof(r *onet.Roster, id skipchain.SkipBlockID, key []byte) 
 
 // DefaultGenesisMsg creates the message that is used to for creating the
 // genesis darc and block.
-func DefaultGenesisMsg(v Version, r *onet.Roster, rules []string, ids ...*darc.Identity) (*CreateGenesisBlock, error) {
+func DefaultGenesisMsg(v Version, r *onet.Roster, rules []string, ids ...darc.Identity) (*CreateGenesisBlock, error) {
 	if len(ids) == 0 {
 		return nil, errors.New("no identities ")
 	}

--- a/omniledger/service/api_test.go
+++ b/omniledger/service/api_test.go
@@ -25,7 +25,7 @@ func TestClient_GetProof(t *testing.T) {
 
 	// The darc inside it should be valid.
 	d := msg.GenesisDarc
-	require.Nil(t, d.Verify())
+	require.Nil(t, d.Verify(true))
 
 	c := NewClient()
 	csr, err := c.CreateGenesisBlock(roster, msg)

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -113,7 +113,7 @@ func (s *Service) CreateGenesisBlock(req *CreateGenesisBlock) (
 	if err != nil {
 		return nil, err
 	}
-	if req.GenesisDarc.Verify() != nil ||
+	if req.GenesisDarc.Verify(true) != nil ||
 		len(req.GenesisDarc.Rules) == 0 {
 		return nil, errors.New("invalid genesis darc")
 	}
@@ -309,6 +309,9 @@ func (s *Service) createNewBlock(scID skipchain.SkipBlockID, r *onet.Roster, cts
 	mr, ctsOK, scs, err = s.createStateChanges(coll, cts)
 	if err != nil {
 		return nil, err
+	}
+	if len(scs) == 0 {
+		return nil, errors.New("no state changes")
 	}
 	header := &DataHeader{
 		CollectionRoot:        mr,

--- a/omniledger/service/transaction_test.go
+++ b/omniledger/service/transaction_test.go
@@ -93,10 +93,10 @@ func TestSortTransactions(t *testing.T) {
 
 func TestTransaction_Signing(t *testing.T) {
 	signer := darc.NewSignerEd25519(nil, nil)
-	ids := []*darc.Identity{signer.Identity()}
+	ids := []darc.Identity{signer.Identity()}
 	d := darc.NewDarc(darc.InitRules(ids, ids), []byte("genesis darc"))
 	d.Rules.AddRule("Spawn_dummy_kind", d.Rules.GetSignExpr())
-	require.Nil(t, d.Verify())
+	require.Nil(t, d.Verify(true))
 
 	instr, err := createInstr(d.GetBaseID(), "dummy_kind", []byte("dummy_value"), signer)
 	require.Nil(t, err)
@@ -108,7 +108,7 @@ func TestTransaction_Signing(t *testing.T) {
 	require.Nil(t, req.Verify(d))
 }
 
-func createOneClientTx(dID darc.ID, kind string, value []byte, signer *darc.Signer) (ClientTransaction, error) {
+func createOneClientTx(dID darc.ID, kind string, value []byte, signer darc.Signer) (ClientTransaction, error) {
 	instr, err := createInstr(dID, kind, value, signer)
 	t := ClientTransaction{
 		Instructions: []Instruction{instr},
@@ -116,7 +116,7 @@ func createOneClientTx(dID darc.ID, kind string, value []byte, signer *darc.Sign
 	return t, err
 }
 
-func createInstr(dID darc.ID, contractID string, value []byte, signer *darc.Signer) (Instruction, error) {
+func createInstr(dID darc.ID, contractID string, value []byte, signer darc.Signer) (Instruction, error) {
 	instr := Instruction{
 		ObjectID: ObjectID{
 			DarcID:     dID,


### PR DESCRIPTION
This commit adds a simple contract that checks the darc evolution
request. The functionality of Instruction.Action had to be changed to
allow this feature. That is, the darc-action for Invoke does not have
the "Invoke_" prefix anymore. This is unecessary because the re-created
darc.Request in an instruction must match the darc.Request during
verification. If the action in the instruction does match the action in
the darc, then verification will fail.

For example, when client submits an instruction, the client signs the
instruction by creating a darc.Request and then signs the request. The
request will contain instruction.Action, which would be "Invoke__evolve"
in the old implementation. This instruction is sent to the omniledger
service and it does two verification, one in the service code and the
other in the contract. (1) The service finds the corresponding darc,
converts the instruction to a darc.Request, and calls
darc.Request.Verify. The verification will fail if the darc doesn't have
"Invoke__evolve" as one of its actions (a simple way to fix it is to
copy the expression from "_evolve" to "Invoke__evolve"). (2) We need to
do the verification again in the contract because the service
verification doesn't try to decode the serialised darc. Hence, the
contract is given the same instruction, decodes it, and calls
darc.Verify. For this verification to work, the darc code will check
that the evolution is valid, e.g., the version is correct, base ID is
correct and most importantly, that the darc is signed by the owners of
the previous darc on the darc.Request representation, which *must*
use "_evolve" as its action. Verification (1) works because we can add
new rules to the darc. But verification (2) will not work unless we make
sure that the action in darc.Request is re-created in the same way, from
an instruction and from a darc (in verifyOneEvolution).

Another change is the Signer and Identity types. Before we always used
pointer types, which is unecessary because we never modify these structs
after creation. Now we use value types.