### PR TITLE
Simplify darc evolution verification in contract

### DIFF
--- a/eventlog/api.go
+++ b/eventlog/api.go
@@ -40,7 +40,7 @@ func AddWriter(r darc.Rules, expr expression.Expr) darc.Rules {
 	if expr == nil {
 		expr = r.GetEvolutionExpr()
 	}
-	r["Spawn_eventlog"] = expr
+	r["spawn:eventlog"] = expr
 	return r
 }
 

--- a/external/java/src/main/java/ch/epfl/dedis/lib/eventlog/EventLog.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/eventlog/EventLog.java
@@ -38,7 +38,7 @@ public class EventLog {
             identities.add(signer.getIdentity());
         }
         Map<String, byte[]> rules = Darc.initRules(identities, new ArrayList<>());
-        rules.put("Spawn_eventlog", rules.get("_evolve"));
+        rules.put("spawn:eventlog", rules.get("invoke:evolve"));
 
         Darc darc = new Darc(rules, "eventlog owner".getBytes());
         byte[] genesisBuf  = this.init(roster, darc, blockInterval);

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/Instruction.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/Instruction.java
@@ -152,11 +152,11 @@ public class Instruction {
     public String action() {
         String a = "invalid";
         if (this.spawn != null ) {
-            a = "Spawn_" + this.spawn.getContractId();
+            a = "spawn:" + this.spawn.getContractId();
         } else if (this.invoke != null) {
-            a = "Invoke_" + this.invoke.getCommand();
+            a = "invoke:" + this.invoke.getCommand();
         } else if (this.delete != null) {
-            a = "Delete";
+            a = "delete";
         }
         return a;
     }

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/darc/Darc.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/darc/Darc.java
@@ -37,7 +37,7 @@ public class Darc {
     public static Map<String, byte[]> initRules(List<Identity> owners, List<Identity> signers)  {
         Map<String, byte[]> rs = new HashMap<>();
         List<String> ownerIDs = owners.stream().map(Identity::toString).collect(Collectors.toList());
-        rs.put("_evolve", String.join(" & ", ownerIDs).getBytes());
+        rs.put("invoke:evolve", String.join(" & ", ownerIDs).getBytes());
 
         List<String> signerIDs = signers.stream().map(Identity::toString).collect(Collectors.toList());
         rs.put("_sign", String.join(" | ", signerIDs).getBytes());

--- a/omniledger/darc/darc_test.go
+++ b/omniledger/darc/darc_test.go
@@ -40,7 +40,7 @@ func TestDarc_Copy(t *testing.T) {
 	d2 := d1.Copy()
 
 	// modify the first one
-	d1.IncrementVersion()
+	d1.Version++
 	desc := []byte("testdarc2")
 	d1.Description = desc
 	err = d1.Rules.UpdateRule("ocs:write", []byte(createIdentity().String()))
@@ -67,13 +67,6 @@ func TestUpdateRule(t *testing.T) {
 
 func TestDeleteRule(t *testing.T) {
 	// TODO
-}
-
-func TestDarc_IncrementVersion(t *testing.T) {
-	d := createDarc(1, "testdarc").darc
-	previousVersion := d.Version
-	d.IncrementVersion()
-	require.NotEqual(t, previousVersion, d.Version)
 }
 
 // TestDarc_EvolveOne creates two darcs, the first has two owners and the

--- a/omniledger/service/api.go
+++ b/omniledger/service/api.go
@@ -77,11 +77,10 @@ func DefaultGenesisMsg(v Version, r *onet.Roster, rules []string, ids ...darc.Id
 	if len(ids) == 0 {
 		return nil, errors.New("no identities ")
 	}
-	d := darc.NewDarc(darc.InitRules(ids, ids), []byte("genesis darc"))
+	d := darc.NewDarc(darc.InitRulesWith(ids, ids, invokeEvolve), []byte("genesis darc"))
 	for _, r := range rules {
 		d.Rules.AddRule(darc.Action(r), d.Rules.GetSignExpr())
 	}
-
 	m := CreateGenesisBlock{
 		Version:       v,
 		Roster:        *r,

--- a/omniledger/service/api_test.go
+++ b/omniledger/service/api_test.go
@@ -19,7 +19,7 @@ func TestClient_GetProof(t *testing.T) {
 
 	// Initialise the genesis message and send it to the service.
 	signer := darc.NewSignerEd25519(nil, nil)
-	msg, err := DefaultGenesisMsg(CurrentVersion, roster, []string{"Spawn_dummy"}, signer.Identity())
+	msg, err := DefaultGenesisMsg(CurrentVersion, roster, []string{"spawn:dummy"}, signer.Identity())
 	msg.BlockInterval = 100 * time.Millisecond
 	require.Nil(t, err)
 

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -24,6 +24,8 @@ import (
 
 const darcIDLen int = 32
 
+const invokeEvolve darc.Action = darc.Action("invoke:evolve")
+
 var omniledgerID onet.ServiceID
 var verifyOmniLedger = skipchain.VerifierID(uuid.NewV5(uuid.NamespaceURL, "OmniLedger"))
 
@@ -478,18 +480,16 @@ func (s *Service) createQueueWorker(scID skipchain.SkipBlockID, interval time.Du
 
 					_, err = s.createNewBlock(scID, sb.Roster, ts)
 
-					// TODO: In createNewBlock, we
-					// need to limit how many tx
-					// we consume according the
-					// final size of the block.
-					// Thus createNewBlock needs to return how
-					// many it took.
+					// TODO: In createNewBlock, we need to
+					// limit how many tx we consume
+					// according the final size of the
+					// block. Thus createNewBlock needs to
+					// return how many it took.
 
-					// (The maximum size
-					// of a block is currently
-					// fixed by (at least) the
-					// maximum message size
-					// allowed in onet.)
+					// (The maximum size of a block is
+					// currently fixed by (at least) the
+					// maximum message size allowed in
+					// onet.)
 					ts = []ClientTransaction{}
 					if err != nil {
 						log.Error("couldn't create new block: " + err.Error())

--- a/omniledger/service/service_test.go
+++ b/omniledger/service/service_test.go
@@ -47,7 +47,7 @@ func TestService_CreateSkipchain(t *testing.T) {
 
 	// create valid darc
 	signer := darc.NewSignerEd25519(nil, nil)
-	genesisMsg, err := DefaultGenesisMsg(CurrentVersion, s.roster, []string{"Spawn_dummy"}, signer.Identity())
+	genesisMsg, err := DefaultGenesisMsg(CurrentVersion, s.roster, []string{"spawn:dummy"}, signer.Identity())
 	genesisMsg.BlockInterval = 100 * time.Millisecond
 	require.Nil(t, err)
 
@@ -64,7 +64,7 @@ func padDarc(key []byte) []byte {
 	return keyPadded
 }
 
-func TestService_AddKeyValue(t *testing.T) {
+func TestService_AddTransaction(t *testing.T) {
 	s := newSer(t, 1, testInterval)
 	defer s.local.CloseAll()
 	defer closeQueues(s.local)
@@ -416,7 +416,7 @@ func darcToTx(t *testing.T, d2 darc.Darc, signer darc.Signer) ClientTransaction 
 	d2Buf, err := d2.ToProto()
 	require.Nil(t, err)
 	invoke := Invoke{
-		Command: "_evolve",
+		Command: "evolve",
 		Args: []Argument{
 			Argument{
 				Name:  "darc",
@@ -497,7 +497,7 @@ func newSer(t *testing.T, step int, interval time.Duration) *ser {
 	}
 	registerDummy(s.services)
 
-	genesisMsg, err := DefaultGenesisMsg(CurrentVersion, s.roster, []string{"Spawn_dummy", "Spawn_invalid", "Spawn_panic"}, s.signer.Identity())
+	genesisMsg, err := DefaultGenesisMsg(CurrentVersion, s.roster, []string{"spawn:dummy", "spawn:invalid", "spawn:panic"}, s.signer.Identity())
 	require.Nil(t, err)
 	s.darc = &genesisMsg.GenesisDarc
 

--- a/omniledger/service/transaction.go
+++ b/omniledger/service/transaction.go
@@ -182,9 +182,9 @@ func (instr Instruction) Action() string {
 	a := "invalid"
 	switch {
 	case instr.Spawn != nil:
-		a = "Spawn_" + instr.Spawn.ContractID
+		a = "spawn:" + instr.Spawn.ContractID
 	case instr.Invoke != nil:
-		a = instr.Invoke.Command
+		a = "invoke:" + instr.Invoke.Command
 	case instr.Delete != nil:
 		a = "Delete"
 	}

--- a/omniledger/service/transaction_test.go
+++ b/omniledger/service/transaction_test.go
@@ -95,7 +95,7 @@ func TestTransaction_Signing(t *testing.T) {
 	signer := darc.NewSignerEd25519(nil, nil)
 	ids := []darc.Identity{signer.Identity()}
 	d := darc.NewDarc(darc.InitRules(ids, ids), []byte("genesis darc"))
-	d.Rules.AddRule("Spawn_dummy_kind", d.Rules.GetSignExpr())
+	d.Rules.AddRule("spawn:dummy_kind", d.Rules.GetSignExpr())
 	require.Nil(t, d.Verify(true))
 
 	instr, err := createInstr(d.GetBaseID(), "dummy_kind", []byte("dummy_value"), signer)


### PR DESCRIPTION
We are doing the darc verification twice, once before contract
execution, on the request type, and once inside the contract. The
contract trusts the omniledger service, so it only needs to do some
sanity check of the evolution and not the full verification. This change
also allows us to bring back the invoke/spawn/delete namespace.

Further, we change the namespace naming scheme to use colon-seperated
strings from undescore-separated. This is because the action name might
become difficult for humans to read when underscores are used for the
command name.