### PR TITLE
Remove needless code in CothorithyJS 

### DIFF
--- a/external/js/cothority/lib/net/net.js
+++ b/external/js/cothority/lib/net/net.js
@@ -75,17 +75,7 @@ function Socket(addr, service) {
       ws.onmessage = event => {
         ws.close();
         const { data } = event;
-        let buffer;
-        if (ws.android) {
-          data.rewind();
-          const len = data.limit();
-          buffer = new Uint8Array(len);
-          for (let i = 0; i < len; i++) {
-            buffer[i] = data.get(i);
-          }
-        } else {
-          buffer = new Uint8Array(data);
-        }
+        let buffer = new Uint8Array(data);
         const unmarshal = responseModel.decode(buffer);
         resolve(unmarshal);
       };

--- a/external/js/cothority/package-lock.json
+++ b/external/js/cothority/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedis/cothority",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedis/cothority",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "module for interacting with cothority nodes",
   "main": "dist/bundle.node.min.js",
   "browser": "dist/bundle.min.js",


### PR DESCRIPTION
A portion of code was added in CothorityJS to handle a special bug in the NativeScript websockets on Android. Now that the module has been fixed, this code is not necessary anymore and makes CothorityJS crashes on the last version of nativescript-websockets.

Closes dedis/student_18_xplatform#73