### PR TITLE
pop check if roster

### DIFF
--- a/pop/service/service.go
+++ b/pop/service/service.go
@@ -174,6 +174,9 @@ func (s *Service) StoreConfig(req *StoreConfig) (network.Message, error) {
 	if req.Desc.Roster == nil {
 		return nil, errors.New("no roster set")
 	}
+	if i, _ := req.Desc.Roster.Search(s.ServerIdentity().ID); i < 0 {
+		return nil, errors.New("this node is not in the roster")
+	}
 	if s.data.Public == nil {
 		return nil, errors.New("Not linked yet")
 	}


### PR DESCRIPTION
Previous check if the node is in the roster was in the propagation function,
which is now only called on the first node. This PR adds the check
for every call to 'StoreConfig'