### PR TITLE
Fix windows build

### DIFF
--- a/conode/Makefile
+++ b/conode/Makefile
@@ -68,7 +68,7 @@ bindist: exe/conode.Linux.x86_64
 	cp exe/conode.Linux.x86_64 $(OUTPUT_DIR)
 	GOOS=linux  GOARCH=arm go build $(flags) -o $(OUTPUT_DIR)/conode.Linux.armv7l
 	GOOS=freebsd GOARCH=amd64 go build $(flags) -o $(OUTPUT_DIR)/conode.FreeBSD.amd64
-	GOOS=windows GOARCH=386 go build $(flags) -o $(OUTPUT_DIR)/conode.exe
+	GOOS=windows GOARCH=amd64 go build $(flags) -o $(OUTPUT_DIR)/conode.exe
 	echo "#!/bin/sh" > $(OUTPUT_DIR)/conode
 	echo "./conode.\`uname -s\`.\`uname -m\` \$$*" >> $(OUTPUT_DIR)/conode
 	chmod +x $(OUTPUT_DIR)/conode


### PR DESCRIPTION
Windows binaries should be 64-bit (this was already true on
the evoting branch, but was forgotten on tip).

Fixes #1326.