### PR TITLE
Set skipchain propagation timeout in OmniLedger

### DIFF
--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -826,11 +826,6 @@ func (s *Service) SetPropTimeout(t time.Duration) {
 	s.propTimeout = t
 }
 
-// GetPropTimeout retrieves the current propagation timeout.
-func (s *Service) GetPropTimeout() time.Duration {
-	return s.propTimeout
-}
-
 func (s *Service) verifySigs(msg, sig []byte) bool {
 	// If there are no clients, all signatures verify.
 	if len(s.Storage.Clients) == 0 {


### PR DESCRIPTION
OmniLedger does not have the same propagation timeout as skipchain when
using the same propagation protocol. This commit sets these timeouts to
be the same. Further, we set the polling timeout to be half of the block
interval, so that the other half can be used for processing
transactions.