### PR TITLE
Allow timestamps a few seconds into the future

### DIFF
--- a/conode/Makefile
+++ b/conode/Makefile
@@ -62,7 +62,7 @@ clean:
 exe/conode.Linux.x86_64:
 	GOOS=linux GOARCH=amd64 go build $(flags) -o $@
 
-bindist: exe/conode.Linux.x86_64
+bindist: clean exe/conode.Linux.x86_64
 	rm -rf $(OUTPUT_DIR)
 	mkdir $(OUTPUT_DIR)
 	cp exe/conode.Linux.x86_64 $(OUTPUT_DIR)

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -484,7 +484,7 @@ func (s *Service) createQueueWorker(scID skipchain.SkipBlockID, interval time.Du
 			select {
 			case t := <-c:
 				ts = append(ts, t)
-				log.LLvlf2("%x: Stored transaction. Next block length: %v, New Tx: %+v", scID, len(ts), t)
+				log.Lvlf2("%x: Stored transaction. Next block length: %v, New Tx: %+v", scID, len(ts), t)
 			case <-to:
 				if len(ts) > 0 {
 					log.Lvlf2("%x: New epoch and transaction-length: %d", scID, len(ts))


### PR DESCRIPTION
Fixes #1331.

Also: Remove forgotten LLvl2.

Also: Add missing clean to bindist, which avoids accidentally
getting a different version than expected if something is lingering
in exe/*.