### PR TITLE
Include roster in ChainConfig

### DIFF
--- a/omniledger/service/api.go
+++ b/omniledger/service/api.go
@@ -166,7 +166,7 @@ func (c *Client) GetChainConfig() (*ChainConfig, error) {
 		return nil, errors.New("expected contract to be config but got: " + string(contractBuf))
 	}
 	config := &ChainConfig{}
-	err = protobuf.Decode(vs[0], config)
+	err = protobuf.DecodeWithConstructors(vs[0], config, network.DefaultConstructors(cothority.Suite))
 	if err != nil {
 		return nil, err
 	}

--- a/omniledger/service/proto.go
+++ b/omniledger/service/proto.go
@@ -89,6 +89,7 @@ type GetProofResponse struct {
 // GenesisDarcID is the value of GenesisReferenceID.
 type ChainConfig struct {
 	BlockInterval time.Duration
+	Roster        onet.Roster
 }
 
 // Proof represents everything necessary to verify a given


### PR DESCRIPTION
We add roster to ChainConfig, so that it is possible to change the
roster via the config contract. Changing the roster currently can only
be done via the client, we will add a way to rotate the roster
automatically (view-change) next.