### PR TITLE
Add some delay to the end of coin simulation

### DIFF
--- a/omniledger/simulation/coins.go
+++ b/omniledger/simulation/coins.go
@@ -238,5 +238,11 @@ func (s *SimulationService) Run(config *onet.SimulationConfig) error {
 		confirm.Record()
 		roundM.Record()
 	}
+	// We wait a bit before closing because c.GetProof is sent to the
+	// leader, but at this point some of the children might still be doing
+	// updateCollection. If we stop the simulation immediately, then the
+	// database gets closed and updateCollection on the children fails to
+	// complete.
+	time.Sleep(time.Second)
 	return nil
 }


### PR DESCRIPTION
This fixes jenkins failures. Reason for the change is:

```
// We wait a bit before closing because c.GetProof is sent to the
// leader, but at this point some of the children might still be doing
// updateCollection. If we stop the simulation immediately, then the
// database gets closed and updateCollection on the children fails to
// complete. 
```