### PR TITLE
jjAdd state change cache

### DIFF
--- a/omniledger/service/statechange_cache.go
+++ b/omniledger/service/statechange_cache.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"bytes"
+	"errors"
+	"sync"
+
+	"github.com/dedis/cothority/skipchain"
+)
+
+// stateChangeCache is a simple struct that maintains a cache of state changes
+// keyed on the skipchain ID. It only keeps one value because state changes
+// should only happen at block interval boundaries. So we do not expect
+// interleaving state changes for the same skipchain. The advantage of this
+// approach is that we do not need to worry about deleting used cache because
+// the memory useage stays constant per skipchain.
+type stateChangeCache struct {
+	sync.Mutex
+	cache map[string]*stateChangeValue
+}
+
+type stateChangeValue struct {
+	digest     []byte
+	merkleRoot []byte
+	ctsOK      ClientTransactions
+	states     StateChanges
+}
+
+func newStateChangeCache() stateChangeCache {
+	return stateChangeCache{
+		cache: make(map[string]*stateChangeValue),
+	}
+}
+
+func (c *stateChangeCache) get(scID skipchain.SkipBlockID, digest []byte) (merkleRoot []byte, ctsOK ClientTransactions, states StateChanges, err error) {
+	c.Lock()
+	defer c.Unlock()
+	key := string(scID)
+	out, ok := c.cache[key]
+	if !ok {
+		err = errors.New("key does not exist")
+		return
+	}
+	if !bytes.Equal(out.digest, digest) {
+		err = errors.New("digest is not the same")
+		return
+	}
+
+	merkleRoot = out.merkleRoot
+	ctsOK = out.ctsOK
+	states = out.states
+	return
+}
+
+func (c *stateChangeCache) update(scID skipchain.SkipBlockID, digest []byte, merkleRoot []byte, ctsOK ClientTransactions, states StateChanges) {
+	c.Lock()
+	defer c.Unlock()
+	key := string(scID)
+	c.cache[key] = &stateChangeValue{
+		digest:     digest,
+		merkleRoot: merkleRoot,
+		ctsOK:      ctsOK,
+		states:     states,
+	}
+}

--- a/omniledger/service/statechange_cache_test.go
+++ b/omniledger/service/statechange_cache_test.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateChangeCache(t *testing.T) {
+	cache := newStateChangeCache()
+	require.NotNil(t, cache.cache)
+
+	scID := []byte("scID")
+	digest := []byte("digest")
+
+	_, _, _, err := cache.get(scID, digest)
+	require.Error(t, err)
+
+	root := []byte("root")
+	txs := ClientTransactions([]ClientTransaction{})
+	scs := StateChanges([]StateChange{})
+	cache.update(scID, digest, root, txs, scs)
+
+	root1, txs1, scs1, err := cache.get(scID, digest)
+	require.NoError(t, err)
+	require.Equal(t, root, root1)
+	require.Equal(t, txs, txs1)
+	require.Equal(t, scs, scs1)
+}


### PR DESCRIPTION
We re-compute state changes three times, one during the initial block
creation, one during block verification and finally one during
updateCollection. This PR introduces a cache to store successful state
change computation so that conodes spends less time running contracts.