### PR TITLE
adding backward-compatible challenge calculation

### DIFF
--- a/ftcosi/protocol/protocol.go
+++ b/ftcosi/protocol/protocol.go
@@ -174,7 +174,11 @@ func (p *FtCosi) Dispatch() error {
 	if err != nil {
 		return err
 	}
-	structChallenge := StructChallenge{p.TreeNode(), Challenge{cosiChallenge}}
+	structChallenge := StructChallenge{p.TreeNode(), Challenge{
+		CoSiChallenge:   cosiChallenge,
+		AggregateCommit: commitment,
+		Mask:            finalMask,
+	}}
 
 	// send challenge to every subprotocol
 	for _, coSiProtocol := range runningSubProtocols {

--- a/ftcosi/protocol/struct.go
+++ b/ftcosi/protocol/struct.go
@@ -76,7 +76,12 @@ type StructCommitment struct {
 
 // Challenge is the ftcosi challenge message
 type Challenge struct {
+	// CoSiChallenge is deprecated and should not be used anymore!
 	CoSiChallenge kyber.Scalar
+	// AggregateCommit should be used by all nodes.
+	AggregateCommit kyber.Point
+	// Mask represents the nodes that participated in the signature.
+	Mask *cosi.Mask
 }
 
 // StructChallenge just contains Challenge and the data necessary to identify and


### PR DESCRIPTION
The current cosi implementation trusts the leader to correctly calculate the challenge - but this means that the leader could propose any challenge he wants and get the nodes to sign off something they did not verify.

As we're in `v2` non-breaking mode, it will output a warning if it receives a pre-calculated challenge, but still continue. In the best case, it will calculate the challenge.

Closes #1293 