### PR TITLE
Fixing Registration test

### DIFF
--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -391,11 +391,17 @@ func TestService_RegisterVerification(t *testing.T) {
 	log.ErrFatal(err)
 	require.NotNil(t, sb.Data)
 	require.Equal(t, 0, len(ver))
+	_, err = s1.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: sb.Hash, NewBlock: sb})
+	require.Nil(t, err)
+	require.Equal(t, 3, len(ver))
 
 	sb, err = makeGenesisRosterArgs(s1, el, nil, []VerifierID{ServiceVerifier}, 1, 1)
 	log.ErrFatal(err)
 	require.NotNil(t, sb.Data)
 	require.Equal(t, 0, len(ServiceVerifierChan))
+	_, err = s1.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: sb.Hash, NewBlock: sb})
+	require.Nil(t, err)
+	require.Equal(t, 3, len(ServiceVerifierChan))
 }
 
 func TestService_StoreSkipBlock2(t *testing.T) {


### PR DESCRIPTION
The test itself was correct, but incomplete. When the genesis block is
added, no verification function is called, as no signature is generated.
Only the second block will have a verification function called.