### PR TITLE
adding a coin contract together with the simulation

### DIFF
--- a/external/java/src/test/java/ch/epfl/dedis/ocs/Ed25519Test.java
+++ b/external/java/src/test/java/ch/epfl/dedis/ocs/Ed25519Test.java
@@ -53,7 +53,7 @@ class Ed25519Test {
         assertTrue(pub.equals(kp.point));
 
         Scalar onep = kp.scalar.addOne();
-        assertEquals(onep.getLittleEndian()[0], kp.scalar.getLittleEndian()[0] + 1);
+        assertEquals(onep.getLittleEndian()[0], ((kp.scalar.getLittleEndian()[0] + 129)%256)-128);
     }
 
     @Test

--- a/external/js/cothority/test/skipchain/build/.gitignore
+++ b/external/js/cothority/test/skipchain/build/.gitignore
@@ -1,0 +1,4 @@
+build/
+test_data/
+public.toml
+genesis.txt

--- a/omniledger/collection/getters.go
+++ b/omniledger/collection/getters.go
@@ -69,7 +69,9 @@ func (g Getter) Proof() (Proof, error) {
 	var proof Proof
 
 	proof.collection = g.collection
-	proof.Key = g.key
+	// To avoid race conditions, we need deep copies here.
+	proof.Key = make([]byte, len(g.key))
+	copy(proof.Key, g.key)
 
 	proof.Root = dumpNode(g.collection.root)
 

--- a/omniledger/collection/node.go
+++ b/omniledger/collection/node.go
@@ -65,6 +65,25 @@ func (n *node) backup() {
 	}
 }
 
+func (n *node) copyKey() []byte {
+	key := make([]byte, len(n.key))
+	copy(key, n.key)
+	return key
+}
+
+func (n *node) copyVal() [][]byte {
+	// n.values == nil | n.Values[0]: []byte
+	if n.values == nil {
+		return nil
+	}
+	cv := make([][]byte, len(n.values))
+	for i := 0; i < len(n.values); i++ {
+		cv[i] = make([]byte, len(n.values[i]))
+		copy(cv[i], n.values[i])
+	}
+	return cv
+}
+
 // overwrite copies the fields from other into n. This is needed because
 // node now has a mutex.
 func (n *node) overwrite(other *node) {
@@ -72,12 +91,18 @@ func (n *node) overwrite(other *node) {
 	n.known = other.known
 	n.transaction.inconsistent = other.transaction.inconsistent
 
-	n.key = other.key
-	n.values = other.values
+	n.key = other.copyKey()
+	n.values = other.copyVal()
 
 	n.parent = other.parent
 	n.children.left = other.children.left
 	n.children.right = other.children.right
+}
+
+func (n *node) copyTo(dst *node) {
+	n.Lock()
+	dst.overwrite(n)
+	n.Unlock()
 }
 
 func (n *node) restore() {

--- a/omniledger/contracts/coins.go
+++ b/omniledger/contracts/coins.go
@@ -1,0 +1,125 @@
+package contracts
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+
+	"github.com/dedis/cothority/omniledger/service"
+	"github.com/dedis/onet/log"
+)
+
+// ContractCoinID denotes a contract that can store and transfer coins.
+var ContractCoinID = "coin"
+
+var olCoin = service.NewInstanceID([]byte("olCoin"))
+
+// ContractCoin is a coin implementation that holds one instance per coin.
+// If you spawn a new ContractCoin, it will create an account with a value
+// of 0 coins.
+// The following methods are available:
+//  - mint will add the number of coins in the argument "coins" to the
+//    current coin instance. The argument must be a 64-bit uint in LittleEndian
+//  - transfer will send the coins given in the argument "coins" to the
+//    instance given in the argument "destination". The "coins"-argument must
+//    be a 64-bit uint in LittleEndian. The "destination" must be a 64-bit
+//    instanceID
+//  - fetch takes "coins" out of the account and returns it as an output
+//    parameter for the next instruction to interpret.
+//  - store puts the coins given to the instance back into the account.
+// You can only delete a contractCoin instance if the account is empty.
+func ContractCoin(cdb service.CollectionView, inst service.Instruction, c []service.Coin) (sc []service.StateChange, cOut []service.Coin, err error) {
+	cOut = c
+	switch {
+	case inst.Spawn != nil:
+		// Spawn creates a new coin account as a separate instance. The subID is
+		// taken from the hash of the instruction.
+		ca := service.InstanceID{
+			DarcID: inst.InstanceID.DarcID,
+			SubID:  service.NewSubID(inst.Hash()),
+		}
+		log.Lvlf3("Spawing coin to %x", ca.Slice())
+		return []service.StateChange{
+			service.NewStateChange(service.Create, ca, ContractCoinID, make([]byte, 8)),
+		}, c, nil
+	case inst.Invoke != nil:
+		// Invoke is one of "mint", "transfer", "fetch", or "store".
+		value, _, err := cdb.GetValues(inst.InstanceID.Slice())
+		if err != nil {
+			return nil, nil, err
+		}
+		coinsCurrent := binary.LittleEndian.Uint64(value)
+		coinsBuf := inst.Invoke.Args.Search("coins")
+		if coinsBuf == nil {
+			return nil, nil, errors.New("please give coins")
+		}
+		coinsArg := binary.LittleEndian.Uint64(coinsBuf)
+		var sc []service.StateChange
+		switch inst.Invoke.Command {
+		case "mint":
+			// mint simply adds this amount of coins to the account.
+			log.Lvl2("minting", coinsArg)
+			coinsCurrent += coinsArg
+		case "transfer":
+			// transfer sends a given amount of coins to another account.
+			if coinsArg > coinsCurrent {
+				return nil, nil, errors.New("not enough coins in instance")
+			}
+			coinsCurrent -= coinsArg
+			target := inst.Invoke.Args.Search("destination")
+			v, cid, err := cdb.GetValues(target)
+			if err == nil && cid != ContractCoinID {
+				err = errors.New("destination is not a coin contract")
+			}
+			if err != nil {
+				return nil, nil, err
+			}
+			targetCoin := binary.LittleEndian.Uint64(v)
+			var w bytes.Buffer
+			binary.Write(&w, binary.LittleEndian, targetCoin+coinsArg)
+			log.Lvlf3("transferring %d to %x", coinsArg, target)
+			sc = append(sc, service.NewStateChange(service.Update, service.NewInstanceID(target),
+				ContractCoinID, w.Bytes()))
+		case "fetch":
+			// fetch removes coins from the account and passes it on to the next
+			// instruction.
+			if coinsArg > coinsCurrent {
+				return nil, nil, errors.New("not enough coins in instance")
+			}
+			coinsCurrent -= coinsArg
+			cOut = append(cOut, service.Coin{Name: olCoin, Value: coinsArg})
+		case "store":
+			// store moves all coins from the last instruction into the account.
+			cOut = []service.Coin{}
+			for _, co := range c {
+				if co.Name.Equal(olCoin) {
+					coinsCurrent += co.Value
+				} else {
+					cOut = append(cOut, co)
+				}
+			}
+		default:
+			return nil, nil, errors.New("Coin contract can only mine and transfer")
+		}
+		// Finally update our own coin value and send one or two stateChanges to
+		// the system.
+		var w bytes.Buffer
+		binary.Write(&w, binary.LittleEndian, coinsCurrent)
+		return append(sc, service.NewStateChange(service.Update, inst.InstanceID,
+			ContractCoinID, w.Bytes())), c, nil
+	case inst.Delete != nil:
+		// Delete our coin address, but only if the current coin is empty.
+		value, _, err := cdb.GetValues(inst.InstanceID.Slice())
+		if err != nil {
+			return nil, nil, err
+		}
+		coinsCurrent := binary.LittleEndian.Uint64(value)
+		if coinsCurrent > 0 {
+			return nil, nil, errors.New("cannot destroy a coinInstance that still has coins in it")
+		}
+		return service.StateChanges{
+			service.NewStateChange(service.Remove, inst.InstanceID, ContractCoinID, nil),
+		}, c, nil
+	}
+	return nil, nil, errors.New("didn't find any instruction")
+}

--- a/omniledger/contracts/coins.go
+++ b/omniledger/contracts/coins.go
@@ -101,8 +101,7 @@ func ContractCoin(cdb service.CollectionView, inst service.Instruction, c []serv
 		default:
 			return nil, nil, errors.New("Coin contract can only mine and transfer")
 		}
-		// Finally update our own coin value and send one or two stateChanges to
-		// the system.
+		// Finally update the coin value.
 		var w bytes.Buffer
 		binary.Write(&w, binary.LittleEndian, coinsCurrent)
 		return append(sc, service.NewStateChange(service.Update, inst.InstanceID,

--- a/omniledger/contracts/coins.go
+++ b/omniledger/contracts/coins.go
@@ -184,8 +184,11 @@ func ContractCoin(cdb omniledger.CollectionView, inst omniledger.Instruction, c 
 	return
 }
 
-// iid uses sha256(in)x2 to get 64 bytes from in, and makes an InstanceID from it.
-// TODO: Find a more appropriate way to make well-known instance ID's.
+// iid uses darc=sha256(in) and subid=sha256(in) in order to manufacture an
+// InstanceID from in.
+//
+// TODO: Find a more appropriate way to make well-known instance ID's, depends
+// on getting rid of subids.
 func iid(in string) omniledger.InstanceID {
 	h := sha256.New()
 	h.Write([]byte(in))

--- a/omniledger/contracts/coins_test.go
+++ b/omniledger/contracts/coins_test.go
@@ -111,7 +111,7 @@ func TestCoin_InvokeStoreFetch(t *testing.T) {
 		},
 	}
 
-	// Try once with no enough coins avail.
+	// Try once with not enough coins available.
 	sc, co, err = ContractCoin(ct, inst, nil)
 	require.Error(t, err)
 

--- a/omniledger/contracts/coins_test.go
+++ b/omniledger/contracts/coins_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/dedis/cothority/omniledger/collection"
 	omniledger "github.com/dedis/cothority/omniledger/service"
+	"github.com/dedis/cothority/skipchain"
 	"github.com/stretchr/testify/require"
 )
 
@@ -194,4 +195,7 @@ func (ct cvTest) GetValue(key []byte) ([]byte, error) {
 }
 func (ct cvTest) GetContractID(key []byte) (string, error) {
 	return ct.contractIDs[string(key)], nil
+}
+func (ct cvTest) GetSkipchainID() skipchain.SkipBlockID {
+	return nil
 }

--- a/omniledger/contracts/coins_test.go
+++ b/omniledger/contracts/coins_test.go
@@ -1,0 +1,124 @@
+package contracts
+
+import (
+	"testing"
+
+	"github.com/dedis/cothority/omniledger/collection"
+	"github.com/dedis/cothority/omniledger/service"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	coinZero = make([]byte, 8)
+	coinOne  = append(make([]byte, 7), byte(1))
+	coinTwo  = append(make([]byte, 7), byte(2))
+)
+
+func TestCoin_Spawn(t *testing.T) {
+	// Testing spawning of a new coin and checking it has zero coins in it.
+	ct := cvTest{}
+	inst := service.Instruction{
+		InstanceID: service.NewInstanceID(nil),
+		Spawn: &service.Spawn{
+			ContractID: ContractCoinID,
+		},
+	}
+
+	c := []service.Coin{}
+	sc, co, err := ContractCoin(ct, inst, c)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(sc))
+	ca := service.InstanceID{DarcID: make([]byte, 32), SubID: service.NewSubID(inst.Hash())}
+	require.Equal(t, service.NewStateChange(service.Create, ca,
+		ContractCoinID, coinZero), sc[0])
+	require.Equal(t, 0, len(co))
+}
+
+func TestCoin_InvokeMint(t *testing.T) {
+	// Test that a coin can be minted
+	ct := newCT()
+	coAddr := service.NewInstanceID(nil)
+	ct.Store(coAddr, coinZero, ContractCoinID)
+
+	inst := service.Instruction{
+		InstanceID: coAddr,
+		Invoke: &service.Invoke{
+			Command: "mint",
+			Args:    service.Arguments{{Name: "coins", Value: coinOne}},
+		},
+	}
+	sc, co, err := ContractCoin(ct, inst, []service.Coin{})
+	require.Nil(t, err)
+	require.Equal(t, 0, len(co))
+	require.Equal(t, 1, len(sc))
+	require.Equal(t, service.NewStateChange(service.Update, coAddr, ContractCoinID, coinOne),
+		sc[0])
+}
+
+func TestCoin_InvokeTransfer(t *testing.T) {
+	// Test that a coin can be transferred
+	ct := newCT()
+	coAddr1 := service.InstanceID{DarcID: make([]byte, 32), SubID: service.SubID{}}
+	coAddr2 := service.InstanceID{DarcID: make([]byte, 32), SubID: service.SubID{}}
+	coAddr2.DarcID[31] = byte(1)
+	ct.Store(coAddr1, coinOne, ContractCoinID)
+	ct.Store(coAddr2, coinZero, ContractCoinID)
+
+	// First create an instruction where the transfer should fail
+	inst := service.Instruction{
+		InstanceID: coAddr2,
+		Invoke: &service.Invoke{
+			Command: "transfer",
+			Args: service.Arguments{
+				{Name: "coins", Value: coinOne},
+				{Name: "destination", Value: coAddr1.Slice()},
+			},
+		},
+	}
+	sc, co, err := ContractCoin(ct, inst, []service.Coin{})
+	require.NotNil(t, err)
+
+	inst = service.Instruction{
+		InstanceID: coAddr1,
+		Invoke: &service.Invoke{
+			Command: "transfer",
+			Args: service.Arguments{
+				{Name: "coins", Value: coinOne},
+				{Name: "destination", Value: coAddr2.Slice()},
+			},
+		},
+	}
+	sc, co, err = ContractCoin(ct, inst, []service.Coin{})
+	require.Nil(t, err)
+	require.Equal(t, 0, len(co))
+	require.Equal(t, 2, len(sc))
+	require.Equal(t, service.NewStateChange(service.Update, coAddr2, ContractCoinID, coinOne), sc[0])
+	require.Equal(t, service.NewStateChange(service.Update, coAddr1, ContractCoinID, coinZero), sc[1])
+}
+
+type cvTest struct {
+	values      map[string][]byte
+	contractIDs map[string]string
+}
+
+func newCT() *cvTest {
+	return &cvTest{make(map[string][]byte), make(map[string]string)}
+}
+
+func (ct cvTest) Get(key []byte) collection.Getter {
+	panic("not implemented")
+}
+func (ct *cvTest) Store(key service.InstanceID, value []byte, contractID string) {
+	k := string(key.Slice())
+	ct.values[k] = value
+	ct.contractIDs[k] = contractID
+}
+func (ct cvTest) GetValues(key []byte) (value []byte, contractID string, err error) {
+	return ct.values[string(key)], ct.contractIDs[string(key)], nil
+}
+func (ct cvTest) GetValue(key []byte) ([]byte, error) {
+	return ct.values[string(key)], nil
+}
+func (ct cvTest) GetContractID(key []byte) (string, error) {
+	return ct.contractIDs[string(key)], nil
+}

--- a/omniledger/contracts/coins_test.go
+++ b/omniledger/contracts/coins_test.go
@@ -4,32 +4,36 @@ import (
 	"testing"
 
 	"github.com/dedis/cothority/omniledger/collection"
-	"github.com/dedis/cothority/omniledger/service"
+	omniledger "github.com/dedis/cothority/omniledger/service"
 	"github.com/stretchr/testify/require"
 )
 
-var (
+var coinZero, coinOne, coinTwo []byte
+
+func init() {
 	coinZero = make([]byte, 8)
-	coinOne  = append(make([]byte, 7), byte(1))
-	coinTwo  = append(make([]byte, 7), byte(2))
-)
+	coinOne = make([]byte, 8)
+	coinOne[0] = 1
+	coinTwo = make([]byte, 8)
+	coinTwo[0] = 2
+}
 
 func TestCoin_Spawn(t *testing.T) {
 	// Testing spawning of a new coin and checking it has zero coins in it.
 	ct := cvTest{}
-	inst := service.Instruction{
-		InstanceID: service.NewInstanceID(nil),
-		Spawn: &service.Spawn{
+	inst := omniledger.Instruction{
+		InstanceID: omniledger.NewInstanceID(nil),
+		Spawn: &omniledger.Spawn{
 			ContractID: ContractCoinID,
 		},
 	}
 
-	c := []service.Coin{}
+	c := []omniledger.Coin{}
 	sc, co, err := ContractCoin(ct, inst, c)
 	require.Nil(t, err)
 	require.Equal(t, 1, len(sc))
-	ca := service.InstanceID{DarcID: make([]byte, 32), SubID: service.NewSubID(inst.Hash())}
-	require.Equal(t, service.NewStateChange(service.Create, ca,
+	ca := omniledger.InstanceID{DarcID: make([]byte, 32), SubID: omniledger.NewSubID(inst.Hash())}
+	require.Equal(t, omniledger.NewStateChange(omniledger.Create, ca,
 		ContractCoinID, coinZero), sc[0])
 	require.Equal(t, 0, len(co))
 }
@@ -37,63 +41,132 @@ func TestCoin_Spawn(t *testing.T) {
 func TestCoin_InvokeMint(t *testing.T) {
 	// Test that a coin can be minted
 	ct := newCT()
-	coAddr := service.NewInstanceID(nil)
+	coAddr := omniledger.NewInstanceID(nil)
 	ct.Store(coAddr, coinZero, ContractCoinID)
 
-	inst := service.Instruction{
+	inst := omniledger.Instruction{
 		InstanceID: coAddr,
-		Invoke: &service.Invoke{
+		Invoke: &omniledger.Invoke{
 			Command: "mint",
-			Args:    service.Arguments{{Name: "coins", Value: coinOne}},
+			Args:    omniledger.Arguments{{Name: "coins", Value: coinOne}},
 		},
 	}
-	sc, co, err := ContractCoin(ct, inst, []service.Coin{})
+	sc, co, err := ContractCoin(ct, inst, []omniledger.Coin{})
 	require.Nil(t, err)
 	require.Equal(t, 0, len(co))
 	require.Equal(t, 1, len(sc))
-	require.Equal(t, service.NewStateChange(service.Update, coAddr, ContractCoinID, coinOne),
+	require.Equal(t, omniledger.NewStateChange(omniledger.Update, coAddr, ContractCoinID, coinOne),
+		sc[0])
+}
+
+func TestCoin_InvokeOverflow(t *testing.T) {
+	uint64max := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+	ct := newCT()
+	coAddr := omniledger.NewInstanceID(nil)
+	ct.Store(coAddr, uint64max, ContractCoinID)
+
+	inst := omniledger.Instruction{
+		InstanceID: coAddr,
+		Invoke: &omniledger.Invoke{
+			Command: "mint",
+			Args:    omniledger.Arguments{{Name: "coins", Value: coinOne}},
+		},
+	}
+	sc, co, err := ContractCoin(ct, inst, []omniledger.Coin{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "overflow")
+	require.Equal(t, 0, len(co))
+	require.Equal(t, 0, len(sc))
+}
+
+func TestCoin_InvokeStoreFetch(t *testing.T) {
+	ct := newCT()
+	coAddr := omniledger.NewInstanceID(nil)
+	ct.Store(coAddr, coinZero, ContractCoinID)
+
+	inst := omniledger.Instruction{
+		InstanceID: coAddr,
+		Invoke: &omniledger.Invoke{
+			Command: "store",
+			Args:    nil,
+		},
+	}
+	c1 := omniledger.Coin{Name: CoinName, Value: 1}
+	notOlCoin := iid("notOlCoin")
+	c2 := omniledger.Coin{Name: notOlCoin, Value: 1}
+
+	sc, co, err := ContractCoin(ct, inst, []omniledger.Coin{c1, c2})
+	require.Nil(t, err)
+	require.Equal(t, 1, len(co))
+	require.Equal(t, co[0].Name, notOlCoin)
+	require.Equal(t, 1, len(sc))
+	require.Equal(t, omniledger.NewStateChange(omniledger.Update, coAddr, ContractCoinID, coinOne),
+		sc[0])
+
+	inst = omniledger.Instruction{
+		InstanceID: coAddr,
+		Invoke: &omniledger.Invoke{
+			Command: "fetch",
+			Args:    omniledger.Arguments{{Name: "coins", Value: coinOne}},
+		},
+	}
+
+	// Try once with no enough coins avail.
+	sc, co, err = ContractCoin(ct, inst, nil)
+	require.Error(t, err)
+
+	// Apply the changes to the mock collection.
+	ct.Store(coAddr, coinOne, ContractCoinID)
+
+	sc, co, err = ContractCoin(ct, inst, nil)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(co))
+	require.Equal(t, co[0].Name, CoinName)
+	require.Equal(t, uint64(1), co[0].Value)
+	require.Equal(t, 1, len(sc))
+	require.Equal(t, omniledger.NewStateChange(omniledger.Update, coAddr, ContractCoinID, coinZero),
 		sc[0])
 }
 
 func TestCoin_InvokeTransfer(t *testing.T) {
 	// Test that a coin can be transferred
 	ct := newCT()
-	coAddr1 := service.InstanceID{DarcID: make([]byte, 32), SubID: service.SubID{}}
-	coAddr2 := service.InstanceID{DarcID: make([]byte, 32), SubID: service.SubID{}}
+	coAddr1 := omniledger.InstanceID{DarcID: make([]byte, 32), SubID: omniledger.SubID{}}
+	coAddr2 := omniledger.InstanceID{DarcID: make([]byte, 32), SubID: omniledger.SubID{}}
 	coAddr2.DarcID[31] = byte(1)
 	ct.Store(coAddr1, coinOne, ContractCoinID)
 	ct.Store(coAddr2, coinZero, ContractCoinID)
 
 	// First create an instruction where the transfer should fail
-	inst := service.Instruction{
+	inst := omniledger.Instruction{
 		InstanceID: coAddr2,
-		Invoke: &service.Invoke{
+		Invoke: &omniledger.Invoke{
 			Command: "transfer",
-			Args: service.Arguments{
+			Args: omniledger.Arguments{
 				{Name: "coins", Value: coinOne},
 				{Name: "destination", Value: coAddr1.Slice()},
 			},
 		},
 	}
-	sc, co, err := ContractCoin(ct, inst, []service.Coin{})
-	require.NotNil(t, err)
+	sc, co, err := ContractCoin(ct, inst, []omniledger.Coin{})
+	require.Error(t, err)
 
-	inst = service.Instruction{
+	inst = omniledger.Instruction{
 		InstanceID: coAddr1,
-		Invoke: &service.Invoke{
+		Invoke: &omniledger.Invoke{
 			Command: "transfer",
-			Args: service.Arguments{
+			Args: omniledger.Arguments{
 				{Name: "coins", Value: coinOne},
 				{Name: "destination", Value: coAddr2.Slice()},
 			},
 		},
 	}
-	sc, co, err = ContractCoin(ct, inst, []service.Coin{})
+	sc, co, err = ContractCoin(ct, inst, []omniledger.Coin{})
 	require.Nil(t, err)
 	require.Equal(t, 0, len(co))
 	require.Equal(t, 2, len(sc))
-	require.Equal(t, service.NewStateChange(service.Update, coAddr2, ContractCoinID, coinOne), sc[0])
-	require.Equal(t, service.NewStateChange(service.Update, coAddr1, ContractCoinID, coinZero), sc[1])
+	require.Equal(t, omniledger.NewStateChange(omniledger.Update, coAddr2, ContractCoinID, coinOne), sc[0])
+	require.Equal(t, omniledger.NewStateChange(omniledger.Update, coAddr1, ContractCoinID, coinZero), sc[1])
 }
 
 type cvTest struct {
@@ -108,7 +181,7 @@ func newCT() *cvTest {
 func (ct cvTest) Get(key []byte) collection.Getter {
 	panic("not implemented")
 }
-func (ct *cvTest) Store(key service.InstanceID, value []byte, contractID string) {
+func (ct *cvTest) Store(key omniledger.InstanceID, value []byte, contractID string) {
 	k := string(key.Slice())
 	ct.values[k] = value
 	ct.contractIDs[k] = contractID

--- a/omniledger/contracts/service.go
+++ b/omniledger/contracts/service.go
@@ -27,5 +27,6 @@ func newService(c *onet.Context) (onet.Service, error) {
 		ServiceProcessor: onet.NewServiceProcessor(c),
 	}
 	service.RegisterContract(c, ContractValueID, ContractValue)
+	service.RegisterContract(c, ContractCoinID, ContractCoin)
 	return s, nil
 }

--- a/omniledger/ol/main.go
+++ b/omniledger/ol/main.go
@@ -251,9 +251,9 @@ func add(c *cli.Context) error {
 		return err
 	}
 
-	_, err = cl.AddTransaction(omniledger.ClientTransaction{
+	_, err = cl.AddTransactionAndWait(omniledger.ClientTransaction{
 		Instructions: []omniledger.Instruction{instr},
-	})
+	}, 10)
 	if err != nil {
 		return err
 	}

--- a/omniledger/service/api.go
+++ b/omniledger/service/api.go
@@ -74,9 +74,9 @@ func (c *Client) AddTransaction(tx ClientTransaction) (*AddTxResponse, error) {
 }
 
 // AddTransactionAndWait adds a transaction and will wait for it to be included
-// in omniledger. It does not return any feedback
-// on the transaction. The Client's Roster and ID should be initialized before
-// calling this method (see NewClientFromConfig).
+// in omniledger, up to a maximum of wait block intervals. It does not return
+// any feedback on the transaction. The Client's Roster and ID should be
+// initialized before calling this method (see NewClientFromConfig).
 func (c *Client) AddTransactionAndWait(tx ClientTransaction, wait int) (*AddTxResponse, error) {
 	reply := &AddTxResponse{}
 	err := c.SendProtobuf(c.Roster.List[0], &AddTxRequest{

--- a/omniledger/service/collect_tx.go
+++ b/omniledger/service/collect_tx.go
@@ -97,6 +97,8 @@ func (p *CollectTxProtocol) Dispatch() error {
 	var req structCollectTxRequest
 	select {
 	case req = <-p.requestChan:
+	case <-p.Finish:
+		return nil
 	case <-time.After(time.Second):
 		// This timeout checks whether the root started the protocol,
 		// it is not like our usual timeout that detect failures.

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -743,6 +743,7 @@ func (s *Service) executeInstruction(cdbI CollectionView, cin []Coin, instr Inst
 			err = errors.New(re.(string))
 		}
 	}()
+
 	contractID, _, err := instr.GetContractState(cdbI)
 	if err != nil {
 		err = errors.New("Couldn't get contract type of instruction: " + err.Error())
@@ -757,8 +758,6 @@ func (s *Service) executeInstruction(cdbI CollectionView, cin []Coin, instr Inst
 		return
 	}
 	// Now we call the contract function with the data of the key.
-	// Wrap up f() inside of g(), so that we can recover panics
-	// from f().
 	log.Lvlf3("%s: Calling contract %s", s.ServerIdentity(), contractID)
 	return contract(cdbI, instr, cin)
 }

--- a/omniledger/service/service_test.go
+++ b/omniledger/service/service_test.go
@@ -254,7 +254,6 @@ func TestService_FloodLedger(t *testing.T) {
 	require.Nil(t, err)
 	before := reply.Update[len(reply.Update)-1]
 
-	// Create a transaction without waiting
 	log.Lvl1("Create 10 transactions and don't wait")
 	for i := 0; i < 10; i++ {
 		sendTransaction(t, s, 0, slowKind, 0)

--- a/omniledger/service/service_test.go
+++ b/omniledger/service/service_test.go
@@ -21,6 +21,7 @@ import (
 
 var tSuite = suites.MustFind("Ed25519")
 var dummyKind = "dummy"
+var slowKind = "slow"
 var invalidKind = "invalid"
 var testInterval = 200 * time.Millisecond
 
@@ -245,7 +246,7 @@ func waitInclusion(t *testing.T, client int) {
 
 // Sends too many transactions to the ledger and waits for all blocks to be done.
 func TestService_FloodLedger(t *testing.T) {
-	s := newSer(t, 2, testInterval)
+	s := newSer(t, 1, testInterval)
 	defer s.local.CloseAll()
 
 	// Store the latest block
@@ -254,19 +255,19 @@ func TestService_FloodLedger(t *testing.T) {
 	before := reply.Update[len(reply.Update)-1]
 
 	// Create a transaction without waiting
-	log.Lvl1("Create transaction and don't wait")
-	for i := 0; i < 50; i++ {
-		sendTransaction(t, s, 0, dummyKind, 0)
+	log.Lvl1("Create 10 transactions and don't wait")
+	for i := 0; i < 10; i++ {
+		sendTransaction(t, s, 0, slowKind, 0)
 	}
 	// Send a last transaction and wait for it to be included
 	sendTransaction(t, s, 0, dummyKind, 100)
 
-	// Suppose we need at least 2 blocks
+	// Suppose we need at least 2 blocks (slowKind waits 1/2 interval for each execution)
 	reply, err = skipchain.NewClient().GetUpdateChain(s.sb.Roster, s.sb.SkipChainID())
 	require.Nil(t, err)
 	latest := reply.Update[len(reply.Update)-1]
-	if latest.Index-before.Index <= 2 {
-		require.Fail(t, "didn't get at least 2 blocks!")
+	if latest.Index-before.Index < 2 {
+		t.Fatalf("didn't get at least 2 blocks: %d %d", latest.Index, before.Index)
 	}
 }
 
@@ -282,6 +283,8 @@ func sendTransaction(t *testing.T, s *ser, client int, kind string, wait int) Pr
 	})
 	switch kind {
 	case dummyKind:
+		require.Nil(t, err)
+	case slowKind:
 		require.Nil(t, err)
 	case invalidKind:
 		require.NotNil(t, err)
@@ -834,7 +837,7 @@ func newSer(t *testing.T, step int, interval time.Duration) *ser {
 	registerDummy(s.hosts)
 
 	genesisMsg, err := DefaultGenesisMsg(CurrentVersion, s.roster,
-		[]string{"spawn:dummy", "spawn:invalid", "spawn:panic", "spawn:darc", "invoke:update_config"}, s.signer.Identity())
+		[]string{"spawn:dummy", "spawn:invalid", "spawn:panic", "spawn:darc", "invoke:update_config", "spawn:slow"}, s.signer.Identity())
 	require.Nil(t, err)
 	s.darc = &genesisMsg.GenesisDarc
 
@@ -884,11 +887,28 @@ func dummyContractFunc(cdb CollectionView, inst Instruction, c []Coin) ([]StateC
 	}, nil, nil
 }
 
+func slowContractFunc(cdb CollectionView, inst Instruction, c []Coin) ([]StateChange, []Coin, error) {
+	// This has to sleep for less than testInterval / 2 or else it will
+	// block the system from processing txs. See #1359.
+
+	time.Sleep(testInterval / 5)
+
+	args := inst.Spawn.Args[0].Value
+	cid, _, err := inst.GetContractState(cdb)
+	if err != nil {
+		return nil, nil, err
+	}
+	return []StateChange{
+		NewStateChange(Create, inst.InstanceID, cid, args),
+	}, nil, nil
+}
+
 func registerDummy(servers []*onet.Server) {
 	// For testing - there must be a better way to do that. But putting
 	// services []skipchain.GetService in the method signature doesn't work :(
 	for _, s := range servers {
 		RegisterContract(s, dummyKind, dummyContractFunc)
+		RegisterContract(s, slowKind, slowContractFunc)
 		RegisterContract(s, invalidKind, invalidContractFunc)
 	}
 }

--- a/omniledger/simulation/.gitignore
+++ b/omniledger/simulation/.gitignore
@@ -1,4 +1,3 @@
-simulation
 build/
 test_data/
 server_list

--- a/omniledger/simulation/coins.go
+++ b/omniledger/simulation/coins.go
@@ -107,18 +107,19 @@ func (s *SimulationService) Run(config *onet.SimulationConfig) error {
 	coinOne := make([]byte, 8)
 	coinOne[0] = byte(1)
 	tx := service.ClientTransaction{
-		Instructions: []service.Instruction{{
-			InstanceID: service.InstanceID{
-				DarcID: gm.GenesisDarc.GetID(),
-				SubID:  service.SubID{},
+		Instructions: []service.Instruction{
+			{
+				InstanceID: service.InstanceID{
+					DarcID: gm.GenesisDarc.GetID(),
+					SubID:  service.SubID{},
+				},
+				Nonce:  service.Nonce{},
+				Index:  0,
+				Length: 3,
+				Spawn: &service.Spawn{
+					ContractID: contracts.ContractCoinID,
+				},
 			},
-			Nonce:  service.Nonce{},
-			Index:  0,
-			Length: 3,
-			Spawn: &service.Spawn{
-				ContractID: contracts.ContractCoinID,
-			},
-		},
 			{
 				InstanceID: service.InstanceID{
 					DarcID: gm.GenesisDarc.GetID(),
@@ -141,7 +142,8 @@ func (s *SimulationService) Run(config *onet.SimulationConfig) error {
 						Name:  "coins",
 						Value: coins}},
 				},
-			}},
+			},
+		},
 	}
 
 	// The first instruction will create an account with the SubID equal to the
@@ -165,13 +167,10 @@ func (s *SimulationService) Run(config *onet.SimulationConfig) error {
 	}
 
 	// And send the instructions to omniledger
-	_, err = c.AddTransaction(tx)
+	_, err = c.AddTransactionAndWait(tx, 2)
 	if err != nil {
 		return errors.New("couldn't add transaction: " + err.Error())
 	}
-
-	// Wait for the instructions to be included
-	time.Sleep(2 * blockInterval)
 
 	for round := 0; round < s.Rounds; round++ {
 		log.Lvl1("Starting round", round)
@@ -239,6 +238,5 @@ func (s *SimulationService) Run(config *onet.SimulationConfig) error {
 		confirm.Record()
 		roundM.Record()
 	}
-	time.Sleep(blockInterval)
 	return nil
 }

--- a/omniledger/simulation/coins.go
+++ b/omniledger/simulation/coins.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/dedis/cothority/omniledger/contracts"
+	"github.com/dedis/cothority/omniledger/darc"
+	"github.com/dedis/cothority/omniledger/service"
+	"github.com/dedis/onet"
+	"github.com/dedis/onet/log"
+	"github.com/dedis/onet/simul/monitor"
+)
+
+/*
+ * Defines the simulation for the service-template
+ */
+
+func init() {
+	onet.SimulationRegister("TransferCoins", NewSimulationService)
+}
+
+// SimulationService only holds the BFTree simulation
+type SimulationService struct {
+	onet.SimulationBFTree
+	Transactions  int
+	BlockInterval string
+	BatchSize     int
+	Keep          bool
+	Delay         int
+}
+
+// NewSimulationService returns the new simulation, where all fields are
+// initialised using the config-file
+func NewSimulationService(config string) (onet.Simulation, error) {
+	es := &SimulationService{}
+	_, err := toml.Decode(config, es)
+	if err != nil {
+		return nil, err
+	}
+	return es, nil
+}
+
+// Setup creates the tree used for that simulation
+func (s *SimulationService) Setup(dir string, hosts []string) (
+	*onet.SimulationConfig, error) {
+	sc := &onet.SimulationConfig{}
+	s.CreateRoster(sc, hosts, 2000)
+	err := s.CreateTree(sc)
+	if err != nil {
+		return nil, err
+	}
+	return sc, nil
+}
+
+// Node can be used to initialize each node before it will be run
+// by the server. Here we call the 'Node'-method of the
+// SimulationBFTree structure which will load the roster- and the
+// tree-structure to speed up the first round.
+func (s *SimulationService) Node(config *onet.SimulationConfig) error {
+	index, _ := config.Roster.Search(config.Server.ServerIdentity.ID)
+	if index < 0 {
+		log.Fatal("Didn't find this node in roster")
+	}
+	log.Lvl3("Initializing node-index", index)
+	return s.SimulationBFTree.Node(config)
+}
+
+// Run is used on the destination machines and runs a number of
+// rounds
+func (s *SimulationService) Run(config *onet.SimulationConfig) error {
+	size := config.Tree.Size()
+	log.Lvl2("Size is:", size, "rounds:", s.Rounds, "transactions:", s.Transactions)
+	var c *service.Client
+	if s.Keep {
+		c = service.NewClientKeep()
+	} else {
+		c = service.NewClient()
+	}
+	signer := darc.NewSignerEd25519(nil, nil)
+
+	// Create omniledger
+	gm, err := service.DefaultGenesisMsg(service.CurrentVersion, config.Roster,
+		[]string{"spawn:coin", "invoke:mint", "invoke:transfer"}, signer.Identity())
+	if err != nil {
+		return errors.New("couldn't setup genesis message: " + err.Error())
+	}
+	// gm.BlockInterval = time.Second
+	blockInterval, err := time.ParseDuration(s.BlockInterval)
+	if err != nil {
+		return errors.New("parse duration of BlockInterval failed: " + err.Error())
+	}
+	gm.BlockInterval = blockInterval
+	rep, err := c.CreateGenesisBlock(gm)
+	if err != nil {
+		return errors.New("couldn't craete genesis block: " + err.Error())
+	}
+	c.ID = rep.Skipblock.SkipChainID()
+	c.Roster = config.Roster
+
+	// Create two accounts and mint 'Transaction' coins on first account.
+	coins := make([]byte, 8)
+	coins[7] = byte(1)
+	coinOne := make([]byte, 8)
+	coinOne[0] = byte(1)
+	tx := service.ClientTransaction{
+		Instructions: []service.Instruction{{
+			InstanceID: service.InstanceID{
+				DarcID: gm.GenesisDarc.GetID(),
+				SubID:  service.SubID{},
+			},
+			Nonce:  service.Nonce{},
+			Index:  0,
+			Length: 3,
+			Spawn: &service.Spawn{
+				ContractID: contracts.ContractCoinID,
+			},
+		},
+			{
+				InstanceID: service.InstanceID{
+					DarcID: gm.GenesisDarc.GetID(),
+					SubID:  service.SubID{},
+				},
+				Nonce:  service.Nonce{},
+				Index:  1,
+				Length: 3,
+				Spawn: &service.Spawn{
+					ContractID: contracts.ContractCoinID,
+				},
+			},
+			{
+				Nonce:  service.Nonce{},
+				Index:  2,
+				Length: 3,
+				Invoke: &service.Invoke{
+					Command: "mint",
+					Args: service.Arguments{{
+						Name:  "coins",
+						Value: coins}},
+				},
+			}},
+	}
+
+	// The first instruction will create an account with the SubID equal to the
+	// hash of the first instruction. So we can mint directly on the hash of this
+	// instruction. Theoretically...
+	coinAddr1 := service.InstanceID{
+		DarcID: gm.GenesisDarc.GetBaseID(),
+		SubID:  service.NewSubID(tx.Instructions[0].Hash()),
+	}
+	coinAddr2 := service.InstanceID{
+		DarcID: gm.GenesisDarc.GetBaseID(),
+		SubID:  service.NewSubID(tx.Instructions[1].Hash()),
+	}
+	tx.Instructions[2].InstanceID = coinAddr1
+
+	// Now sign all the instructions
+	for i := range tx.Instructions {
+		if err = service.SignInstruction(&tx.Instructions[i], signer); err != nil {
+			return errors.New("signing of instruction failed: " + err.Error())
+		}
+	}
+
+	// And send the instructions to omniledger
+	_, err = c.AddTransaction(tx)
+	if err != nil {
+		return errors.New("couldn't add transaction: " + err.Error())
+	}
+
+	// Wait for the instructions to be included
+	time.Sleep(2 * blockInterval)
+
+	for round := 0; round < s.Rounds; round++ {
+		log.Lvl1("Starting round", round)
+		roundM := monitor.NewTimeMeasure("round")
+
+		txs := s.Transactions / s.BatchSize
+		insts := s.BatchSize
+		log.Lvlf2("Sending %d transactions with %d instructions each", txs, insts)
+		for t := 0; t < txs; t++ {
+			tx := service.ClientTransaction{}
+			prepare := monitor.NewTimeMeasure("prepare")
+			for i := 0; i < insts; i++ {
+				var buf bytes.Buffer
+				binary.Write(&buf, binary.LittleEndian, i+1)
+				tx.Instructions = append(tx.Instructions, service.Instruction{
+					InstanceID: coinAddr1,
+					Nonce:      service.NewNonce(buf.Bytes()),
+					Index:      i,
+					Length:     insts,
+					Invoke: &service.Invoke{
+						Command: "transfer",
+						Args: service.Arguments{
+							{
+								Name:  "coins",
+								Value: coinOne,
+							},
+							{
+								Name:  "destination",
+								Value: coinAddr2.Slice(),
+							}},
+					},
+				})
+				err = service.SignInstruction(&tx.Instructions[i], signer)
+				if err != nil {
+					return errors.New("signature error: " + err.Error())
+				}
+			}
+			prepare.Record()
+			send := monitor.NewTimeMeasure("send")
+			_, err = c.AddTransaction(tx)
+			if err != nil {
+				return errors.New("couldn't add transfer transaction: " + err.Error())
+			}
+			send.Record()
+		}
+		confirm := monitor.NewTimeMeasure("confirm")
+		var i int
+		for {
+			proof, err := c.GetProof(coinAddr2.Slice())
+			if err != nil {
+				return errors.New("couldn't get proof for transaction: " + err.Error())
+			}
+			_, v, err := proof.Proof.KeyValue()
+			if err != nil {
+				return errors.New("proof doesn't hold transaction: " + err.Error())
+			}
+			account := int(binary.LittleEndian.Uint64(v[0]))
+			log.Lvlf1("[%03d] account has %d", i, account)
+			if account == s.Transactions*(round+1) {
+				break
+			}
+			time.Sleep(time.Second / 10)
+			i++
+		}
+		confirm.Record()
+		roundM.Record()
+	}
+	time.Sleep(blockInterval)
+	return nil
+}

--- a/omniledger/simulation/coins.toml
+++ b/omniledger/simulation/coins.toml
@@ -1,0 +1,13 @@
+Simulation = "TransferCoins"
+Servers = 2
+Bf = 4
+Rounds = 1
+RunWait = "6000s"
+Suite = "Ed25519"
+# Keep the different columns in case someboday wants to run another battery
+# of tests
+
+Keep,   Transactions, BatchSize,  Hosts,  Delay, BlockInterval
+true,   200,          5,          10,     10,    "2s"
+# true,   200,          10,         10,     10,    "2s"
+# true,   200,          20,         10,     10,    "2s"

--- a/omniledger/simulation/plot_sim.py
+++ b/omniledger/simulation/plot_sim.py
@@ -1,0 +1,72 @@
+import matplotlib.pyplot as plt
+import pandas as pd
+import os
+
+data_dir = './test_data/'
+files = [(data_dir + fname) for fname in os.listdir(data_dir)\
+         if fname.startswith('service') and fname.endswith('.csv')]
+
+def read_all_files(files):
+    df = pd.DataFrame()
+    for fname in files:
+        data = pd.read_csv(fname)
+        # We need to add variables regarding
+        # batching and keeping here.
+        batch = '_batch' in fname
+        keep = not '_nokeep' in fname
+        rowcount = len(data.index)
+        b_vals = pd.Series([batch for i in range(rowcount)])
+        k_vals = pd.Series([keep for i in range(rowcount)])
+        data = data.assign(batch=b_vals.values)
+        data = data.assign(keep=k_vals.values)
+        # If the data frame is empty (first iteration),
+        # we append no matter what. Otherwise, we append
+        # IFF the colums are the same.
+        if df.empty \
+           or (len(data.columns) == len(df.columns) \
+           and (data.columns == df.columns).all()):
+            df = df.append(data, ignore_index=True)
+    return df
+
+df = read_all_files(files)
+delays = list(set(df['delay']))
+keep = list(set(df['keep']))
+batch = list(set(df['batch']))
+
+for delay in delays:
+    for k in keep:
+        for b in batch:
+            titlestring = 'Transactions: 1000, delay: {}, keep: {}, batch: {}'.format(delay, k, b)
+            # No whitespace, colons or commata in filenames
+            namestring = titlestring.replace(' ','').replace(':','-').replace(',','_') 
+            data = df.ix[df['delay'] == delay].sort_values('hosts')
+            data = data.ix[data['keep'] == k]
+            data = data.ix[data['batch'] == b]
+            data = data.reset_index()
+
+            ax = data.plot.bar(\
+                    x='hosts',\
+                    y=['prepare_wall_sum','send_wall_sum','confirm_wall_avg'],\
+                    stacked=True)
+            data.plot(y='round_wall_avg', marker='o', ax=ax)
+
+            plt.xlabel('number of hosts')
+            plt.ylabel('time in seconds')
+            plt.title(titlestring)
+            plt.savefig(data_dir + 'barplot_' + namestring + '.png')
+            plt.close()
+            
+            
+            ax = data.plot.bar(\
+                    x='hosts',\
+                    y=['prepare_wall_sum','send_wall_sum','confirm_wall_avg'],\
+                    stacked=True)
+            data.plot(y='round_wall_avg', marker='o', ax=ax)
+
+            ax.set_yscale('log')
+ 
+            plt.xlabel('number of hosts')
+            plt.ylabel('logarithm of time in seconds')
+            plt.title(titlestring)
+            plt.savefig(data_dir + 'barplot_log_delay_' + namestring + '.png')
+            plt.close()

--- a/omniledger/simulation/simul.go
+++ b/omniledger/simulation/simul.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	// Service needs to be imported here to be instantiated.
+	_ "github.com/dedis/cothority/omniledger/contracts"
+	_ "github.com/dedis/cothority/omniledger/service"
+	"github.com/dedis/onet/simul"
+)
+
+func main() {
+	simul.Start()
+}

--- a/omniledger/simulation/simul_test.go
+++ b/omniledger/simulation/simul_test.go
@@ -1,0 +1,16 @@
+package main_test
+
+import (
+	"testing"
+
+	"github.com/dedis/onet/log"
+	"github.com/dedis/onet/simul"
+)
+
+func TestMain(m *testing.M) {
+	log.MainTest(m)
+}
+
+func TestSimulation(t *testing.T) {
+	simul.Start("coins.toml")
+}


### PR DESCRIPTION
This is the follow-up of #1323 

This adds a coin-contract with the following possibilities:
- `Spawn` to create a new account with a 0-balance
- `Invoke:transfer` to transfer coins from one to another account
- `Invoke:mint` to create new coins (must be protected by a darc)

In addition to this, a simulation allows for testing the performance of the contract.