### PR TITLE
Add SecureKG server configuration

### DIFF
--- a/external/java/src/main/java/ch/epfl/dedis/lib/eventlog/Event.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/eventlog/Event.java
@@ -47,8 +47,8 @@ public final class Event {
         EventLogProto.Event.Builder b = EventLogProto.Event.newBuilder();
         b.setWhen(this.when);
         b.setTopic(this.topic);
-        b.setContent(this.topic);
-        return  b.build();
+        b.setContent(this.content);
+        return b.build();
     }
 
     @Override

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/InstanceId.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/InstanceId.java
@@ -84,4 +84,13 @@ public class InstanceId implements HashId {
             throw new RuntimeException(e);
         }
     }
+
+    /**
+     * Creates an instance ID of all zeros.
+     * @return the zero instance ID
+     * @throws CothorityCryptoException
+     */
+    public static InstanceId zero() throws CothorityCryptoException {
+        return new InstanceId(DarcId.zero(), SubId.zero());
+    }
 }

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/SecureKG.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/SecureKG.java
@@ -1,0 +1,76 @@
+package ch.epfl.dedis.lib.omniledger;
+
+import ch.epfl.dedis.lib.Roster;
+import ch.epfl.dedis.lib.SkipblockId;
+import ch.epfl.dedis.lib.exception.CothorityCryptoException;
+import ch.epfl.dedis.lib.exception.CothorityException;
+import ch.epfl.dedis.lib.omniledger.darc.DarcId;
+import ch.epfl.dedis.lib.omniledger.darc.Signer;
+import ch.epfl.dedis.lib.omniledger.darc.SignerEd25519;
+
+import javax.xml.bind.DatatypeConverter;
+
+public final class SecureKG {
+    /**
+     * Gets the roster of the secure KG server.
+     * @return the roster
+     */
+    public static Roster getRoster() {
+        return Roster.FromToml("[[servers]]\n" +
+                "  Address = \"tls://securekg.dedis.ch:18002\"\n" +
+                "  Suite = \"Ed25519\"\n" +
+                "  Public = \"fcf9492de37b1115637206f3bc6ace77e6d8e7ae29b0b40dd7a0f18bdd2eb7db\"\n" +
+                "  Description = \"Conode_1\"\n" +
+                "[[servers]]\n" +
+                "  Address = \"tls://securekg.dedis.ch:18004\"\n" +
+                "  Suite = \"Ed25519\"\n" +
+                "  Public = \"11c7c22112328f151e6d853f47bb3b404bbcbcaf1bc1ab30a25eedd3d7682324\"\n" +
+                "  Description = \"Conode_2\"\n" +
+                "[[servers]]\n" +
+                "  Address = \"tls://securekg.dedis.ch:18006\"\n" +
+                "  Suite = \"Ed25519\"\n" +
+                "  Public = \"2aec81a7d16891c4806fb73f7e247eca311415fc21a54193e84e6c73f6df9b3f\"\n" +
+                "  Description = \"Conode_3\"");
+    }
+
+    /**
+     * Gets the genesis skipblock ID of an existing omniledger service.
+     * @return the genesis skipblock ID
+     */
+    public static SkipblockId getSkipchainId() throws CothorityCryptoException {
+        return new SkipblockId(DatatypeConverter.parseHexBinary("30cdbf5b5acc0e4dd227d8ee7fa845d419f79d43e824a3523a30d921a895838e"));
+    }
+
+    /**
+     * Gets the signer that has "invoke:eventlog" and "spawn:eventlog" permissions.
+     */
+    public static Signer getSigner() {
+        // public is 73cfc340c552145a8d8619cbbc0e788379c7a261764afd1d81fa0f971442140f
+        return new SignerEd25519(DatatypeConverter.parseHexBinary("022f59c145d4863d72cfd541628da08f4c907fb34f921dfeca8a1f35b3c0310a"));
+    }
+
+    /**
+     * Gets the darc ID that has the "invoke:eventlog" and "spawn:eventlog" rules.
+     * @return the darc ID
+     */
+    public static DarcId getDarcId() throws CothorityCryptoException {
+        return new DarcId(DatatypeConverter.parseHexBinary("b880482b89fba327e36fbb27b482d883a9e4354ae72078b37592ae86c8219580"));
+    }
+
+    /**
+     * Gets the eventlog instance ID.
+     * @return the instance ID.
+     */
+    public static InstanceId getEventlogId() throws CothorityCryptoException {
+        return new InstanceId(DatatypeConverter.parseHexBinary("b880482b89fba327e36fbb27b482d883a9e4354ae72078b37592ae86c8219580eeca4910a865c9fc246d1933a79ef1b44f776029b213ad6541f0f5b5025da2f1"));
+    }
+
+    /**
+     * Get the pre-configured omniledger RPC.
+     * @return the omniledger RPC object
+     */
+    public static OmniledgerRPC getOmniledgerRPC() throws CothorityException {
+        return new OmniledgerRPC(getRoster(), getSkipchainId());
+    }
+
+}

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/SubId.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/SubId.java
@@ -46,8 +46,24 @@ public class SubId implements HashId {
         return DatatypeConverter.printHexBinary(id);
     }
 
+    /**
+     * Creates a sub ID with all bytes set to 0.
+     * @return the sub ID
+     * @throws CothorityCryptoException
+     */
     public static SubId zero() throws CothorityCryptoException {
         return new SubId(new byte[32]);
+    }
+
+    /**
+     * Creates a sub ID with the first byte set to 1.
+     * @return the sub ID
+     * @throws CothorityCryptoException
+     */
+    public static SubId one() throws CothorityCryptoException {
+        byte[] buf  = new byte[32];
+        buf[31] = 1;
+        return new SubId(buf);
     }
 
     public static SubId random() throws CothorityCryptoException{

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/EventLogInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/EventLogInstance.java
@@ -87,9 +87,7 @@ public class EventLogInstance {
      * @throws CothorityException
      */
     public InstanceId log(Event event, List<Signer> signers) throws CothorityException {
-        List<Event> events = new ArrayList<>();
-        events.add(event);
-        return this.log(events, signers).get(0);
+        return this.log(Arrays.asList(event), signers).get(0);
     }
 
     /**

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/darc/DarcId.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/darc/DarcId.java
@@ -8,11 +8,30 @@ import com.google.protobuf.ByteString;
  * This class represents a DarcId, which is the hash of the fixed fields.
  */
 public class DarcId extends Sha256id {
-    public DarcId(byte[] id) throws CothorityCryptoException{
+    /**
+     * Constructs a darc ID from a byte array.
+     * @param id the darc ID
+     * @throws CothorityCryptoException
+     */
+    public DarcId(byte[] id) throws CothorityCryptoException {
         super(id);
     }
 
-    public DarcId(ByteString id) throws CothorityCryptoException{
+    /**
+     * Constructs a darc ID from ByteString.
+     * @param id the darc ID
+     * @throws CothorityCryptoException
+     */
+    public DarcId(ByteString id) throws CothorityCryptoException {
         this(id.toByteArray());
+    }
+
+    /**
+     * Creates a darc ID with all zeros.
+     * @return the darc ID
+     * @throws CothorityCryptoException
+     */
+    public static DarcId zero() throws CothorityCryptoException {
+        return new DarcId(new byte[32]);
     }
 }


### PR DESCRIPTION
We add a SecureKG class that contains the configuration information. It
can be used in the EventLogInstance tests instead of docker. However, we
disable it by default because running the tests repeatedly might
overwhelm the server.