### PR TITLE
Add invoke to ConfigContract to update ChainConfig

### DIFF
--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -581,6 +581,8 @@ func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool
 		log.Lvl2(s.ServerIdentity(), "State Changes hash doesn't verify")
 		return false
 	}
+	// TODO compute new state and check if there's a state change on the
+	// config, if there is, then we check whether newSB matches the config
 	return true
 }
 


### PR DESCRIPTION
We give the owners of the genesis darc the ability to update the
configuration. The next step is to update the roster and eventually do
view-change.

Closes #1319