### PR TITLE
Remove getValueContract code duplication

### DIFF
--- a/omniledger/service/struct.go
+++ b/omniledger/service/struct.go
@@ -53,11 +53,7 @@ func (r *roCollection) Get(key []byte) collection.Getter {
 // GetValues returns the value of the key and the contractID. If the key
 // does not exist, it returns an error.
 func (r *roCollection) GetValues(key []byte) (value []byte, contractID string, err error) {
-	record, err := r.c.Get(key).Record()
-	if err != nil {
-		return
-	}
-	return getValuesFromRecord(record, key)
+	return getValueContract(r, key)
 }
 
 // OmniLedgerContract is the type signature of the class functions
@@ -140,11 +136,7 @@ func (c *collectionDB) Get(key []byte) collection.Getter {
 }
 
 func (c *collectionDB) GetValues(key []byte) (value []byte, contractID string, err error) {
-	record, err := c.coll.Get(key).Record()
-	if err != nil {
-		return
-	}
-	return getValuesFromRecord(record, key)
+	return getValueContract(c, key)
 }
 
 // FIXME: if there is a failure in boltdb update, then our state will be
@@ -220,58 +212,35 @@ func (c *collectionDB) StoreAll(ts StateChanges) error {
 	})
 }
 
-func (c *collectionDB) GetValueContract(key []byte) ([]byte, []byte, error) {
-	// getValueContract does not use skipchain ID, so we just set it to nil
-	return getValueContract(&roCollection{c.coll}, key)
-}
-
-// TODO this function can be merged with getValuesFromRecord
-func getValueContract(coll CollectionView, key []byte) (value, contract []byte, err error) {
-	proof, err := coll.Get(key).Record()
-	if err != nil {
-		return
-	}
-	hashes, err := proof.Values()
-	if err != nil {
-		return
-	}
-	if len(hashes) == 0 {
-		err = errors.New("nothing stored under that key")
-		return
-	}
-	value, ok := hashes[0].([]byte)
-	if !ok {
-		err = errors.New("the value is not of type []byte")
-		return
-	}
-	contract, ok = hashes[1].([]byte)
-	if !ok {
-		err = errors.New("the contract is not of type []byte")
-		return
-	}
-	return
-}
-
 // RootHash returns the hash of the root node in the merkle tree.
 func (c *collectionDB) RootHash() []byte {
 	return c.coll.GetRoot()
 }
 
-func getValuesFromRecord(record collection.Record, key []byte) (value []byte, contractID string, err error) {
+func getValueContract(coll CollectionView, key []byte) (value []byte, contract string, err error) {
+	record, err := coll.Get(key).Record()
+	if err != nil {
+		return
+	}
 	values, err := record.Values()
 	if err != nil {
 		return
 	}
-	var ok bool
-	value, ok = values[0].([]byte)
-	if !ok {
-		err = errors.New("first value is not a slice of bytes")
+	if len(values) == 0 {
+		err = errors.New("nothing stored under that key")
 		return
 	}
-	contractID, ok = values[1].(string)
+	value, ok := values[0].([]byte)
 	if !ok {
-		contractID = string(values[1].([]byte))
+		err = errors.New("the value is not of type []byte")
+		return
 	}
+	contractBytes, ok := values[1].([]byte)
+	if !ok {
+		err = errors.New("the contract is not of type []byte")
+		return
+	}
+	contract = string(contractBytes)
 	return
 }
 

--- a/omniledger/service/struct_test.go
+++ b/omniledger/service/struct_test.go
@@ -24,15 +24,15 @@ func TestCollectionDBStrange(t *testing.T) {
 	cdb := newCollectionDB(db, testName)
 	key := []byte("first")
 	value := []byte("value")
-	contract := []byte("mycontract")
+	contract := "mycontract"
 	err = cdb.Store(&StateChange{
 		StateAction: Create,
 		InstanceID:  key,
 		Value:       value,
-		ContractID:  contract,
+		ContractID:  []byte(contract),
 	})
 	require.Nil(t, err)
-	v, c, err := cdb.GetValueContract([]byte("first"))
+	v, c, err := cdb.GetValues([]byte("first"))
 	require.Nil(t, err)
 	require.Equal(t, value, v)
 	require.Equal(t, contract, c)
@@ -51,7 +51,7 @@ func TestCollectionDB(t *testing.T) {
 
 	cdb := newCollectionDB(db, testName)
 	pairs := map[string]string{}
-	myContract := []byte("myContract")
+	myContract := "myContract"
 	for i := 0; i < kvPairs; i++ {
 		pairs[fmt.Sprintf("Key%d", i)] = fmt.Sprintf("value%d", i)
 	}
@@ -62,14 +62,14 @@ func TestCollectionDB(t *testing.T) {
 			StateAction: Create,
 			InstanceID:  []byte(k),
 			Value:       []byte(v),
-			ContractID:  myContract,
+			ContractID:  []byte(myContract),
 		}
 		require.Nil(t, cdb.Store(sc))
 	}
 
 	// Verify it's all there
 	for c, v := range pairs {
-		stored, contract, err := cdb.GetValueContract([]byte(c))
+		stored, contract, err := cdb.GetValues([]byte(c))
 		require.Nil(t, err)
 		require.Equal(t, v, string(stored))
 		require.Equal(t, myContract, contract)
@@ -80,7 +80,7 @@ func TestCollectionDB(t *testing.T) {
 
 	// Verify it's all there
 	for c, v := range pairs {
-		stored, _, err := cdb2.GetValueContract([]byte(c))
+		stored, _, err := cdb2.GetValues([]byte(c))
 		require.Nil(t, err)
 		require.Equal(t, v, string(stored))
 	}
@@ -94,12 +94,12 @@ func TestCollectionDB(t *testing.T) {
 			StateAction: Update,
 			InstanceID:  []byte(k),
 			Value:       []byte(v),
-			ContractID:  myContract,
+			ContractID:  []byte(myContract),
 		}
 		require.Nil(t, cdb2.Store(sc), k)
 	}
 	for k, v := range pairs {
-		stored, contract, err := cdb2.GetValueContract([]byte(k))
+		stored, contract, err := cdb2.GetValues([]byte(k))
 		require.Nil(t, err)
 		require.Equal(t, v, string(stored))
 		require.Equal(t, myContract, contract)
@@ -110,12 +110,12 @@ func TestCollectionDB(t *testing.T) {
 		sc := &StateChange{
 			StateAction: Remove,
 			InstanceID:  []byte(c),
-			ContractID:  myContract,
+			ContractID:  []byte(myContract),
 		}
 		require.Nil(t, cdb2.Store(sc))
 	}
 	for c := range pairs {
-		_, _, err := cdb2.GetValueContract([]byte(c))
+		_, _, err := cdb2.GetValues([]byte(c))
 		require.NotNil(t, err, c)
 	}
 }
@@ -146,9 +146,9 @@ func TestCollectionDBtryHash(t *testing.T) {
 	}
 	mrTrial, err := cdb.tryHash(scs)
 	require.Nil(t, err)
-	_, _, err = cdb.GetValueContract([]byte("key1"))
+	_, _, err = cdb.GetValues([]byte("key1"))
 	require.EqualError(t, err, "no match found")
-	_, _, err = cdb.GetValueContract([]byte("key2"))
+	_, _, err = cdb.GetValues([]byte("key2"))
 	require.EqualError(t, err, "no match found")
 	cdb.Store(&scs[0])
 	cdb.Store(&scs[1])


### PR DESCRIPTION
Closes #1363

Further, we change collectionDb and CollectionView API to return `[]byte` for contract ID, because the lower-level API do not know about how the application is going to interpret the data, so it should not do any conversion and let the high level code handle it.