### PR TITLE
Add a bit more delay in the long eventlog test

### DIFF
--- a/eventlog/api_test.go
+++ b/eventlog/api_test.go
@@ -110,6 +110,9 @@ func TestClient_Log200(t *testing.T) {
 	require.Nil(t, err)
 
 	for i := 0; i < 10; i++ {
+		// Apparently leader.waitForBlock isn't enough for jenkins, so
+		// wait a bit longer.
+		time.Sleep(time.Second)
 		leader.waitForBlock(c.OmniLedger.ID)
 		if err = leader.checkBuckets(c.EventlogID, c.OmniLedger.ID, 2*logCount); err == nil {
 			break

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -400,9 +400,9 @@ func (s *Service) updateCollection(msg network.Message) {
 	}
 
 	if i, _ := sb.Roster.Search(s.ServerIdentity().ID); i == 0 {
-		log.Lvlf2("%s: Storing state changes %v", s.ServerIdentity(), scs.ShortStrings())
+		log.Lvlf2("%s: Storing %d state changes %v", s.ServerIdentity(), len(scs), scs.ShortStrings())
 	} else {
-		log.Lvlf3("%s: Storing state changes %v", s.ServerIdentity(), scs.ShortStrings())
+		log.Lvlf3("%s: Storing %d state changes %v", s.ServerIdentity(), len(scs), scs.ShortStrings())
 	}
 	for _, sc := range scs {
 		err = cdb.Store(&sc)


### PR DESCRIPTION
The way that blocks get added got changed slightly in the follower queue
PR, which broke Jenkins. This PR makes Jenkins happy again.