### PR TITLE
Using deriveID

### DIFF
--- a/external/java/pom.xml
+++ b/external/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ch.epfl.dedis</groupId>
     <artifactId>cothority</artifactId>
-    <version>master-180704</version>
+    <version>master-180717</version>
     <name>Cothority client library for Java</name>
     <description>A client library for communicating with cothorities (a collective authority).</description>
     <url>https://github.com/dedis/cothority</url>

--- a/external/java/src/test/java/ch/epfl/dedis/lib/omniledger/OmniledgerRPCTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/lib/omniledger/OmniledgerRPCTest.java
@@ -93,7 +93,7 @@ public class OmniledgerRPCTest {
         Darc newDarc = new Darc(id, id, "new darc".getBytes());
 
         Proof p = dc.spawnContractAndWait("darc", admin,
-                Argument.NewList("darc", newDarc.toProto().toByteArray()));
+                Argument.NewList("darc", newDarc.toProto().toByteArray()), 10);
         assertTrue(p.matches());
 
         logger.info("creating DarcInstance");
@@ -114,7 +114,7 @@ public class OmniledgerRPCTest {
         dc.evolveDarcAndWait(darc2, admin);
 
         byte[] myvalue = "314159".getBytes();
-        Proof p = dc.spawnContractAndWait("value", admin, Argument.NewList("value", myvalue));
+        Proof p = dc.spawnContractAndWait("value", admin, Argument.NewList("value", myvalue), 10);
         assertTrue(p.matches());
 
         ValueInstance vi = new ValueInstance(ol, p);

--- a/omniledger/contracts/value.go
+++ b/omniledger/contracts/value.go
@@ -22,12 +22,8 @@ var ContractValueID = "value"
 func ContractValue(cdb service.CollectionView, inst service.Instruction, c []service.Coin) ([]service.StateChange, []service.Coin, error) {
 	switch {
 	case inst.Spawn != nil:
-		iid := service.InstanceID{
-			DarcID: inst.InstanceID.DarcID,
-			SubID:  service.NewSubID(inst.Hash()),
-		}
 		return []service.StateChange{
-			service.NewStateChange(service.Create, iid,
+			service.NewStateChange(service.Create, inst.DeriveID(ContractValueID),
 				ContractValueID, inst.Spawn.Args.Search("value")),
 		}, c, nil
 	case inst.Invoke != nil:

--- a/omniledger/contracts/value_test.go
+++ b/omniledger/contracts/value_test.go
@@ -52,11 +52,7 @@ func TestValue_Spawn(t *testing.T) {
 
 	_, err = cl.AddTransaction(ctx)
 	require.Nil(t, err)
-	instID := service.InstanceID{
-		DarcID: ctx.Instructions[0].InstanceID.DarcID,
-		SubID:  service.NewSubID(ctx.Instructions[0].Hash()),
-	}
-	pr, err := cl.WaitProof(instID, genesisMsg.BlockInterval, myvalue)
+	pr, err := cl.WaitProof(ctx.Instructions[0].DeriveID(ContractValueID), genesisMsg.BlockInterval, myvalue)
 	require.Nil(t, err)
 	require.True(t, pr.InclusionProof.Match())
 	values, err := pr.InclusionProof.RawValues()

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"encoding/hex"
+
 	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/messaging"
 	"github.com/dedis/cothority/omniledger/collection"


### PR DESCRIPTION
Value-contract uses `DeriveID` now
java:spawnContractAndWait uses `deriveID` now