### PR TITLE
Remove DeriveConfigID

### DIFF
--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/InstanceId.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/InstanceId.java
@@ -54,7 +54,9 @@ public class InstanceId implements HashId {
     }
 
     /**
-     * Creates an instance ID of all zeros.
+     * Creates an instance ID of all zeros, which is the place where the OmniLedger
+     * config is stored.
+     *
      * @return the zero instance ID
      */
     public static InstanceId zero() {
@@ -66,18 +68,4 @@ public class InstanceId implements HashId {
             throw new RuntimeException(e);
         }
     }
-
-    public static InstanceId deriveConfigId(DarcId id) throws CothorityCryptoException {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            digest.update(id.getId());
-            byte zero = 0;
-            digest.update(zero);
-            digest.update("config".getBytes());
-            return new InstanceId(digest.digest());
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
 }

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/OmniledgerRPC.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/OmniledgerRPC.java
@@ -80,25 +80,14 @@ public class OmniledgerRPC {
      * @param skipchainId the ID of the genesis skipblock, aka skipchain ID
      * @throws CothorityException
      */
-    public OmniledgerRPC(Roster roster, SkipblockId skipchainId) throws CothorityException {
-        // find the darc ID
+    public OmniledgerRPC(Roster roster, SkipblockId skipchainId) throws CothorityException, InvalidProtocolBufferException {
         Proof proof = OmniledgerRPC.getProof(roster, skipchainId, InstanceId.zero());
         OmniledgerRPC.checkProof(proof, "config");
-        DarcId darcId = new DarcId(proof.getValues().get(0));
-
-        // find the actual darc
-        proof = OmniledgerRPC.getProof(roster, skipchainId, new InstanceId(darcId.getId()));
-        OmniledgerRPC.checkProof(proof, "darc");
-        try {
-            genesisDarc = new Darc(proof.getValues().get(0));
-        } catch (InvalidProtocolBufferException e) {
-            throw new CothorityCommunicationException(e);
-        }
-
-        // find the config info
-        proof = OmniledgerRPC.getProof(roster, skipchainId, InstanceId.deriveConfigId(darcId));
-        OmniledgerRPC.checkProof(proof, "config");
         config = new Config(proof.getValues().get(0));
+
+        Proof proof2 = OmniledgerRPC.getProof(roster, skipchainId, new InstanceId(proof.getValues().get(2)));
+        OmniledgerRPC.checkProof(proof2, "darc");
+        genesisDarc = new Darc(proof2.getValues().get(0));
 
         // find the skipchain info
         skipchain = new SkipchainRPC(roster, skipchainId);

--- a/omniledger/service/api.go
+++ b/omniledger/service/api.go
@@ -111,7 +111,8 @@ func (c *Client) GetProof(key []byte) (*GetProofResponse, error) {
 // GetGenDarc uses the GetProof method to fetch the latest version of the
 // Genesis Darc from OmniLedger and parses it.
 func (c *Client) GetGenDarc() (*darc.Darc, error) {
-	p, err := c.GetProof(GenesisReferenceID.Slice())
+	configId := NewInstanceID(nil)
+	p, err := c.GetProof(configId.Slice())
 	if err != nil {
 		return nil, err
 	}
@@ -121,14 +122,14 @@ func (c *Client) GetGenDarc() (*darc.Darc, error) {
 
 	_, vs, err := p.Proof.KeyValue()
 
-	if len(vs) < 2 {
+	if len(vs) < 3 {
 		return nil, errors.New("not enough records")
 	}
 	contractBuf := vs[1]
 	if string(contractBuf) != ContractConfigID {
 		return nil, errors.New("expected contract to be config but got: " + string(contractBuf))
 	}
-	darcID := vs[0]
+	darcID := vs[2]
 	if len(darcID) != 32 {
 		return nil, errors.New("genesis darc ID is wrong length")
 	}
@@ -160,10 +161,7 @@ func (c *Client) GetGenDarc() (*darc.Darc, error) {
 // GetChainConfig uses the GetProof method to fetch the chain config
 // from OmniLedger.
 func (c *Client) GetChainConfig() (*ChainConfig, error) {
-	d, err := c.GetGenDarc()
-	cfid := DeriveConfigID(d.GetBaseID())
-
-	p, err := c.GetProof(cfid.Slice())
+	p, err := c.GetProof(NewInstanceID(nil).Slice())
 	if err != nil {
 		return nil, err
 	}

--- a/omniledger/service/api.go
+++ b/omniledger/service/api.go
@@ -111,8 +111,7 @@ func (c *Client) GetProof(key []byte) (*GetProofResponse, error) {
 // GetGenDarc uses the GetProof method to fetch the latest version of the
 // Genesis Darc from OmniLedger and parses it.
 func (c *Client) GetGenDarc() (*darc.Darc, error) {
-	configId := NewInstanceID(nil)
-	p, err := c.GetProof(configId.Slice())
+	p, err := c.GetProof(NewInstanceID(nil).Slice())
 	if err != nil {
 		return nil, err
 	}

--- a/omniledger/service/service_test.go
+++ b/omniledger/service/service_test.go
@@ -897,11 +897,9 @@ func createConfigTx(t *testing.T, s *ser, isgood bool) (ClientTransaction, Chain
 	configBuf, err := protobuf.Encode(&config)
 	require.NoError(t, err)
 
-	cfgid := DeriveConfigID(s.darc.GetBaseID())
-
 	ctx := ClientTransaction{
 		Instructions: []Instruction{{
-			InstanceID: cfgid,
+			InstanceID: NewInstanceID(nil),
 			Nonce:      GenNonce(),
 			Index:      0,
 			Length:     1,

--- a/omniledger/service/transaction.go
+++ b/omniledger/service/transaction.go
@@ -43,8 +43,9 @@ func NewNonce(buf []byte) Nonce {
 	return n
 }
 
-// NewInstanceID converts the first 32 bytes of in into
-// an InstanceID.
+// NewInstanceID converts the first 32 bytes of in into an InstanceID.
+// Giving nil as in results in the zero InstanceID, which is the special
+// key that holds the OmniLedger config.
 func NewInstanceID(in []byte) InstanceID {
 	var i InstanceID
 	copy(i[:], in)


### PR DESCRIPTION
Simplify everything by storing the config data at the zero instance
instead of in an adjacent one. This is now possible because we store
the darc ID with the config data.

Fixes #1390.