### PR TITLE
Piggyback getTxs to sync omniledger state

### DIFF
--- a/omniledger/service/collect_tx_test.go
+++ b/omniledger/service/collect_tx_test.go
@@ -15,7 +15,7 @@ var testSuite = cothority.Suite
 
 func TestCollectTx(t *testing.T) {
 	protoPrefix := "TestCollectTx"
-	getTx := func(leader *network.ServerIdentity, scID skipchain.SkipBlockID) ClientTransactions {
+	getTx := func(leader *network.ServerIdentity, roster *onet.Roster, scID skipchain.SkipBlockID, latestID skipchain.SkipBlockID) ClientTransactions {
 		tx := ClientTransaction{
 			Instructions: []Instruction{Instruction{}},
 		}
@@ -34,6 +34,7 @@ func TestCollectTx(t *testing.T) {
 
 		root := p.(*CollectTxProtocol)
 		root.SkipchainID = skipchain.SkipBlockID("hello")
+		root.LatestID = skipchain.SkipBlockID("goodbye")
 		require.NoError(t, root.Start())
 
 		var txs ClientTransactions


### PR DESCRIPTION
We give nodes that were previously down the ability to catch-up to the
latest state. This is done by modifying the getTxs callback used in the
CollectTx protocol to take an additional argument - the latest
skipblock ID. When called, the node will check whether they are up to
date, if not, they'll attempt to synchronise with other nodes.

An earlier implementation maintained its own "background process" to
periodically try to catch-up. It has better encapsulation, but makes
extra communication and requires a lot more code change. Hence,
the piggybacking technique is used.