### PR TITLE
Do not re-order transactions

### DIFF
--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -355,11 +355,6 @@ func (s *Service) createNewBlock(scID skipchain.SkipBlockID, r *onet.Roster, cts
 		coll = s.getCollection(scID).coll
 	}
 
-	// Note that the transactions are sorted in-place.
-	if err := sortTransactions(cts); err != nil {
-		return nil, err
-	}
-
 	// Create header of skipblock containing only hashes
 	var scs StateChanges
 	var err error

--- a/omniledger/service/transaction.go
+++ b/omniledger/service/transaction.go
@@ -6,10 +6,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"sort"
 	"sync"
 
-	"github.com/dedis/cothority"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
 
@@ -432,71 +430,4 @@ func (r *txBuffer) add(key string, newTx ClientTransaction) {
 		txs = append(txs, newTx)
 		r.txsMap[key] = txs
 	}
-}
-
-// sortWithSalt sorts transactions according to their salted hash:
-// The salt is prepended to the transactions []byte representation
-// and this concatenation is hashed then.
-// Using a salt here makes the resulting order of the transactions
-// harder to guess.
-func sortWithSalt(ts [][]byte, salt []byte) {
-	less := func(i, j int) bool {
-		h1 := sha256.Sum256(append(salt, ts[i]...))
-		h2 := sha256.Sum256(append(salt, ts[j]...))
-		return bytes.Compare(h1[:], h2[:]) == -1
-	}
-	sort.Slice(ts, less)
-}
-
-// sortTransactions needs to marshal transactions, if it fails to do so,
-// it returns an error and leaves the slice unchanged.
-// The helper functions (sortWithSalt, xorTransactions) operate on []byte
-// representations directly. This allows for some more compact error handling
-// when (un)marshalling.
-func sortTransactions(ts []ClientTransaction) error {
-	bs := make([][]byte, len(ts))
-	sortedTs := make([]*ClientTransaction, len(ts))
-	var err error
-	var ok bool
-	for i := range ts {
-		bs[i], err = network.Marshal(&ts[i])
-		if err != nil {
-			return err
-		}
-	}
-
-	// An alternative to XOR-ing the transactions would have been to
-	// concatenate them and hash the result. However, if we generate the salt
-	// as the hash of the concatenation of the transactions, we have to
-	// concatenate them in a specific order to be deterministic.
-	// This means we would have to sort them, just to get the salt.
-	// In order to avoid this, we XOR them.
-	salt := xorTransactions(bs)
-	sortWithSalt(bs, salt)
-	for i := range bs {
-		_, tmp, err := network.Unmarshal(bs[i], cothority.Suite)
-		if err != nil {
-			return err
-		}
-		sortedTs[i], ok = tmp.(*ClientTransaction)
-		if !ok {
-			return errors.New("Data of wrong type")
-		}
-	}
-	for i := range sortedTs {
-		ts[i] = *sortedTs[i]
-	}
-	return nil
-}
-
-// xorTransactions returns the XOR of the hash values of all the transactions.
-func xorTransactions(ts [][]byte) []byte {
-	result := make([]byte, sha256.Size)
-	for _, t := range ts {
-		hs := sha256.Sum256(t)
-		for i := range result {
-			result[i] = result[i] ^ hs[i]
-		}
-	}
-	return result
 }

--- a/omniledger/service/transaction_test.go
+++ b/omniledger/service/transaction_test.go
@@ -11,62 +11,6 @@ func id(s string) InstanceID {
 	return NewInstanceID([]byte(s))
 }
 
-func TestSortTransactions(t *testing.T) {
-	ts1 := []ClientTransaction{
-		{
-			Instructions: []Instruction{{
-				InstanceID: id("nonce1"),
-				Spawn: &Spawn{
-					ContractID: "kind1",
-				},
-			}}},
-		{
-			Instructions: []Instruction{{
-				InstanceID: id("nonce2"),
-				Spawn: &Spawn{
-					ContractID: "kind2",
-				},
-			}}},
-		{
-			Instructions: []Instruction{{
-				InstanceID: id("nonce3"),
-				Spawn: &Spawn{
-					ContractID: "kind3",
-				},
-			}}},
-	}
-	ts2 := []ClientTransaction{
-		{
-			Instructions: []Instruction{{
-				InstanceID: id("nonce2"),
-				Spawn: &Spawn{
-					ContractID: "kind2",
-				},
-			}}},
-		{
-			Instructions: []Instruction{{
-				InstanceID: id("nonce1"),
-				Spawn: &Spawn{
-					ContractID: "kind1",
-				},
-			}}},
-		{
-			Instructions: []Instruction{{
-				InstanceID: id("nonce3"),
-				Spawn: &Spawn{
-					ContractID: "kind3",
-				},
-			}}},
-	}
-	err := sortTransactions(ts1)
-	require.Nil(t, err)
-	err = sortTransactions(ts2)
-	require.Nil(t, err)
-	for i := range ts1 {
-		require.Equal(t, ts1[i], ts2[i])
-	}
-}
-
 func TestTransaction_Signing(t *testing.T) {
 	signer := darc.NewSignerEd25519(nil, nil)
 	ids := []darc.Identity{signer.Identity()}


### PR DESCRIPTION
Transactions are re-ordered in createNewBlock, which means that if we
cache the state changes in startPolling, then the cache will be invalid
in createNewBlock.

Depends on https://github.com/dedis/cothority/pull/1388