### PR TITLE
Correctly return merkle root

### DIFF
--- a/omniledger/collection/collection.go
+++ b/omniledger/collection/collection.go
@@ -119,5 +119,5 @@ func (c *Collection) Clone() (collection *Collection) {
 func (c *Collection) GetRoot() []byte {
 	c.Lock()
 	defer c.Unlock()
-	return c.root.key
+	return c.root.label[:]
 }

--- a/omniledger/collection/collection_test.go
+++ b/omniledger/collection/collection_test.go
@@ -1,37 +1,38 @@
 package collection
 
 import (
+	"bytes"
 	"encoding/binary"
 	"testing"
 )
 
-func TestCollectionEmptyCollection(test *testing.T) {
-	ctx := testCtx("[collection.go]", test)
+func TestCollectionEmptyCollection(t *testing.T) {
+	ctx := testCtx("[collection.go]", t)
 
 	baseCollection := New()
 
 	if !(baseCollection.autoCollect.value) {
-		test.Error("[collection.go]", "[autocollect]", "AutoCollect does not have true as default value.")
+		t.Error("[collection.go]", "[autocollect]", "AutoCollect does not have true as default value.")
 	}
 
 	if !(baseCollection.root.known) || !(baseCollection.root.children.left.known) || !(baseCollection.root.children.right.known) {
-		test.Error("[collection.go]", "[known]", "New collection has unknown nodes.")
+		t.Error("[collection.go]", "[known]", "New collection has unknown nodes.")
 	}
 
 	if !(baseCollection.root.root()) {
-		test.Error("[collection.go]", "[root]", "Collection root is not a root.")
+		t.Error("[collection.go]", "[root]", "Collection root is not a root.")
 	}
 
 	if baseCollection.root.leaf() {
-		test.Error("[collection.go]", "[root]", "Collection root doesn't have children.")
+		t.Error("[collection.go]", "[root]", "Collection root doesn't have children.")
 	}
 
 	if !(baseCollection.root.children.left.placeholder()) || !(baseCollection.root.children.right.placeholder()) {
-		test.Error("[collection.go]", "[leaves]", "Collection leaves are not placeholder leaves.")
+		t.Error("[collection.go]", "[leaves]", "Collection leaves are not placeholder leaves.")
 	}
 
 	if len(baseCollection.root.values) != 0 || len(baseCollection.root.children.left.values) != 0 || len(baseCollection.root.children.right.values) != 0 {
-		test.Error("[collection.go]", "[values]", "Nodes of a collection without fields have values.")
+		t.Error("[collection.go]", "[values]", "Nodes of a collection without fields have values.")
 	}
 
 	ctx.verify.tree("[baseCollection]", baseCollection)
@@ -40,29 +41,29 @@ func TestCollectionEmptyCollection(test *testing.T) {
 	stakeCollection := New(stake64)
 
 	if len(stakeCollection.root.values) != 1 || len(stakeCollection.root.children.left.values) != 1 || len(stakeCollection.root.children.right.values) != 1 {
-		test.Error("[collection.go]", "[values]", "Nodes of a stake collection don't have exactly one value.")
+		t.Error("[collection.go]", "[values]", "Nodes of a stake collection don't have exactly one value.")
 	}
 
 	rootStake, rootError := stake64.Decode(stakeCollection.root.values[0])
 
 	if rootError != nil {
-		test.Error("[collection.go]", "[stake]", "Malformed stake root value.")
+		t.Error("[collection.go]", "[stake]", "Malformed stake root value.")
 	}
 
 	leftStake, leftError := stake64.Decode(stakeCollection.root.children.left.values[0])
 
 	if leftError != nil {
-		test.Error("[collection.go]", "[stake]", "Malformed stake left child value.")
+		t.Error("[collection.go]", "[stake]", "Malformed stake left child value.")
 	}
 
 	rightStake, rightError := stake64.Decode(stakeCollection.root.children.right.values[0])
 
 	if rightError != nil {
-		test.Error("[collection.go]", "[stake]", "Malformed stake right child value")
+		t.Error("[collection.go]", "[stake]", "Malformed stake right child value")
 	}
 
 	if rootStake.(uint64) != 0 || leftStake.(uint64) != 0 || rightStake.(uint64) != 0 {
-		test.Error("[collection.go]", "[stake]", "Nodes of an empty stake collection don't have zero stake.")
+		t.Error("[collection.go]", "[stake]", "Nodes of an empty stake collection don't have zero stake.")
 	}
 
 	ctx.verify.tree("[stakeCollection]", stakeCollection)
@@ -71,34 +72,34 @@ func TestCollectionEmptyCollection(test *testing.T) {
 	stakeDataCollection := New(stake64, data)
 
 	if len(stakeDataCollection.root.values) != 2 || len(stakeDataCollection.root.children.left.values) != 2 || len(stakeDataCollection.root.children.right.values) != 2 {
-		test.Error("[collection.go]", "[values]", "Nodes of a data and stake collection don't have exactly one value.")
+		t.Error("[collection.go]", "[values]", "Nodes of a data and stake collection don't have exactly one value.")
 	}
 
 	if len(stakeDataCollection.root.values[1]) != 0 || len(stakeDataCollection.root.children.left.values[1]) != 0 || len(stakeDataCollection.root.children.right.values[1]) != 0 {
-		test.Error("[collection.go]", "[values]", "Nodes of a data and stake collection don't have empty data value.")
+		t.Error("[collection.go]", "[values]", "Nodes of a data and stake collection don't have empty data value.")
 	}
 
 	ctx.verify.tree("[stakeDataCollection]", stakeDataCollection)
 }
 
-func TestCollectionEmptyVerifier(test *testing.T) {
+func TestCollectionEmptyVerifier(t *testing.T) {
 	baseCollection := New()
 	baseVerifier := NewVerifier()
 
 	if !(baseVerifier.autoCollect.value) {
-		test.Error("[collection.go]", "[autocollect]", "AutoCollect does not have true as default value.")
+		t.Error("[collection.go]", "[autocollect]", "AutoCollect does not have true as default value.")
 	}
 
 	if baseVerifier.root.known {
-		test.Error("[collection.go]", "[known]", "Empty verifier has known root.")
+		t.Error("[collection.go]", "[known]", "Empty verifier has known root.")
 	}
 
 	if (baseVerifier.root.children.left != nil) || (baseVerifier.root.children.right != nil) {
-		test.Error("[collection.go]", "[root]", "Empty verifier root has children.")
+		t.Error("[collection.go]", "[root]", "Empty verifier root has children.")
 	}
 
 	if baseVerifier.root.label != baseCollection.root.label {
-		test.Error("[collection.go]", "[Label]", "Wrong verifier label.")
+		t.Error("[collection.go]", "[Label]", "Wrong verifier label.")
 	}
 
 	stake64 := Stake64{}
@@ -107,15 +108,15 @@ func TestCollectionEmptyVerifier(test *testing.T) {
 	stakeVerifier := NewVerifier(stake64)
 
 	if stakeVerifier.root.known {
-		test.Error("[collection.go]", "[known]", "Empty stake verifier has known root.")
+		t.Error("[collection.go]", "[known]", "Empty stake verifier has known root.")
 	}
 
 	if (stakeVerifier.root.children.left != nil) || (stakeVerifier.root.children.right != nil) {
-		test.Error("[collection.go]", "[root]", "Empty stake verifier root has children.")
+		t.Error("[collection.go]", "[root]", "Empty stake verifier root has children.")
 	}
 
 	if stakeVerifier.root.label != stakeCollection.root.label {
-		test.Error("[collection.go]", "[Label]", "Wrong stake verifier label.")
+		t.Error("[collection.go]", "[Label]", "Wrong stake verifier label.")
 	}
 
 	data := Data{}
@@ -124,20 +125,20 @@ func TestCollectionEmptyVerifier(test *testing.T) {
 	stakeDataVerifier := NewVerifier(stake64, data)
 
 	if stakeDataVerifier.root.known {
-		test.Error("[collection.go]", "[known]", "Empty stake and data verifier has known root.")
+		t.Error("[collection.go]", "[known]", "Empty stake and data verifier has known root.")
 	}
 
 	if (stakeDataVerifier.root.children.left != nil) || (stakeDataVerifier.root.children.right != nil) {
-		test.Error("[collection.go]", "[root]", "Empty stake and data verifier root has children.")
+		t.Error("[collection.go]", "[root]", "Empty stake and data verifier root has children.")
 	}
 
 	if stakeDataVerifier.root.label != stakeDataCollection.root.label {
-		test.Error("[collection.go]", "[Label]", "Wrong stake and data verifier label.")
+		t.Error("[collection.go]", "[Label]", "Wrong stake and data verifier label.")
 	}
 }
 
-func TestCollectionClone(test *testing.T) {
-	ctx := testCtx("[collection.go]", test)
+func TestCollectionClone(t *testing.T) {
+	ctx := testCtx("[collection.go]", t)
 
 	stake64 := Stake64{}
 	data := Data{}
@@ -151,6 +152,10 @@ func TestCollectionClone(test *testing.T) {
 		collection.Add(key, uint64(index), key)
 	}
 
+	if collection.GetRoot() == nil {
+		t.Error("nil root")
+	}
+
 	clone := collection.Clone()
 
 	ctx.verify.tree("[clone]", clone)
@@ -162,9 +167,35 @@ func TestCollectionClone(test *testing.T) {
 		ctx.verify.values("[clone]", clone, key, uint64(index), key)
 	}
 
+	if !bytes.Equal(collection.GetRoot(), clone.GetRoot()) {
+		t.Error("unequal root")
+	}
+
 	ctx.shouldPanic("[clone]", func() {
 		collection.Begin()
 		collection.Clone()
 		collection.End()
 	})
+}
+
+func TestCollectionGetRoot(t *testing.T) {
+	stake64 := Stake64{}
+	data := Data{}
+
+	collection := New(stake64, data)
+
+	root := make([]byte, 32)
+	oldRoot := make([]byte, 32)
+	for index := 0; index < 512; index++ {
+		key := make([]byte, 8)
+		binary.BigEndian.PutUint64(key, uint64(index))
+
+		collection.Add(key, uint64(index), key)
+
+		root = collection.GetRoot()
+		if bytes.Equal(root, oldRoot) {
+			t.Error("root should change")
+		}
+		copy(oldRoot, root)
+	}
 }

--- a/omniledger/collection/proof.go
+++ b/omniledger/collection/proof.go
@@ -79,7 +79,7 @@ func (d *dump) to(node *node) {
 
 // TreeRootHash returns the hash of the merkle tree root.
 func (p Proof) TreeRootHash() []byte {
-	return p.Root.Key
+	return p.Root.Label[:]
 }
 
 // Methods


### PR DESCRIPTION
If not mistaken, the label is the contains the root hash and not the key, because it is updated on after every `collection.Add`.

Closes  #1274