### PR TITLE
Increase timeout and better propagate blocks

### DIFF
--- a/evoting/service/service.go
+++ b/evoting/service/service.go
@@ -41,7 +41,7 @@ func init() {
 }
 
 // timeout for protocol termination.
-var timeout = 120 * time.Second
+var timeout = 600 * time.Second
 
 // serviceID is the onet identifier.
 var serviceID onet.ServiceID


### PR DESCRIPTION
* setting decrypt/shuffle timeout to 10 minutes
* propagating forward link and last block together to avoid dangling forward links