### PR TITLE
Make our java compatible with Android

### DIFF
--- a/external/java/pom.xml
+++ b/external/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ch.epfl.dedis</groupId>
     <artifactId>cothority</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <name>Cothority client library for Java</name>
     <description>A client library for communicating with cothorities (a collective authority).</description>
     <url>https://github.com/dedis/cothority</url>
@@ -111,11 +111,6 @@
     </build>
 
     <dependencies>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
-        </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>

--- a/external/java/src/main/java/ch/epfl/dedis/byzgen/OcsFactory.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzgen/OcsFactory.java
@@ -8,7 +8,6 @@ import ch.epfl.dedis.lib.darc.Signer;
 import ch.epfl.dedis.lib.exception.CothorityCommunicationException;
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 
-import javax.annotation.Nonnull;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -79,7 +78,7 @@ public class OcsFactory {
      *
      * @return skipblock ID of a new genesis block
      */
-    public SkipblockId initialiseNewSkipchain(@Nonnull Signer admin) throws CothorityCommunicationException {
+    public SkipblockId initialiseNewSkipchain(Signer admin) throws CothorityCommunicationException {
         try {
             Roster roster = createRoster();
 
@@ -98,7 +97,7 @@ public class OcsFactory {
         }
         return new Roster(servers);
     }
-    private Darc createAdminDarc(@Nonnull Signer admin) throws CothorityCommunicationException {
+    private Darc createAdminDarc(Signer admin) throws CothorityCommunicationException {
         try {
             return new Darc(admin, null, null);
         } catch (CothorityCryptoException e) {

--- a/external/java/src/main/java/ch/epfl/dedis/byzgen/User.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzgen/User.java
@@ -1,7 +1,6 @@
 package ch.epfl.dedis.byzgen;
 
 
-import javax.annotation.Nonnull;
 import java.security.SignatureException;
 
 /**
@@ -12,7 +11,6 @@ public interface User {
      * Return immutable getId of skipchain user.
      * @return getId of user
      */
-    @Nonnull
     UserId getUserId();
 
     /**
@@ -23,7 +21,6 @@ public interface User {
      * @throws SignatureException can be thrown in case of internal processing problems and also when user decide to
      * reject request.
      */
-    @Nonnull
-    UserSignature sign(@Nonnull byte[] signRequest) throws SignatureException;
+    UserSignature sign(byte[] signRequest) throws SignatureException;
 
 }

--- a/external/java/src/main/java/ch/epfl/dedis/byzgen/UserId.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzgen/UserId.java
@@ -1,6 +1,5 @@
 package ch.epfl.dedis.byzgen;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 
 public final class UserId {
@@ -10,11 +9,11 @@ public final class UserId {
         return Arrays.copyOf(id, id.length);
     }
 
-    public UserId(@Nonnull UserId userId) {
+    public UserId(UserId userId) {
         this(userId.id);
     }
 
-    public UserId(@Nonnull byte id[]) {
+    public UserId(byte id[]) {
         if (id.length != 32) {
             throw new IllegalArgumentException("Expected size of getId of user is 32 bytes");
         }

--- a/external/java/src/main/java/ch/epfl/dedis/byzgen/UserSignature.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzgen/UserSignature.java
@@ -1,6 +1,5 @@
 package ch.epfl.dedis.byzgen;
 
-import javax.annotation.Nonnull;
 import java.security.PublicKey;
 import java.security.Signature;
 
@@ -10,7 +9,6 @@ public interface UserSignature {
      * @return signature body
      * @see Signature#sign()
      */
-    @Nonnull
     byte [] getSignature();
 
     /**
@@ -20,13 +18,11 @@ public interface UserSignature {
      *
      * @return algorithm used for signature
      */
-    @Nonnull
     String getAlgorithm();
 
     /**
      * Returns public key used for signing document
      * @return public key used for signing document
      */
-    @Nonnull
     PublicKey getPublicKey();
 }

--- a/external/java/src/main/java/ch/epfl/dedis/lib/HashId.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/HashId.java
@@ -1,12 +1,9 @@
 package ch.epfl.dedis.lib;
 
-import javax.annotation.Nonnull;
-
 public interface HashId {
     /**
      * Return binary form of block getId used by skipchain
      * @return binary form of block getId
      */
-    @Nonnull
     byte [] getId();
 }

--- a/external/java/src/main/java/ch/epfl/dedis/lib/ServerIdentity.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/ServerIdentity.java
@@ -1,6 +1,7 @@
 package ch.epfl.dedis.lib;
 
 import ch.epfl.dedis.lib.crypto.Ed25519Point;
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.crypto.Point;
 import ch.epfl.dedis.lib.exception.CothorityCommunicationException;
 import ch.epfl.dedis.proto.ServerIdentityProto;
@@ -13,7 +14,6 @@ import org.java_websocket.handshake.ServerHandshake;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.DatatypeConverter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
@@ -34,7 +34,7 @@ public class ServerIdentity {
     public ServerIdentity(final URI serverWsAddress, final String publicKey) {
         this.conodeAddress = serverWsAddress;
         // TODO: It will be better to use some class for server key and move this conversion outside of this class
-        this.Public = new Ed25519Point(DatatypeConverter.parseHexBinary(publicKey));
+        this.Public = new Ed25519Point(Hex.parseHexBinary(publicKey));
     }
 
     public ServerIdentity(Toml siToml) throws URISyntaxException {
@@ -42,7 +42,7 @@ public class ServerIdentity {
     }
 
     public ServerIdentity(ServerIdentityProto.ServerIdentity sid) throws URISyntaxException {
-        this(new URI(sid.getAddress()), DatatypeConverter.printHexBinary(sid.getPublic().toByteArray()));
+        this(new URI(sid.getAddress()), Hex.printHexBinary(sid.getPublic().toByteArray()));
     }
 
     public URI getAddress() {

--- a/external/java/src/main/java/ch/epfl/dedis/lib/Sha256id.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/Sha256id.java
@@ -1,10 +1,9 @@
 package ch.epfl.dedis.lib;
 
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 import com.google.protobuf.ByteString;
 
-import javax.annotation.Nonnull;
-import javax.xml.bind.DatatypeConverter;
 import java.util.Arrays;
 
 /**
@@ -22,7 +21,6 @@ public class Sha256id implements HashId {
     }
 
     @Override
-    @Nonnull
     public byte[] getId() {
         return Arrays.copyOf(id, id.length);
     }
@@ -42,7 +40,7 @@ public class Sha256id implements HashId {
 
     @Override
     public String toString(){
-        return DatatypeConverter.printHexBinary(id);
+        return Hex.printHexBinary(id);
     }
 
     public ByteString toProto(){

--- a/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Ed25519Point.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Ed25519Point.java
@@ -8,7 +8,6 @@ import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.DatatypeConverter;
 import java.security.PublicKey;
 import java.util.Arrays;
 
@@ -26,7 +25,7 @@ public class Ed25519Point implements Point {
     }
 
     public Ed25519Point(String str) {
-        this(DatatypeConverter.parseHexBinary(str));
+        this(Hex.parseHexBinary(str));
     }
 
     public Ed25519Point(byte[] b) {
@@ -73,7 +72,7 @@ public class Ed25519Point implements Point {
     }
 
     public String toString() {
-        return DatatypeConverter.printHexBinary(toBytes());
+        return Hex.printHexBinary(toBytes());
     }
 
     public EdDSAPublicKey toEdDSAPub() {
@@ -89,7 +88,7 @@ public class Ed25519Point implements Point {
         byte[] bytes = toBytes();
         int len = bytes[0];
         if (len > Ed25519.pubLen || len < 0) {
-            logger.info(DatatypeConverter.printHexBinary(bytes));
+            logger.info(Hex.printHexBinary(bytes));
             throw new CothorityCryptoException("doesn't seem to be a valid point");
         }
         return Arrays.copyOfRange(bytes, 1, len + 1);

--- a/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Ed25519Scalar.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Ed25519Scalar.java
@@ -6,7 +6,6 @@ import net.i2p.crypto.eddsa.math.FieldElement;
 import net.i2p.crypto.eddsa.math.ed25519.Ed25519ScalarOps;
 import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec;
 
-import javax.xml.bind.DatatypeConverter;
 import java.util.Arrays;
 
 public class Ed25519Scalar implements Scalar {
@@ -17,7 +16,7 @@ public class Ed25519Scalar implements Scalar {
     }
 
     public Ed25519Scalar(String str, boolean reduce) {
-        this(DatatypeConverter.parseHexBinary(str), reduce);
+        this(Hex.parseHexBinary(str), reduce);
     }
 
     public Ed25519Scalar(byte[] b) {
@@ -38,7 +37,7 @@ public class Ed25519Scalar implements Scalar {
     }
 
     public String toString() {
-        return DatatypeConverter.printHexBinary(getLittleEndian());
+        return Hex.printHexBinary(getLittleEndian());
     }
 
     public ByteString toProto() {

--- a/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Hex.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Hex.java
@@ -1,0 +1,52 @@
+package ch.epfl.dedis.lib.crypto;
+
+// This is the minimum stuff we need, extracted from
+// Apache's DatatypeFactoryImpl.html
+
+public class Hex {
+    private static final char[] hexCode = "0123456789ABCDEF".toCharArray();
+
+    public static String printHexBinary(byte[] data) {
+        StringBuilder r = new StringBuilder(data.length * 2);
+        byte[] var3 = data;
+        int var4 = data.length;
+
+        for(int var5 = 0; var5 < var4; ++var5) {
+            byte b = var3[var5];
+            r.append(hexCode[b >> 4 & 15]);
+            r.append(hexCode[b & 15]);
+        }
+
+        return r.toString();
+    }
+
+    public static byte[] parseHexBinary(String s) {
+        int len = s.length();
+        if (len % 2 != 0) {
+            throw new IllegalArgumentException("hexBinary needs to be even-length: " + s);
+        } else {
+            byte[] out = new byte[len / 2];
+
+            for(int i = 0; i < len; i += 2) {
+                int h = hexToBin(s.charAt(i));
+                int l = hexToBin(s.charAt(i + 1));
+                if (h == -1 || l == -1) {
+                    throw new IllegalArgumentException("contains illegal character for hexBinary: " + s);
+                }
+
+                out[i / 2] = (byte)(h * 16 + l);
+            }
+
+            return out;
+        }
+    }
+    private static int hexToBin(char ch) {
+        if ('0' <= ch && ch <= '9') {
+            return ch - 48;
+        } else if ('A' <= ch && ch <= 'F') {
+            return ch - 65 + 10;
+        } else {
+            return 'a' <= ch && ch <= 'f' ? ch - 97 + 10 : -1;
+        }
+    }
+}

--- a/external/java/src/main/java/ch/epfl/dedis/lib/darc/DarcSignature.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/darc/DarcSignature.java
@@ -1,12 +1,12 @@
 package ch.epfl.dedis.lib.darc;
 
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 import ch.epfl.dedis.proto.DarcOCSProto;
 import com.google.protobuf.ByteString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.DatatypeConverter;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -96,8 +96,8 @@ public class DarcSignature {
     private byte[] getHash(byte[] msg) throws CothorityCryptoException {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            logger.debug("path: " + DatatypeConverter.printHexBinary(path.getPathMsg()));
-            logger.debug("msg: " + DatatypeConverter.printHexBinary(msg));
+            logger.debug("path: " + Hex.printHexBinary(path.getPathMsg()));
+            logger.debug("msg: " + Hex.printHexBinary(msg));
             digest.update(path.getPathMsg());
             digest.update(msg);
             return digest.digest();

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/InstanceId.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/InstanceId.java
@@ -1,13 +1,12 @@
 package ch.epfl.dedis.lib.omniledger;
 
 import ch.epfl.dedis.lib.HashId;
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 import ch.epfl.dedis.lib.omniledger.darc.DarcId;
 import ch.epfl.dedis.proto.TransactionProto;
 import com.google.protobuf.ByteString;
 
-import javax.annotation.Nonnull;
-import javax.xml.bind.DatatypeConverter;
 import java.util.Arrays;
 
 /**
@@ -31,7 +30,6 @@ public class InstanceId implements HashId {
     }
 
     @Override
-    @Nonnull
     public byte[] getId() {
         return Arrays.copyOf(id, id.length);
     }
@@ -67,7 +65,7 @@ public class InstanceId implements HashId {
 
     @Override
     public String toString(){
-        return DatatypeConverter.printHexBinary(id);
+        return Hex.printHexBinary(id);
     }
 
     public ByteString toByteString(){

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/SubId.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/SubId.java
@@ -1,10 +1,9 @@
 package ch.epfl.dedis.lib.omniledger;
 
 import ch.epfl.dedis.lib.HashId;
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 
-import javax.annotation.Nonnull;
-import javax.xml.bind.DatatypeConverter;
 import java.security.SecureRandom;
 import java.util.Arrays;
 
@@ -23,7 +22,6 @@ public class SubId implements HashId {
     }
 
     @Override
-    @Nonnull
     public byte[] getId() {
         return Arrays.copyOf(id, id.length);
     }
@@ -43,7 +41,7 @@ public class SubId implements HashId {
 
     @Override
     public String toString() {
-        return DatatypeConverter.printHexBinary(id);
+        return Hex.printHexBinary(id);
     }
 
     /**

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/TransactionId.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/TransactionId.java
@@ -1,12 +1,11 @@
 package ch.epfl.dedis.lib.omniledger;
 
 import ch.epfl.dedis.lib.HashId;
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 import ch.epfl.dedis.lib.omniledger.darc.DarcId;
 import com.google.protobuf.ByteString;
 
-import javax.annotation.Nonnull;
-import javax.xml.bind.DatatypeConverter;
 import java.util.Arrays;
 
 /**
@@ -30,7 +29,6 @@ public class TransactionId implements HashId {
     }
 
     @Override
-    @Nonnull
     public byte[] getId() {
         return Arrays.copyOf(id, id.length);
     }
@@ -66,7 +64,7 @@ public class TransactionId implements HashId {
 
     @Override
     public String toString(){
-        return DatatypeConverter.printHexBinary(id);
+        return Hex.printHexBinary(id);
     }
 
     public ByteString toProto(){

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/DarcInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/DarcInstance.java
@@ -1,5 +1,6 @@
 package ch.epfl.dedis.lib.omniledger.contracts;
 
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.exception.CothorityCommunicationException;
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 import ch.epfl.dedis.lib.exception.CothorityException;
@@ -10,7 +11,6 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.DatatypeConverter;
 import java.util.Arrays;
 import java.util.List;
 
@@ -91,7 +91,7 @@ public class DarcInstance {
         try {
             Request r = new Request(darc.getBaseId(), "invoke:evolve", inst.hash(),
                     Arrays.asList(owner.getIdentity()), null);
-            logger.info("Signing: {}", DatatypeConverter.printHexBinary(r.hash()));
+            logger.info("Signing: {}", Hex.printHexBinary(r.hash()));
             Signature sign = new Signature(owner.sign(r.hash()), owner.getIdentity());
             inst.setSignatures(Arrays.asList(sign));
         } catch (Signer.SignRequestRejectedException e) {
@@ -157,7 +157,7 @@ public class DarcInstance {
         try {
             Request r = new Request(darc.getBaseId(), "spawn:" + contractID, inst.hash(),
                     Arrays.asList(s.getIdentity()), null);
-            logger.info("Signing: {}", DatatypeConverter.printHexBinary(r.hash()));
+            logger.info("Signing: {}", Hex.printHexBinary(r.hash()));
             Signature sign = new Signature(s.sign(r.hash()), s.getIdentity());
             inst.setSignatures(Arrays.asList(sign));
         } catch (Signer.SignRequestRejectedException e) {

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/ValueInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/ValueInstance.java
@@ -1,5 +1,6 @@
 package ch.epfl.dedis.lib.omniledger.contracts;
 
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.exception.CothorityCommunicationException;
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 import ch.epfl.dedis.lib.exception.CothorityException;
@@ -9,7 +10,6 @@ import ch.epfl.dedis.lib.omniledger.darc.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.DatatypeConverter;
 import java.util.Arrays;
 
 /**
@@ -71,7 +71,7 @@ public class ValueInstance {
         try {
             Request r = new Request(instance.getId().getDarcId(), "invoke:update", inst.hash(),
                     Arrays.asList(owner.getIdentity()), null);
-            logger.info("Signing: {}", DatatypeConverter.printHexBinary(r.hash()));
+            logger.info("Signing: {}", Hex.printHexBinary(r.hash()));
             Signature sign = new Signature(owner.sign(r.hash()), owner.getIdentity());
             inst.setSignatures(Arrays.asList(sign));
         } catch (Signer.SignRequestRejectedException e) {
@@ -101,8 +101,8 @@ public class ValueInstance {
         for (int i = 0; i < 10; i++) {
             Proof p = ol.getProof(instance.getId());
             Instance inst = new Instance(p);
-            logger.info("Values are: {} - {}", DatatypeConverter.printHexBinary(inst.getData()),
-                    DatatypeConverter.printHexBinary(newValue));
+            logger.info("Values are: {} - {}", Hex.printHexBinary(inst.getData()),
+                    Hex.printHexBinary(newValue));
             if (Arrays.equals(inst.getData(), newValue)){
                 value = newValue;
                 return;

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/darc/Darc.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/darc/Darc.java
@@ -1,5 +1,6 @@
 package ch.epfl.dedis.lib.omniledger.darc;
 
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 import ch.epfl.dedis.lib.exception.CothorityException;
 import ch.epfl.dedis.proto.DarcProto;
@@ -8,7 +9,6 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.DatatypeConverter;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.MessageDigest;
@@ -242,19 +242,19 @@ public class Darc {
 
     public String toString() {
         try {
-            String base = DatatypeConverter.printHexBinary(getBaseId().getId());
+            String base = Hex.printHexBinary(getBaseId().getId());
             if (baseID != null) {
-                base = String.format("stored: %s", DatatypeConverter.printHexBinary(baseID.getId()));
+                base = String.format("stored: %s", Hex.printHexBinary(baseID.getId()));
             }
             String ret = String.format("Base: %s\nId: %s\nPrevId: %s\nVersion: %d\nRules:",
                     base,
-                    DatatypeConverter.printHexBinary(getId().getId()),
-                    DatatypeConverter.printHexBinary(getPrevID().getId()),
+                    Hex.printHexBinary(getId().getId()),
+                    Hex.printHexBinary(getPrevID().getId()),
                     version);
             for (String r : rules.keySet()) {
-                ret += String.format("\n%s - %s", r, DatatypeConverter.printHexBinary(rules.get(r)));
+                ret += String.format("\n%s - %s", r, Hex.printHexBinary(rules.get(r)));
             }
-            ret += String.format("\nDescription: %s", DatatypeConverter.printHexBinary(description));
+            ret += String.format("\nDescription: %s", Hex.printHexBinary(description));
             return ret;
         } catch (CothorityException e) {
             throw new RuntimeException(e);

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/darc/IdentityDarc.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/darc/IdentityDarc.java
@@ -1,10 +1,9 @@
 package ch.epfl.dedis.lib.omniledger.darc;
 
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 import ch.epfl.dedis.proto.DarcProto;
 import com.google.protobuf.ByteString;
-
-import javax.xml.bind.DatatypeConverter;
 
 public class IdentityDarc implements Identity {
     private DarcId darcID;
@@ -87,7 +86,7 @@ public class IdentityDarc implements Identity {
     }
 
     public String toString() {
-        return String.format("%s:%s", this.typeString(), DatatypeConverter.printHexBinary(this.darcID.getId()).toLowerCase());
+        return String.format("%s:%s", this.typeString(), Hex.printHexBinary(this.darcID.getId()).toLowerCase());
     }
 
     public String typeString() {

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/darc/IdentityX509EC.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/darc/IdentityX509EC.java
@@ -1,10 +1,10 @@
 package ch.epfl.dedis.lib.omniledger.darc;
 
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 import ch.epfl.dedis.proto.DarcProto;
 import com.google.protobuf.ByteString;
 
-import javax.xml.bind.DatatypeConverter;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
@@ -85,7 +85,7 @@ public class IdentityX509EC implements Identity {
     }
 
     public String toString(){
-        return String.format("%s:%s", this.typeString(), DatatypeConverter.printHexBinary(this.pubKey.getEncoded()).toLowerCase());
+        return String.format("%s:%s", this.typeString(), Hex.printHexBinary(this.pubKey.getEncoded()).toLowerCase());
     }
 
     @Override

--- a/external/java/src/main/java/ch/epfl/dedis/ocs/Document.java
+++ b/external/java/src/main/java/ch/epfl/dedis/ocs/Document.java
@@ -1,10 +1,10 @@
 package ch.epfl.dedis.ocs;
 
 import ch.epfl.dedis.lib.crypto.Encryption;
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.darc.Darc;
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 
-import javax.xml.bind.DatatypeConverter;
 import java.util.Arrays;
 
 import static ch.epfl.dedis.lib.crypto.Encryption.encryptData;
@@ -139,9 +139,9 @@ public class Document {
         }
         return String.format("dataEncrypted: %s\ndataPublic: %s\nkeyMaterial: %s\n" +
                         "readers: %s\nwriteRequestId: %s",
-                DatatypeConverter.printHexBinary(dataEncrypted),
-                DatatypeConverter.printHexBinary(dataPublic),
-                DatatypeConverter.printHexBinary(keyMaterial),
+                Hex.printHexBinary(dataEncrypted),
+                Hex.printHexBinary(dataPublic),
+                Hex.printHexBinary(keyMaterial),
                 readers.toString(),
                 wrid);
     }

--- a/external/java/src/main/java/ch/epfl/dedis/ocs/OnchainSecretsRPC.java
+++ b/external/java/src/main/java/ch/epfl/dedis/ocs/OnchainSecretsRPC.java
@@ -4,6 +4,7 @@ import ch.epfl.dedis.lib.Roster;
 import ch.epfl.dedis.lib.ServerIdentity;
 import ch.epfl.dedis.lib.SkipblockId;
 import ch.epfl.dedis.lib.crypto.Ed25519Point;
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.crypto.Point;
 import ch.epfl.dedis.lib.darc.*;
 import ch.epfl.dedis.lib.exception.CothorityCommunicationException;
@@ -17,7 +18,6 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.DatatypeConverter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -158,7 +158,7 @@ public class OnchainSecretsRPC {
             logger.debug("received reply: {}", reply.toString());
             logger.info("Updated darc {} stored in block: {}",
                     newAccount.getId().toString(),
-                    DatatypeConverter.printHexBinary(reply.getSb().getHash().toByteArray()));
+                    Hex.printHexBinary(reply.getSb().getHash().toByteArray()));
         } catch (InvalidProtocolBufferException e) {
             throw new CothorityCommunicationException(e);
         }

--- a/external/java/src/test/java/ch/epfl/dedis/byzgen/GetPathTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzgen/GetPathTest.java
@@ -3,6 +3,7 @@ package ch.epfl.dedis.byzgen;
 import ch.epfl.dedis.integration.TestServerController;
 import ch.epfl.dedis.integration.TestServerInit;
 import ch.epfl.dedis.lib.SkipblockId;
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.darc.*;
 import ch.epfl.dedis.lib.darc.IdentityDarc;
 import ch.epfl.dedis.lib.exception.CothorityCommunicationException;
@@ -14,7 +15,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-import javax.xml.bind.DatatypeConverter;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -48,7 +48,7 @@ public class GetPathTest {
         // given
         WriteRequestId documentId = publishDocumentAndGrantAccessToGroup();
 
-        SignerEd25519 consumer = new SignerEd25519(DatatypeConverter.parseHexBinary(CONSUMER_SCALAR));
+        SignerEd25519 consumer = new SignerEd25519(Hex.parseHexBinary(CONSUMER_SCALAR));
 
         OCSProto.Write document = ocs.getWrite(documentId);
         Darc documentDarc = new Darc(document.getReader());
@@ -114,7 +114,7 @@ public class GetPathTest {
 
     private WriteRequestId publishDocumentAndGrantAccessToGroup() throws Exception {
         WriteRequestId documentId;
-        SignerEd25519 publisherSigner = new SignerEd25519(DatatypeConverter.parseHexBinary(PUBLISHER_SCALAR));
+        SignerEd25519 publisherSigner = new SignerEd25519(Hex.parseHexBinary(PUBLISHER_SCALAR));
         documentId = publishTestDocument(publisherSigner, publisherId, readersGroupId);
         return documentId;
     }
@@ -134,7 +134,7 @@ public class GetPathTest {
     }
 
     private DarcId createUserGroup(OnchainSecrets ocs, DarcId... members) throws Exception {
-        SignerEd25519 admin = new SignerEd25519(DatatypeConverter.parseHexBinary(SUPERADMIN_SCALAR));
+        SignerEd25519 admin = new SignerEd25519(Hex.parseHexBinary(SUPERADMIN_SCALAR));
 
         Darc groupDarc = new Darc(admin, Collections.emptyList(), "group".getBytes());
         for (DarcId id : members) {
@@ -145,7 +145,7 @@ public class GetPathTest {
     }
 
     private DarcId createConsumer(OnchainSecrets ocs) throws Exception {
-        Darc user = createUser(ocs, new IdentityEd25519(new SignerEd25519(DatatypeConverter.parseHexBinary(CONSUMER_SCALAR))));
+        Darc user = createUser(ocs, new IdentityEd25519(new SignerEd25519(Hex.parseHexBinary(CONSUMER_SCALAR))));
         return new DarcId(user.getId().getId());
     }
 
@@ -157,7 +157,7 @@ public class GetPathTest {
     }
 
     private DarcId createPublisher(OnchainSecrets ocs) throws Exception {
-        Darc user = createUser(ocs, new IdentityEd25519(new SignerEd25519(DatatypeConverter.parseHexBinary(PUBLISHER_SCALAR))));
+        Darc user = createUser(ocs, new IdentityEd25519(new SignerEd25519(Hex.parseHexBinary(PUBLISHER_SCALAR))));
         grantSystemWriteAccess(ocs, user);
         return new DarcId(user.getId().getId()); // copy to be sure that it is not the same object
     }
@@ -166,7 +166,7 @@ public class GetPathTest {
         return new OcsFactory()
                 .addConodes(testServerController.getConodes())
                 .initialiseNewSkipchain(new SignerEd25519(
-                        DatatypeConverter.parseHexBinary(SUPERADMIN_SCALAR)));
+                        Hex.parseHexBinary(SUPERADMIN_SCALAR)));
     }
 
     private static Darc createUser(OnchainSecrets ocs, IdentityEd25519 user) throws Exception {
@@ -176,7 +176,7 @@ public class GetPathTest {
     }
 
     private static void grantSystemWriteAccess(OnchainSecrets ocs, Darc userDarc) throws Exception {
-        SignerEd25519 admin = new SignerEd25519(DatatypeConverter.parseHexBinary(SUPERADMIN_SCALAR));
+        SignerEd25519 admin = new SignerEd25519(Hex.parseHexBinary(SUPERADMIN_SCALAR));
         ocs.addIdentityToDarc(ocs.getAdminDarc(), IdentityFactory.New(userDarc), admin, SignaturePath.USER);
         ocs.addIdentityToDarc(ocs.getAdminDarc(), IdentityFactory.New(userDarc), admin, SignaturePath.OWNER);
     }

--- a/external/java/src/test/java/ch/epfl/dedis/byzgen/GrantAccessTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzgen/GrantAccessTest.java
@@ -3,6 +3,7 @@ package ch.epfl.dedis.byzgen;
 import ch.epfl.dedis.integration.TestServerController;
 import ch.epfl.dedis.integration.TestServerInit;
 import ch.epfl.dedis.lib.SkipblockId;
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.darc.Darc;
 import ch.epfl.dedis.lib.darc.DarcId;
 import ch.epfl.dedis.lib.darc.Identity;
@@ -21,7 +22,6 @@ import ch.epfl.dedis.ocs.WriteRequestId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.xml.bind.DatatypeConverter;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -137,7 +137,7 @@ public class GrantAccessTest {
         return new OcsFactory()
                 .addConodes(testServerController.getConodes())
                 .initialiseNewSkipchain(new SignerEd25519(
-                        DatatypeConverter.parseHexBinary(SUPERADMIN_SCALAR)));
+                        Hex.parseHexBinary(SUPERADMIN_SCALAR)));
     }
 
     private static Darc createUser(OnchainSecrets ocs, Identity user) throws Exception {
@@ -147,7 +147,7 @@ public class GrantAccessTest {
     }
 
     private static void grantSystemWriteAccess(OnchainSecrets ocs, Darc userDarc) throws Exception {
-        SignerEd25519 admin = new SignerEd25519(DatatypeConverter.parseHexBinary(SUPERADMIN_SCALAR));
+        SignerEd25519 admin = new SignerEd25519(Hex.parseHexBinary(SUPERADMIN_SCALAR));
         ocs.addIdentityToDarc(ocs.getAdminDarc(), IdentityFactory.New(userDarc), admin, SignaturePath.USER);
         ocs.addIdentityToDarc(ocs.getAdminDarc(), IdentityFactory.New(userDarc), admin, SignaturePath.OWNER);
     }

--- a/external/java/src/test/java/ch/epfl/dedis/byzgen/OcsFactoryTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzgen/OcsFactoryTest.java
@@ -3,13 +3,13 @@ package ch.epfl.dedis.byzgen;
 import ch.epfl.dedis.integration.TestServerController;
 import ch.epfl.dedis.integration.TestServerInit;
 import ch.epfl.dedis.lib.SkipblockId;
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.darc.SignerEd25519;
 import ch.epfl.dedis.lib.exception.CothorityCommunicationException;
 import ch.epfl.dedis.ocs.OnchainSecretsRPC;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.xml.bind.DatatypeConverter;
 import java.net.URI;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -53,7 +53,7 @@ class OcsFactoryTest {
     public void shouldFailWhenServersAreNotSpecified() {
         OcsFactory ocsFactory = new OcsFactory();
         Throwable exception = assertThrows(IllegalStateException.class, () -> {
-            ocsFactory.setGenesis(new SkipblockId(DatatypeConverter.parseHexBinary(SAMPLE_GENESIS_ID)));
+            ocsFactory.setGenesis(new SkipblockId(Hex.parseHexBinary(SAMPLE_GENESIS_ID)));
             ocsFactory.createConnection();
         });
         assertThat(exception.getMessage(), containsString("No cothority server"));
@@ -77,7 +77,7 @@ class OcsFactoryTest {
 
         // when
         SkipblockId genesis = ocsFactory.initialiseNewSkipchain(
-                new SignerEd25519(DatatypeConverter.parseHexBinary("AEE42B6A924BDFBB6DAEF8B252258D2FDF70AFD31852368AF55549E1DF8FC80D")));
+                new SignerEd25519(Hex.parseHexBinary("AEE42B6A924BDFBB6DAEF8B252258D2FDF70AFD31852368AF55549E1DF8FC80D")));
 
         // then
         assertNotNull(genesis);
@@ -103,6 +103,6 @@ class OcsFactoryTest {
         return new OcsFactory()
                 .addConodes(testServerController.getConodes())
                 .initialiseNewSkipchain(new SignerEd25519(
-                        DatatypeConverter.parseHexBinary("AEE42B6A924BDFBB6DAEF8B252258D2FDF70AFD31852368AF55549E1DF8FC80D")));
+                        Hex.parseHexBinary("AEE42B6A924BDFBB6DAEF8B252258D2FDF70AFD31852368AF55549E1DF8FC80D")));
     }
 }

--- a/external/java/src/test/java/ch/epfl/dedis/ocs/Ed25519Test.java
+++ b/external/java/src/test/java/ch/epfl/dedis/ocs/Ed25519Test.java
@@ -10,7 +10,6 @@ import org.slf4j.LoggerFactory;
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 
 import java.security.SecureRandom;
 
@@ -26,7 +25,7 @@ class Ed25519Test {
         assertEquals(32, ed25519Point2.toBytes().length);
         assertTrue(new Ed25519Point(ed25519Point2.toBytes()).equals(ed25519Point2));
 
-        byte[] point_bytes = DatatypeConverter.parseHexBinary("3B6A27BCCEB6A42D62A3A8D02A6F0D73653215771DE243A63AC048A18B59DA29");
+        byte[] point_bytes = Hex.parseHexBinary("3B6A27BCCEB6A42D62A3A8D02A6F0D73653215771DE243A63AC048A18B59DA29");
         assertTrue(new Ed25519Point(point_bytes).equals(ed25519Point2));
     }
 
@@ -137,7 +136,7 @@ class Ed25519Test {
     @Test
     void schnorrVerify() {
         byte[] msg = "Hello Schnorr".getBytes();
-        byte[] sigBuf = DatatypeConverter.parseHexBinary("b95fc52a5fd2e18aa7ace5b2250c2a25e368f75c148ea3403c8f32b5f100781b" +
+        byte[] sigBuf = Hex.parseHexBinary("b95fc52a5fd2e18aa7ace5b2250c2a25e368f75c148ea3403c8f32b5f100781b" +
                 "362c668aab4cf50eafdc2fcf45214c0dfbe86fce72e4632158c02c571e977306");
         SchnorrSig sig = new SchnorrSig(sigBuf);
         Point pub = new Ed25519Point("59d7fd947fc88e47d3f878e82e26629dea7a28e8d4233f11068a6b464e195bfd");

--- a/external/java/src/test/java/ch/epfl/dedis/ocs/OnchainSecretsRPCTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/ocs/OnchainSecretsRPCTest.java
@@ -2,6 +2,7 @@ package ch.epfl.dedis.ocs;
 
 import ch.epfl.dedis.integration.TestServerController;
 import ch.epfl.dedis.integration.TestServerInit;
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.crypto.Point;
 import ch.epfl.dedis.lib.crypto.Encryption;
 import ch.epfl.dedis.lib.darc.*;
@@ -14,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.DatatypeConverter;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -86,7 +86,7 @@ class OnchainSecretsRPCTest {
     void darcID() throws Exception {
         logger.info("Admin darc after: " + adminDarc.getId().toString());
         logger.info("Admin-darc prot: " +
-                DatatypeConverter.printHexBinary(adminDarc.toProto().toByteArray()));
+                Hex.printHexBinary(adminDarc.toProto().toByteArray()));
     }
 
     @Test
@@ -233,7 +233,7 @@ class OnchainSecretsRPCTest {
 
     @Test
     void createDarcForTheSameUserInDifferentSkipchain() throws Exception {
-        Darc userDarc = new Darc(new SignerEd25519(DatatypeConverter.parseHexBinary("AEE42B6A924BDFBB6DAEF8B252258D2FDF70AFD31852368AF55549E1DF8FC80D")), null, null);
+        Darc userDarc = new Darc(new SignerEd25519(Hex.parseHexBinary("AEE42B6A924BDFBB6DAEF8B252258D2FDF70AFD31852368AF55549E1DF8FC80D")), null, null);
         ocs.updateDarc(userDarc);
 
         OnchainSecretsRPC ocs2 = new OnchainSecretsRPC(testInstanceController.getRoster(), adminDarc);
@@ -244,7 +244,7 @@ class OnchainSecretsRPCTest {
             logger.info("correctly refusing to save again");
         }
 
-        Darc userDarc2 = new Darc(new SignerEd25519(DatatypeConverter.parseHexBinary("AEE42B6A924BDFBB6DAEF8B252258D2FDF70AFD31852368AF55549E1DF8FC80D")), null, null);
+        Darc userDarc2 = new Darc(new SignerEd25519(Hex.parseHexBinary("AEE42B6A924BDFBB6DAEF8B252258D2FDF70AFD31852368AF55549E1DF8FC80D")), null, null);
         ocs2.updateDarc(userDarc2);
         logger.info("new user darc created and stored");
     }

--- a/external/java/src/test/java/ch/epfl/dedis/ocs/RestartError.java
+++ b/external/java/src/test/java/ch/epfl/dedis/ocs/RestartError.java
@@ -4,6 +4,7 @@ import ch.epfl.dedis.integration.TestServerController;
 import ch.epfl.dedis.integration.TestServerInit;
 import ch.epfl.dedis.lib.Roster;
 import ch.epfl.dedis.lib.SkipblockId;
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.lib.darc.Darc;
 import ch.epfl.dedis.lib.darc.SignerEd25519;
 import ch.epfl.dedis.lib.darc.Signer;
@@ -13,8 +14,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.xml.bind.DatatypeConverter;
 
 public class RestartError {
     Roster roster;
@@ -39,7 +38,7 @@ public class RestartError {
 
     @Test
     void Step2() throws CothorityException {
-        SkipblockId ocsid = new SkipblockId(DatatypeConverter.parseHexBinary(ocsStr));
+        SkipblockId ocsid = new SkipblockId(Hex.parseHexBinary(ocsStr));
         OnchainSecretsRPC ocs = new OnchainSecretsRPC(roster, ocsid);
         ocs.verify();
         listBlocks(ocs);
@@ -48,7 +47,7 @@ public class RestartError {
     void listBlocks(OnchainSecretsRPC ocs) throws CothorityException {
         SkipBlockProto.SkipBlock sb = ocs.getSkipblock(ocs.ocsID);
         for (;;){
-            logger.info(DatatypeConverter.printHexBinary(sb.getHash().toByteArray()));
+            logger.info(Hex.printHexBinary(sb.getHash().toByteArray()));
             if (sb.getForwardCount() == 0){
                 break;
             }

--- a/external/java/src/test/java/ch/epfl/dedis/ocs/ServerIdentityTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/ocs/ServerIdentityTest.java
@@ -3,6 +3,7 @@ package ch.epfl.dedis.ocs;
 import ch.epfl.dedis.integration.TestServerController;
 import ch.epfl.dedis.integration.TestServerInit;
 import ch.epfl.dedis.lib.ServerIdentity;
+import ch.epfl.dedis.lib.crypto.Hex;
 import ch.epfl.dedis.proto.ServerIdentityProto;
 import ch.epfl.dedis.proto.StatusProto;
 import com.google.protobuf.ByteString;
@@ -11,8 +12,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.xml.bind.DatatypeConverter;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -49,7 +48,7 @@ class ServerIdentityTest {
     @Test
     void testProto(){
         ServerIdentityProto.ServerIdentity si_proto = si.toProto();
-        byte[] id = DatatypeConverter.parseHexBinary("482FB9CFC2B55AB68C5F811C1D47B9E1");
+        byte[] id = Hex.parseHexBinary("482FB9CFC2B55AB68C5F811C1D47B9E1");
         assertArrayEquals(ByteString.copyFrom(id).toByteArray(), si_proto.getId().toByteArray());
     }
 }


### PR DESCRIPTION
Remove dependency on javax.xml.bind, which is not available in Android
Remove @nonnull, which is not supported in the same way on
Java and Android. See issue #1328.