### PR TITLE
Collection mutex

### DIFF
--- a/omniledger/collection/collection.go
+++ b/omniledger/collection/collection.go
@@ -25,7 +25,8 @@ type Collection struct {
 // Constructors
 
 // New creates a new collection, with one root node and the given Fields
-func New(fields ...Field) (collection Collection) {
+func New(fields ...Field) (collection *Collection) {
+	collection = &Collection{}
 	collection.fields = fields
 
 	collection.scope.All()
@@ -70,9 +71,10 @@ func NewVerifier(fields ...Field) (verifier Collection) {
 
 // Clone returns a deep copy of the collection.
 // Note that the transaction id are restarted from 0 for the copy.
-func (c *Collection) Clone() (collection Collection) {
+func (c *Collection) Clone() (collection *Collection) {
 	c.Lock()
 	defer c.Unlock()
+	collection = &Collection{}
 	if c.transaction.ongoing {
 		panic("Cannot clone a collection while a transaction is ongoing.")
 	}

--- a/omniledger/collection/collection.go
+++ b/omniledger/collection/collection.go
@@ -5,9 +5,12 @@
 // distributed and decentralized ledgers with minimal bootstrapping time.
 package collection
 
+import "sync"
+
 // Collection represents the Merkle-tree based data structure.
 // The data is defined by a pointer to its root.
 type Collection struct {
+	sync.Mutex
 	root   *node
 	fields []Field
 	scope  scope
@@ -68,6 +71,8 @@ func NewVerifier(fields ...Field) (verifier Collection) {
 // Clone returns a deep copy of the collection.
 // Note that the transaction id are restarted from 0 for the copy.
 func (c *Collection) Clone() (collection Collection) {
+	c.Lock()
+	defer c.Unlock()
 	if c.transaction.ongoing {
 		panic("Cannot clone a collection while a transaction is ongoing.")
 	}
@@ -110,5 +115,7 @@ func (c *Collection) Clone() (collection Collection) {
 // GetRoot returns the root hash of the collection, which cryptographically
 // represents the whole set of key/value pairs in the collection.
 func (c *Collection) GetRoot() []byte {
+	c.Lock()
+	defer c.Unlock()
 	return c.root.key
 }

--- a/omniledger/collection/collection_test.go
+++ b/omniledger/collection/collection_test.go
@@ -34,7 +34,7 @@ func TestCollectionEmptyCollection(test *testing.T) {
 		test.Error("[collection.go]", "[values]", "Nodes of a collection without fields have values.")
 	}
 
-	ctx.verify.tree("[baseCollection]", &baseCollection)
+	ctx.verify.tree("[baseCollection]", baseCollection)
 
 	stake64 := Stake64{}
 	stakeCollection := New(stake64)
@@ -65,7 +65,7 @@ func TestCollectionEmptyCollection(test *testing.T) {
 		test.Error("[collection.go]", "[stake]", "Nodes of an empty stake collection don't have zero stake.")
 	}
 
-	ctx.verify.tree("[stakeCollection]", &stakeCollection)
+	ctx.verify.tree("[stakeCollection]", stakeCollection)
 
 	data := Data{}
 	stakeDataCollection := New(stake64, data)
@@ -78,7 +78,7 @@ func TestCollectionEmptyCollection(test *testing.T) {
 		test.Error("[collection.go]", "[values]", "Nodes of a data and stake collection don't have empty data value.")
 	}
 
-	ctx.verify.tree("[stakeDataCollection]", &stakeDataCollection)
+	ctx.verify.tree("[stakeDataCollection]", stakeDataCollection)
 }
 
 func TestCollectionEmptyVerifier(test *testing.T) {
@@ -153,13 +153,13 @@ func TestCollectionClone(test *testing.T) {
 
 	clone := collection.Clone()
 
-	ctx.verify.tree("[clone]", &clone)
+	ctx.verify.tree("[clone]", clone)
 
 	for index := 0; index < 512; index++ {
 		key := make([]byte, 8)
 		binary.BigEndian.PutUint64(key, uint64(index))
 
-		ctx.verify.values("[clone]", &clone, key, uint64(index), key)
+		ctx.verify.values("[clone]", clone, key, uint64(index), key)
 	}
 
 	ctx.shouldPanic("[clone]", func() {

--- a/omniledger/collection/getters.go
+++ b/omniledger/collection/getters.go
@@ -26,6 +26,8 @@ func (c *Collection) Get(key []byte) Getter {
 // Record returns a Record object that correspond to the result of the key search.
 // The Record will contain a boolean "match" that is true if the search was successful and false otherwise.
 func (g Getter) Record() (Record, error) {
+	g.collection.Lock()
+	defer g.collection.Unlock()
 	if len(g.key) == 0 {
 		return Record{}, errors.New("cannot create a record with no key")
 	}
@@ -59,6 +61,8 @@ func (g Getter) Record() (Record, error) {
 // The location the proof points to can contains the actual key.
 // It can also contain another key, effectively proving that the key is absent from the collection.
 func (g Getter) Proof() (Proof, error) {
+	g.collection.Lock()
+	defer g.collection.Unlock()
 	if len(g.key) == 0 {
 		return Proof{}, errors.New("cannot create a proof with no key")
 	}

--- a/omniledger/collection/getters_test.go
+++ b/omniledger/collection/getters_test.go
@@ -10,7 +10,7 @@ func TestGettersConstructors(test *testing.T) {
 	collection := New()
 	getter := collection.Get([]byte("mykey"))
 
-	if getter.collection != &collection {
+	if getter.collection != collection {
 		test.Error("[getters.go]", "[constructors]", "Getter constructor sets wrong collection pointer.")
 	}
 
@@ -94,7 +94,7 @@ func TestGettersProof(test *testing.T) {
 			test.Error("[getters.go]", "[proof]", "Proof() yields a matching record on non-existing key.")
 		}
 
-		if proof.collection != &collection {
+		if proof.collection != collection {
 			test.Error("[getters.go]", "[proof]", "Proof() returns proof with wrong collection pointer.")
 		}
 

--- a/omniledger/collection/manipulators.go
+++ b/omniledger/collection/manipulators.go
@@ -205,7 +205,6 @@ func (c *Collection) Set(key []byte, values ...interface{}) error {
 // SetField updates one of the the value associated with a key to a new value.
 // It updates the field with the index given by the parameter field to a new
 // value.
-// FIXME: locking here will cause a deadlock because Set already has a lock
 func (c *Collection) SetField(key []byte, field int, value interface{}) error {
 	c.Lock()
 	defer c.Unlock()

--- a/omniledger/collection/manipulators_test.go
+++ b/omniledger/collection/manipulators_test.go
@@ -3,9 +3,10 @@ package collection
 import (
 	"crypto/sha256"
 	"encoding/binary"
-	"github.com/stretchr/testify/require"
 	"math/rand"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestManipulatorsAdd(test *testing.T) {
@@ -22,14 +23,14 @@ func TestManipulatorsAdd(test *testing.T) {
 		binary.BigEndian.PutUint64(key, uint64(index))
 
 		collection.Add(key, uint64(rand.Uint32()))
-		ctx.verify.tree("[stakecollection]", &collection)
+		ctx.verify.tree("[stakecollection]", collection)
 	}
 
 	for index := 0; index < 512; index++ {
 		key := make([]byte, 8)
 		binary.BigEndian.PutUint64(key, uint64(index))
 
-		ctx.verify.key("[stakecollection]", &collection, key)
+		ctx.verify.key("[stakecollection]", collection, key)
 	}
 
 	unknownRoot := New()
@@ -70,7 +71,7 @@ func TestManipulatorsAdd(test *testing.T) {
 	for index := 0; index < 512; index++ {
 		key := make([]byte, 8)
 		binary.BigEndian.PutUint64(key, uint64(index))
-		ctx.verify.key("[transactioncollection]", &transaction, key)
+		ctx.verify.key("[transactioncollection]", transaction, key)
 	}
 
 	ctx.shouldPanic("[wrongvalues]", func() {
@@ -110,14 +111,14 @@ func TestManipulatorsSet(test *testing.T) {
 		binary.BigEndian.PutUint64(key, uint64(index))
 
 		collection.Set(key, uint64(2*index))
-		ctx.verify.tree("[stakecollection]", &collection)
+		ctx.verify.tree("[stakecollection]", collection)
 	}
 
 	for index := 0; index < 512; index++ {
 		key := make([]byte, 8)
 		binary.BigEndian.PutUint64(key, uint64(index))
 
-		ctx.verify.values("[set]", &collection, key, uint64(index*2))
+		ctx.verify.values("[set]", collection, key, uint64(index*2))
 	}
 
 	unknownRoot := New(stake64)
@@ -162,7 +163,7 @@ func TestManipulatorsSet(test *testing.T) {
 	for index := 0; index < 512; index++ {
 		key := make([]byte, 8)
 		binary.BigEndian.PutUint64(key, uint64(index))
-		ctx.verify.values("[transactioncollection]", &transaction, key, uint64(2*index))
+		ctx.verify.values("[transactioncollection]", transaction, key, uint64(2*index))
 	}
 
 	ctx.shouldPanic("[wrongvalues]", func() {
@@ -199,9 +200,9 @@ func TestManipulatorsSetField(test *testing.T) {
 		binary.BigEndian.PutUint64(key, uint64(index))
 
 		if index%2 == 0 {
-			ctx.verify.values("[setfield]", &collection, key, []byte("x"), []byte{})
+			ctx.verify.values("[setfield]", collection, key, []byte("x"), []byte{})
 		} else {
-			ctx.verify.values("[setfield]", &collection, key, []byte{}, []byte("x"))
+			ctx.verify.values("[setfield]", collection, key, []byte{}, []byte("x"))
 		}
 	}
 
@@ -234,7 +235,7 @@ func TestManipulatorsRemove(test *testing.T) {
 		binary.BigEndian.PutUint64(key, uint64(index))
 
 		collection.Remove(key)
-		ctx.verify.tree("[remove]", &collection)
+		ctx.verify.tree("[remove]", collection)
 	}
 
 	if collection.root.label != reference.root.label {
@@ -284,13 +285,13 @@ func TestManipulatorsRemove(test *testing.T) {
 	for index := 0; index < 512; index += 2 {
 		key := make([]byte, 8)
 		binary.BigEndian.PutUint64(key, uint64(index))
-		ctx.verify.noKey("[transactioncollection]", &transaction, key)
+		ctx.verify.noKey("[transactioncollection]", transaction, key)
 	}
 
 	for index := 1; index < 512; index += 2 {
 		key := make([]byte, 8)
 		binary.BigEndian.PutUint64(key, uint64(index))
-		ctx.verify.key("[transactioncollection]", &transaction, key)
+		ctx.verify.key("[transactioncollection]", transaction, key)
 	}
 
 	for index := 1; index < 512; index += 2 {

--- a/omniledger/collection/navigators.go
+++ b/omniledger/collection/navigators.go
@@ -14,6 +14,8 @@ type Navigator struct {
 
 // Navigate creates a Navigator associated with a given field and value.
 func (c *Collection) Navigate(field int, value interface{}) Navigator {
+	c.Lock()
+	defer c.Unlock()
 	if (field < 0) || (field >= len(c.fields)) {
 		panic("Field unknown.")
 	}
@@ -26,6 +28,8 @@ func (c *Collection) Navigate(field int, value interface{}) Navigator {
 // Record returns the Record obtained by navigating the tree to the searched field's value.
 // It returns an error if the value in question is in an unknown subtree or if the Navigate function of the field returns an error.
 func (n Navigator) Record() (Record, error) {
+	n.collection.Lock()
+	defer n.collection.Unlock()
 	cursor := n.collection.root
 
 	for {

--- a/omniledger/collection/navigators_test.go
+++ b/omniledger/collection/navigators_test.go
@@ -16,7 +16,7 @@ func TestNavigatorsConstructors(test *testing.T) {
 	collection := New(stake64, data, stake64)
 	navigator := collection.Navigate(2, uint64(14))
 
-	if navigator.collection != &collection {
+	if navigator.collection != collection {
 		test.Error("[navigators.go]", "[constructors]", "Navigator constructor sets wrong collection pointer.")
 	}
 

--- a/omniledger/collection/node.go
+++ b/omniledger/collection/node.go
@@ -2,12 +2,10 @@ package collection
 
 import (
 	"crypto/sha256"
-	"sync"
 )
 
 //A node represents one element of the Merkle tree like data-structure.
 type node struct {
-	sync.Mutex
 	label [sha256.Size]byte
 
 	known bool
@@ -30,29 +28,21 @@ type node struct {
 // Getters
 
 func (n *node) root() bool {
-	n.Lock()
-	defer n.Unlock()
 	return n.parent == nil
 }
 
 func (n *node) leaf() bool {
-	n.Lock()
-	defer n.Unlock()
 	return n.children.left == nil
 }
 
 func (n *node) placeholder() bool {
 	isLeaf := n.leaf()
-	n.Lock()
-	defer n.Unlock()
 	return isLeaf && (len(n.key) == 0)
 }
 
 // Methods
 
 func (n *node) backup() {
-	n.Lock()
-	defer n.Unlock()
 	if n.transaction.backup == nil {
 		n.transaction.backup = new(node)
 		n.transaction.backup.overwrite(n)
@@ -81,8 +71,6 @@ func (n *node) overwrite(other *node) {
 }
 
 func (n *node) restore() {
-	n.Lock()
-	defer n.Unlock()
 	if n.transaction.backup != nil {
 		backup := n.transaction.backup
 		n.overwrite(backup)
@@ -91,8 +79,6 @@ func (n *node) restore() {
 }
 
 func (n *node) branch() {
-	n.Lock()
-	defer n.Unlock()
 	n.children.left = new(node)
 	n.children.right = new(node)
 
@@ -101,8 +87,6 @@ func (n *node) branch() {
 }
 
 func (n *node) prune() {
-	n.Lock()
-	defer n.Unlock()
 	n.children.left = nil
 	n.children.right = nil
 }

--- a/omniledger/collection/proof.go
+++ b/omniledger/collection/proof.go
@@ -24,22 +24,14 @@ type dump struct {
 // Constructors
 
 func dumpNode(node *node) (dump dump) {
-	node.Lock()
-	defer node.Unlock()
-
 	dump.Label = node.label
 	dump.Values = node.values
 
-	// NOTE: this is the same as node.leaf() without the locks.
-	if node.children.left == nil {
+	if node.leaf() {
 		dump.Key = node.key
 	} else {
-		node.children.left.Lock()
-		node.children.right.Lock()
 		dump.Children.Left = node.children.left.label
 		dump.Children.Right = node.children.right.label
-		node.children.left.Unlock()
-		node.children.right.Unlock()
 	}
 
 	return

--- a/omniledger/collection/proof_test.go
+++ b/omniledger/collection/proof_test.go
@@ -189,11 +189,11 @@ func TestProofDumpTo(test *testing.T) {
 		test.Error("[proof.go]", "[to]", "Fixing a collection expanded from dumps has a non-null effect on the root label.")
 	}
 
-	ctx.verify.tree("[to]", &unknown)
+	ctx.verify.tree("[to]", unknown)
 
 	leftDump.to(unknown.root.children.right)
 	unknown.fix()
-	ctx.verify.tree("[to]", &unknown)
+	ctx.verify.tree("[to]", unknown)
 
 	if unknown.root.label != collection.root.label {
 		test.Error("[proof.go]", "[to]", "Method to() has non-null effect when used on node with non-matching label.")
@@ -234,7 +234,7 @@ func TestProofMatchValues(test *testing.T) {
 	collection.Add(secondKey, uint64(99), []byte("secondvalue"))
 
 	proof := Proof{}
-	proof.collection = &collection
+	proof.collection = collection
 	proof.Key = firstKey
 	proof.Root = dumpNode(collection.root)
 
@@ -511,7 +511,7 @@ func TestProofSerialization(test *testing.T) {
 			test.Error("[proof.go]", "[serialization]", "Serialize() / Deserialize() yields an error on a valid proof.")
 		}
 
-		if otherProof.collection != &collection {
+		if otherProof.collection != collection {
 			test.Error("[proof.go]", "[serialization]", "Deserialize() does not properly set the collection pointer.")
 		}
 

--- a/omniledger/collection/record.go
+++ b/omniledger/collection/record.go
@@ -34,6 +34,8 @@ func recordKeyMismatch(collection *Collection, key []byte) Record {
 // Query returns the original query, decoded, that generated the record.
 // It returns an error if the record was generated from a getter (key search).
 func (r Record) Query() (interface{}, error) {
+	r.collection.Lock()
+	defer r.collection.Unlock()
 	if len(r.query) == 0 {
 		return nil, errors.New("no query specified")
 	}
@@ -53,17 +55,23 @@ func (r Record) Query() (interface{}, error) {
 
 // Match returns true if the record match the query that generated it, and false otherwise.
 func (r Record) Match() bool {
+	r.collection.Lock()
+	defer r.collection.Unlock()
 	return r.match
 }
 
 // Key returns the key of the record
 func (r Record) Key() []byte {
+	r.collection.Lock()
+	defer r.collection.Unlock()
 	return r.key
 }
 
 // Values returns a copy of the values of a record.
 // If the record didn't match the query, an error will be returned.
 func (r Record) Values() ([]interface{}, error) {
+	r.collection.Lock()
+	defer r.collection.Unlock()
 	if !(r.match) {
 		return []interface{}{}, errors.New("no match found")
 	}

--- a/omniledger/collection/record_test.go
+++ b/omniledger/collection/record_test.go
@@ -1,8 +1,9 @@
 package collection
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestRecord(test *testing.T) {
@@ -20,11 +21,11 @@ func TestRecord(test *testing.T) {
 		leaf = collection.root.children.left
 	}
 
-	keyMatch := recordKeyMatch(&collection, leaf)
-	queryMatch := recordQueryMatch(&collection, 0, stake64.Encode(uint64(99)), leaf)
-	keyMismatch := recordKeyMismatch(&collection, []byte("wrongkey"))
+	keyMatch := recordKeyMatch(collection, leaf)
+	queryMatch := recordQueryMatch(collection, 0, stake64.Encode(uint64(99)), leaf)
+	keyMismatch := recordKeyMismatch(collection, []byte("wrongkey"))
 
-	if (keyMatch.collection != &collection) || (queryMatch.collection != &collection) || (keyMismatch.collection != &collection) {
+	if (keyMatch.collection != collection) || (queryMatch.collection != collection) || (keyMismatch.collection != collection) {
 		test.Error("[record.go]", "[constructors]", "Constructors don't set collection appropriately.")
 	}
 

--- a/omniledger/collection/singlenode.go
+++ b/omniledger/collection/singlenode.go
@@ -19,15 +19,11 @@ type toHash struct {
 // Private methods (collection) (single node operations)
 
 func (c *Collection) update(node *node) error {
-	node.Lock()
-	defer node.Unlock()
-
 	if !(node.known) {
 		return errors.New("updating an unknown node")
 	}
 
-	// NOTE: this is the same as !node.leaf() without the locks.
-	if !(node.children.left == nil) {
+	if !node.leaf() {
 		if !(node.children.left.known) || !(node.children.right.known) {
 			return errors.New("updating internal node with unknown children")
 		}
@@ -73,8 +69,7 @@ func (c *Collection) setPlaceholder(node *node) error {
 func (n *node) generateHash() [sha256.Size]byte {
 
 	var toEncode toHash
-	// NOTE: this is the same as node.leaf() without the locks.
-	if n.children.left == nil {
+	if n.leaf() {
 		toEncode = toHash{true, n.key, n.values, [sha256.Size]byte{}, [sha256.Size]byte{}}
 	} else {
 		toEncode = toHash{false, []byte{}, n.values, n.children.left.label, n.children.right.label}

--- a/omniledger/collection/singlenode_test.go
+++ b/omniledger/collection/singlenode_test.go
@@ -116,7 +116,7 @@ func TestSingleNodeUpdate(test *testing.T) {
 		test.Error("[singlenode.go]", "[stake]", "Wrong value on stake root.")
 	}
 
-	ctx.verify.tree("[tree]", &stakeCollection)
+	ctx.verify.tree("[tree]", stakeCollection)
 
 	stakeCollection.root.children.left.values[0] = make([]byte, 5)
 

--- a/omniledger/collection/transaction_test.go
+++ b/omniledger/collection/transaction_test.go
@@ -71,7 +71,7 @@ func TestTransactionRollback(test *testing.T) {
 		test.Error("[transaction.go]", "[rollback]", "Rollback() does not increment the transaction id.")
 	}
 
-	ctx.verify.tree("[rollback]", &collection)
+	ctx.verify.tree("[rollback]", collection)
 
 	if collection.root.label != reference.root.label {
 		test.Error("[transaction.go]", "[rollback]", "Rollback() doesn't produce the same tree as before.")
@@ -150,18 +150,18 @@ func TestTransactionEnd(test *testing.T) {
 		test.Error("[transaction.go]", "[end]", "End() does not increment transaction id.")
 	}
 
-	ctx.verify.tree("[end]", &collection)
+	ctx.verify.tree("[end]", collection)
 
 	for index := 0; index < 1024; index++ {
 		key := make([]byte, 8)
 		binary.BigEndian.PutUint64(key, uint64(index))
 
 		if (index % 3) == 0 {
-			ctx.verify.values("[end]", &collection, key, uint64(3*index))
+			ctx.verify.values("[end]", collection, key, uint64(3*index))
 		} else if (index % 3) == 1 {
-			ctx.verify.noKey("[end]", &collection, key)
+			ctx.verify.noKey("[end]", collection, key)
 		} else {
-			ctx.verify.values("[end]", &collection, key, uint64(index))
+			ctx.verify.values("[end]", collection, key, uint64(index))
 		}
 	}
 
@@ -172,7 +172,7 @@ func TestTransactionEnd(test *testing.T) {
 		test.Error("[transaction.go]", "[end]", "Fixing after End() alters the tree root.")
 	}
 
-	ctx.verify.scope("[scope]", &collection)
+	ctx.verify.scope("[scope]", collection)
 
 	ctx.shouldPanic("[endagain]", func() {
 		collection.End()
@@ -218,7 +218,7 @@ func TestTransactionCollect(test *testing.T) {
 	collection.Collect()
 	collection.transaction.ongoing = false
 
-	ctx.verify.scope("[collect]", &collection)
+	ctx.verify.scope("[collect]", collection)
 
 	unknownRoot := New()
 	unknownRoot.root.known = false
@@ -307,7 +307,7 @@ func TestTransactionFix(test *testing.T) {
 	collection.root.transaction.inconsistent = true
 
 	collection.fix()
-	ctx.verify.tree("[fix]", &collection)
+	ctx.verify.tree("[fix]", collection)
 
 	oldRootLabel := collection.root.label
 
@@ -336,5 +336,5 @@ func TestTransactionFix(test *testing.T) {
 		test.Error("[transaction.go]", "[fix]", "Fix should alter the label of the root of a collection tree.")
 	}
 
-	ctx.verify.tree("[fix]", &collection)
+	ctx.verify.tree("[fix]", collection)
 }

--- a/omniledger/collection/update_test.go
+++ b/omniledger/collection/update_test.go
@@ -10,7 +10,7 @@ func TestUpdateProxy(test *testing.T) {
 
 	proxy := collection.proxy([][]byte{[]byte("firstkey"), []byte("secondkey"), []byte("thirdkey")})
 
-	if proxy.collection != &collection {
+	if proxy.collection != collection {
 		test.Error("[update.go]", "[proxy]", "proxy() method sets wrong collection pointer.")
 	}
 

--- a/omniledger/collection/verifiers_test.go
+++ b/omniledger/collection/verifiers_test.go
@@ -37,13 +37,13 @@ func TestVerifiersVerify(test *testing.T) {
 		}
 	}
 
-	ctx.verify.tree("[verify]", &unknown)
+	ctx.verify.tree("[verify]", unknown)
 
 	for index := 0; index < 512; index++ {
 		key := make([]byte, 8)
 		binary.BigEndian.PutUint64(key, uint64(index))
 
-		ctx.verify.values("[verify]", &unknown, key, uint64(index), key)
+		ctx.verify.values("[verify]", unknown, key, uint64(index), key)
 	}
 
 	proof, _ := collection.Get(make([]byte, 8)).Proof()

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -270,7 +270,7 @@ func (s *Service) verifyInstruction(scID skipchain.SkipBlockID, instr Instructio
 func (s *Service) createNewBlock(scID skipchain.SkipBlockID, r *onet.Roster, cts ClientTransactions) (*skipchain.SkipBlock, error) {
 	var sb *skipchain.SkipBlock
 	var mr []byte
-	var coll collection.Collection
+	var coll *collection.Collection
 
 	if scID.IsNull() {
 		// For a genesis block, we create a throwaway collection.
@@ -587,7 +587,7 @@ func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool
 // createStateChanges goes through all ClientTransactions and creates
 // the appropriate StateChanges. If any of the transactions are invalid,
 // it returns an error.
-func (s *Service) createStateChanges(coll collection.Collection, cts ClientTransactions) (merkleRoot []byte, ctsOK ClientTransactions, states StateChanges, err error) {
+func (s *Service) createStateChanges(coll *collection.Collection, cts ClientTransactions) (merkleRoot []byte, ctsOK ClientTransactions, states StateChanges, err error) {
 
 	// TODO: Because we depend on making at least one clone per transaction
 	// we need to find out if this is as expensive as it looks, and if so if

--- a/omniledger/service/struct.go
+++ b/omniledger/service/struct.go
@@ -19,7 +19,7 @@ func init() {
 type collectionDB struct {
 	db         *bolt.DB
 	bucketName []byte
-	coll       collection.Collection
+	coll       *collection.Collection
 }
 
 // A CollectionView is an interface that defines the read-only operations
@@ -40,7 +40,7 @@ type CollectionView interface {
 // CollectionView chooses to use package unsafe, then it's all over;
 // they can get write access.
 type roCollection struct {
-	c collection.Collection
+	c *collection.Collection
 }
 
 // Get returns the collection.Getter for the key.
@@ -134,7 +134,7 @@ func (c *collectionDB) loadAll() error {
 	})
 }
 
-func storeInColl(coll collection.Collection, t *StateChange) error {
+func storeInColl(coll *collection.Collection, t *StateChange) error {
 	switch t.StateAction {
 	case Create:
 		return coll.Add(t.InstanceID, t.Value, t.ContractID)


### PR DESCRIPTION
- Add mutex on collection: 
Previously the mutex was on the nodes, which meant that race conditions
is still possible in other parts of the collection. This change removes
that and adds mutex on collections.
- Pass around collections as reference:
If we pass collections around as value, then the mutex changes and we'll
have reace conditions.