### PR TITLE
Very simple bats test

### DIFF
--- a/status/test.bats
+++ b/status/test.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+DBG_TEST=1
+DBG_APP=2
+
+setup() {
+    . $(go env GOPATH)/src/github.com/dedis/onet/app/libtest.sh
+    startTest
+    buildConode
+}
+
+teardown() {
+    stopTest
+}
+
+runCl(){
+    dbgRun ./status -d $DBG_APP $@
+}
+
+@test "network" {
+    runCoBG 1 2
+    testOut "Running network"
+    testGrep "Available_Services" runCl -g public.toml
+    testGrep "Available_Services" runCl -g public.toml
+}
+
+@test "build" {
+    runCl --help
+    runCo 1 --help
+}


### PR DESCRIPTION
This is a very simple example of a [bats](https://github.com/bats-core/bats-core/tree/master) test. The reason I picked it is because `atf`, the FreeBSD test framework, comes with a lot of things that we don't need, e.g., it has a c/cpp test framework; and bats is the first result when I searched for "bash integration test framework".

Here are my initial thought about bats. The framework is very minimalistic, and very easy to get started. Just do `brew install bats-core` and put `#!/usr/bin/env bats` in your file and you're done. It does not replace our `libtest.sh`, but enhances it because we still need to build conodes and other binaries. Other than the typical features that you'd find in unit tests like skip and fixtures. The most important thing for me is the error messages. Here is an example.

```
   (from function `cleanup' in file /Users/kc1212/go/src/github.com/dedis/onet/app/libtest.sh, line 292,
    from function `fail' in file /Users/kc1212/go/src/github.com/dedis/onet/app/libtest.sh, line 174,
    from function `build' in file /Users/kc1212/go/src/github.com/dedis/onet/app/libtest.sh, line 188,
    from function `startTest' in file /Users/kc1212/go/src/github.com/dedis/onet/app/libtest.sh, line 27,
    from function `setup' in test file ./status/test.bats, line 8)
     `startTest' failed
   Working in /var/folders/s3/wvjnpm690kd1kjkwsstfq_5c0000gp/T/tmp.dAU7Fep5
   Building cothority
   # command-line-arguments
   /Users/kc1212/go/src/github.com/dedis/cothority/suite_vartime.go:9:5: Suite redeclared in this block
   	previous declaration at /Users/kc1212/go/src/github.com/dedis/cothority/suite.go:9:5

   	FAILED: Couldn't build /Users/kc1212/go/src/github.com/dedis/cothority
   Success
```

The first few lines are the backtraces, which I think are exceptionally useful for debugging failures.

However, if we decide to go with the framework, we need to make sure our functions work well with it. One of the things that we may need to change is output redirect. We sometimes redirect stdout to `/dev/null` or store it somewhere else (not completely sure). But the framework takes care of that for us, using the [`run` command](https://github.com/bats-core/bats-core/tree/master#run-test-other-commands). It will store the exit code and output to temporary variables which we can use in test/grep/sed later. Having multiple levels of configurable redirects is going to be very confusing.

Further, it's easy to run the tests recursively, you simply write `bats -r .`. But I think `libtest.sh` has some issues when the test is not started in the same directory as the test file. I'm not sure what the exact issue is yet, but that's also something that needs to be fixed.

In my opinion, the bottom line is - bats (or another simple bash integration test framework) is not going to replace `libtest.sh` but is going be a useful addition because it produces backtraces on error. We still keep `libtest.sh` but it needs to be simplified (perhaps functions such as `dbgRun` and anything that uses `DBG_TEST` needs to be removed) and we need to document all the functions.