### PR TITLE
Improved java API

### DIFF
--- a/external/java/src/main/java/ch/epfl/dedis/lib/Sha256id.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/Sha256id.java
@@ -13,6 +13,10 @@ public class Sha256id implements HashId {
     private final byte[] id;
     public final static int length = 32;
 
+    public Sha256id(ByteString bs) throws CothorityCryptoException{
+        this(bs.toByteArray());
+    }
+
     public Sha256id(byte[] id) throws CothorityCryptoException {
         if (id.length != length) {
             throw new CothorityCryptoException("need 32 bytes for sha256-hash, only got " + id.length);

--- a/external/java/src/main/java/ch/epfl/dedis/lib/SkipBlock.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/SkipBlock.java
@@ -2,10 +2,14 @@ package ch.epfl.dedis.lib;
 
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 import ch.epfl.dedis.lib.exception.CothorityException;
+import ch.epfl.dedis.lib.skipchain.ForwardLink;
 import ch.epfl.dedis.proto.SkipchainProto;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * SkipBlock is a wrapper around the protobuf SkipBlock class. It is mainly used to serialize the genesis block for
@@ -14,10 +18,21 @@ import java.net.URISyntaxException;
 public class SkipBlock {
     private SkipchainProto.SkipBlock skipBlock;
 
+    /**
+     * Instantiates a new skipblock given its protobuf representation.
+     *
+     * @param skipBlock the protobuf representation of the skipblock.
+     */
     public SkipBlock(SkipchainProto.SkipBlock skipBlock) {
         this.skipBlock = skipBlock;
     }
 
+    /**
+     * Instantiates a new skipblock given its binary representation.
+     *
+     * @param sb the binary representation of the skipblock.
+     * @throws CothorityException
+     */
     public SkipBlock(byte[] sb) throws CothorityException {
         try {
             this.skipBlock = SkipchainProto.SkipBlock.parseFrom(sb);
@@ -26,39 +41,91 @@ public class SkipBlock {
         }
     }
 
-    public SkipchainProto.SkipBlock getProto(){
+    /**
+     * @return the protobuf representation of the skipblock.
+     */
+    public SkipchainProto.SkipBlock getProto() {
         return skipBlock;
     }
 
     /**
-     * Returns the serialized skipblock.
+     * @return the serialized skipblock.
      */
     public byte[] toByteArray() {
         return this.skipBlock.toByteArray();
     }
 
+    /**
+     * @return the hash of the skipblock - this only includes the header, not an eventual payload.
+     */
     public byte[] getHash() {
         return skipBlock.getHash().toByteArray();
     }
 
+    /**
+     * @return the id of the skipblock, which is its hash.
+     * @throws CothorityCryptoException
+     */
     public SkipblockId getId() throws CothorityCryptoException {
         return new SkipblockId(this.getHash());
     }
 
-    public SkipblockId getSkipchainId() throws CothorityCryptoException{
-        if (skipBlock.getIndex() == 0){
+    /**
+     * @return the id of the skipchain this block belongs to. This is the hash of the genesis block.
+     * @throws CothorityCryptoException
+     */
+    public SkipblockId getSkipchainId() throws CothorityCryptoException {
+        if (skipBlock.getIndex() == 0) {
             return getId();
         }
         return new SkipblockId(skipBlock.getGenesis().toByteArray());
     }
 
-    public byte[] getData(){
+    /**
+     * @return the data of the skipblock. This is included in the hash.
+     */
+    public byte[] getData() {
         return skipBlock.getData().toByteArray();
     }
 
-    public int getIndex(){
+    /**
+     * @return the payload of the skipblock. This is not included in the hash.
+     */
+    public byte[] getPayload() {
+        return skipBlock.getPayload().toByteArray();
+    }
+
+    /**
+     * @return the index of the skipblock. Index == 0 is the genesis block. All other blocks have monotonically increasing
+     * indexes.
+     */
+    public int getIndex() {
         // Because we're using protobuf's zigzag encoding.
         return skipBlock.getIndex() / 2;
+    }
+
+    /**
+     * @return a list of backlinkIDs that point to previous blocks.
+     * @throws CothorityCryptoException
+     */
+    public List<SkipblockId> getBacklinks() throws CothorityCryptoException{
+        List<SkipblockId> sbids = new ArrayList<>();
+        for (ByteString sbid : skipBlock.getBacklinksList()) {
+            sbids.add(new SkipblockId(sbid));
+        }
+        return sbids;
+    }
+
+    /**
+     * @return a list of forwardlinks that point to future blocks - might be empty in case it's the last block.
+     * @throws CothorityCryptoException
+     */
+    public List<ForwardLink> getForwardLinks() throws CothorityCryptoException{
+        List<ForwardLink> fls = new ArrayList<>();
+        for (SkipchainProto.ForwardLink fl: skipBlock.getForwardList()){
+            fls.add(new ForwardLink(fl));
+        }
+        return fls;
     }
 
     /**

--- a/external/java/src/main/java/ch/epfl/dedis/lib/SkipblockId.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/SkipblockId.java
@@ -1,6 +1,7 @@
 package ch.epfl.dedis.lib;
 
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
+import com.google.protobuf.ByteString;
 
 /**
  * This class represents a SkipblockId, which is a sha256-hash of
@@ -9,5 +10,9 @@ import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 public class SkipblockId extends Sha256id {
     public SkipblockId(byte[] id) throws CothorityCryptoException{
         super(id);
+    }
+
+    public SkipblockId(ByteString bs) throws CothorityCryptoException{
+        this(bs.toByteArray());
     }
 }

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/ClientTransaction.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/ClientTransaction.java
@@ -1,7 +1,12 @@
 package ch.epfl.dedis.lib.omniledger;
 
+import ch.epfl.dedis.lib.Sha256id;
+import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 import ch.epfl.dedis.proto.OmniLedgerProto;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -16,6 +21,13 @@ public class ClientTransaction {
      */
     public ClientTransaction(List<Instruction> instructions) {
         this.instructions = instructions;
+    }
+
+    public ClientTransaction(OmniLedgerProto.ClientTransaction ct) throws CothorityCryptoException{
+        instructions = new ArrayList<>();
+        for (OmniLedgerProto.Instruction inst: ct.getInstructionsList()){
+            instructions.add(new Instruction(inst));
+        }
     }
 
     /**
@@ -36,5 +48,20 @@ public class ClientTransaction {
             b.addInstructions(instr.toProto());
         }
         return b.build();
+    }
+
+    /**
+     * @return the hash of the clientTransaction
+     */
+    public Sha256id hash(){
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            for (Instruction inst: instructions){
+                digest.update(inst.hash());
+            }
+            return new Sha256id(digest.digest());
+        } catch (NoSuchAlgorithmException | CothorityCryptoException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/InstanceId.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/InstanceId.java
@@ -26,6 +26,10 @@ public class InstanceId implements HashId {
         this.id = Arrays.copyOf(id, id.length);
     }
 
+    public InstanceId(ByteString bs) throws CothorityCryptoException{
+        this(bs.toByteArray());
+    }
+
     @Override
     public byte[] getId() {
         return Arrays.copyOf(id, id.length);

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/Instruction.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/Instruction.java
@@ -76,6 +76,10 @@ public class Instruction {
         this.delete = delete;
     }
 
+    public Instruction(OmniLedgerProto.Instruction inst) throws CothorityCryptoException{
+        this.instId = new InstanceId(inst.getInstanceid());
+    }
+
     /**
      * Getter for the instance ID.
      */
@@ -229,18 +233,70 @@ public class Instruction {
         }
     }
 
+    /**
+     * @return the nonce of the instruction.
+     */
+    public byte[] getNonce() {
+        return nonce;
+    }
+
+    /**
+     * @return the index of the instruction - should be always smaller than the length.
+     */
+    public int getIndex() {
+        return index;
+    }
+
+    /**
+     * @return the length of the instruction - should be always bigger than the index.
+     */
+    public int getLength() {
+        return length;
+    }
+
+    /**
+     * @return the spawn-argument of the instruction - only one of spawn, invoke, and delete should be present.
+     */
+    public Spawn getSpawn() {
+        return spawn;
+    }
+
+    /**
+     * @return the invoke-argument of the instruction - only one of spawn, invoke, and delete should be present.
+     */
+    public Invoke getInvoke() {
+        return invoke;
+    }
+
+    /**
+     * @return the delete-argument of the instruction - only one of spawn, invoke, and delete should be present.
+     */
+    public Delete getDelete() {
+        return delete;
+    }
+
+    /**
+     * @return the signatures in this instruction.
+     */
+    public List<Signature> getSignatures() {
+        return signatures;
+    }
+
+    /**
+     * TODO: define how nonces are used.
+     * @return generates a nonce to be used in the instructions.
+     */
+    public static byte[] genNonce()  {
+        SecureRandom sr = new SecureRandom();
+        byte[] nonce = new byte[32];
+        sr.nextBytes(nonce);
+        return nonce;
+    }
 
     private static byte[] intToArr4(int x) {
         ByteBuffer b = ByteBuffer.allocate(4);
         b.order(ByteOrder.LITTLE_ENDIAN);
         b.putInt(x);
         return b.array();
-    }
-
-    public static byte[] genNonce() {
-        SecureRandom sr = new SecureRandom();
-        byte[] nonce = new byte[32];
-        sr.nextBytes(nonce);
-        return nonce;
     }
 }

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/OmniBlock.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/OmniBlock.java
@@ -1,0 +1,89 @@
+package ch.epfl.dedis.lib.omniledger;
+
+import ch.epfl.dedis.lib.Sha256id;
+import ch.epfl.dedis.lib.SkipBlock;
+import ch.epfl.dedis.lib.exception.CothorityCryptoException;
+import ch.epfl.dedis.proto.OmniLedgerProto;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * OmniBlock represents the data stored in a skipblock that is relevant to OmniLedger. This data is split in
+ * two parts:
+ * - header, which contains hashes of the current state and which is hashed in the block
+ * - body, which contains the actual data (currently ClientTransactions) and which is not directly hashed in the block
+ */
+public class OmniBlock {
+    private SkipBlock skipBlock;
+    private OmniLedgerProto.DataHeader dataHeader;
+    private OmniLedgerProto.DataBody dataBody;
+
+    /**
+     * Instantiates a new OmniBlock given a skipblock.
+     *
+     * @param sb skipblock holding data for an OmniBLock.
+     * @throws CothorityCryptoException
+     */
+    public OmniBlock(SkipBlock sb) throws CothorityCryptoException {
+        try {
+            // TODO: check that it is actually an OmniBlock by looking at the verifiers
+            dataHeader = OmniLedgerProto.DataHeader.parseFrom(sb.getData());
+            dataBody = OmniLedgerProto.DataBody.parseFrom(sb.getPayload());
+        } catch (InvalidProtocolBufferException e) {
+            throw new CothorityCryptoException(e.getMessage());
+        }
+    }
+
+    /**
+     * @return the root hash of the merkle tree of the global state.
+     * @throws CothorityCryptoException
+     */
+    public Sha256id getCollectionRoot() throws CothorityCryptoException {
+        return new Sha256id(dataHeader.getCollectionroot());
+    }
+
+    /**
+     * @return the sha256 of all clientTransactions stored in this block.
+     * @throws CothorityCryptoException
+     */
+    public Sha256id getClientTransactionHash() throws CothorityCryptoException {
+        return new Sha256id(dataHeader.getClienttransactionhash());
+    }
+
+    /**
+     * @return the sha256 hash of all state changes created by the clientTransactions in this block.
+     * @throws CothorityCryptoException
+     */
+    public Sha256id getStateChangesHash() throws CothorityCryptoException {
+        return new Sha256id(dataHeader.getStatechangeshash());
+    }
+
+    /**
+     * @return the unix-timestamp in nanoseconds of the block creation time.
+     */
+    public long getTimestampNano() {
+        return dataHeader.getTimestamp();
+    }
+
+    /**
+     * @return A java.time.Instant representing the creation of this block.
+     */
+    public Instant getTimestamp() {
+        return Instant.ofEpochMilli(getTimestampNano() / 1000 / 1000);
+    }
+
+    /**
+     * @return the list of all clientTransactions that went into this block.
+     * @throws CothorityCryptoException
+     */
+    public List<ClientTransaction> getClientTransactions() throws CothorityCryptoException {
+        List<ClientTransaction> cts = new ArrayList<>();
+        for (OmniLedgerProto.ClientTransaction ct : dataBody.getTransactionsList()) {
+            cts.add(new ClientTransaction(ct));
+        }
+        return cts;
+    }
+}

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/DarcInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/DarcInstance.java
@@ -21,6 +21,9 @@ import java.util.List;
  * If you evolve the DarcInstance, it will update its internal darc.
  */
 public class DarcInstance {
+    // ContractId is how the contract for a darc is represented.
+    public static String ContractId = "darc";
+
     private Instance instance;
     private Darc darc;
     private OmniledgerRPC ol;
@@ -41,7 +44,7 @@ public class DarcInstance {
         this.ol = ol;
         Proof p = ol.getProof(id);
         instance = new Instance(p);
-        if (!instance.getContractId().equals("darc")) {
+        if (!instance.getContractId().equals(ContractId)) {
             logger.error("wrong instance: {}", instance.getContractId());
             throw new CothorityNotFoundException("this is not a darc instance");
         }
@@ -86,7 +89,7 @@ public class DarcInstance {
                 newDarc.getVersion() != darc.getVersion() + 1) {
             throw new CothorityCryptoException("not correct darc to evolve");
         }
-        Invoke inv = new Invoke("evolve", "darc", newDarc.toProto().toByteArray());
+        Invoke inv = new Invoke("evolve", ContractId, newDarc.toProto().toByteArray());
         byte[] d = newDarc.getBaseId().getId();
         Instruction inst = new Instruction(new InstanceId(d), Instruction.genNonce(), pos, len, inv);
         try {
@@ -194,7 +197,7 @@ public class DarcInstance {
         ClientTransaction ct = new ClientTransaction(Arrays.asList(inst));
         ol.sendTransactionAndWait(ct, wait);
         InstanceId iid = inst.deriveId(contractID);
-        if (contractID.equals("darc")) {
+        if (contractID.equals(ContractId)) {
             // Special case for a darc, then the resulting instanceId is based
             // on the darc itself.
             try {

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/EventLogInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/EventLogInstance.java
@@ -48,6 +48,8 @@ import java.util.List;
  * </ul>
  */
 public class EventLogInstance {
+    // ContractId is how this contract is represented in OmniLedger;
+    public static String ContractId = "eventlog";
     private Instance instance;
     private OmniledgerRPC ol;
 
@@ -180,7 +182,7 @@ public class EventLogInstance {
         if (this.instance != null) {
             throw new CothorityException("already have an instance");
         }
-        Spawn spawn = new Spawn("eventlog", new ArrayList<>());
+        Spawn spawn = new Spawn(ContractId, new ArrayList<>());
         Instruction instr = new Instruction(new InstanceId(darcId.getId()), Instruction.genNonce(), 0, 1, spawn);
         instr.signBy(darcId, signers);
 
@@ -194,7 +196,7 @@ public class EventLogInstance {
     private void setInstance(InstanceId id) throws CothorityException {
         Proof p = ol.getProof(id);
         Instance inst = new Instance(p);
-        if (!inst.getContractId().equals("eventlog")) {
+        if (!inst.getContractId().equals(ContractId)) {
             logger.error("wrong instance: {}", inst.getContractId());
             throw new CothorityNotFoundException("this is not an eventlog instance");
         }
@@ -219,7 +221,7 @@ public class EventLogInstance {
         for (Event e : events) {
             List<Argument> args = new ArrayList<>();
             args.add(new Argument("event", e.toProto().toByteArray()));
-            Invoke invoke = new Invoke("eventlog", args);
+            Invoke invoke = new Invoke(ContractId, args);
             Instruction instr = new Instruction(instance.getId(), Instruction.genNonce(), idx, events.size(), invoke);
             instr.signBy(darcId, signers);
             instrs.add(instr);

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/ValueInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/ValueInstance.java
@@ -16,6 +16,8 @@ import java.util.Arrays;
  * ValueInstance represents a simple value store on omniledger.
  */
 public class ValueInstance {
+    // ContractId is how a valueInstance is represented in OmniLedger.
+    public static String ContractId = "value";
     private Instance instance;
     private OmniledgerRPC ol;
     private byte[] value;
@@ -36,7 +38,7 @@ public class ValueInstance {
         this.ol = ol;
         Proof p = ol.getProof(id);
         instance = new Instance(p);
-        if (!instance.getContractId().equals("value")) {
+        if (!instance.getContractId().equals(ContractId)) {
             logger.error("wrong instance: {}", instance.getContractId());
             throw new CothorityNotFoundException("this is not a value instance");
         }
@@ -66,7 +68,7 @@ public class ValueInstance {
      * @throws CothorityCryptoException
      */
     public Instruction evolveValueInstruction(byte[] newValue, Signer owner, int pos, int len) throws CothorityCryptoException {
-        Invoke inv = new Invoke("update", "value", newValue);
+        Invoke inv = new Invoke("update", ContractId, newValue);
         Instruction inst = new Instruction(instance.getId(), Instruction.genNonce(), pos, len, inv);
         try {
             Request r = new Request(instance.getDarcId(), "invoke:update", inst.hash(),

--- a/external/java/src/main/java/ch/epfl/dedis/lib/skipchain/ByzcoinSig.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/skipchain/ByzcoinSig.java
@@ -1,0 +1,48 @@
+package ch.epfl.dedis.lib.skipchain;
+
+import ch.epfl.dedis.lib.Roster;
+import ch.epfl.dedis.proto.SkipchainProto;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+/**
+ * ByzcoinSig represents a signature from the byzcoin-protocol. It holds both the message and the signature.
+ */
+public class ByzcoinSig {
+    private SkipchainProto.ByzcoinSig byzcoinSig;
+
+    public ByzcoinSig(SkipchainProto.ByzcoinSig bs){
+        byzcoinSig = bs;
+    }
+
+    public ByzcoinSig(byte[] buf) throws InvalidProtocolBufferException {
+        byzcoinSig = SkipchainProto.ByzcoinSig.parseFrom(buf);
+    }
+
+    public ByzcoinSig(ByteString bs) throws InvalidProtocolBufferException{
+        byzcoinSig = SkipchainProto.ByzcoinSig.parseFrom(bs);
+    }
+
+    /**
+     * Verifies the signature given a roster of potential signers.
+     * @param roster a list of signers
+     * @return true if the signature is correct, false otherwise
+     */
+    public boolean verify(Roster roster){
+        throw new RuntimeException("Not implemented yet");
+    }
+
+    /**
+     * @return the signed message, it's a sha256 hash of the actual message.
+     */
+    public byte[] getMsg(){
+        return byzcoinSig.getMsg().toByteArray();
+    }
+
+    /**
+     * @return the aggregated schnorr signature on the message, plus a filter to indicate which nodes signed.
+     */
+    public byte[] getSignature(){
+        return byzcoinSig.getSig().toByteArray();
+    }
+}

--- a/external/java/src/main/java/ch/epfl/dedis/lib/skipchain/ForwardLink.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/skipchain/ForwardLink.java
@@ -1,0 +1,64 @@
+package ch.epfl.dedis.lib.skipchain;
+
+import ch.epfl.dedis.lib.Roster;
+import ch.epfl.dedis.lib.SkipblockId;
+import ch.epfl.dedis.lib.exception.CothorityCryptoException;
+import ch.epfl.dedis.proto.SkipchainProto;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import java.net.URISyntaxException;
+
+/**
+ * A forwardlink represents a signed proof that a future block has been accepted by the set of nodes of
+ * the current block.
+ */
+public class ForwardLink {
+    private SkipchainProto.ForwardLink forwardLink;
+
+    public ForwardLink(SkipchainProto.ForwardLink fl){
+        forwardLink = fl;
+    }
+
+    public ForwardLink(byte[] buf) throws InvalidProtocolBufferException{
+        forwardLink = SkipchainProto.ForwardLink.parseFrom(buf);
+    }
+
+    public ForwardLink(ByteString bs) throws InvalidProtocolBufferException{
+        forwardLink = SkipchainProto.ForwardLink.parseFrom(bs);
+    }
+
+    /**
+     * @return the block where this link originates.
+     * @throws CothorityCryptoException
+     */
+    public SkipblockId getFrom() throws CothorityCryptoException{
+        return new SkipblockId(forwardLink.getFrom());
+    }
+
+    /**
+     * @return the block where this link points to.
+     * @throws CothorityCryptoException
+     */
+    public SkipblockId getTo() throws CothorityCryptoException{
+        return new SkipblockId(forwardLink.getFrom());
+    }
+
+    /**
+     * @return the new roster of the 'to' block. If the roster of 'to' and 'from' are the same, this returns null.
+     * @throws URISyntaxException
+     */
+    public Roster getNewRoster() throws URISyntaxException{
+        if (forwardLink.hasNewRoster()) {
+            return new Roster(forwardLink.getNewRoster());
+        }
+        return null;
+    }
+
+    /**
+     * @return the byzcoin signature on the concatenated 'from', 'to', and 'newRoster', if present.
+     */
+    public ByzcoinSig getByzcoinSig(){
+        return new ByzcoinSig(forwardLink.getSignature());
+    }
+}

--- a/external/java/src/main/java/ch/epfl/dedis/proto/CiscProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/proto/CiscProto.java
@@ -86,9 +86,6 @@ public final class CiscProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -100,6 +97,13 @@ public final class CiscProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.CiscProto.Data.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -139,13 +143,6 @@ public final class CiscProto {
               bitField0_ |= 0x00000004;
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -163,7 +160,6 @@ public final class CiscProto {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_IDBlock_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_IDBlock_fieldAccessorTable
@@ -236,7 +232,6 @@ public final class CiscProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -264,7 +259,6 @@ public final class CiscProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -279,7 +273,6 @@ public final class CiscProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -426,7 +419,6 @@ public final class CiscProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -434,7 +426,6 @@ public final class CiscProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CiscProto.IDBlock prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -462,7 +453,6 @@ public final class CiscProto {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_IDBlock_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_IDBlock_fieldAccessorTable
@@ -488,7 +478,6 @@ public final class CiscProto {
           getLatestskipblockFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (latestBuilder_ == null) {
@@ -512,18 +501,15 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_IDBlock_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.IDBlock getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CiscProto.IDBlock.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.IDBlock build() {
         ch.epfl.dedis.proto.CiscProto.IDBlock result = buildPartial();
         if (!result.isInitialized()) {
@@ -532,7 +518,6 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.IDBlock buildPartial() {
         ch.epfl.dedis.proto.CiscProto.IDBlock result = new ch.epfl.dedis.proto.CiscProto.IDBlock(this);
         int from_bitField0_ = bitField0_;
@@ -566,39 +551,32 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CiscProto.IDBlock) {
           return mergeFrom((ch.epfl.dedis.proto.CiscProto.IDBlock)other);
@@ -624,7 +602,6 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (hasLatest()) {
           if (!getLatest().isInitialized()) {
@@ -644,7 +621,6 @@ public final class CiscProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1017,13 +993,11 @@ public final class CiscProto {
         }
         return latestskipblockBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -1045,12 +1019,11 @@ public final class CiscProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<IDBlock>
         PARSER = new com.google.protobuf.AbstractParser<IDBlock>() {
-      @java.lang.Override
       public IDBlock parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new IDBlock(input, extensionRegistry);
+          return new IDBlock(input, extensionRegistry);
       }
     };
 
@@ -1063,7 +1036,6 @@ public final class CiscProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CiscProto.IDBlock getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -1319,9 +1291,6 @@ public final class CiscProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1333,6 +1302,13 @@ public final class CiscProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 8: {
               bitField0_ |= 0x00000001;
               threshold_ = input.readSInt32();
@@ -1390,13 +1366,6 @@ public final class CiscProto {
                   votes__.getKey(), votes__.getValue());
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -1415,7 +1384,6 @@ public final class CiscProto {
     }
 
     @SuppressWarnings({"rawtypes"})
-    @java.lang.Override
     protected com.google.protobuf.MapField internalGetMapField(
         int number) {
       switch (number) {
@@ -1430,7 +1398,6 @@ public final class CiscProto {
               "Invalid map field number: " + number);
       }
     }
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_Data_fieldAccessorTable
@@ -1780,7 +1747,6 @@ public final class CiscProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1806,7 +1772,6 @@ public final class CiscProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -1836,7 +1801,6 @@ public final class CiscProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -2018,7 +1982,6 @@ public final class CiscProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -2026,7 +1989,6 @@ public final class CiscProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CiscProto.Data prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -2085,7 +2047,6 @@ public final class CiscProto {
                 "Invalid map field number: " + number);
         }
       }
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_Data_fieldAccessorTable
@@ -2109,7 +2070,6 @@ public final class CiscProto {
           getRosterFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         threshold_ = 0;
@@ -2126,18 +2086,15 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_Data_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.Data getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CiscProto.Data.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.Data build() {
         ch.epfl.dedis.proto.CiscProto.Data result = buildPartial();
         if (!result.isInitialized()) {
@@ -2146,7 +2103,6 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.Data buildPartial() {
         ch.epfl.dedis.proto.CiscProto.Data result = new ch.epfl.dedis.proto.CiscProto.Data(this);
         int from_bitField0_ = bitField0_;
@@ -2174,39 +2130,32 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CiscProto.Data) {
           return mergeFrom((ch.epfl.dedis.proto.CiscProto.Data)other);
@@ -2235,7 +2184,6 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasThreshold()) {
           return false;
@@ -2253,7 +2201,6 @@ public final class CiscProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2941,13 +2888,11 @@ public final class CiscProto {
             .putAll(values);
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -2969,12 +2914,11 @@ public final class CiscProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Data>
         PARSER = new com.google.protobuf.AbstractParser<Data>() {
-      @java.lang.Override
       public Data parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Data(input, extensionRegistry);
+          return new Data(input, extensionRegistry);
       }
     };
 
@@ -2987,7 +2931,6 @@ public final class CiscProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CiscProto.Data getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -3045,9 +2988,6 @@ public final class CiscProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -3059,16 +2999,16 @@ public final class CiscProto {
             case 0:
               done = true;
               break;
-            case 10: {
-              bitField0_ |= 0x00000001;
-              point_ = input.readBytes();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              point_ = input.readBytes();
               break;
             }
           }
@@ -3088,7 +3028,6 @@ public final class CiscProto {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_Device_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_Device_fieldAccessorTable
@@ -3121,7 +3060,6 @@ public final class CiscProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -3135,7 +3073,6 @@ public final class CiscProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -3144,7 +3081,6 @@ public final class CiscProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -3265,7 +3201,6 @@ public final class CiscProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -3273,7 +3208,6 @@ public final class CiscProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CiscProto.Device prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -3301,7 +3235,6 @@ public final class CiscProto {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_Device_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_Device_fieldAccessorTable
@@ -3324,7 +3257,6 @@ public final class CiscProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         point_ = com.google.protobuf.ByteString.EMPTY;
@@ -3332,18 +3264,15 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_Device_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.Device getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CiscProto.Device.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.Device build() {
         ch.epfl.dedis.proto.CiscProto.Device result = buildPartial();
         if (!result.isInitialized()) {
@@ -3352,7 +3281,6 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.Device buildPartial() {
         ch.epfl.dedis.proto.CiscProto.Device result = new ch.epfl.dedis.proto.CiscProto.Device(this);
         int from_bitField0_ = bitField0_;
@@ -3366,39 +3294,32 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CiscProto.Device) {
           return mergeFrom((ch.epfl.dedis.proto.CiscProto.Device)other);
@@ -3418,7 +3339,6 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasPoint()) {
           return false;
@@ -3426,7 +3346,6 @@ public final class CiscProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -3496,13 +3415,11 @@ public final class CiscProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -3524,12 +3441,11 @@ public final class CiscProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Device>
         PARSER = new com.google.protobuf.AbstractParser<Device>() {
-      @java.lang.Override
       public Device parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Device(input, extensionRegistry);
+          return new Device(input, extensionRegistry);
       }
     };
 
@@ -3542,7 +3458,6 @@ public final class CiscProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CiscProto.Device getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -3607,9 +3522,6 @@ public final class CiscProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -3621,6 +3533,13 @@ public final class CiscProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
@@ -3630,13 +3549,6 @@ public final class CiscProto {
             case 18: {
               bitField0_ |= 0x00000002;
               public_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -3656,7 +3568,6 @@ public final class CiscProto {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_PinRequest_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_PinRequest_fieldAccessorTable
@@ -3723,7 +3634,6 @@ public final class CiscProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -3741,7 +3651,6 @@ public final class CiscProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -3753,7 +3662,6 @@ public final class CiscProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -3886,7 +3794,6 @@ public final class CiscProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -3894,7 +3801,6 @@ public final class CiscProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CiscProto.PinRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -3922,7 +3828,6 @@ public final class CiscProto {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_PinRequest_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_PinRequest_fieldAccessorTable
@@ -3945,7 +3850,6 @@ public final class CiscProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         pin_ = "";
@@ -3955,18 +3859,15 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_PinRequest_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.PinRequest getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CiscProto.PinRequest.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.PinRequest build() {
         ch.epfl.dedis.proto.CiscProto.PinRequest result = buildPartial();
         if (!result.isInitialized()) {
@@ -3975,7 +3876,6 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.PinRequest buildPartial() {
         ch.epfl.dedis.proto.CiscProto.PinRequest result = new ch.epfl.dedis.proto.CiscProto.PinRequest(this);
         int from_bitField0_ = bitField0_;
@@ -3993,39 +3893,32 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CiscProto.PinRequest) {
           return mergeFrom((ch.epfl.dedis.proto.CiscProto.PinRequest)other);
@@ -4050,7 +3943,6 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasPin()) {
           return false;
@@ -4061,7 +3953,6 @@ public final class CiscProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -4191,13 +4082,11 @@ public final class CiscProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -4219,12 +4108,11 @@ public final class CiscProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<PinRequest>
         PARSER = new com.google.protobuf.AbstractParser<PinRequest>() {
-      @java.lang.Override
       public PinRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new PinRequest(input, extensionRegistry);
+          return new PinRequest(input, extensionRegistry);
       }
     };
 
@@ -4237,7 +4125,6 @@ public final class CiscProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CiscProto.PinRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -4324,9 +4211,6 @@ public final class CiscProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -4338,6 +4222,13 @@ public final class CiscProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 8: {
               bitField0_ |= 0x00000001;
               type_ = input.readSInt32();
@@ -4369,13 +4260,6 @@ public final class CiscProto {
               sig_ = input.readBytes();
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -4396,7 +4280,6 @@ public final class CiscProto {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_StoreKeys_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_StoreKeys_fieldAccessorTable
@@ -4479,7 +4362,6 @@ public final class CiscProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -4503,7 +4385,6 @@ public final class CiscProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -4521,7 +4402,6 @@ public final class CiscProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -4683,7 +4563,6 @@ public final class CiscProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -4691,7 +4570,6 @@ public final class CiscProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CiscProto.StoreKeys prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -4719,7 +4597,6 @@ public final class CiscProto {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_StoreKeys_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_StoreKeys_fieldAccessorTable
@@ -4743,7 +4620,6 @@ public final class CiscProto {
           getFinalFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         type_ = 0;
@@ -4761,18 +4637,15 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_StoreKeys_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.StoreKeys getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CiscProto.StoreKeys.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.StoreKeys build() {
         ch.epfl.dedis.proto.CiscProto.StoreKeys result = buildPartial();
         if (!result.isInitialized()) {
@@ -4781,7 +4654,6 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.StoreKeys buildPartial() {
         ch.epfl.dedis.proto.CiscProto.StoreKeys result = new ch.epfl.dedis.proto.CiscProto.StoreKeys(this);
         int from_bitField0_ = bitField0_;
@@ -4812,39 +4684,32 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CiscProto.StoreKeys) {
           return mergeFrom((ch.epfl.dedis.proto.CiscProto.StoreKeys)other);
@@ -4880,7 +4745,6 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasType()) {
           return false;
@@ -4896,7 +4760,6 @@ public final class CiscProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -5172,13 +5035,11 @@ public final class CiscProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -5200,12 +5061,11 @@ public final class CiscProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<StoreKeys>
         PARSER = new com.google.protobuf.AbstractParser<StoreKeys>() {
-      @java.lang.Override
       public StoreKeys parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new StoreKeys(input, extensionRegistry);
+          return new StoreKeys(input, extensionRegistry);
       }
     };
 
@@ -5218,7 +5078,6 @@ public final class CiscProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CiscProto.StoreKeys getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -5359,9 +5218,6 @@ public final class CiscProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -5373,6 +5229,13 @@ public final class CiscProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.CiscProto.Data.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -5406,13 +5269,6 @@ public final class CiscProto {
               nonce_ = input.readBytes();
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -5430,7 +5286,6 @@ public final class CiscProto {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_CreateIdentity_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_CreateIdentity_fieldAccessorTable
@@ -5568,7 +5423,6 @@ public final class CiscProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -5596,7 +5450,6 @@ public final class CiscProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -5617,7 +5470,6 @@ public final class CiscProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -5790,7 +5642,6 @@ public final class CiscProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -5798,7 +5649,6 @@ public final class CiscProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CiscProto.CreateIdentity prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -5827,7 +5677,6 @@ public final class CiscProto {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_CreateIdentity_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_CreateIdentity_fieldAccessorTable
@@ -5851,7 +5700,6 @@ public final class CiscProto {
           getDataFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (dataBuilder_ == null) {
@@ -5871,18 +5719,15 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_CreateIdentity_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.CreateIdentity getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CiscProto.CreateIdentity.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.CreateIdentity build() {
         ch.epfl.dedis.proto.CiscProto.CreateIdentity result = buildPartial();
         if (!result.isInitialized()) {
@@ -5891,7 +5736,6 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.CreateIdentity buildPartial() {
         ch.epfl.dedis.proto.CiscProto.CreateIdentity result = new ch.epfl.dedis.proto.CiscProto.CreateIdentity(this);
         int from_bitField0_ = bitField0_;
@@ -5925,39 +5769,32 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CiscProto.CreateIdentity) {
           return mergeFrom((ch.epfl.dedis.proto.CiscProto.CreateIdentity)other);
@@ -5989,7 +5826,6 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasType()) {
           return false;
@@ -6008,7 +5844,6 @@ public final class CiscProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -6391,13 +6226,11 @@ public final class CiscProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -6419,12 +6252,11 @@ public final class CiscProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<CreateIdentity>
         PARSER = new com.google.protobuf.AbstractParser<CreateIdentity>() {
-      @java.lang.Override
       public CreateIdentity parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CreateIdentity(input, extensionRegistry);
+          return new CreateIdentity(input, extensionRegistry);
       }
     };
 
@@ -6437,7 +6269,6 @@ public final class CiscProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CiscProto.CreateIdentity getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -6491,9 +6322,6 @@ public final class CiscProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -6505,6 +6333,13 @@ public final class CiscProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.SkipchainProto.SkipBlock.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -6516,13 +6351,6 @@ public final class CiscProto {
                 genesis_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000001;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -6542,7 +6370,6 @@ public final class CiscProto {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_CreateIdentityReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_CreateIdentityReply_fieldAccessorTable
@@ -6573,7 +6400,6 @@ public final class CiscProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -6589,7 +6415,6 @@ public final class CiscProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -6598,7 +6423,6 @@ public final class CiscProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -6719,7 +6543,6 @@ public final class CiscProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -6727,7 +6550,6 @@ public final class CiscProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CiscProto.CreateIdentityReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -6756,7 +6578,6 @@ public final class CiscProto {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_CreateIdentityReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_CreateIdentityReply_fieldAccessorTable
@@ -6780,7 +6601,6 @@ public final class CiscProto {
           getGenesisFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (genesisBuilder_ == null) {
@@ -6792,18 +6612,15 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_CreateIdentityReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.CreateIdentityReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CiscProto.CreateIdentityReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.CreateIdentityReply build() {
         ch.epfl.dedis.proto.CiscProto.CreateIdentityReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -6812,7 +6629,6 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.CreateIdentityReply buildPartial() {
         ch.epfl.dedis.proto.CiscProto.CreateIdentityReply result = new ch.epfl.dedis.proto.CiscProto.CreateIdentityReply(this);
         int from_bitField0_ = bitField0_;
@@ -6830,39 +6646,32 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CiscProto.CreateIdentityReply) {
           return mergeFrom((ch.epfl.dedis.proto.CiscProto.CreateIdentityReply)other);
@@ -6882,7 +6691,6 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (hasGenesis()) {
           if (!getGenesis().isInitialized()) {
@@ -6892,7 +6700,6 @@ public final class CiscProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -7029,13 +6836,11 @@ public final class CiscProto {
         }
         return genesisBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -7057,12 +6862,11 @@ public final class CiscProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<CreateIdentityReply>
         PARSER = new com.google.protobuf.AbstractParser<CreateIdentityReply>() {
-      @java.lang.Override
       public CreateIdentityReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CreateIdentityReply(input, extensionRegistry);
+          return new CreateIdentityReply(input, extensionRegistry);
       }
     };
 
@@ -7075,7 +6879,6 @@ public final class CiscProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CiscProto.CreateIdentityReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -7125,9 +6928,6 @@ public final class CiscProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -7139,16 +6939,16 @@ public final class CiscProto {
             case 0:
               done = true;
               break;
-            case 10: {
-              bitField0_ |= 0x00000001;
-              id_ = input.readBytes();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              id_ = input.readBytes();
               break;
             }
           }
@@ -7168,7 +6968,6 @@ public final class CiscProto {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_DataUpdate_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_DataUpdate_fieldAccessorTable
@@ -7193,7 +6992,6 @@ public final class CiscProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -7207,7 +7005,6 @@ public final class CiscProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -7216,7 +7013,6 @@ public final class CiscProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -7337,7 +7133,6 @@ public final class CiscProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -7345,7 +7140,6 @@ public final class CiscProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CiscProto.DataUpdate prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -7373,7 +7167,6 @@ public final class CiscProto {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_DataUpdate_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_DataUpdate_fieldAccessorTable
@@ -7396,7 +7189,6 @@ public final class CiscProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         id_ = com.google.protobuf.ByteString.EMPTY;
@@ -7404,18 +7196,15 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_DataUpdate_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.DataUpdate getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CiscProto.DataUpdate.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.DataUpdate build() {
         ch.epfl.dedis.proto.CiscProto.DataUpdate result = buildPartial();
         if (!result.isInitialized()) {
@@ -7424,7 +7213,6 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.DataUpdate buildPartial() {
         ch.epfl.dedis.proto.CiscProto.DataUpdate result = new ch.epfl.dedis.proto.CiscProto.DataUpdate(this);
         int from_bitField0_ = bitField0_;
@@ -7438,39 +7226,32 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CiscProto.DataUpdate) {
           return mergeFrom((ch.epfl.dedis.proto.CiscProto.DataUpdate)other);
@@ -7490,7 +7271,6 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasId()) {
           return false;
@@ -7498,7 +7278,6 @@ public final class CiscProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -7552,13 +7331,11 @@ public final class CiscProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -7580,12 +7357,11 @@ public final class CiscProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<DataUpdate>
         PARSER = new com.google.protobuf.AbstractParser<DataUpdate>() {
-      @java.lang.Override
       public DataUpdate parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new DataUpdate(input, extensionRegistry);
+          return new DataUpdate(input, extensionRegistry);
       }
     };
 
@@ -7598,7 +7374,6 @@ public final class CiscProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CiscProto.DataUpdate getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -7651,9 +7426,6 @@ public final class CiscProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -7665,6 +7437,13 @@ public final class CiscProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.CiscProto.Data.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -7676,13 +7455,6 @@ public final class CiscProto {
                 data_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000001;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -7702,7 +7474,6 @@ public final class CiscProto {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_DataUpdateReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_DataUpdateReply_fieldAccessorTable
@@ -7733,7 +7504,6 @@ public final class CiscProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -7749,7 +7519,6 @@ public final class CiscProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -7758,7 +7527,6 @@ public final class CiscProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -7879,7 +7647,6 @@ public final class CiscProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -7887,7 +7654,6 @@ public final class CiscProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CiscProto.DataUpdateReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -7915,7 +7681,6 @@ public final class CiscProto {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_DataUpdateReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_DataUpdateReply_fieldAccessorTable
@@ -7939,7 +7704,6 @@ public final class CiscProto {
           getDataFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (dataBuilder_ == null) {
@@ -7951,18 +7715,15 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_DataUpdateReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.DataUpdateReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CiscProto.DataUpdateReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.DataUpdateReply build() {
         ch.epfl.dedis.proto.CiscProto.DataUpdateReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -7971,7 +7732,6 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.DataUpdateReply buildPartial() {
         ch.epfl.dedis.proto.CiscProto.DataUpdateReply result = new ch.epfl.dedis.proto.CiscProto.DataUpdateReply(this);
         int from_bitField0_ = bitField0_;
@@ -7989,39 +7749,32 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CiscProto.DataUpdateReply) {
           return mergeFrom((ch.epfl.dedis.proto.CiscProto.DataUpdateReply)other);
@@ -8041,7 +7794,6 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (hasData()) {
           if (!getData().isInitialized()) {
@@ -8051,7 +7803,6 @@ public final class CiscProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -8188,13 +7939,11 @@ public final class CiscProto {
         }
         return dataBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -8216,12 +7965,11 @@ public final class CiscProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<DataUpdateReply>
         PARSER = new com.google.protobuf.AbstractParser<DataUpdateReply>() {
-      @java.lang.Override
       public DataUpdateReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new DataUpdateReply(input, extensionRegistry);
+          return new DataUpdateReply(input, extensionRegistry);
       }
     };
 
@@ -8234,7 +7982,6 @@ public final class CiscProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CiscProto.DataUpdateReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -8298,9 +8045,6 @@ public final class CiscProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -8312,6 +8056,13 @@ public final class CiscProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               id_ = input.readBytes();
@@ -8328,13 +8079,6 @@ public final class CiscProto {
                 propose_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000002;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -8354,7 +8098,6 @@ public final class CiscProto {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeSend_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeSend_fieldAccessorTable
@@ -8400,7 +8143,6 @@ public final class CiscProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -8420,7 +8162,6 @@ public final class CiscProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -8432,7 +8173,6 @@ public final class CiscProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -8566,7 +8306,6 @@ public final class CiscProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -8574,7 +8313,6 @@ public final class CiscProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CiscProto.ProposeSend prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -8603,7 +8341,6 @@ public final class CiscProto {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeSend_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeSend_fieldAccessorTable
@@ -8627,7 +8364,6 @@ public final class CiscProto {
           getProposeFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         id_ = com.google.protobuf.ByteString.EMPTY;
@@ -8641,18 +8377,15 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeSend_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.ProposeSend getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CiscProto.ProposeSend.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.ProposeSend build() {
         ch.epfl.dedis.proto.CiscProto.ProposeSend result = buildPartial();
         if (!result.isInitialized()) {
@@ -8661,7 +8394,6 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.ProposeSend buildPartial() {
         ch.epfl.dedis.proto.CiscProto.ProposeSend result = new ch.epfl.dedis.proto.CiscProto.ProposeSend(this);
         int from_bitField0_ = bitField0_;
@@ -8683,39 +8415,32 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CiscProto.ProposeSend) {
           return mergeFrom((ch.epfl.dedis.proto.CiscProto.ProposeSend)other);
@@ -8738,7 +8463,6 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasId()) {
           return false;
@@ -8751,7 +8475,6 @@ public final class CiscProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -8923,13 +8646,11 @@ public final class CiscProto {
         }
         return proposeBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -8951,12 +8672,11 @@ public final class CiscProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<ProposeSend>
         PARSER = new com.google.protobuf.AbstractParser<ProposeSend>() {
-      @java.lang.Override
       public ProposeSend parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ProposeSend(input, extensionRegistry);
+          return new ProposeSend(input, extensionRegistry);
       }
     };
 
@@ -8969,7 +8689,6 @@ public final class CiscProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CiscProto.ProposeSend getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -9019,9 +8738,6 @@ public final class CiscProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -9033,16 +8749,16 @@ public final class CiscProto {
             case 0:
               done = true;
               break;
-            case 10: {
-              bitField0_ |= 0x00000001;
-              id_ = input.readBytes();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              id_ = input.readBytes();
               break;
             }
           }
@@ -9062,7 +8778,6 @@ public final class CiscProto {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeUpdate_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeUpdate_fieldAccessorTable
@@ -9087,7 +8802,6 @@ public final class CiscProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -9101,7 +8815,6 @@ public final class CiscProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -9110,7 +8823,6 @@ public final class CiscProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -9231,7 +8943,6 @@ public final class CiscProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -9239,7 +8950,6 @@ public final class CiscProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CiscProto.ProposeUpdate prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -9267,7 +8977,6 @@ public final class CiscProto {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeUpdate_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeUpdate_fieldAccessorTable
@@ -9290,7 +8999,6 @@ public final class CiscProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         id_ = com.google.protobuf.ByteString.EMPTY;
@@ -9298,18 +9006,15 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeUpdate_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.ProposeUpdate getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CiscProto.ProposeUpdate.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.ProposeUpdate build() {
         ch.epfl.dedis.proto.CiscProto.ProposeUpdate result = buildPartial();
         if (!result.isInitialized()) {
@@ -9318,7 +9023,6 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.ProposeUpdate buildPartial() {
         ch.epfl.dedis.proto.CiscProto.ProposeUpdate result = new ch.epfl.dedis.proto.CiscProto.ProposeUpdate(this);
         int from_bitField0_ = bitField0_;
@@ -9332,39 +9036,32 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CiscProto.ProposeUpdate) {
           return mergeFrom((ch.epfl.dedis.proto.CiscProto.ProposeUpdate)other);
@@ -9384,7 +9081,6 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasId()) {
           return false;
@@ -9392,7 +9088,6 @@ public final class CiscProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -9446,13 +9141,11 @@ public final class CiscProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -9474,12 +9167,11 @@ public final class CiscProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<ProposeUpdate>
         PARSER = new com.google.protobuf.AbstractParser<ProposeUpdate>() {
-      @java.lang.Override
       public ProposeUpdate parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ProposeUpdate(input, extensionRegistry);
+          return new ProposeUpdate(input, extensionRegistry);
       }
     };
 
@@ -9492,7 +9184,6 @@ public final class CiscProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CiscProto.ProposeUpdate getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -9545,9 +9236,6 @@ public final class CiscProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -9559,6 +9247,13 @@ public final class CiscProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.CiscProto.Data.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -9570,13 +9265,6 @@ public final class CiscProto {
                 propose_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000001;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -9596,7 +9284,6 @@ public final class CiscProto {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeUpdateReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeUpdateReply_fieldAccessorTable
@@ -9627,7 +9314,6 @@ public final class CiscProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -9643,7 +9329,6 @@ public final class CiscProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -9652,7 +9337,6 @@ public final class CiscProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -9773,7 +9457,6 @@ public final class CiscProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -9781,7 +9464,6 @@ public final class CiscProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CiscProto.ProposeUpdateReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -9809,7 +9491,6 @@ public final class CiscProto {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeUpdateReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeUpdateReply_fieldAccessorTable
@@ -9833,7 +9514,6 @@ public final class CiscProto {
           getProposeFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (proposeBuilder_ == null) {
@@ -9845,18 +9525,15 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeUpdateReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.ProposeUpdateReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CiscProto.ProposeUpdateReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.ProposeUpdateReply build() {
         ch.epfl.dedis.proto.CiscProto.ProposeUpdateReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -9865,7 +9542,6 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.ProposeUpdateReply buildPartial() {
         ch.epfl.dedis.proto.CiscProto.ProposeUpdateReply result = new ch.epfl.dedis.proto.CiscProto.ProposeUpdateReply(this);
         int from_bitField0_ = bitField0_;
@@ -9883,39 +9559,32 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CiscProto.ProposeUpdateReply) {
           return mergeFrom((ch.epfl.dedis.proto.CiscProto.ProposeUpdateReply)other);
@@ -9935,7 +9604,6 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (hasPropose()) {
           if (!getPropose().isInitialized()) {
@@ -9945,7 +9613,6 @@ public final class CiscProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -10082,13 +9749,11 @@ public final class CiscProto {
         }
         return proposeBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -10110,12 +9775,11 @@ public final class CiscProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<ProposeUpdateReply>
         PARSER = new com.google.protobuf.AbstractParser<ProposeUpdateReply>() {
-      @java.lang.Override
       public ProposeUpdateReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ProposeUpdateReply(input, extensionRegistry);
+          return new ProposeUpdateReply(input, extensionRegistry);
       }
     };
 
@@ -10128,7 +9792,6 @@ public final class CiscProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CiscProto.ProposeUpdateReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -10204,9 +9867,6 @@ public final class CiscProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -10218,6 +9878,13 @@ public final class CiscProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               id_ = input.readBytes();
@@ -10232,13 +9899,6 @@ public final class CiscProto {
             case 26: {
               bitField0_ |= 0x00000004;
               signature_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -10258,7 +9918,6 @@ public final class CiscProto {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeVote_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeVote_fieldAccessorTable
@@ -10340,7 +9999,6 @@ public final class CiscProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -10362,7 +10020,6 @@ public final class CiscProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -10377,7 +10034,6 @@ public final class CiscProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -10523,7 +10179,6 @@ public final class CiscProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -10531,7 +10186,6 @@ public final class CiscProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CiscProto.ProposeVote prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -10560,7 +10214,6 @@ public final class CiscProto {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeVote_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeVote_fieldAccessorTable
@@ -10583,7 +10236,6 @@ public final class CiscProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         id_ = com.google.protobuf.ByteString.EMPTY;
@@ -10595,18 +10247,15 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeVote_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.ProposeVote getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CiscProto.ProposeVote.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.ProposeVote build() {
         ch.epfl.dedis.proto.CiscProto.ProposeVote result = buildPartial();
         if (!result.isInitialized()) {
@@ -10615,7 +10264,6 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.ProposeVote buildPartial() {
         ch.epfl.dedis.proto.CiscProto.ProposeVote result = new ch.epfl.dedis.proto.CiscProto.ProposeVote(this);
         int from_bitField0_ = bitField0_;
@@ -10637,39 +10285,32 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CiscProto.ProposeVote) {
           return mergeFrom((ch.epfl.dedis.proto.CiscProto.ProposeVote)other);
@@ -10697,7 +10338,6 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasId()) {
           return false;
@@ -10711,7 +10351,6 @@ public final class CiscProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -10876,13 +10515,11 @@ public final class CiscProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -10904,12 +10541,11 @@ public final class CiscProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<ProposeVote>
         PARSER = new com.google.protobuf.AbstractParser<ProposeVote>() {
-      @java.lang.Override
       public ProposeVote parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ProposeVote(input, extensionRegistry);
+          return new ProposeVote(input, extensionRegistry);
       }
     };
 
@@ -10922,7 +10558,6 @@ public final class CiscProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CiscProto.ProposeVote getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -10976,9 +10611,6 @@ public final class CiscProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -10990,6 +10622,13 @@ public final class CiscProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.SkipchainProto.SkipBlock.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -11001,13 +10640,6 @@ public final class CiscProto {
                 data_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000001;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -11027,7 +10659,6 @@ public final class CiscProto {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeVoteReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeVoteReply_fieldAccessorTable
@@ -11058,7 +10689,6 @@ public final class CiscProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -11074,7 +10704,6 @@ public final class CiscProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -11083,7 +10712,6 @@ public final class CiscProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -11204,7 +10832,6 @@ public final class CiscProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -11212,7 +10839,6 @@ public final class CiscProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CiscProto.ProposeVoteReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -11241,7 +10867,6 @@ public final class CiscProto {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeVoteReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeVoteReply_fieldAccessorTable
@@ -11265,7 +10890,6 @@ public final class CiscProto {
           getDataFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (dataBuilder_ == null) {
@@ -11277,18 +10901,15 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_ProposeVoteReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.ProposeVoteReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CiscProto.ProposeVoteReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.ProposeVoteReply build() {
         ch.epfl.dedis.proto.CiscProto.ProposeVoteReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -11297,7 +10918,6 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.ProposeVoteReply buildPartial() {
         ch.epfl.dedis.proto.CiscProto.ProposeVoteReply result = new ch.epfl.dedis.proto.CiscProto.ProposeVoteReply(this);
         int from_bitField0_ = bitField0_;
@@ -11315,39 +10935,32 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CiscProto.ProposeVoteReply) {
           return mergeFrom((ch.epfl.dedis.proto.CiscProto.ProposeVoteReply)other);
@@ -11367,7 +10980,6 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (hasData()) {
           if (!getData().isInitialized()) {
@@ -11377,7 +10989,6 @@ public final class CiscProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -11514,13 +11125,11 @@ public final class CiscProto {
         }
         return dataBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -11542,12 +11151,11 @@ public final class CiscProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<ProposeVoteReply>
         PARSER = new com.google.protobuf.AbstractParser<ProposeVoteReply>() {
-      @java.lang.Override
       public ProposeVoteReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ProposeVoteReply(input, extensionRegistry);
+          return new ProposeVoteReply(input, extensionRegistry);
       }
     };
 
@@ -11560,7 +11168,6 @@ public final class CiscProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CiscProto.ProposeVoteReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -11643,9 +11250,6 @@ public final class CiscProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -11657,6 +11261,13 @@ public final class CiscProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.CiscProto.IDBlock.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -11682,13 +11293,6 @@ public final class CiscProto {
               pubstr_ = bs;
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -11706,7 +11310,6 @@ public final class CiscProto {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_PropagateIdentity_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_PropagateIdentity_fieldAccessorTable
@@ -11821,7 +11424,6 @@ public final class CiscProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -11845,7 +11447,6 @@ public final class CiscProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -11860,7 +11461,6 @@ public final class CiscProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -12005,7 +11605,6 @@ public final class CiscProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -12013,7 +11612,6 @@ public final class CiscProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CiscProto.PropagateIdentity prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -12041,7 +11639,6 @@ public final class CiscProto {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_PropagateIdentity_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_PropagateIdentity_fieldAccessorTable
@@ -12065,7 +11662,6 @@ public final class CiscProto {
           getIdblockFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (idblockBuilder_ == null) {
@@ -12081,18 +11677,15 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_PropagateIdentity_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.PropagateIdentity getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CiscProto.PropagateIdentity.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.PropagateIdentity build() {
         ch.epfl.dedis.proto.CiscProto.PropagateIdentity result = buildPartial();
         if (!result.isInitialized()) {
@@ -12101,7 +11694,6 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.PropagateIdentity buildPartial() {
         ch.epfl.dedis.proto.CiscProto.PropagateIdentity result = new ch.epfl.dedis.proto.CiscProto.PropagateIdentity(this);
         int from_bitField0_ = bitField0_;
@@ -12127,39 +11719,32 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CiscProto.PropagateIdentity) {
           return mergeFrom((ch.epfl.dedis.proto.CiscProto.PropagateIdentity)other);
@@ -12189,7 +11774,6 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasTag()) {
           return false;
@@ -12205,7 +11789,6 @@ public final class CiscProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -12494,13 +12077,11 @@ public final class CiscProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -12522,12 +12103,11 @@ public final class CiscProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<PropagateIdentity>
         PARSER = new com.google.protobuf.AbstractParser<PropagateIdentity>() {
-      @java.lang.Override
       public PropagateIdentity parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new PropagateIdentity(input, extensionRegistry);
+          return new PropagateIdentity(input, extensionRegistry);
       }
     };
 
@@ -12540,7 +12120,6 @@ public final class CiscProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CiscProto.PropagateIdentity getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -12603,9 +12182,6 @@ public final class CiscProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -12617,6 +12193,13 @@ public final class CiscProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               id_ = input.readBytes();
@@ -12633,13 +12216,6 @@ public final class CiscProto {
                 latest_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000002;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -12659,7 +12235,6 @@ public final class CiscProto {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_UpdateSkipBlock_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_UpdateSkipBlock_fieldAccessorTable
@@ -12705,7 +12280,6 @@ public final class CiscProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -12725,7 +12299,6 @@ public final class CiscProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -12737,7 +12310,6 @@ public final class CiscProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -12871,7 +12443,6 @@ public final class CiscProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -12879,7 +12450,6 @@ public final class CiscProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CiscProto.UpdateSkipBlock prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -12907,7 +12477,6 @@ public final class CiscProto {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_UpdateSkipBlock_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_UpdateSkipBlock_fieldAccessorTable
@@ -12931,7 +12500,6 @@ public final class CiscProto {
           getLatestFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         id_ = com.google.protobuf.ByteString.EMPTY;
@@ -12945,18 +12513,15 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_UpdateSkipBlock_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.UpdateSkipBlock getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CiscProto.UpdateSkipBlock.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.UpdateSkipBlock build() {
         ch.epfl.dedis.proto.CiscProto.UpdateSkipBlock result = buildPartial();
         if (!result.isInitialized()) {
@@ -12965,7 +12530,6 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.UpdateSkipBlock buildPartial() {
         ch.epfl.dedis.proto.CiscProto.UpdateSkipBlock result = new ch.epfl.dedis.proto.CiscProto.UpdateSkipBlock(this);
         int from_bitField0_ = bitField0_;
@@ -12987,39 +12551,32 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CiscProto.UpdateSkipBlock) {
           return mergeFrom((ch.epfl.dedis.proto.CiscProto.UpdateSkipBlock)other);
@@ -13042,7 +12599,6 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasId()) {
           return false;
@@ -13055,7 +12611,6 @@ public final class CiscProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -13227,13 +12782,11 @@ public final class CiscProto {
         }
         return latestBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -13255,12 +12808,11 @@ public final class CiscProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<UpdateSkipBlock>
         PARSER = new com.google.protobuf.AbstractParser<UpdateSkipBlock>() {
-      @java.lang.Override
       public UpdateSkipBlock parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new UpdateSkipBlock(input, extensionRegistry);
+          return new UpdateSkipBlock(input, extensionRegistry);
       }
     };
 
@@ -13273,7 +12825,6 @@ public final class CiscProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CiscProto.UpdateSkipBlock getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -13335,9 +12886,6 @@ public final class CiscProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -13349,6 +12897,13 @@ public final class CiscProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               nonce_ = input.readBytes();
@@ -13357,13 +12912,6 @@ public final class CiscProto {
             case 18: {
               bitField0_ |= 0x00000002;
               ctx_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -13383,7 +12931,6 @@ public final class CiscProto {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_Authenticate_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_Authenticate_fieldAccessorTable
@@ -13423,7 +12970,6 @@ public final class CiscProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -13441,7 +12987,6 @@ public final class CiscProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -13453,7 +12998,6 @@ public final class CiscProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -13587,7 +13131,6 @@ public final class CiscProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -13595,7 +13138,6 @@ public final class CiscProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CiscProto.Authenticate prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -13625,7 +13167,6 @@ public final class CiscProto {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_Authenticate_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_Authenticate_fieldAccessorTable
@@ -13648,7 +13189,6 @@ public final class CiscProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         nonce_ = com.google.protobuf.ByteString.EMPTY;
@@ -13658,18 +13198,15 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CiscProto.internal_static_cisc_Authenticate_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.Authenticate getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CiscProto.Authenticate.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.Authenticate build() {
         ch.epfl.dedis.proto.CiscProto.Authenticate result = buildPartial();
         if (!result.isInitialized()) {
@@ -13678,7 +13215,6 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CiscProto.Authenticate buildPartial() {
         ch.epfl.dedis.proto.CiscProto.Authenticate result = new ch.epfl.dedis.proto.CiscProto.Authenticate(this);
         int from_bitField0_ = bitField0_;
@@ -13696,39 +13232,32 @@ public final class CiscProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CiscProto.Authenticate) {
           return mergeFrom((ch.epfl.dedis.proto.CiscProto.Authenticate)other);
@@ -13751,7 +13280,6 @@ public final class CiscProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasNonce()) {
           return false;
@@ -13762,7 +13290,6 @@ public final class CiscProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -13851,13 +13378,11 @@ public final class CiscProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -13879,12 +13404,11 @@ public final class CiscProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Authenticate>
         PARSER = new com.google.protobuf.AbstractParser<Authenticate>() {
-      @java.lang.Override
       public Authenticate parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Authenticate(input, extensionRegistry);
+          return new Authenticate(input, extensionRegistry);
       }
     };
 
@@ -13897,7 +13421,6 @@ public final class CiscProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CiscProto.Authenticate getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -14022,7 +13545,7 @@ public final class CiscProto {
       "ry\022(\n\007storage\030\003 \003(\0132\027.cisc.Data.StorageE" +
       "ntry\022\034\n\006roster\030\004 \001(\0132\014.onet.Roster\022$\n\005vo" +
       "tes\030\005 \003(\0132\025.cisc.Data.VotesEntry\032;\n\013Devi" +
-      "ceEntry\022\013\n\003key\030\001 \001(\t\022\033\n\005value\030\002 \001(\0132\014.ci" +
+      "ceEntry\022\013\n\003key\030\001 \001(\t\022\033\n\005value\030\002 \001(\0132\014.ci",
       "sc.Device:\0028\001\032.\n\014StorageEntry\022\013\n\003key\030\001 \001" +
       "(\t\022\r\n\005value\030\002 \001(\t:\0028\001\032,\n\nVotesEntry\022\013\n\003k" +
       "ey\030\001 \001(\t\022\r\n\005value\030\002 \001(\014:\0028\001\"\027\n\006Device\022\r\n" +
@@ -14032,7 +13555,7 @@ public final class CiscProto {
       "\n\007publics\030\003 \003(\014\022\013\n\003sig\030\004 \002(\014\"e\n\016CreateId" +
       "entity\022\030\n\004data\030\001 \001(\0132\n.cisc.Data\022\014\n\004type" +
       "\030\002 \002(\021\022\017\n\007schnsig\030\003 \001(\014\022\013\n\003sig\030\004 \002(\014\022\r\n\005" +
-      "nonce\030\005 \002(\014\"<\n\023CreateIdentityReply\022%\n\007ge" +
+      "nonce\030\005 \002(\014\"<\n\023CreateIdentityReply\022%\n\007ge",
       "nesis\030\001 \001(\0132\024.skipchain.SkipBlock\"\030\n\nDat" +
       "aUpdate\022\n\n\002id\030\001 \002(\014\"+\n\017DataUpdateReply\022\030" +
       "\n\004data\030\001 \001(\0132\n.cisc.Data\"6\n\013ProposeSend\022" +
@@ -14042,7 +13565,7 @@ public final class CiscProto {
       "\"<\n\013ProposeVote\022\n\n\002id\030\001 \002(\014\022\016\n\006signer\030\002 " +
       "\002(\t\022\021\n\tsignature\030\003 \002(\014\"6\n\020ProposeVoteRep" +
       "ly\022\"\n\004data\030\001 \001(\0132\024.skipchain.SkipBlock\"P" +
-      "\n\021PropagateIdentity\022\036\n\007idblock\030\001 \001(\0132\r.c" +
+      "\n\021PropagateIdentity\022\036\n\007idblock\030\001 \001(\0132\r.c",
       "isc.IDBlock\022\013\n\003tag\030\002 \002(\t\022\016\n\006pubstr\030\003 \002(\t" +
       "\"C\n\017UpdateSkipBlock\022\n\n\002id\030\001 \002(\014\022$\n\006lates" +
       "t\030\002 \001(\0132\024.skipchain.SkipBlock\"*\n\014Authent" +

--- a/external/java/src/main/java/ch/epfl/dedis/proto/CollectionProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/proto/CollectionProto.java
@@ -90,9 +90,6 @@ public final class CollectionProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -104,6 +101,13 @@ public final class CollectionProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               key_ = input.readBytes();
@@ -135,13 +139,6 @@ public final class CollectionProto {
               label_ = input.readBytes();
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -162,7 +159,6 @@ public final class CollectionProto {
       return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Dump_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Dump_fieldAccessorTable
@@ -245,7 +241,6 @@ public final class CollectionProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -271,7 +266,6 @@ public final class CollectionProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -289,7 +283,6 @@ public final class CollectionProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -451,7 +444,6 @@ public final class CollectionProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -459,7 +451,6 @@ public final class CollectionProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CollectionProto.Dump prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -483,7 +474,6 @@ public final class CollectionProto {
         return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Dump_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Dump_fieldAccessorTable
@@ -507,7 +497,6 @@ public final class CollectionProto {
           getChildrenFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         key_ = com.google.protobuf.ByteString.EMPTY;
@@ -525,18 +514,15 @@ public final class CollectionProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Dump_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CollectionProto.Dump getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CollectionProto.Dump.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CollectionProto.Dump build() {
         ch.epfl.dedis.proto.CollectionProto.Dump result = buildPartial();
         if (!result.isInitialized()) {
@@ -545,7 +531,6 @@ public final class CollectionProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CollectionProto.Dump buildPartial() {
         ch.epfl.dedis.proto.CollectionProto.Dump result = new ch.epfl.dedis.proto.CollectionProto.Dump(this);
         int from_bitField0_ = bitField0_;
@@ -576,39 +561,32 @@ public final class CollectionProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CollectionProto.Dump) {
           return mergeFrom((ch.epfl.dedis.proto.CollectionProto.Dump)other);
@@ -644,7 +622,6 @@ public final class CollectionProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasKey()) {
           return false;
@@ -661,7 +638,6 @@ public final class CollectionProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -940,13 +916,11 @@ public final class CollectionProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -968,12 +942,11 @@ public final class CollectionProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Dump>
         PARSER = new com.google.protobuf.AbstractParser<Dump>() {
-      @java.lang.Override
       public Dump parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Dump(input, extensionRegistry);
+          return new Dump(input, extensionRegistry);
       }
     };
 
@@ -986,7 +959,6 @@ public final class CollectionProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CollectionProto.Dump getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -1042,9 +1014,6 @@ public final class CollectionProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1056,6 +1025,13 @@ public final class CollectionProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               left_ = input.readBytes();
@@ -1064,13 +1040,6 @@ public final class CollectionProto {
             case 18: {
               bitField0_ |= 0x00000002;
               right_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -1090,7 +1059,6 @@ public final class CollectionProto {
       return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Children_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Children_fieldAccessorTable
@@ -1130,7 +1098,6 @@ public final class CollectionProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1148,7 +1115,6 @@ public final class CollectionProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -1160,7 +1126,6 @@ public final class CollectionProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -1294,7 +1259,6 @@ public final class CollectionProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -1302,7 +1266,6 @@ public final class CollectionProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CollectionProto.Children prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -1326,7 +1289,6 @@ public final class CollectionProto {
         return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Children_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Children_fieldAccessorTable
@@ -1349,7 +1311,6 @@ public final class CollectionProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         left_ = com.google.protobuf.ByteString.EMPTY;
@@ -1359,18 +1320,15 @@ public final class CollectionProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Children_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CollectionProto.Children getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CollectionProto.Children.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CollectionProto.Children build() {
         ch.epfl.dedis.proto.CollectionProto.Children result = buildPartial();
         if (!result.isInitialized()) {
@@ -1379,7 +1337,6 @@ public final class CollectionProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CollectionProto.Children buildPartial() {
         ch.epfl.dedis.proto.CollectionProto.Children result = new ch.epfl.dedis.proto.CollectionProto.Children(this);
         int from_bitField0_ = bitField0_;
@@ -1397,39 +1354,32 @@ public final class CollectionProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CollectionProto.Children) {
           return mergeFrom((ch.epfl.dedis.proto.CollectionProto.Children)other);
@@ -1452,7 +1402,6 @@ public final class CollectionProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasLeft()) {
           return false;
@@ -1463,7 +1412,6 @@ public final class CollectionProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1552,13 +1500,11 @@ public final class CollectionProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -1580,12 +1526,11 @@ public final class CollectionProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Children>
         PARSER = new com.google.protobuf.AbstractParser<Children>() {
-      @java.lang.Override
       public Children parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Children(input, extensionRegistry);
+          return new Children(input, extensionRegistry);
       }
     };
 
@@ -1598,7 +1543,6 @@ public final class CollectionProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CollectionProto.Children getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -1660,9 +1604,6 @@ public final class CollectionProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1674,6 +1615,13 @@ public final class CollectionProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.CollectionProto.Dump.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -1700,13 +1648,6 @@ public final class CollectionProto {
               bitField0_ |= 0x00000002;
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -1724,7 +1665,6 @@ public final class CollectionProto {
       return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Step_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Step_fieldAccessorTable
@@ -1776,7 +1716,6 @@ public final class CollectionProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1802,7 +1741,6 @@ public final class CollectionProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -1814,7 +1752,6 @@ public final class CollectionProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -1948,7 +1885,6 @@ public final class CollectionProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -1956,7 +1892,6 @@ public final class CollectionProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CollectionProto.Step prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -1980,7 +1915,6 @@ public final class CollectionProto {
         return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Step_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Step_fieldAccessorTable
@@ -2005,7 +1939,6 @@ public final class CollectionProto {
           getRightFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (leftBuilder_ == null) {
@@ -2023,18 +1956,15 @@ public final class CollectionProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Step_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CollectionProto.Step getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CollectionProto.Step.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CollectionProto.Step build() {
         ch.epfl.dedis.proto.CollectionProto.Step result = buildPartial();
         if (!result.isInitialized()) {
@@ -2043,7 +1973,6 @@ public final class CollectionProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CollectionProto.Step buildPartial() {
         ch.epfl.dedis.proto.CollectionProto.Step result = new ch.epfl.dedis.proto.CollectionProto.Step(this);
         int from_bitField0_ = bitField0_;
@@ -2069,39 +1998,32 @@ public final class CollectionProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CollectionProto.Step) {
           return mergeFrom((ch.epfl.dedis.proto.CollectionProto.Step)other);
@@ -2124,7 +2046,6 @@ public final class CollectionProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasLeft()) {
           return false;
@@ -2141,7 +2062,6 @@ public final class CollectionProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2396,13 +2316,11 @@ public final class CollectionProto {
         }
         return rightBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -2424,12 +2342,11 @@ public final class CollectionProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Step>
         PARSER = new com.google.protobuf.AbstractParser<Step>() {
-      @java.lang.Override
       public Step parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Step(input, extensionRegistry);
+          return new Step(input, extensionRegistry);
       }
     };
 
@@ -2442,7 +2359,6 @@ public final class CollectionProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CollectionProto.Step getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -2570,9 +2486,6 @@ public final class CollectionProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -2584,6 +2497,13 @@ public final class CollectionProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               key_ = input.readBytes();
@@ -2611,13 +2531,6 @@ public final class CollectionProto {
                   input.readMessage(ch.epfl.dedis.proto.CollectionProto.Step.PARSER, extensionRegistry));
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -2638,7 +2551,6 @@ public final class CollectionProto {
       return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Proof_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Proof_fieldAccessorTable
@@ -2759,7 +2671,6 @@ public final class CollectionProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -2787,7 +2698,6 @@ public final class CollectionProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -2802,7 +2712,6 @@ public final class CollectionProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -2946,7 +2855,6 @@ public final class CollectionProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -2954,7 +2862,6 @@ public final class CollectionProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.CollectionProto.Proof prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -2982,7 +2889,6 @@ public final class CollectionProto {
         return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Proof_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Proof_fieldAccessorTable
@@ -3007,7 +2913,6 @@ public final class CollectionProto {
           getStepsFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         key_ = com.google.protobuf.ByteString.EMPTY;
@@ -3027,18 +2932,15 @@ public final class CollectionProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.CollectionProto.internal_static_collection_Proof_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CollectionProto.Proof getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.CollectionProto.Proof.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CollectionProto.Proof build() {
         ch.epfl.dedis.proto.CollectionProto.Proof result = buildPartial();
         if (!result.isInitialized()) {
@@ -3047,7 +2949,6 @@ public final class CollectionProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.CollectionProto.Proof buildPartial() {
         ch.epfl.dedis.proto.CollectionProto.Proof result = new ch.epfl.dedis.proto.CollectionProto.Proof(this);
         int from_bitField0_ = bitField0_;
@@ -3078,39 +2979,32 @@ public final class CollectionProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.CollectionProto.Proof) {
           return mergeFrom((ch.epfl.dedis.proto.CollectionProto.Proof)other);
@@ -3159,7 +3053,6 @@ public final class CollectionProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasKey()) {
           return false;
@@ -3178,7 +3071,6 @@ public final class CollectionProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -3714,13 +3606,11 @@ public final class CollectionProto {
         }
         return stepsBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -3742,12 +3632,11 @@ public final class CollectionProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Proof>
         PARSER = new com.google.protobuf.AbstractParser<Proof>() {
-      @java.lang.Override
       public Proof parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Proof(input, extensionRegistry);
+          return new Proof(input, extensionRegistry);
       }
     };
 
@@ -3760,7 +3649,6 @@ public final class CollectionProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.CollectionProto.Proof getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }

--- a/external/java/src/main/java/ch/epfl/dedis/proto/DarcOCSProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/proto/DarcOCSProto.java
@@ -222,9 +222,6 @@ public final class DarcOCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -236,6 +233,13 @@ public final class DarcOCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 owners_ = new java.util.ArrayList<ch.epfl.dedis.proto.DarcOCSProto.Identity>();
@@ -282,13 +286,6 @@ public final class DarcOCSProto {
               bitField0_ |= 0x00000008;
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -312,7 +309,6 @@ public final class DarcOCSProto {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Darc_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Darc_fieldAccessorTable
@@ -539,7 +535,6 @@ public final class DarcOCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -571,7 +566,6 @@ public final class DarcOCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       for (int i = 0; i < owners_.size(); i++) {
@@ -595,7 +589,6 @@ public final class DarcOCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -775,7 +768,6 @@ public final class DarcOCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -783,7 +775,6 @@ public final class DarcOCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcOCSProto.Darc prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -812,7 +803,6 @@ public final class DarcOCSProto {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Darc_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Darc_fieldAccessorTable
@@ -838,7 +828,6 @@ public final class DarcOCSProto {
           getSignatureFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (ownersBuilder_ == null) {
@@ -868,18 +857,15 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Darc_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.Darc getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.Darc.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.Darc build() {
         ch.epfl.dedis.proto.DarcOCSProto.Darc result = buildPartial();
         if (!result.isInitialized()) {
@@ -888,7 +874,6 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.Darc buildPartial() {
         ch.epfl.dedis.proto.DarcOCSProto.Darc result = new ch.epfl.dedis.proto.DarcOCSProto.Darc(this);
         int from_bitField0_ = bitField0_;
@@ -936,39 +921,32 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcOCSProto.Darc) {
           return mergeFrom((ch.epfl.dedis.proto.DarcOCSProto.Darc)other);
@@ -1049,7 +1027,6 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasVersion()) {
           return false;
@@ -1072,7 +1049,6 @@ public final class DarcOCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2032,13 +2008,11 @@ public final class DarcOCSProto {
         }
         return signatureBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -2060,12 +2034,11 @@ public final class DarcOCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Darc>
         PARSER = new com.google.protobuf.AbstractParser<Darc>() {
-      @java.lang.Override
       public Darc parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Darc(input, extensionRegistry);
+          return new Darc(input, extensionRegistry);
       }
     };
 
@@ -2078,7 +2051,6 @@ public final class DarcOCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcOCSProto.Darc getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -2193,9 +2165,6 @@ public final class DarcOCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -2207,6 +2176,13 @@ public final class DarcOCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.DarcOCSProto.IdentityDarc.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -2246,13 +2222,6 @@ public final class DarcOCSProto {
               bitField0_ |= 0x00000004;
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -2270,7 +2239,6 @@ public final class DarcOCSProto {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Identity_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Identity_fieldAccessorTable
@@ -2379,7 +2347,6 @@ public final class DarcOCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -2407,7 +2374,6 @@ public final class DarcOCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -2422,7 +2388,6 @@ public final class DarcOCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -2569,7 +2534,6 @@ public final class DarcOCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -2577,7 +2541,6 @@ public final class DarcOCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcOCSProto.Identity prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -2605,7 +2568,6 @@ public final class DarcOCSProto {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Identity_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Identity_fieldAccessorTable
@@ -2631,7 +2593,6 @@ public final class DarcOCSProto {
           getX509EcFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (darcBuilder_ == null) {
@@ -2655,18 +2616,15 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Identity_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.Identity getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.Identity.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.Identity build() {
         ch.epfl.dedis.proto.DarcOCSProto.Identity result = buildPartial();
         if (!result.isInitialized()) {
@@ -2675,7 +2633,6 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.Identity buildPartial() {
         ch.epfl.dedis.proto.DarcOCSProto.Identity result = new ch.epfl.dedis.proto.DarcOCSProto.Identity(this);
         int from_bitField0_ = bitField0_;
@@ -2709,39 +2666,32 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcOCSProto.Identity) {
           return mergeFrom((ch.epfl.dedis.proto.DarcOCSProto.Identity)other);
@@ -2767,7 +2717,6 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (hasDarc()) {
           if (!getDarc().isInitialized()) {
@@ -2787,7 +2736,6 @@ public final class DarcOCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -3268,13 +3216,11 @@ public final class DarcOCSProto {
         }
         return x509EcBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -3296,12 +3242,11 @@ public final class DarcOCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Identity>
         PARSER = new com.google.protobuf.AbstractParser<Identity>() {
-      @java.lang.Override
       public Identity parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Identity(input, extensionRegistry);
+          return new Identity(input, extensionRegistry);
       }
     };
 
@@ -3314,7 +3259,6 @@ public final class DarcOCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcOCSProto.Identity getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -3364,9 +3308,6 @@ public final class DarcOCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -3378,16 +3319,16 @@ public final class DarcOCSProto {
             case 0:
               done = true;
               break;
-            case 10: {
-              bitField0_ |= 0x00000001;
-              point_ = input.readBytes();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              point_ = input.readBytes();
               break;
             }
           }
@@ -3407,7 +3348,6 @@ public final class DarcOCSProto {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_IdentityEd25519_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_IdentityEd25519_fieldAccessorTable
@@ -3432,7 +3372,6 @@ public final class DarcOCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -3446,7 +3385,6 @@ public final class DarcOCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -3455,7 +3393,6 @@ public final class DarcOCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -3576,7 +3513,6 @@ public final class DarcOCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -3584,7 +3520,6 @@ public final class DarcOCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcOCSProto.IdentityEd25519 prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -3612,7 +3547,6 @@ public final class DarcOCSProto {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_IdentityEd25519_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_IdentityEd25519_fieldAccessorTable
@@ -3635,7 +3569,6 @@ public final class DarcOCSProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         point_ = com.google.protobuf.ByteString.EMPTY;
@@ -3643,18 +3576,15 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_IdentityEd25519_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.IdentityEd25519 getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.IdentityEd25519.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.IdentityEd25519 build() {
         ch.epfl.dedis.proto.DarcOCSProto.IdentityEd25519 result = buildPartial();
         if (!result.isInitialized()) {
@@ -3663,7 +3593,6 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.IdentityEd25519 buildPartial() {
         ch.epfl.dedis.proto.DarcOCSProto.IdentityEd25519 result = new ch.epfl.dedis.proto.DarcOCSProto.IdentityEd25519(this);
         int from_bitField0_ = bitField0_;
@@ -3677,39 +3606,32 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcOCSProto.IdentityEd25519) {
           return mergeFrom((ch.epfl.dedis.proto.DarcOCSProto.IdentityEd25519)other);
@@ -3729,7 +3651,6 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasPoint()) {
           return false;
@@ -3737,7 +3658,6 @@ public final class DarcOCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -3791,13 +3711,11 @@ public final class DarcOCSProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -3819,12 +3737,11 @@ public final class DarcOCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<IdentityEd25519>
         PARSER = new com.google.protobuf.AbstractParser<IdentityEd25519>() {
-      @java.lang.Override
       public IdentityEd25519 parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new IdentityEd25519(input, extensionRegistry);
+          return new IdentityEd25519(input, extensionRegistry);
       }
     };
 
@@ -3837,7 +3754,6 @@ public final class DarcOCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcOCSProto.IdentityEd25519 getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -3887,9 +3803,6 @@ public final class DarcOCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -3901,16 +3814,16 @@ public final class DarcOCSProto {
             case 0:
               done = true;
               break;
-            case 10: {
-              bitField0_ |= 0x00000001;
-              public_ = input.readBytes();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              public_ = input.readBytes();
               break;
             }
           }
@@ -3930,7 +3843,6 @@ public final class DarcOCSProto {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_IdentityX509EC_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_IdentityX509EC_fieldAccessorTable
@@ -3955,7 +3867,6 @@ public final class DarcOCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -3969,7 +3880,6 @@ public final class DarcOCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -3978,7 +3888,6 @@ public final class DarcOCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -4099,7 +4008,6 @@ public final class DarcOCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -4107,7 +4015,6 @@ public final class DarcOCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcOCSProto.IdentityX509EC prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -4135,7 +4042,6 @@ public final class DarcOCSProto {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_IdentityX509EC_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_IdentityX509EC_fieldAccessorTable
@@ -4158,7 +4064,6 @@ public final class DarcOCSProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         public_ = com.google.protobuf.ByteString.EMPTY;
@@ -4166,18 +4071,15 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_IdentityX509EC_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.IdentityX509EC getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.IdentityX509EC.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.IdentityX509EC build() {
         ch.epfl.dedis.proto.DarcOCSProto.IdentityX509EC result = buildPartial();
         if (!result.isInitialized()) {
@@ -4186,7 +4088,6 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.IdentityX509EC buildPartial() {
         ch.epfl.dedis.proto.DarcOCSProto.IdentityX509EC result = new ch.epfl.dedis.proto.DarcOCSProto.IdentityX509EC(this);
         int from_bitField0_ = bitField0_;
@@ -4200,39 +4101,32 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcOCSProto.IdentityX509EC) {
           return mergeFrom((ch.epfl.dedis.proto.DarcOCSProto.IdentityX509EC)other);
@@ -4252,7 +4146,6 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasPublic()) {
           return false;
@@ -4260,7 +4153,6 @@ public final class DarcOCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -4314,13 +4206,11 @@ public final class DarcOCSProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -4342,12 +4232,11 @@ public final class DarcOCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<IdentityX509EC>
         PARSER = new com.google.protobuf.AbstractParser<IdentityX509EC>() {
-      @java.lang.Override
       public IdentityX509EC parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new IdentityX509EC(input, extensionRegistry);
+          return new IdentityX509EC(input, extensionRegistry);
       }
     };
 
@@ -4360,7 +4249,6 @@ public final class DarcOCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcOCSProto.IdentityX509EC getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -4410,9 +4298,6 @@ public final class DarcOCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -4424,16 +4309,16 @@ public final class DarcOCSProto {
             case 0:
               done = true;
               break;
-            case 10: {
-              bitField0_ |= 0x00000001;
-              id_ = input.readBytes();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              id_ = input.readBytes();
               break;
             }
           }
@@ -4453,7 +4338,6 @@ public final class DarcOCSProto {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_IdentityDarc_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_IdentityDarc_fieldAccessorTable
@@ -4478,7 +4362,6 @@ public final class DarcOCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -4492,7 +4375,6 @@ public final class DarcOCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -4501,7 +4383,6 @@ public final class DarcOCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -4622,7 +4503,6 @@ public final class DarcOCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -4630,7 +4510,6 @@ public final class DarcOCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcOCSProto.IdentityDarc prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -4658,7 +4537,6 @@ public final class DarcOCSProto {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_IdentityDarc_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_IdentityDarc_fieldAccessorTable
@@ -4681,7 +4559,6 @@ public final class DarcOCSProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         id_ = com.google.protobuf.ByteString.EMPTY;
@@ -4689,18 +4566,15 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_IdentityDarc_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.IdentityDarc getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.IdentityDarc.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.IdentityDarc build() {
         ch.epfl.dedis.proto.DarcOCSProto.IdentityDarc result = buildPartial();
         if (!result.isInitialized()) {
@@ -4709,7 +4583,6 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.IdentityDarc buildPartial() {
         ch.epfl.dedis.proto.DarcOCSProto.IdentityDarc result = new ch.epfl.dedis.proto.DarcOCSProto.IdentityDarc(this);
         int from_bitField0_ = bitField0_;
@@ -4723,39 +4596,32 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcOCSProto.IdentityDarc) {
           return mergeFrom((ch.epfl.dedis.proto.DarcOCSProto.IdentityDarc)other);
@@ -4775,7 +4641,6 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasId()) {
           return false;
@@ -4783,7 +4648,6 @@ public final class DarcOCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -4837,13 +4701,11 @@ public final class DarcOCSProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -4865,12 +4727,11 @@ public final class DarcOCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<IdentityDarc>
         PARSER = new com.google.protobuf.AbstractParser<IdentityDarc>() {
-      @java.lang.Override
       public IdentityDarc parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new IdentityDarc(input, extensionRegistry);
+          return new IdentityDarc(input, extensionRegistry);
       }
     };
 
@@ -4883,7 +4744,6 @@ public final class DarcOCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcOCSProto.IdentityDarc getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -4967,9 +4827,6 @@ public final class DarcOCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -4981,6 +4838,13 @@ public final class DarcOCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               signature_ = input.readBytes();
@@ -4997,13 +4861,6 @@ public final class DarcOCSProto {
                 signaturepath_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000002;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -5023,7 +4880,6 @@ public final class DarcOCSProto {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Signature_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Signature_fieldAccessorTable
@@ -5089,7 +4945,6 @@ public final class DarcOCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -5111,7 +4966,6 @@ public final class DarcOCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -5123,7 +4977,6 @@ public final class DarcOCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -5257,7 +5110,6 @@ public final class DarcOCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -5265,7 +5117,6 @@ public final class DarcOCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcOCSProto.Signature prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -5294,7 +5145,6 @@ public final class DarcOCSProto {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Signature_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Signature_fieldAccessorTable
@@ -5318,7 +5168,6 @@ public final class DarcOCSProto {
           getSignaturepathFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         signature_ = com.google.protobuf.ByteString.EMPTY;
@@ -5332,18 +5181,15 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Signature_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.Signature getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.Signature.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.Signature build() {
         ch.epfl.dedis.proto.DarcOCSProto.Signature result = buildPartial();
         if (!result.isInitialized()) {
@@ -5352,7 +5198,6 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.Signature buildPartial() {
         ch.epfl.dedis.proto.DarcOCSProto.Signature result = new ch.epfl.dedis.proto.DarcOCSProto.Signature(this);
         int from_bitField0_ = bitField0_;
@@ -5374,39 +5219,32 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcOCSProto.Signature) {
           return mergeFrom((ch.epfl.dedis.proto.DarcOCSProto.Signature)other);
@@ -5429,7 +5267,6 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasSignature()) {
           return false;
@@ -5443,7 +5280,6 @@ public final class DarcOCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -5667,13 +5503,11 @@ public final class DarcOCSProto {
         }
         return signaturepathBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -5695,12 +5529,11 @@ public final class DarcOCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Signature>
         PARSER = new com.google.protobuf.AbstractParser<Signature>() {
-      @java.lang.Override
       public Signature parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Signature(input, extensionRegistry);
+          return new Signature(input, extensionRegistry);
       }
     };
 
@@ -5713,7 +5546,6 @@ public final class DarcOCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcOCSProto.Signature getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -5841,9 +5673,6 @@ public final class DarcOCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -5855,6 +5684,13 @@ public final class DarcOCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 darcs_ = new java.util.ArrayList<ch.epfl.dedis.proto.DarcOCSProto.Darc>();
@@ -5882,13 +5718,6 @@ public final class DarcOCSProto {
               role_ = input.readSInt32();
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -5909,7 +5738,6 @@ public final class DarcOCSProto {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_SignaturePath_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_SignaturePath_fieldAccessorTable
@@ -6030,7 +5858,6 @@ public final class DarcOCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -6058,7 +5885,6 @@ public final class DarcOCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       for (int i = 0; i < darcs_.size(); i++) {
@@ -6073,7 +5899,6 @@ public final class DarcOCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -6217,7 +6042,6 @@ public final class DarcOCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -6225,7 +6049,6 @@ public final class DarcOCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcOCSProto.SignaturePath prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -6253,7 +6076,6 @@ public final class DarcOCSProto {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_SignaturePath_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_SignaturePath_fieldAccessorTable
@@ -6278,7 +6100,6 @@ public final class DarcOCSProto {
           getSignerFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (darcsBuilder_ == null) {
@@ -6298,18 +6119,15 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_SignaturePath_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.SignaturePath getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.SignaturePath.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.SignaturePath build() {
         ch.epfl.dedis.proto.DarcOCSProto.SignaturePath result = buildPartial();
         if (!result.isInitialized()) {
@@ -6318,7 +6136,6 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.SignaturePath buildPartial() {
         ch.epfl.dedis.proto.DarcOCSProto.SignaturePath result = new ch.epfl.dedis.proto.DarcOCSProto.SignaturePath(this);
         int from_bitField0_ = bitField0_;
@@ -6349,39 +6166,32 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcOCSProto.SignaturePath) {
           return mergeFrom((ch.epfl.dedis.proto.DarcOCSProto.SignaturePath)other);
@@ -6430,7 +6240,6 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasSigner()) {
           return false;
@@ -6449,7 +6258,6 @@ public final class DarcOCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -6982,13 +6790,11 @@ public final class DarcOCSProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -7010,12 +6816,11 @@ public final class DarcOCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<SignaturePath>
         PARSER = new com.google.protobuf.AbstractParser<SignaturePath>() {
-      @java.lang.Override
       public SignaturePath parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new SignaturePath(input, extensionRegistry);
+          return new SignaturePath(input, extensionRegistry);
       }
     };
 
@@ -7028,7 +6833,6 @@ public final class DarcOCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcOCSProto.SignaturePath getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -7094,9 +6898,6 @@ public final class DarcOCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -7108,6 +6909,13 @@ public final class DarcOCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.DarcOCSProto.SignerEd25519.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -7134,13 +6942,6 @@ public final class DarcOCSProto {
               bitField0_ |= 0x00000002;
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -7158,7 +6959,6 @@ public final class DarcOCSProto {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Signer_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Signer_fieldAccessorTable
@@ -7210,7 +7010,6 @@ public final class DarcOCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -7232,7 +7031,6 @@ public final class DarcOCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -7244,7 +7042,6 @@ public final class DarcOCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -7378,7 +7175,6 @@ public final class DarcOCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -7386,7 +7182,6 @@ public final class DarcOCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcOCSProto.Signer prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -7414,7 +7209,6 @@ public final class DarcOCSProto {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Signer_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Signer_fieldAccessorTable
@@ -7439,7 +7233,6 @@ public final class DarcOCSProto {
           getX509EcFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (ed25519Builder_ == null) {
@@ -7457,18 +7250,15 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_Signer_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.Signer getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.Signer.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.Signer build() {
         ch.epfl.dedis.proto.DarcOCSProto.Signer result = buildPartial();
         if (!result.isInitialized()) {
@@ -7477,7 +7267,6 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.Signer buildPartial() {
         ch.epfl.dedis.proto.DarcOCSProto.Signer result = new ch.epfl.dedis.proto.DarcOCSProto.Signer(this);
         int from_bitField0_ = bitField0_;
@@ -7503,39 +7292,32 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcOCSProto.Signer) {
           return mergeFrom((ch.epfl.dedis.proto.DarcOCSProto.Signer)other);
@@ -7558,7 +7340,6 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (hasEd25519()) {
           if (!getEd25519().isInitialized()) {
@@ -7573,7 +7354,6 @@ public final class DarcOCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -7828,13 +7608,11 @@ public final class DarcOCSProto {
         }
         return x509EcBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -7856,12 +7634,11 @@ public final class DarcOCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Signer>
         PARSER = new com.google.protobuf.AbstractParser<Signer>() {
-      @java.lang.Override
       public Signer parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Signer(input, extensionRegistry);
+          return new Signer(input, extensionRegistry);
       }
     };
 
@@ -7874,7 +7651,6 @@ public final class DarcOCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcOCSProto.Signer getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -7934,9 +7710,6 @@ public final class DarcOCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -7948,6 +7721,13 @@ public final class DarcOCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               point_ = input.readBytes();
@@ -7956,13 +7736,6 @@ public final class DarcOCSProto {
             case 18: {
               bitField0_ |= 0x00000002;
               secret_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -7982,7 +7755,6 @@ public final class DarcOCSProto {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_SignerEd25519_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_SignerEd25519_fieldAccessorTable
@@ -8022,7 +7794,6 @@ public final class DarcOCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -8040,7 +7811,6 @@ public final class DarcOCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -8052,7 +7822,6 @@ public final class DarcOCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -8186,7 +7955,6 @@ public final class DarcOCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -8194,7 +7962,6 @@ public final class DarcOCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcOCSProto.SignerEd25519 prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -8222,7 +7989,6 @@ public final class DarcOCSProto {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_SignerEd25519_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_SignerEd25519_fieldAccessorTable
@@ -8245,7 +8011,6 @@ public final class DarcOCSProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         point_ = com.google.protobuf.ByteString.EMPTY;
@@ -8255,18 +8020,15 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_SignerEd25519_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.SignerEd25519 getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.SignerEd25519.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.SignerEd25519 build() {
         ch.epfl.dedis.proto.DarcOCSProto.SignerEd25519 result = buildPartial();
         if (!result.isInitialized()) {
@@ -8275,7 +8037,6 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.SignerEd25519 buildPartial() {
         ch.epfl.dedis.proto.DarcOCSProto.SignerEd25519 result = new ch.epfl.dedis.proto.DarcOCSProto.SignerEd25519(this);
         int from_bitField0_ = bitField0_;
@@ -8293,39 +8054,32 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcOCSProto.SignerEd25519) {
           return mergeFrom((ch.epfl.dedis.proto.DarcOCSProto.SignerEd25519)other);
@@ -8348,7 +8102,6 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasPoint()) {
           return false;
@@ -8359,7 +8112,6 @@ public final class DarcOCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -8448,13 +8200,11 @@ public final class DarcOCSProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -8476,12 +8226,11 @@ public final class DarcOCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<SignerEd25519>
         PARSER = new com.google.protobuf.AbstractParser<SignerEd25519>() {
-      @java.lang.Override
       public SignerEd25519 parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new SignerEd25519(input, extensionRegistry);
+          return new SignerEd25519(input, extensionRegistry);
       }
     };
 
@@ -8494,7 +8243,6 @@ public final class DarcOCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcOCSProto.SignerEd25519 getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -8545,9 +8293,6 @@ public final class DarcOCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -8559,16 +8304,16 @@ public final class DarcOCSProto {
             case 0:
               done = true;
               break;
-            case 10: {
-              bitField0_ |= 0x00000001;
-              point_ = input.readBytes();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              point_ = input.readBytes();
               break;
             }
           }
@@ -8588,7 +8333,6 @@ public final class DarcOCSProto {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_SignerX509EC_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_SignerX509EC_fieldAccessorTable
@@ -8613,7 +8357,6 @@ public final class DarcOCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -8627,7 +8370,6 @@ public final class DarcOCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -8636,7 +8378,6 @@ public final class DarcOCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -8757,7 +8498,6 @@ public final class DarcOCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -8765,7 +8505,6 @@ public final class DarcOCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcOCSProto.SignerX509EC prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -8794,7 +8533,6 @@ public final class DarcOCSProto {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_SignerX509EC_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_SignerX509EC_fieldAccessorTable
@@ -8817,7 +8555,6 @@ public final class DarcOCSProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         point_ = com.google.protobuf.ByteString.EMPTY;
@@ -8825,18 +8562,15 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.internal_static_darcOCS_SignerX509EC_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.SignerX509EC getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcOCSProto.SignerX509EC.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.SignerX509EC build() {
         ch.epfl.dedis.proto.DarcOCSProto.SignerX509EC result = buildPartial();
         if (!result.isInitialized()) {
@@ -8845,7 +8579,6 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcOCSProto.SignerX509EC buildPartial() {
         ch.epfl.dedis.proto.DarcOCSProto.SignerX509EC result = new ch.epfl.dedis.proto.DarcOCSProto.SignerX509EC(this);
         int from_bitField0_ = bitField0_;
@@ -8859,39 +8592,32 @@ public final class DarcOCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcOCSProto.SignerX509EC) {
           return mergeFrom((ch.epfl.dedis.proto.DarcOCSProto.SignerX509EC)other);
@@ -8911,7 +8637,6 @@ public final class DarcOCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasPoint()) {
           return false;
@@ -8919,7 +8644,6 @@ public final class DarcOCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -8973,13 +8697,11 @@ public final class DarcOCSProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -9001,12 +8723,11 @@ public final class DarcOCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<SignerX509EC>
         PARSER = new com.google.protobuf.AbstractParser<SignerX509EC>() {
-      @java.lang.Override
       public SignerX509EC parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new SignerX509EC(input, extensionRegistry);
+          return new SignerX509EC(input, extensionRegistry);
       }
     };
 
@@ -9019,7 +8740,6 @@ public final class DarcOCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcOCSProto.SignerX509EC getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -9094,7 +8814,7 @@ public final class DarcOCSProto {
       "yDarc\022)\n\007ed25519\030\002 \001(\0132\030.darcOCS.Identit" +
       "yEd25519\022\'\n\006x509ec\030\003 \001(\0132\027.darcOCS.Ident" +
       "ityX509EC\" \n\017IdentityEd25519\022\r\n\005point\030\001 " +
-      "\002(\014\" \n\016IdentityX509EC\022\016\n\006public\030\001 \002(\014\"\032\n" +
+      "\002(\014\" \n\016IdentityX509EC\022\016\n\006public\030\001 \002(\014\"\032\n",
       "\014IdentityDarc\022\n\n\002id\030\001 \002(\014\"M\n\tSignature\022\021" +
       "\n\tsignature\030\001 \002(\014\022-\n\rsignaturepath\030\002 \002(\013" +
       "2\026.darcOCS.SignaturePath\"^\n\rSignaturePat" +
@@ -9104,7 +8824,7 @@ public final class DarcOCSProto {
       "gnerEd25519\022%\n\006x509ec\030\002 \001(\0132\025.darcOCS.Si" +
       "gnerX509EC\".\n\rSignerEd25519\022\r\n\005point\030\001 \002" +
       "(\014\022\016\n\006secret\030\002 \002(\014\"\035\n\014SignerX509EC\022\r\n\005po" +
-      "int\030\001 \002(\014B#\n\023ch.epfl.dedis.protoB\014DarcOC" +
+      "int\030\001 \002(\014B#\n\023ch.epfl.dedis.protoB\014DarcOC",
       "SProto"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =

--- a/external/java/src/main/java/ch/epfl/dedis/proto/DarcProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/proto/DarcProto.java
@@ -264,9 +264,6 @@ public final class DarcProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -278,6 +275,13 @@ public final class DarcProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 8: {
               bitField0_ |= 0x00000001;
               version_ = input.readUInt64();
@@ -329,13 +333,6 @@ public final class DarcProto {
                   input.readMessage(ch.epfl.dedis.proto.DarcProto.Darc.PARSER, extensionRegistry));
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -359,7 +356,6 @@ public final class DarcProto {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Darc_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Darc_fieldAccessorTable
@@ -632,7 +628,6 @@ public final class DarcProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -674,7 +669,6 @@ public final class DarcProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -701,7 +695,6 @@ public final class DarcProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -895,7 +888,6 @@ public final class DarcProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -903,7 +895,6 @@ public final class DarcProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcProto.Darc prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -933,7 +924,6 @@ public final class DarcProto {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Darc_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Darc_fieldAccessorTable
@@ -959,7 +949,6 @@ public final class DarcProto {
           getVerificationdarcsFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         version_ = 0L;
@@ -991,18 +980,15 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Darc_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Darc getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcProto.Darc.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Darc build() {
         ch.epfl.dedis.proto.DarcProto.Darc result = buildPartial();
         if (!result.isInitialized()) {
@@ -1011,7 +997,6 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Darc buildPartial() {
         ch.epfl.dedis.proto.DarcProto.Darc result = new ch.epfl.dedis.proto.DarcProto.Darc(this);
         int from_bitField0_ = bitField0_;
@@ -1063,39 +1048,32 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcProto.Darc) {
           return mergeFrom((ch.epfl.dedis.proto.DarcProto.Darc)other);
@@ -1179,7 +1157,6 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasVersion()) {
           return false;
@@ -1209,7 +1186,6 @@ public final class DarcProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2295,13 +2271,11 @@ public final class DarcProto {
         }
         return verificationdarcsBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -2323,12 +2297,11 @@ public final class DarcProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Darc>
         PARSER = new com.google.protobuf.AbstractParser<Darc>() {
-      @java.lang.Override
       public Darc parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Darc(input, extensionRegistry);
+          return new Darc(input, extensionRegistry);
       }
     };
 
@@ -2341,7 +2314,6 @@ public final class DarcProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcProto.Darc getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -2457,9 +2429,6 @@ public final class DarcProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -2471,6 +2440,13 @@ public final class DarcProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.DarcProto.IdentityDarc.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -2510,13 +2486,6 @@ public final class DarcProto {
               bitField0_ |= 0x00000004;
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -2534,7 +2503,6 @@ public final class DarcProto {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Identity_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Identity_fieldAccessorTable
@@ -2643,7 +2611,6 @@ public final class DarcProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -2671,7 +2638,6 @@ public final class DarcProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -2686,7 +2652,6 @@ public final class DarcProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -2833,7 +2798,6 @@ public final class DarcProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -2841,7 +2805,6 @@ public final class DarcProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcProto.Identity prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -2870,7 +2833,6 @@ public final class DarcProto {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Identity_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Identity_fieldAccessorTable
@@ -2896,7 +2858,6 @@ public final class DarcProto {
           getX509EcFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (darcBuilder_ == null) {
@@ -2920,18 +2881,15 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Identity_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Identity getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcProto.Identity.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Identity build() {
         ch.epfl.dedis.proto.DarcProto.Identity result = buildPartial();
         if (!result.isInitialized()) {
@@ -2940,7 +2898,6 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Identity buildPartial() {
         ch.epfl.dedis.proto.DarcProto.Identity result = new ch.epfl.dedis.proto.DarcProto.Identity(this);
         int from_bitField0_ = bitField0_;
@@ -2974,39 +2931,32 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcProto.Identity) {
           return mergeFrom((ch.epfl.dedis.proto.DarcProto.Identity)other);
@@ -3032,7 +2982,6 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (hasDarc()) {
           if (!getDarc().isInitialized()) {
@@ -3052,7 +3001,6 @@ public final class DarcProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -3533,13 +3481,11 @@ public final class DarcProto {
         }
         return x509EcBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -3561,12 +3507,11 @@ public final class DarcProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Identity>
         PARSER = new com.google.protobuf.AbstractParser<Identity>() {
-      @java.lang.Override
       public Identity parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Identity(input, extensionRegistry);
+          return new Identity(input, extensionRegistry);
       }
     };
 
@@ -3579,7 +3524,6 @@ public final class DarcProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcProto.Identity getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -3629,9 +3573,6 @@ public final class DarcProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -3643,16 +3584,16 @@ public final class DarcProto {
             case 0:
               done = true;
               break;
-            case 10: {
-              bitField0_ |= 0x00000001;
-              point_ = input.readBytes();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              point_ = input.readBytes();
               break;
             }
           }
@@ -3672,7 +3613,6 @@ public final class DarcProto {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_IdentityEd25519_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_IdentityEd25519_fieldAccessorTable
@@ -3697,7 +3637,6 @@ public final class DarcProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -3711,7 +3650,6 @@ public final class DarcProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -3720,7 +3658,6 @@ public final class DarcProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -3841,7 +3778,6 @@ public final class DarcProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -3849,7 +3785,6 @@ public final class DarcProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcProto.IdentityEd25519 prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -3877,7 +3812,6 @@ public final class DarcProto {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_IdentityEd25519_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_IdentityEd25519_fieldAccessorTable
@@ -3900,7 +3834,6 @@ public final class DarcProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         point_ = com.google.protobuf.ByteString.EMPTY;
@@ -3908,18 +3841,15 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_IdentityEd25519_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.IdentityEd25519 getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcProto.IdentityEd25519.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.IdentityEd25519 build() {
         ch.epfl.dedis.proto.DarcProto.IdentityEd25519 result = buildPartial();
         if (!result.isInitialized()) {
@@ -3928,7 +3858,6 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.IdentityEd25519 buildPartial() {
         ch.epfl.dedis.proto.DarcProto.IdentityEd25519 result = new ch.epfl.dedis.proto.DarcProto.IdentityEd25519(this);
         int from_bitField0_ = bitField0_;
@@ -3942,39 +3871,32 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcProto.IdentityEd25519) {
           return mergeFrom((ch.epfl.dedis.proto.DarcProto.IdentityEd25519)other);
@@ -3994,7 +3916,6 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasPoint()) {
           return false;
@@ -4002,7 +3923,6 @@ public final class DarcProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -4056,13 +3976,11 @@ public final class DarcProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -4084,12 +4002,11 @@ public final class DarcProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<IdentityEd25519>
         PARSER = new com.google.protobuf.AbstractParser<IdentityEd25519>() {
-      @java.lang.Override
       public IdentityEd25519 parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new IdentityEd25519(input, extensionRegistry);
+          return new IdentityEd25519(input, extensionRegistry);
       }
     };
 
@@ -4102,7 +4019,6 @@ public final class DarcProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcProto.IdentityEd25519 getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -4152,9 +4068,6 @@ public final class DarcProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -4166,16 +4079,16 @@ public final class DarcProto {
             case 0:
               done = true;
               break;
-            case 10: {
-              bitField0_ |= 0x00000001;
-              public_ = input.readBytes();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              public_ = input.readBytes();
               break;
             }
           }
@@ -4195,7 +4108,6 @@ public final class DarcProto {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_IdentityX509EC_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_IdentityX509EC_fieldAccessorTable
@@ -4220,7 +4132,6 @@ public final class DarcProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -4234,7 +4145,6 @@ public final class DarcProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -4243,7 +4153,6 @@ public final class DarcProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -4364,7 +4273,6 @@ public final class DarcProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -4372,7 +4280,6 @@ public final class DarcProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcProto.IdentityX509EC prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -4400,7 +4307,6 @@ public final class DarcProto {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_IdentityX509EC_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_IdentityX509EC_fieldAccessorTable
@@ -4423,7 +4329,6 @@ public final class DarcProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         public_ = com.google.protobuf.ByteString.EMPTY;
@@ -4431,18 +4336,15 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_IdentityX509EC_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.IdentityX509EC getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcProto.IdentityX509EC.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.IdentityX509EC build() {
         ch.epfl.dedis.proto.DarcProto.IdentityX509EC result = buildPartial();
         if (!result.isInitialized()) {
@@ -4451,7 +4353,6 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.IdentityX509EC buildPartial() {
         ch.epfl.dedis.proto.DarcProto.IdentityX509EC result = new ch.epfl.dedis.proto.DarcProto.IdentityX509EC(this);
         int from_bitField0_ = bitField0_;
@@ -4465,39 +4366,32 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcProto.IdentityX509EC) {
           return mergeFrom((ch.epfl.dedis.proto.DarcProto.IdentityX509EC)other);
@@ -4517,7 +4411,6 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasPublic()) {
           return false;
@@ -4525,7 +4418,6 @@ public final class DarcProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -4579,13 +4471,11 @@ public final class DarcProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -4607,12 +4497,11 @@ public final class DarcProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<IdentityX509EC>
         PARSER = new com.google.protobuf.AbstractParser<IdentityX509EC>() {
-      @java.lang.Override
       public IdentityX509EC parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new IdentityX509EC(input, extensionRegistry);
+          return new IdentityX509EC(input, extensionRegistry);
       }
     };
 
@@ -4625,7 +4514,6 @@ public final class DarcProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcProto.IdentityX509EC getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -4684,9 +4572,6 @@ public final class DarcProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -4698,16 +4583,16 @@ public final class DarcProto {
             case 0:
               done = true;
               break;
-            case 10: {
-              bitField0_ |= 0x00000001;
-              id_ = input.readBytes();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              id_ = input.readBytes();
               break;
             }
           }
@@ -4727,7 +4612,6 @@ public final class DarcProto {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_IdentityDarc_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_IdentityDarc_fieldAccessorTable
@@ -4760,7 +4644,6 @@ public final class DarcProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -4774,7 +4657,6 @@ public final class DarcProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -4783,7 +4665,6 @@ public final class DarcProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -4904,7 +4785,6 @@ public final class DarcProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -4912,7 +4792,6 @@ public final class DarcProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcProto.IdentityDarc prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -4941,7 +4820,6 @@ public final class DarcProto {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_IdentityDarc_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_IdentityDarc_fieldAccessorTable
@@ -4964,7 +4842,6 @@ public final class DarcProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         id_ = com.google.protobuf.ByteString.EMPTY;
@@ -4972,18 +4849,15 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_IdentityDarc_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.IdentityDarc getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcProto.IdentityDarc.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.IdentityDarc build() {
         ch.epfl.dedis.proto.DarcProto.IdentityDarc result = buildPartial();
         if (!result.isInitialized()) {
@@ -4992,7 +4866,6 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.IdentityDarc buildPartial() {
         ch.epfl.dedis.proto.DarcProto.IdentityDarc result = new ch.epfl.dedis.proto.DarcProto.IdentityDarc(this);
         int from_bitField0_ = bitField0_;
@@ -5006,39 +4879,32 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcProto.IdentityDarc) {
           return mergeFrom((ch.epfl.dedis.proto.DarcProto.IdentityDarc)other);
@@ -5058,7 +4924,6 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasId()) {
           return false;
@@ -5066,7 +4931,6 @@ public final class DarcProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -5136,13 +5000,11 @@ public final class DarcProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -5164,12 +5026,11 @@ public final class DarcProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<IdentityDarc>
         PARSER = new com.google.protobuf.AbstractParser<IdentityDarc>() {
-      @java.lang.Override
       public IdentityDarc parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new IdentityDarc(input, extensionRegistry);
+          return new IdentityDarc(input, extensionRegistry);
       }
     };
 
@@ -5182,7 +5043,6 @@ public final class DarcProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcProto.IdentityDarc getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -5266,9 +5126,6 @@ public final class DarcProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -5280,6 +5137,13 @@ public final class DarcProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               signature_ = input.readBytes();
@@ -5296,13 +5160,6 @@ public final class DarcProto {
                 signer_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000002;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -5322,7 +5179,6 @@ public final class DarcProto {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Signature_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Signature_fieldAccessorTable
@@ -5388,7 +5244,6 @@ public final class DarcProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -5410,7 +5265,6 @@ public final class DarcProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -5422,7 +5276,6 @@ public final class DarcProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -5556,7 +5409,6 @@ public final class DarcProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -5564,7 +5416,6 @@ public final class DarcProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcProto.Signature prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -5593,7 +5444,6 @@ public final class DarcProto {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Signature_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Signature_fieldAccessorTable
@@ -5617,7 +5467,6 @@ public final class DarcProto {
           getSignerFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         signature_ = com.google.protobuf.ByteString.EMPTY;
@@ -5631,18 +5480,15 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Signature_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Signature getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcProto.Signature.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Signature build() {
         ch.epfl.dedis.proto.DarcProto.Signature result = buildPartial();
         if (!result.isInitialized()) {
@@ -5651,7 +5497,6 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Signature buildPartial() {
         ch.epfl.dedis.proto.DarcProto.Signature result = new ch.epfl.dedis.proto.DarcProto.Signature(this);
         int from_bitField0_ = bitField0_;
@@ -5673,39 +5518,32 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcProto.Signature) {
           return mergeFrom((ch.epfl.dedis.proto.DarcProto.Signature)other);
@@ -5728,7 +5566,6 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasSignature()) {
           return false;
@@ -5742,7 +5579,6 @@ public final class DarcProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -5966,13 +5802,11 @@ public final class DarcProto {
         }
         return signerBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -5994,12 +5828,11 @@ public final class DarcProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Signature>
         PARSER = new com.google.protobuf.AbstractParser<Signature>() {
-      @java.lang.Override
       public Signature parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Signature(input, extensionRegistry);
+          return new Signature(input, extensionRegistry);
       }
     };
 
@@ -6012,7 +5845,6 @@ public final class DarcProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcProto.Signature getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -6078,9 +5910,6 @@ public final class DarcProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -6092,6 +5921,13 @@ public final class DarcProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.DarcProto.SignerEd25519.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -6118,13 +5954,6 @@ public final class DarcProto {
               bitField0_ |= 0x00000002;
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -6142,7 +5971,6 @@ public final class DarcProto {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Signer_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Signer_fieldAccessorTable
@@ -6194,7 +6022,6 @@ public final class DarcProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -6216,7 +6043,6 @@ public final class DarcProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -6228,7 +6054,6 @@ public final class DarcProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -6362,7 +6187,6 @@ public final class DarcProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -6370,7 +6194,6 @@ public final class DarcProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcProto.Signer prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -6398,7 +6221,6 @@ public final class DarcProto {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Signer_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Signer_fieldAccessorTable
@@ -6423,7 +6245,6 @@ public final class DarcProto {
           getX509EcFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (ed25519Builder_ == null) {
@@ -6441,18 +6262,15 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Signer_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Signer getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcProto.Signer.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Signer build() {
         ch.epfl.dedis.proto.DarcProto.Signer result = buildPartial();
         if (!result.isInitialized()) {
@@ -6461,7 +6279,6 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Signer buildPartial() {
         ch.epfl.dedis.proto.DarcProto.Signer result = new ch.epfl.dedis.proto.DarcProto.Signer(this);
         int from_bitField0_ = bitField0_;
@@ -6487,39 +6304,32 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcProto.Signer) {
           return mergeFrom((ch.epfl.dedis.proto.DarcProto.Signer)other);
@@ -6542,7 +6352,6 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (hasEd25519()) {
           if (!getEd25519().isInitialized()) {
@@ -6557,7 +6366,6 @@ public final class DarcProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -6812,13 +6620,11 @@ public final class DarcProto {
         }
         return x509EcBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -6840,12 +6646,11 @@ public final class DarcProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Signer>
         PARSER = new com.google.protobuf.AbstractParser<Signer>() {
-      @java.lang.Override
       public Signer parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Signer(input, extensionRegistry);
+          return new Signer(input, extensionRegistry);
       }
     };
 
@@ -6858,7 +6663,6 @@ public final class DarcProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcProto.Signer getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -6918,9 +6722,6 @@ public final class DarcProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -6932,6 +6733,13 @@ public final class DarcProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               point_ = input.readBytes();
@@ -6940,13 +6748,6 @@ public final class DarcProto {
             case 18: {
               bitField0_ |= 0x00000002;
               secret_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -6966,7 +6767,6 @@ public final class DarcProto {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_SignerEd25519_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_SignerEd25519_fieldAccessorTable
@@ -7006,7 +6806,6 @@ public final class DarcProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -7024,7 +6823,6 @@ public final class DarcProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -7036,7 +6834,6 @@ public final class DarcProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -7170,7 +6967,6 @@ public final class DarcProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -7178,7 +6974,6 @@ public final class DarcProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcProto.SignerEd25519 prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -7206,7 +7001,6 @@ public final class DarcProto {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_SignerEd25519_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_SignerEd25519_fieldAccessorTable
@@ -7229,7 +7023,6 @@ public final class DarcProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         point_ = com.google.protobuf.ByteString.EMPTY;
@@ -7239,18 +7032,15 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_SignerEd25519_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.SignerEd25519 getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcProto.SignerEd25519.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.SignerEd25519 build() {
         ch.epfl.dedis.proto.DarcProto.SignerEd25519 result = buildPartial();
         if (!result.isInitialized()) {
@@ -7259,7 +7049,6 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.SignerEd25519 buildPartial() {
         ch.epfl.dedis.proto.DarcProto.SignerEd25519 result = new ch.epfl.dedis.proto.DarcProto.SignerEd25519(this);
         int from_bitField0_ = bitField0_;
@@ -7277,39 +7066,32 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcProto.SignerEd25519) {
           return mergeFrom((ch.epfl.dedis.proto.DarcProto.SignerEd25519)other);
@@ -7332,7 +7114,6 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasPoint()) {
           return false;
@@ -7343,7 +7124,6 @@ public final class DarcProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -7432,13 +7212,11 @@ public final class DarcProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -7460,12 +7238,11 @@ public final class DarcProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<SignerEd25519>
         PARSER = new com.google.protobuf.AbstractParser<SignerEd25519>() {
-      @java.lang.Override
       public SignerEd25519 parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new SignerEd25519(input, extensionRegistry);
+          return new SignerEd25519(input, extensionRegistry);
       }
     };
 
@@ -7478,7 +7255,6 @@ public final class DarcProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcProto.SignerEd25519 getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -7529,9 +7305,6 @@ public final class DarcProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -7543,16 +7316,16 @@ public final class DarcProto {
             case 0:
               done = true;
               break;
-            case 10: {
-              bitField0_ |= 0x00000001;
-              point_ = input.readBytes();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              point_ = input.readBytes();
               break;
             }
           }
@@ -7572,7 +7345,6 @@ public final class DarcProto {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_SignerX509EC_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_SignerX509EC_fieldAccessorTable
@@ -7597,7 +7369,6 @@ public final class DarcProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -7611,7 +7382,6 @@ public final class DarcProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -7620,7 +7390,6 @@ public final class DarcProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -7741,7 +7510,6 @@ public final class DarcProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -7749,7 +7517,6 @@ public final class DarcProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcProto.SignerX509EC prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -7778,7 +7545,6 @@ public final class DarcProto {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_SignerX509EC_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_SignerX509EC_fieldAccessorTable
@@ -7801,7 +7567,6 @@ public final class DarcProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         point_ = com.google.protobuf.ByteString.EMPTY;
@@ -7809,18 +7574,15 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_SignerX509EC_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.SignerX509EC getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcProto.SignerX509EC.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.SignerX509EC build() {
         ch.epfl.dedis.proto.DarcProto.SignerX509EC result = buildPartial();
         if (!result.isInitialized()) {
@@ -7829,7 +7591,6 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.SignerX509EC buildPartial() {
         ch.epfl.dedis.proto.DarcProto.SignerX509EC result = new ch.epfl.dedis.proto.DarcProto.SignerX509EC(this);
         int from_bitField0_ = bitField0_;
@@ -7843,39 +7604,32 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcProto.SignerX509EC) {
           return mergeFrom((ch.epfl.dedis.proto.DarcProto.SignerX509EC)other);
@@ -7895,7 +7649,6 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasPoint()) {
           return false;
@@ -7903,7 +7656,6 @@ public final class DarcProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -7957,13 +7709,11 @@ public final class DarcProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -7985,12 +7735,11 @@ public final class DarcProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<SignerX509EC>
         PARSER = new com.google.protobuf.AbstractParser<SignerX509EC>() {
-      @java.lang.Override
       public SignerX509EC parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new SignerX509EC(input, extensionRegistry);
+          return new SignerX509EC(input, extensionRegistry);
       }
     };
 
@@ -8003,7 +7752,6 @@ public final class DarcProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcProto.SignerX509EC getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -8117,9 +7865,6 @@ public final class DarcProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -8131,6 +7876,13 @@ public final class DarcProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               baseid_ = input.readBytes();
@@ -8164,13 +7916,6 @@ public final class DarcProto {
               signatures_.add(input.readBytes());
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -8194,7 +7939,6 @@ public final class DarcProto {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Request_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Request_fieldAccessorTable
@@ -8333,7 +8077,6 @@ public final class DarcProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -8361,7 +8104,6 @@ public final class DarcProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -8382,7 +8124,6 @@ public final class DarcProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -8553,7 +8294,6 @@ public final class DarcProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -8561,7 +8301,6 @@ public final class DarcProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcProto.Request prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -8589,7 +8328,6 @@ public final class DarcProto {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Request_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Request_fieldAccessorTable
@@ -8613,7 +8351,6 @@ public final class DarcProto {
           getIdentitiesFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         baseid_ = com.google.protobuf.ByteString.EMPTY;
@@ -8633,18 +8370,15 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Request_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Request getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcProto.Request.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Request build() {
         ch.epfl.dedis.proto.DarcProto.Request result = buildPartial();
         if (!result.isInitialized()) {
@@ -8653,7 +8387,6 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Request buildPartial() {
         ch.epfl.dedis.proto.DarcProto.Request result = new ch.epfl.dedis.proto.DarcProto.Request(this);
         int from_bitField0_ = bitField0_;
@@ -8689,39 +8422,32 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcProto.Request) {
           return mergeFrom((ch.epfl.dedis.proto.DarcProto.Request)other);
@@ -8785,7 +8511,6 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasBaseid()) {
           return false;
@@ -8804,7 +8529,6 @@ public final class DarcProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -9281,13 +9005,11 @@ public final class DarcProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -9309,12 +9031,11 @@ public final class DarcProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Request>
         PARSER = new com.google.protobuf.AbstractParser<Request>() {
-      @java.lang.Override
       public Request parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Request(input, extensionRegistry);
+          return new Request(input, extensionRegistry);
       }
     };
 
@@ -9327,7 +9048,6 @@ public final class DarcProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcProto.Request getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -9364,7 +9084,7 @@ public final class DarcProto {
   }
   /**
    * <pre>
-   * Rules are action-expression associations.
+   * Rules is a list of action-expression associations.
    * </pre>
    *
    * Protobuf type {@code darc.Rules}
@@ -9392,9 +9112,6 @@ public final class DarcProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -9406,6 +9123,13 @@ public final class DarcProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 list_ = new java.util.ArrayList<ch.epfl.dedis.proto.DarcProto.Rule>();
@@ -9413,13 +9137,6 @@ public final class DarcProto {
               }
               list_.add(
                   input.readMessage(ch.epfl.dedis.proto.DarcProto.Rule.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -9442,7 +9159,6 @@ public final class DarcProto {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Rules_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Rules_fieldAccessorTable
@@ -9486,7 +9202,6 @@ public final class DarcProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -9502,7 +9217,6 @@ public final class DarcProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       for (int i = 0; i < list_.size(); i++) {
@@ -9511,7 +9225,6 @@ public final class DarcProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -9629,7 +9342,6 @@ public final class DarcProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -9637,7 +9349,6 @@ public final class DarcProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcProto.Rules prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -9651,7 +9362,7 @@ public final class DarcProto {
     }
     /**
      * <pre>
-     * Rules are action-expression associations.
+     * Rules is a list of action-expression associations.
      * </pre>
      *
      * Protobuf type {@code darc.Rules}
@@ -9665,7 +9376,6 @@ public final class DarcProto {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Rules_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Rules_fieldAccessorTable
@@ -9689,7 +9399,6 @@ public final class DarcProto {
           getListFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (listBuilder_ == null) {
@@ -9701,18 +9410,15 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Rules_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Rules getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcProto.Rules.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Rules build() {
         ch.epfl.dedis.proto.DarcProto.Rules result = buildPartial();
         if (!result.isInitialized()) {
@@ -9721,7 +9427,6 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Rules buildPartial() {
         ch.epfl.dedis.proto.DarcProto.Rules result = new ch.epfl.dedis.proto.DarcProto.Rules(this);
         int from_bitField0_ = bitField0_;
@@ -9738,39 +9443,32 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcProto.Rules) {
           return mergeFrom((ch.epfl.dedis.proto.DarcProto.Rules)other);
@@ -9813,7 +9511,6 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         for (int i = 0; i < getListCount(); i++) {
           if (!getList(i).isInitialized()) {
@@ -9823,7 +9520,6 @@ public final class DarcProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -10082,13 +9778,11 @@ public final class DarcProto {
         }
         return listBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -10110,12 +9804,11 @@ public final class DarcProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Rules>
         PARSER = new com.google.protobuf.AbstractParser<Rules>() {
-      @java.lang.Override
       public Rules parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Rules(input, extensionRegistry);
+          return new Rules(input, extensionRegistry);
       }
     };
 
@@ -10128,7 +9821,6 @@ public final class DarcProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcProto.Rules getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -10193,9 +9885,6 @@ public final class DarcProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -10207,6 +9896,13 @@ public final class DarcProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
@@ -10216,13 +9912,6 @@ public final class DarcProto {
             case 18: {
               bitField0_ |= 0x00000002;
               expr_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -10242,7 +9931,6 @@ public final class DarcProto {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Rule_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Rule_fieldAccessorTable
@@ -10309,7 +9997,6 @@ public final class DarcProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -10327,7 +10014,6 @@ public final class DarcProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -10339,7 +10025,6 @@ public final class DarcProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -10472,7 +10157,6 @@ public final class DarcProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -10480,7 +10164,6 @@ public final class DarcProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.DarcProto.Rule prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -10508,7 +10191,6 @@ public final class DarcProto {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Rule_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Rule_fieldAccessorTable
@@ -10531,7 +10213,6 @@ public final class DarcProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         action_ = "";
@@ -10541,18 +10222,15 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.DarcProto.internal_static_darc_Rule_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Rule getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.DarcProto.Rule.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Rule build() {
         ch.epfl.dedis.proto.DarcProto.Rule result = buildPartial();
         if (!result.isInitialized()) {
@@ -10561,7 +10239,6 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.DarcProto.Rule buildPartial() {
         ch.epfl.dedis.proto.DarcProto.Rule result = new ch.epfl.dedis.proto.DarcProto.Rule(this);
         int from_bitField0_ = bitField0_;
@@ -10579,39 +10256,32 @@ public final class DarcProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.DarcProto.Rule) {
           return mergeFrom((ch.epfl.dedis.proto.DarcProto.Rule)other);
@@ -10636,7 +10306,6 @@ public final class DarcProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasAction()) {
           return false;
@@ -10647,7 +10316,6 @@ public final class DarcProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -10777,13 +10445,11 @@ public final class DarcProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -10805,12 +10471,11 @@ public final class DarcProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Rule>
         PARSER = new com.google.protobuf.AbstractParser<Rule>() {
-      @java.lang.Override
       public Rule parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Rule(input, extensionRegistry);
+          return new Rule(input, extensionRegistry);
       }
     };
 
@@ -10823,7 +10488,6 @@ public final class DarcProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.DarcProto.Rule getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -10908,7 +10572,7 @@ public final class DarcProto {
       "ityDarc\022&\n\007ed25519\030\002 \001(\0132\025.darc.Identity" +
       "Ed25519\022$\n\006x509ec\030\003 \001(\0132\024.darc.IdentityX" +
       "509EC\" \n\017IdentityEd25519\022\r\n\005point\030\001 \002(\014\"" +
-      " \n\016IdentityX509EC\022\016\n\006public\030\001 \002(\014\"\032\n\014Ide" +
+      " \n\016IdentityX509EC\022\016\n\006public\030\001 \002(\014\"\032\n\014Ide",
       "ntityDarc\022\n\n\002id\030\001 \002(\014\">\n\tSignature\022\021\n\tsi" +
       "gnature\030\001 \002(\014\022\036\n\006signer\030\002 \002(\0132\016.darc.Ide" +
       "ntity\"R\n\006Signer\022$\n\007ed25519\030\001 \001(\0132\023.darc." +
@@ -10918,7 +10582,7 @@ public final class DarcProto {
       "nt\030\001 \002(\014\"n\n\007Request\022\016\n\006baseid\030\001 \002(\014\022\016\n\006a" +
       "ction\030\002 \002(\t\022\013\n\003msg\030\003 \002(\014\022\"\n\nidentities\030\004" +
       " \003(\0132\016.darc.Identity\022\022\n\nsignatures\030\005 \003(\014" +
-      "\"!\n\005Rules\022\030\n\004list\030\001 \003(\0132\n.darc.Rule\"$\n\004R" +
+      "\"!\n\005Rules\022\030\n\004list\030\001 \003(\0132\n.darc.Rule\"$\n\004R",
       "ule\022\016\n\006action\030\001 \002(\t\022\014\n\004expr\030\002 \002(\014B \n\023ch." +
       "epfl.dedis.protoB\tDarcProto"
     };

--- a/external/java/src/main/java/ch/epfl/dedis/proto/EventLogProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/proto/EventLogProto.java
@@ -133,9 +133,6 @@ public final class EventLogProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -147,6 +144,13 @@ public final class EventLogProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               instance_ = input.readBytes();
@@ -173,13 +177,6 @@ public final class EventLogProto {
               to_ = input.readSInt64();
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -197,7 +194,6 @@ public final class EventLogProto {
       return ch.epfl.dedis.proto.EventLogProto.internal_static_eventlog_SearchRequest_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.EventLogProto.internal_static_eventlog_SearchRequest_fieldAccessorTable
@@ -337,7 +333,6 @@ public final class EventLogProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -367,7 +362,6 @@ public final class EventLogProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -388,7 +382,6 @@ public final class EventLogProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -562,7 +555,6 @@ public final class EventLogProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -570,7 +562,6 @@ public final class EventLogProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.EventLogProto.SearchRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -601,7 +592,6 @@ public final class EventLogProto {
         return ch.epfl.dedis.proto.EventLogProto.internal_static_eventlog_SearchRequest_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.EventLogProto.internal_static_eventlog_SearchRequest_fieldAccessorTable
@@ -624,7 +614,6 @@ public final class EventLogProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         instance_ = com.google.protobuf.ByteString.EMPTY;
@@ -640,18 +629,15 @@ public final class EventLogProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.EventLogProto.internal_static_eventlog_SearchRequest_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.EventLogProto.SearchRequest getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.EventLogProto.SearchRequest.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.EventLogProto.SearchRequest build() {
         ch.epfl.dedis.proto.EventLogProto.SearchRequest result = buildPartial();
         if (!result.isInitialized()) {
@@ -660,7 +646,6 @@ public final class EventLogProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.EventLogProto.SearchRequest buildPartial() {
         ch.epfl.dedis.proto.EventLogProto.SearchRequest result = new ch.epfl.dedis.proto.EventLogProto.SearchRequest(this);
         int from_bitField0_ = bitField0_;
@@ -690,39 +675,32 @@ public final class EventLogProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.EventLogProto.SearchRequest) {
           return mergeFrom((ch.epfl.dedis.proto.EventLogProto.SearchRequest)other);
@@ -756,7 +734,6 @@ public final class EventLogProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasInstance()) {
           return false;
@@ -776,7 +753,6 @@ public final class EventLogProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1061,13 +1037,11 @@ public final class EventLogProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -1089,12 +1063,11 @@ public final class EventLogProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<SearchRequest>
         PARSER = new com.google.protobuf.AbstractParser<SearchRequest>() {
-      @java.lang.Override
       public SearchRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new SearchRequest(input, extensionRegistry);
+          return new SearchRequest(input, extensionRegistry);
       }
     };
 
@@ -1107,7 +1080,6 @@ public final class EventLogProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.EventLogProto.SearchRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -1194,9 +1166,6 @@ public final class EventLogProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1208,6 +1177,13 @@ public final class EventLogProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 events_ = new java.util.ArrayList<ch.epfl.dedis.proto.EventLogProto.Event>();
@@ -1220,13 +1196,6 @@ public final class EventLogProto {
             case 16: {
               bitField0_ |= 0x00000001;
               truncated_ = input.readBool();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -1249,7 +1218,6 @@ public final class EventLogProto {
       return ch.epfl.dedis.proto.EventLogProto.internal_static_eventlog_SearchResponse_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.EventLogProto.internal_static_eventlog_SearchResponse_fieldAccessorTable
@@ -1321,7 +1289,6 @@ public final class EventLogProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1341,7 +1308,6 @@ public final class EventLogProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       for (int i = 0; i < events_.size(); i++) {
@@ -1353,7 +1319,6 @@ public final class EventLogProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -1485,7 +1450,6 @@ public final class EventLogProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -1493,7 +1457,6 @@ public final class EventLogProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.EventLogProto.SearchResponse prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -1521,7 +1484,6 @@ public final class EventLogProto {
         return ch.epfl.dedis.proto.EventLogProto.internal_static_eventlog_SearchResponse_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.EventLogProto.internal_static_eventlog_SearchResponse_fieldAccessorTable
@@ -1545,7 +1507,6 @@ public final class EventLogProto {
           getEventsFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (eventsBuilder_ == null) {
@@ -1559,18 +1520,15 @@ public final class EventLogProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.EventLogProto.internal_static_eventlog_SearchResponse_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.EventLogProto.SearchResponse getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.EventLogProto.SearchResponse.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.EventLogProto.SearchResponse build() {
         ch.epfl.dedis.proto.EventLogProto.SearchResponse result = buildPartial();
         if (!result.isInitialized()) {
@@ -1579,7 +1537,6 @@ public final class EventLogProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.EventLogProto.SearchResponse buildPartial() {
         ch.epfl.dedis.proto.EventLogProto.SearchResponse result = new ch.epfl.dedis.proto.EventLogProto.SearchResponse(this);
         int from_bitField0_ = bitField0_;
@@ -1602,39 +1559,32 @@ public final class EventLogProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.EventLogProto.SearchResponse) {
           return mergeFrom((ch.epfl.dedis.proto.EventLogProto.SearchResponse)other);
@@ -1680,7 +1630,6 @@ public final class EventLogProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasTruncated()) {
           return false;
@@ -1693,7 +1642,6 @@ public final class EventLogProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2008,13 +1956,11 @@ public final class EventLogProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -2036,12 +1982,11 @@ public final class EventLogProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<SearchResponse>
         PARSER = new com.google.protobuf.AbstractParser<SearchResponse>() {
-      @java.lang.Override
       public SearchResponse parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new SearchResponse(input, extensionRegistry);
+          return new SearchResponse(input, extensionRegistry);
       }
     };
 
@@ -2054,7 +1999,6 @@ public final class EventLogProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.EventLogProto.SearchResponse getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -2135,9 +2079,6 @@ public final class EventLogProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -2149,6 +2090,13 @@ public final class EventLogProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 8: {
               bitField0_ |= 0x00000001;
               when_ = input.readSInt64();
@@ -2164,13 +2112,6 @@ public final class EventLogProto {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000004;
               content_ = bs;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -2190,7 +2131,6 @@ public final class EventLogProto {
       return ch.epfl.dedis.proto.EventLogProto.internal_static_eventlog_Event_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.EventLogProto.internal_static_eventlog_Event_fieldAccessorTable
@@ -2299,7 +2239,6 @@ public final class EventLogProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -2321,7 +2260,6 @@ public final class EventLogProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -2336,7 +2274,6 @@ public final class EventLogProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -2482,7 +2419,6 @@ public final class EventLogProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -2490,7 +2426,6 @@ public final class EventLogProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.EventLogProto.Event prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -2519,7 +2454,6 @@ public final class EventLogProto {
         return ch.epfl.dedis.proto.EventLogProto.internal_static_eventlog_Event_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.EventLogProto.internal_static_eventlog_Event_fieldAccessorTable
@@ -2542,7 +2476,6 @@ public final class EventLogProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         when_ = 0L;
@@ -2554,18 +2487,15 @@ public final class EventLogProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.EventLogProto.internal_static_eventlog_Event_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.EventLogProto.Event getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.EventLogProto.Event.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.EventLogProto.Event build() {
         ch.epfl.dedis.proto.EventLogProto.Event result = buildPartial();
         if (!result.isInitialized()) {
@@ -2574,7 +2504,6 @@ public final class EventLogProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.EventLogProto.Event buildPartial() {
         ch.epfl.dedis.proto.EventLogProto.Event result = new ch.epfl.dedis.proto.EventLogProto.Event(this);
         int from_bitField0_ = bitField0_;
@@ -2596,39 +2525,32 @@ public final class EventLogProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.EventLogProto.Event) {
           return mergeFrom((ch.epfl.dedis.proto.EventLogProto.Event)other);
@@ -2658,7 +2580,6 @@ public final class EventLogProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasWhen()) {
           return false;
@@ -2672,7 +2593,6 @@ public final class EventLogProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2875,13 +2795,11 @@ public final class EventLogProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -2903,12 +2821,11 @@ public final class EventLogProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Event>
         PARSER = new com.google.protobuf.AbstractParser<Event>() {
-      @java.lang.Override
       public Event parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Event(input, extensionRegistry);
+          return new Event(input, extensionRegistry);
       }
     };
 
@@ -2921,7 +2838,6 @@ public final class EventLogProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.EventLogProto.Event getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }

--- a/external/java/src/main/java/ch/epfl/dedis/proto/NetworkProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/proto/NetworkProto.java
@@ -93,9 +93,6 @@ public final class NetworkProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -107,6 +104,13 @@ public final class NetworkProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               public_ = input.readBytes();
@@ -129,13 +133,6 @@ public final class NetworkProto {
               description_ = bs;
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -153,7 +150,6 @@ public final class NetworkProto {
       return ch.epfl.dedis.proto.NetworkProto.internal_static_network_ServerIdentity_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.NetworkProto.internal_static_network_ServerIdentity_fieldAccessorTable
@@ -277,7 +273,6 @@ public final class NetworkProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -303,7 +298,6 @@ public final class NetworkProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -321,7 +315,6 @@ public final class NetworkProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -479,7 +472,6 @@ public final class NetworkProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -487,7 +479,6 @@ public final class NetworkProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.NetworkProto.ServerIdentity prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -511,7 +502,6 @@ public final class NetworkProto {
         return ch.epfl.dedis.proto.NetworkProto.internal_static_network_ServerIdentity_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.NetworkProto.internal_static_network_ServerIdentity_fieldAccessorTable
@@ -534,7 +524,6 @@ public final class NetworkProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         public_ = com.google.protobuf.ByteString.EMPTY;
@@ -548,18 +537,15 @@ public final class NetworkProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.NetworkProto.internal_static_network_ServerIdentity_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.NetworkProto.ServerIdentity getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.NetworkProto.ServerIdentity.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.NetworkProto.ServerIdentity build() {
         ch.epfl.dedis.proto.NetworkProto.ServerIdentity result = buildPartial();
         if (!result.isInitialized()) {
@@ -568,7 +554,6 @@ public final class NetworkProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.NetworkProto.ServerIdentity buildPartial() {
         ch.epfl.dedis.proto.NetworkProto.ServerIdentity result = new ch.epfl.dedis.proto.NetworkProto.ServerIdentity(this);
         int from_bitField0_ = bitField0_;
@@ -594,39 +579,32 @@ public final class NetworkProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.NetworkProto.ServerIdentity) {
           return mergeFrom((ch.epfl.dedis.proto.NetworkProto.ServerIdentity)other);
@@ -659,7 +637,6 @@ public final class NetworkProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasPublic()) {
           return false;
@@ -676,7 +653,6 @@ public final class NetworkProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -917,13 +893,11 @@ public final class NetworkProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -945,12 +919,11 @@ public final class NetworkProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<ServerIdentity>
         PARSER = new com.google.protobuf.AbstractParser<ServerIdentity>() {
-      @java.lang.Override
       public ServerIdentity parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ServerIdentity(input, extensionRegistry);
+          return new ServerIdentity(input, extensionRegistry);
       }
     };
 
@@ -963,7 +936,6 @@ public final class NetworkProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.NetworkProto.ServerIdentity getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }

--- a/external/java/src/main/java/ch/epfl/dedis/proto/OCSProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/proto/OCSProto.java
@@ -168,9 +168,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -182,6 +179,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.OCSProto.Write.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -231,13 +235,6 @@ public final class OCSProto {
               timestamp_ = input.readSInt64();
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -255,7 +252,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_Transaction_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_Transaction_fieldAccessorTable
@@ -413,7 +409,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -445,7 +440,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -466,7 +460,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -640,7 +633,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -648,7 +640,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.Transaction prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -683,7 +674,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_Transaction_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_Transaction_fieldAccessorTable
@@ -709,7 +699,6 @@ public final class OCSProto {
           getDarcFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (writeBuilder_ == null) {
@@ -737,18 +726,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_Transaction_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.Transaction getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.Transaction.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.Transaction build() {
         ch.epfl.dedis.proto.OCSProto.Transaction result = buildPartial();
         if (!result.isInitialized()) {
@@ -757,7 +743,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.Transaction buildPartial() {
         ch.epfl.dedis.proto.OCSProto.Transaction result = new ch.epfl.dedis.proto.OCSProto.Transaction(this);
         int from_bitField0_ = bitField0_;
@@ -799,39 +784,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.Transaction) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.Transaction)other);
@@ -863,7 +841,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasTimestamp()) {
           return false;
@@ -886,7 +863,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1475,13 +1451,11 @@ public final class OCSProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -1503,12 +1477,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Transaction>
         PARSER = new com.google.protobuf.AbstractParser<Transaction>() {
-      @java.lang.Override
       public Transaction parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Transaction(input, extensionRegistry);
+          return new Transaction(input, extensionRegistry);
       }
     };
 
@@ -1521,7 +1494,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.Transaction getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -1762,9 +1734,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1776,6 +1745,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               data_ = input.readBytes();
@@ -1840,13 +1816,6 @@ public final class OCSProto {
               bitField0_ |= 0x00000080;
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -1867,7 +1836,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_Write_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_Write_fieldAccessorTable
@@ -2132,7 +2100,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -2176,7 +2143,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -2209,7 +2175,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -2436,7 +2401,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -2444,7 +2408,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.Write prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -2472,7 +2435,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_Write_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_Write_fieldAccessorTable
@@ -2497,7 +2459,6 @@ public final class OCSProto {
           getSignatureFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         data_ = com.google.protobuf.ByteString.EMPTY;
@@ -2529,18 +2490,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_Write_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.Write getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.Write.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.Write build() {
         ch.epfl.dedis.proto.OCSProto.Write result = buildPartial();
         if (!result.isInitialized()) {
@@ -2549,7 +2507,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.Write buildPartial() {
         ch.epfl.dedis.proto.OCSProto.Write result = new ch.epfl.dedis.proto.OCSProto.Write(this);
         int from_bitField0_ = bitField0_;
@@ -2604,39 +2561,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.Write) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.Write)other);
@@ -2687,7 +2637,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasData()) {
           return false;
@@ -2718,7 +2667,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -3492,13 +3440,11 @@ public final class OCSProto {
         }
         return signatureBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -3520,12 +3466,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Write>
         PARSER = new com.google.protobuf.AbstractParser<Write>() {
-      @java.lang.Override
       public Write parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Write(input, extensionRegistry);
+          return new Write(input, extensionRegistry);
       }
     };
 
@@ -3538,7 +3483,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.Write getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -3626,9 +3570,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -3640,6 +3581,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               dataid_ = input.readBytes();
@@ -3656,13 +3604,6 @@ public final class OCSProto {
                 signature_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000002;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -3682,7 +3623,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_Read_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_Read_fieldAccessorTable
@@ -3751,7 +3691,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -3773,7 +3712,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -3785,7 +3723,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -3919,7 +3856,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -3927,7 +3863,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.Read prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -3957,7 +3892,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_Read_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_Read_fieldAccessorTable
@@ -3981,7 +3915,6 @@ public final class OCSProto {
           getSignatureFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         dataid_ = com.google.protobuf.ByteString.EMPTY;
@@ -3995,18 +3928,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_Read_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.Read getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.Read.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.Read build() {
         ch.epfl.dedis.proto.OCSProto.Read result = buildPartial();
         if (!result.isInitialized()) {
@@ -4015,7 +3945,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.Read buildPartial() {
         ch.epfl.dedis.proto.OCSProto.Read result = new ch.epfl.dedis.proto.OCSProto.Read(this);
         int from_bitField0_ = bitField0_;
@@ -4037,39 +3966,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.Read) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.Read)other);
@@ -4092,7 +4014,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasDataid()) {
           return false;
@@ -4106,7 +4027,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -4339,13 +4259,11 @@ public final class OCSProto {
         }
         return signatureBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -4367,12 +4285,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Read>
         PARSER = new com.google.protobuf.AbstractParser<Read>() {
-      @java.lang.Override
       public Read parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Read(input, extensionRegistry);
+          return new Read(input, extensionRegistry);
       }
     };
 
@@ -4385,7 +4302,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.Read getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -4458,9 +4374,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -4472,6 +4385,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.DarcOCSProto.Identity.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -4495,13 +4415,6 @@ public final class OCSProto {
               dataid_ = input.readBytes();
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -4519,7 +4432,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_ReadDoc_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_ReadDoc_fieldAccessorTable
@@ -4580,7 +4492,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -4606,7 +4517,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -4621,7 +4531,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -4768,7 +4677,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -4776,7 +4684,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.ReadDoc prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -4804,7 +4711,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_ReadDoc_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_ReadDoc_fieldAccessorTable
@@ -4828,7 +4734,6 @@ public final class OCSProto {
           getReaderFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (readerBuilder_ == null) {
@@ -4844,18 +4749,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_ReadDoc_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.ReadDoc getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.ReadDoc.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.ReadDoc build() {
         ch.epfl.dedis.proto.OCSProto.ReadDoc result = buildPartial();
         if (!result.isInitialized()) {
@@ -4864,7 +4766,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.ReadDoc buildPartial() {
         ch.epfl.dedis.proto.OCSProto.ReadDoc result = new ch.epfl.dedis.proto.OCSProto.ReadDoc(this);
         int from_bitField0_ = bitField0_;
@@ -4890,39 +4791,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.ReadDoc) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.ReadDoc)other);
@@ -4948,7 +4842,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasReader()) {
           return false;
@@ -4965,7 +4858,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -5172,13 +5064,11 @@ public final class OCSProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -5200,12 +5090,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<ReadDoc>
         PARSER = new com.google.protobuf.AbstractParser<ReadDoc>() {
-      @java.lang.Override
       public ReadDoc parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ReadDoc(input, extensionRegistry);
+          return new ReadDoc(input, extensionRegistry);
       }
     };
 
@@ -5218,7 +5107,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.ReadDoc getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -5284,9 +5172,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -5298,6 +5183,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.OnetProto.Roster.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -5324,13 +5216,6 @@ public final class OCSProto {
               bitField0_ |= 0x00000002;
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -5348,7 +5233,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_CreateSkipchainsRequest_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_CreateSkipchainsRequest_fieldAccessorTable
@@ -5400,7 +5284,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -5426,7 +5309,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -5438,7 +5320,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -5572,7 +5453,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -5580,7 +5460,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.CreateSkipchainsRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -5608,7 +5487,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_CreateSkipchainsRequest_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_CreateSkipchainsRequest_fieldAccessorTable
@@ -5633,7 +5511,6 @@ public final class OCSProto {
           getWritersFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (rosterBuilder_ == null) {
@@ -5651,18 +5528,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_CreateSkipchainsRequest_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.CreateSkipchainsRequest getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.CreateSkipchainsRequest.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.CreateSkipchainsRequest build() {
         ch.epfl.dedis.proto.OCSProto.CreateSkipchainsRequest result = buildPartial();
         if (!result.isInitialized()) {
@@ -5671,7 +5545,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.CreateSkipchainsRequest buildPartial() {
         ch.epfl.dedis.proto.OCSProto.CreateSkipchainsRequest result = new ch.epfl.dedis.proto.OCSProto.CreateSkipchainsRequest(this);
         int from_bitField0_ = bitField0_;
@@ -5697,39 +5570,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.CreateSkipchainsRequest) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.CreateSkipchainsRequest)other);
@@ -5752,7 +5618,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasRoster()) {
           return false;
@@ -5769,7 +5634,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -6024,13 +5888,11 @@ public final class OCSProto {
         }
         return writersBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -6052,12 +5914,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<CreateSkipchainsRequest>
         PARSER = new com.google.protobuf.AbstractParser<CreateSkipchainsRequest>() {
-      @java.lang.Override
       public CreateSkipchainsRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CreateSkipchainsRequest(input, extensionRegistry);
+          return new CreateSkipchainsRequest(input, extensionRegistry);
       }
     };
 
@@ -6070,7 +5931,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.CreateSkipchainsRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -6133,9 +5993,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -6147,6 +6004,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.SkipchainProto.SkipBlock.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -6163,13 +6027,6 @@ public final class OCSProto {
             case 18: {
               bitField0_ |= 0x00000002;
               x_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -6189,7 +6046,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_CreateSkipchainsReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_CreateSkipchainsReply_fieldAccessorTable
@@ -6235,7 +6091,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -6255,7 +6110,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -6267,7 +6121,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -6401,7 +6254,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -6409,7 +6261,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.CreateSkipchainsReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -6437,7 +6288,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_CreateSkipchainsReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_CreateSkipchainsReply_fieldAccessorTable
@@ -6461,7 +6311,6 @@ public final class OCSProto {
           getOcsFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (ocsBuilder_ == null) {
@@ -6475,18 +6324,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_CreateSkipchainsReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.CreateSkipchainsReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.CreateSkipchainsReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.CreateSkipchainsReply build() {
         ch.epfl.dedis.proto.OCSProto.CreateSkipchainsReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -6495,7 +6341,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.CreateSkipchainsReply buildPartial() {
         ch.epfl.dedis.proto.OCSProto.CreateSkipchainsReply result = new ch.epfl.dedis.proto.OCSProto.CreateSkipchainsReply(this);
         int from_bitField0_ = bitField0_;
@@ -6517,39 +6362,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.CreateSkipchainsReply) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.CreateSkipchainsReply)other);
@@ -6572,7 +6410,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasX()) {
           return false;
@@ -6585,7 +6422,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -6757,13 +6593,11 @@ public final class OCSProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -6785,12 +6619,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<CreateSkipchainsReply>
         PARSER = new com.google.protobuf.AbstractParser<CreateSkipchainsReply>() {
-      @java.lang.Override
       public CreateSkipchainsReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CreateSkipchainsReply(input, extensionRegistry);
+          return new CreateSkipchainsReply(input, extensionRegistry);
       }
     };
 
@@ -6803,7 +6636,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.CreateSkipchainsReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -6887,9 +6719,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -6901,6 +6730,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               ocs_ = input.readBytes();
@@ -6929,13 +6765,6 @@ public final class OCSProto {
               role_ = input.readSInt32();
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -6953,7 +6782,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetDarcPath_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetDarcPath_fieldAccessorTable
@@ -7029,7 +6857,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -7059,7 +6886,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -7077,7 +6903,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -7237,7 +7062,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -7245,7 +7069,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.GetDarcPath prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -7274,7 +7097,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetDarcPath_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetDarcPath_fieldAccessorTable
@@ -7298,7 +7120,6 @@ public final class OCSProto {
           getIdentityFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         ocs_ = com.google.protobuf.ByteString.EMPTY;
@@ -7316,18 +7137,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetDarcPath_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetDarcPath getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.GetDarcPath.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetDarcPath build() {
         ch.epfl.dedis.proto.OCSProto.GetDarcPath result = buildPartial();
         if (!result.isInitialized()) {
@@ -7336,7 +7154,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetDarcPath buildPartial() {
         ch.epfl.dedis.proto.OCSProto.GetDarcPath result = new ch.epfl.dedis.proto.OCSProto.GetDarcPath(this);
         int from_bitField0_ = bitField0_;
@@ -7366,39 +7183,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.GetDarcPath) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.GetDarcPath)other);
@@ -7427,7 +7237,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasOcs()) {
           return false;
@@ -7447,7 +7256,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -7686,13 +7494,11 @@ public final class OCSProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -7714,12 +7520,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<GetDarcPath>
         PARSER = new com.google.protobuf.AbstractParser<GetDarcPath>() {
-      @java.lang.Override
       public GetDarcPath parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GetDarcPath(input, extensionRegistry);
+          return new GetDarcPath(input, extensionRegistry);
       }
     };
 
@@ -7732,7 +7537,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.GetDarcPath getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -7798,9 +7602,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -7812,6 +7613,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 path_ = new java.util.ArrayList<ch.epfl.dedis.proto.DarcOCSProto.Darc>();
@@ -7819,13 +7627,6 @@ public final class OCSProto {
               }
               path_.add(
                   input.readMessage(ch.epfl.dedis.proto.DarcOCSProto.Darc.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -7848,7 +7649,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetDarcPathReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetDarcPathReply_fieldAccessorTable
@@ -7892,7 +7692,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -7908,7 +7707,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       for (int i = 0; i < path_.size(); i++) {
@@ -7917,7 +7715,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -8035,7 +7832,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -8043,7 +7839,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.GetDarcPathReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -8072,7 +7867,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetDarcPathReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetDarcPathReply_fieldAccessorTable
@@ -8096,7 +7890,6 @@ public final class OCSProto {
           getPathFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (pathBuilder_ == null) {
@@ -8108,18 +7901,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetDarcPathReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetDarcPathReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.GetDarcPathReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetDarcPathReply build() {
         ch.epfl.dedis.proto.OCSProto.GetDarcPathReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -8128,7 +7918,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetDarcPathReply buildPartial() {
         ch.epfl.dedis.proto.OCSProto.GetDarcPathReply result = new ch.epfl.dedis.proto.OCSProto.GetDarcPathReply(this);
         int from_bitField0_ = bitField0_;
@@ -8145,39 +7934,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.GetDarcPathReply) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.GetDarcPathReply)other);
@@ -8220,7 +8002,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         for (int i = 0; i < getPathCount(); i++) {
           if (!getPath(i).isInitialized()) {
@@ -8230,7 +8011,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -8489,13 +8269,11 @@ public final class OCSProto {
         }
         return pathBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -8517,12 +8295,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<GetDarcPathReply>
         PARSER = new com.google.protobuf.AbstractParser<GetDarcPathReply>() {
-      @java.lang.Override
       public GetDarcPathReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GetDarcPathReply(input, extensionRegistry);
+          return new GetDarcPathReply(input, extensionRegistry);
       }
     };
 
@@ -8535,7 +8312,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.GetDarcPathReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -8599,9 +8375,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -8613,6 +8386,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               ocs_ = input.readBytes();
@@ -8629,13 +8409,6 @@ public final class OCSProto {
                 darc_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000002;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -8655,7 +8428,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_UpdateDarc_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_UpdateDarc_fieldAccessorTable
@@ -8701,7 +8473,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -8723,7 +8494,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -8735,7 +8505,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -8869,7 +8638,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -8877,7 +8645,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.UpdateDarc prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -8906,7 +8673,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_UpdateDarc_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_UpdateDarc_fieldAccessorTable
@@ -8930,7 +8696,6 @@ public final class OCSProto {
           getDarcFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         ocs_ = com.google.protobuf.ByteString.EMPTY;
@@ -8944,18 +8709,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_UpdateDarc_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.UpdateDarc getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.UpdateDarc.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.UpdateDarc build() {
         ch.epfl.dedis.proto.OCSProto.UpdateDarc result = buildPartial();
         if (!result.isInitialized()) {
@@ -8964,7 +8726,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.UpdateDarc buildPartial() {
         ch.epfl.dedis.proto.OCSProto.UpdateDarc result = new ch.epfl.dedis.proto.OCSProto.UpdateDarc(this);
         int from_bitField0_ = bitField0_;
@@ -8986,39 +8747,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.UpdateDarc) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.UpdateDarc)other);
@@ -9041,7 +8795,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasOcs()) {
           return false;
@@ -9055,7 +8808,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -9227,13 +8979,11 @@ public final class OCSProto {
         }
         return darcBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -9255,12 +9005,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<UpdateDarc>
         PARSER = new com.google.protobuf.AbstractParser<UpdateDarc>() {
-      @java.lang.Override
       public UpdateDarc parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new UpdateDarc(input, extensionRegistry);
+          return new UpdateDarc(input, extensionRegistry);
       }
     };
 
@@ -9273,7 +9022,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.UpdateDarc getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -9328,9 +9076,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -9342,6 +9087,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.SkipchainProto.SkipBlock.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -9353,13 +9105,6 @@ public final class OCSProto {
                 sb_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000001;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -9379,7 +9124,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_UpdateDarcReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_UpdateDarcReply_fieldAccessorTable
@@ -9410,7 +9154,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -9426,7 +9169,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -9435,7 +9177,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -9556,7 +9297,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -9564,7 +9304,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.UpdateDarcReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -9594,7 +9333,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_UpdateDarcReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_UpdateDarcReply_fieldAccessorTable
@@ -9618,7 +9356,6 @@ public final class OCSProto {
           getSbFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (sbBuilder_ == null) {
@@ -9630,18 +9367,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_UpdateDarcReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.UpdateDarcReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.UpdateDarcReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.UpdateDarcReply build() {
         ch.epfl.dedis.proto.OCSProto.UpdateDarcReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -9650,7 +9384,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.UpdateDarcReply buildPartial() {
         ch.epfl.dedis.proto.OCSProto.UpdateDarcReply result = new ch.epfl.dedis.proto.OCSProto.UpdateDarcReply(this);
         int from_bitField0_ = bitField0_;
@@ -9668,39 +9401,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.UpdateDarcReply) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.UpdateDarcReply)other);
@@ -9720,7 +9446,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (hasSb()) {
           if (!getSb().isInitialized()) {
@@ -9730,7 +9455,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -9867,13 +9591,11 @@ public final class OCSProto {
         }
         return sbBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -9895,12 +9617,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<UpdateDarcReply>
         PARSER = new com.google.protobuf.AbstractParser<UpdateDarcReply>() {
-      @java.lang.Override
       public UpdateDarcReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new UpdateDarcReply(input, extensionRegistry);
+          return new UpdateDarcReply(input, extensionRegistry);
       }
     };
 
@@ -9913,7 +9634,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.UpdateDarcReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -10006,9 +9726,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -10020,6 +9737,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               ocs_ = input.readBytes();
@@ -10064,13 +9788,6 @@ public final class OCSProto {
               bitField0_ |= 0x00000008;
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -10088,7 +9805,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_WriteRequest_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_WriteRequest_fieldAccessorTable
@@ -10176,7 +9892,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -10212,7 +9927,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -10230,7 +9944,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -10390,7 +10103,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -10398,7 +10110,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.WriteRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -10430,7 +10141,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_WriteRequest_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_WriteRequest_fieldAccessorTable
@@ -10456,7 +10166,6 @@ public final class OCSProto {
           getReadersFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         ocs_ = com.google.protobuf.ByteString.EMPTY;
@@ -10482,18 +10191,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_WriteRequest_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.WriteRequest getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.WriteRequest.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.WriteRequest build() {
         ch.epfl.dedis.proto.OCSProto.WriteRequest result = buildPartial();
         if (!result.isInitialized()) {
@@ -10502,7 +10208,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.WriteRequest buildPartial() {
         ch.epfl.dedis.proto.OCSProto.WriteRequest result = new ch.epfl.dedis.proto.OCSProto.WriteRequest(this);
         int from_bitField0_ = bitField0_;
@@ -10540,39 +10245,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.WriteRequest) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.WriteRequest)other);
@@ -10601,7 +10299,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasOcs()) {
           return false;
@@ -10626,7 +10323,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -11034,13 +10730,11 @@ public final class OCSProto {
         }
         return readersBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -11062,12 +10756,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<WriteRequest>
         PARSER = new com.google.protobuf.AbstractParser<WriteRequest>() {
-      @java.lang.Override
       public WriteRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new WriteRequest(input, extensionRegistry);
+          return new WriteRequest(input, extensionRegistry);
       }
     };
 
@@ -11080,7 +10773,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.WriteRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -11133,9 +10825,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -11147,6 +10836,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.SkipchainProto.SkipBlock.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -11158,13 +10854,6 @@ public final class OCSProto {
                 sb_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000001;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -11184,7 +10873,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_WriteReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_WriteReply_fieldAccessorTable
@@ -11215,7 +10903,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -11231,7 +10918,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -11240,7 +10926,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -11361,7 +11046,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -11369,7 +11053,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.WriteReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -11397,7 +11080,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_WriteReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_WriteReply_fieldAccessorTable
@@ -11421,7 +11103,6 @@ public final class OCSProto {
           getSbFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (sbBuilder_ == null) {
@@ -11433,18 +11114,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_WriteReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.WriteReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.WriteReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.WriteReply build() {
         ch.epfl.dedis.proto.OCSProto.WriteReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -11453,7 +11131,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.WriteReply buildPartial() {
         ch.epfl.dedis.proto.OCSProto.WriteReply result = new ch.epfl.dedis.proto.OCSProto.WriteReply(this);
         int from_bitField0_ = bitField0_;
@@ -11471,39 +11148,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.WriteReply) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.WriteReply)other);
@@ -11523,7 +11193,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (hasSb()) {
           if (!getSb().isInitialized()) {
@@ -11533,7 +11202,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -11670,13 +11338,11 @@ public final class OCSProto {
         }
         return sbBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -11698,12 +11364,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<WriteReply>
         PARSER = new com.google.protobuf.AbstractParser<WriteReply>() {
-      @java.lang.Override
       public WriteReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new WriteReply(input, extensionRegistry);
+          return new WriteReply(input, extensionRegistry);
       }
     };
 
@@ -11716,7 +11381,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.WriteReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -11779,9 +11443,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -11793,6 +11454,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               ocs_ = input.readBytes();
@@ -11809,13 +11477,6 @@ public final class OCSProto {
                 read_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000002;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -11835,7 +11496,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_ReadRequest_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_ReadRequest_fieldAccessorTable
@@ -11881,7 +11541,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -11903,7 +11562,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -11915,7 +11573,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -12049,7 +11706,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -12057,7 +11713,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.ReadRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -12085,7 +11740,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_ReadRequest_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_ReadRequest_fieldAccessorTable
@@ -12109,7 +11763,6 @@ public final class OCSProto {
           getReadFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         ocs_ = com.google.protobuf.ByteString.EMPTY;
@@ -12123,18 +11776,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_ReadRequest_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.ReadRequest getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.ReadRequest.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.ReadRequest build() {
         ch.epfl.dedis.proto.OCSProto.ReadRequest result = buildPartial();
         if (!result.isInitialized()) {
@@ -12143,7 +11793,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.ReadRequest buildPartial() {
         ch.epfl.dedis.proto.OCSProto.ReadRequest result = new ch.epfl.dedis.proto.OCSProto.ReadRequest(this);
         int from_bitField0_ = bitField0_;
@@ -12165,39 +11814,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.ReadRequest) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.ReadRequest)other);
@@ -12220,7 +11862,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasOcs()) {
           return false;
@@ -12234,7 +11875,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -12406,13 +12046,11 @@ public final class OCSProto {
         }
         return readBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -12434,12 +12072,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<ReadRequest>
         PARSER = new com.google.protobuf.AbstractParser<ReadRequest>() {
-      @java.lang.Override
       public ReadRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ReadRequest(input, extensionRegistry);
+          return new ReadRequest(input, extensionRegistry);
       }
     };
 
@@ -12452,7 +12089,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.ReadRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -12505,9 +12141,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -12519,6 +12152,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.SkipchainProto.SkipBlock.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -12530,13 +12170,6 @@ public final class OCSProto {
                 sb_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000001;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -12556,7 +12189,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_ReadReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_ReadReply_fieldAccessorTable
@@ -12587,7 +12219,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -12603,7 +12234,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -12612,7 +12242,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -12733,7 +12362,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -12741,7 +12369,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.ReadReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -12769,7 +12396,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_ReadReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_ReadReply_fieldAccessorTable
@@ -12793,7 +12419,6 @@ public final class OCSProto {
           getSbFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (sbBuilder_ == null) {
@@ -12805,18 +12430,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_ReadReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.ReadReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.ReadReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.ReadReply build() {
         ch.epfl.dedis.proto.OCSProto.ReadReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -12825,7 +12447,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.ReadReply buildPartial() {
         ch.epfl.dedis.proto.OCSProto.ReadReply result = new ch.epfl.dedis.proto.OCSProto.ReadReply(this);
         int from_bitField0_ = bitField0_;
@@ -12843,39 +12464,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.ReadReply) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.ReadReply)other);
@@ -12895,7 +12509,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (hasSb()) {
           if (!getSb().isInitialized()) {
@@ -12905,7 +12518,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -13042,13 +12654,11 @@ public final class OCSProto {
         }
         return sbBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -13070,12 +12680,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<ReadReply>
         PARSER = new com.google.protobuf.AbstractParser<ReadReply>() {
-      @java.lang.Override
       public ReadReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ReadReply(input, extensionRegistry);
+          return new ReadReply(input, extensionRegistry);
       }
     };
 
@@ -13088,7 +12697,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.ReadReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -13139,9 +12747,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -13153,16 +12758,16 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
-            case 10: {
-              bitField0_ |= 0x00000001;
-              genesis_ = input.readBytes();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              genesis_ = input.readBytes();
               break;
             }
           }
@@ -13182,7 +12787,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_SharedPublicRequest_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_SharedPublicRequest_fieldAccessorTable
@@ -13207,7 +12811,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -13221,7 +12824,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -13230,7 +12832,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -13351,7 +12952,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -13359,7 +12959,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.SharedPublicRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -13388,7 +12987,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_SharedPublicRequest_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_SharedPublicRequest_fieldAccessorTable
@@ -13411,7 +13009,6 @@ public final class OCSProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         genesis_ = com.google.protobuf.ByteString.EMPTY;
@@ -13419,18 +13016,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_SharedPublicRequest_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.SharedPublicRequest getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.SharedPublicRequest.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.SharedPublicRequest build() {
         ch.epfl.dedis.proto.OCSProto.SharedPublicRequest result = buildPartial();
         if (!result.isInitialized()) {
@@ -13439,7 +13033,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.SharedPublicRequest buildPartial() {
         ch.epfl.dedis.proto.OCSProto.SharedPublicRequest result = new ch.epfl.dedis.proto.OCSProto.SharedPublicRequest(this);
         int from_bitField0_ = bitField0_;
@@ -13453,39 +13046,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.SharedPublicRequest) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.SharedPublicRequest)other);
@@ -13505,7 +13091,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasGenesis()) {
           return false;
@@ -13513,7 +13098,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -13567,13 +13151,11 @@ public final class OCSProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -13595,12 +13177,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<SharedPublicRequest>
         PARSER = new com.google.protobuf.AbstractParser<SharedPublicRequest>() {
-      @java.lang.Override
       public SharedPublicRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new SharedPublicRequest(input, extensionRegistry);
+          return new SharedPublicRequest(input, extensionRegistry);
       }
     };
 
@@ -13613,7 +13194,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.SharedPublicRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -13663,9 +13243,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -13677,16 +13254,16 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
-            case 10: {
-              bitField0_ |= 0x00000001;
-              x_ = input.readBytes();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              x_ = input.readBytes();
               break;
             }
           }
@@ -13706,7 +13283,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_SharedPublicReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_SharedPublicReply_fieldAccessorTable
@@ -13731,7 +13307,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -13745,7 +13320,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -13754,7 +13328,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -13875,7 +13448,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -13883,7 +13455,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.SharedPublicReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -13911,7 +13482,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_SharedPublicReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_SharedPublicReply_fieldAccessorTable
@@ -13934,7 +13504,6 @@ public final class OCSProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         x_ = com.google.protobuf.ByteString.EMPTY;
@@ -13942,18 +13511,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_SharedPublicReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.SharedPublicReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.SharedPublicReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.SharedPublicReply build() {
         ch.epfl.dedis.proto.OCSProto.SharedPublicReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -13962,7 +13528,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.SharedPublicReply buildPartial() {
         ch.epfl.dedis.proto.OCSProto.SharedPublicReply result = new ch.epfl.dedis.proto.OCSProto.SharedPublicReply(this);
         int from_bitField0_ = bitField0_;
@@ -13976,39 +13541,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.SharedPublicReply) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.SharedPublicReply)other);
@@ -14028,7 +13586,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasX()) {
           return false;
@@ -14036,7 +13593,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -14090,13 +13646,11 @@ public final class OCSProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -14118,12 +13672,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<SharedPublicReply>
         PARSER = new com.google.protobuf.AbstractParser<SharedPublicReply>() {
-      @java.lang.Override
       public SharedPublicReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new SharedPublicReply(input, extensionRegistry);
+          return new SharedPublicReply(input, extensionRegistry);
       }
     };
 
@@ -14136,7 +13689,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.SharedPublicReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -14211,9 +13763,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -14225,6 +13774,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               read_ = input.readBytes();
@@ -14248,13 +13804,6 @@ public final class OCSProto {
               bitField0_ |= 0x00000004;
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -14272,7 +13821,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_DecryptKeyRequest_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_DecryptKeyRequest_fieldAccessorTable
@@ -14333,7 +13881,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -14353,7 +13900,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -14368,7 +13914,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -14515,7 +14060,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -14523,7 +14067,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.DecryptKeyRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -14553,7 +14096,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_DecryptKeyRequest_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_DecryptKeyRequest_fieldAccessorTable
@@ -14577,7 +14119,6 @@ public final class OCSProto {
           getSignatureFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         read_ = com.google.protobuf.ByteString.EMPTY;
@@ -14593,18 +14134,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_DecryptKeyRequest_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.DecryptKeyRequest getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.DecryptKeyRequest.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.DecryptKeyRequest build() {
         ch.epfl.dedis.proto.OCSProto.DecryptKeyRequest result = buildPartial();
         if (!result.isInitialized()) {
@@ -14613,7 +14151,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.DecryptKeyRequest buildPartial() {
         ch.epfl.dedis.proto.OCSProto.DecryptKeyRequest result = new ch.epfl.dedis.proto.OCSProto.DecryptKeyRequest(this);
         int from_bitField0_ = bitField0_;
@@ -14639,39 +14176,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.DecryptKeyRequest) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.DecryptKeyRequest)other);
@@ -14697,7 +14227,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasRead()) {
           return false;
@@ -14710,7 +14239,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -14917,13 +14445,11 @@ public final class OCSProto {
         }
         return signatureBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -14945,12 +14471,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<DecryptKeyRequest>
         PARSER = new com.google.protobuf.AbstractParser<DecryptKeyRequest>() {
-      @java.lang.Override
       public DecryptKeyRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new DecryptKeyRequest(input, extensionRegistry);
+          return new DecryptKeyRequest(input, extensionRegistry);
       }
     };
 
@@ -14963,7 +14488,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.DecryptKeyRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -15038,9 +14562,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -15052,6 +14573,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 cs_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
@@ -15068,13 +14596,6 @@ public final class OCSProto {
             case 26: {
               bitField0_ |= 0x00000002;
               x_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -15097,7 +14618,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_DecryptKeyReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_DecryptKeyReply_fieldAccessorTable
@@ -15159,7 +14679,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -15177,7 +14696,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       for (int i = 0; i < cs_.size(); i++) {
@@ -15192,7 +14710,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -15341,7 +14858,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -15349,7 +14865,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.DecryptKeyReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -15378,7 +14893,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_DecryptKeyReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_DecryptKeyReply_fieldAccessorTable
@@ -15401,7 +14915,6 @@ public final class OCSProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         cs_ = java.util.Collections.emptyList();
@@ -15413,18 +14926,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_DecryptKeyReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.DecryptKeyReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.DecryptKeyReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.DecryptKeyReply build() {
         ch.epfl.dedis.proto.OCSProto.DecryptKeyReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -15433,7 +14943,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.DecryptKeyReply buildPartial() {
         ch.epfl.dedis.proto.OCSProto.DecryptKeyReply result = new ch.epfl.dedis.proto.OCSProto.DecryptKeyReply(this);
         int from_bitField0_ = bitField0_;
@@ -15456,39 +14965,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.DecryptKeyReply) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.DecryptKeyReply)other);
@@ -15521,7 +15023,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasXhatenc()) {
           return false;
@@ -15532,7 +15033,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -15693,13 +15193,11 @@ public final class OCSProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -15721,12 +15219,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<DecryptKeyReply>
         PARSER = new com.google.protobuf.AbstractParser<DecryptKeyReply>() {
-      @java.lang.Override
       public DecryptKeyReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new DecryptKeyReply(input, extensionRegistry);
+          return new DecryptKeyReply(input, extensionRegistry);
       }
     };
 
@@ -15739,7 +15236,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.DecryptKeyReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -15799,9 +15295,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -15813,6 +15306,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               start_ = input.readBytes();
@@ -15821,13 +15321,6 @@ public final class OCSProto {
             case 16: {
               bitField0_ |= 0x00000002;
               count_ = input.readSInt32();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -15847,7 +15340,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetReadRequests_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetReadRequests_fieldAccessorTable
@@ -15887,7 +15379,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -15905,7 +15396,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -15917,7 +15407,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -16051,7 +15540,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -16059,7 +15547,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.GetReadRequests prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -16087,7 +15574,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetReadRequests_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetReadRequests_fieldAccessorTable
@@ -16110,7 +15596,6 @@ public final class OCSProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         start_ = com.google.protobuf.ByteString.EMPTY;
@@ -16120,18 +15605,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetReadRequests_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetReadRequests getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.GetReadRequests.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetReadRequests build() {
         ch.epfl.dedis.proto.OCSProto.GetReadRequests result = buildPartial();
         if (!result.isInitialized()) {
@@ -16140,7 +15622,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetReadRequests buildPartial() {
         ch.epfl.dedis.proto.OCSProto.GetReadRequests result = new ch.epfl.dedis.proto.OCSProto.GetReadRequests(this);
         int from_bitField0_ = bitField0_;
@@ -16158,39 +15639,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.GetReadRequests) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.GetReadRequests)other);
@@ -16213,7 +15687,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasStart()) {
           return false;
@@ -16224,7 +15697,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -16310,13 +15782,11 @@ public final class OCSProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -16338,12 +15808,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<GetReadRequests>
         PARSER = new com.google.protobuf.AbstractParser<GetReadRequests>() {
-      @java.lang.Override
       public GetReadRequests parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GetReadRequests(input, extensionRegistry);
+          return new GetReadRequests(input, extensionRegistry);
       }
     };
 
@@ -16356,7 +15825,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.GetReadRequests getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -16421,9 +15889,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -16435,6 +15900,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 documents_ = new java.util.ArrayList<ch.epfl.dedis.proto.OCSProto.ReadDoc>();
@@ -16442,13 +15914,6 @@ public final class OCSProto {
               }
               documents_.add(
                   input.readMessage(ch.epfl.dedis.proto.OCSProto.ReadDoc.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -16471,7 +15936,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetReadRequestsReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetReadRequestsReply_fieldAccessorTable
@@ -16515,7 +15979,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -16531,7 +15994,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       for (int i = 0; i < documents_.size(); i++) {
@@ -16540,7 +16002,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -16658,7 +16119,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -16666,7 +16126,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.GetReadRequestsReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -16694,7 +16153,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetReadRequestsReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetReadRequestsReply_fieldAccessorTable
@@ -16718,7 +16176,6 @@ public final class OCSProto {
           getDocumentsFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (documentsBuilder_ == null) {
@@ -16730,18 +16187,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetReadRequestsReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetReadRequestsReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.GetReadRequestsReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetReadRequestsReply build() {
         ch.epfl.dedis.proto.OCSProto.GetReadRequestsReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -16750,7 +16204,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetReadRequestsReply buildPartial() {
         ch.epfl.dedis.proto.OCSProto.GetReadRequestsReply result = new ch.epfl.dedis.proto.OCSProto.GetReadRequestsReply(this);
         int from_bitField0_ = bitField0_;
@@ -16767,39 +16220,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.GetReadRequestsReply) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.GetReadRequestsReply)other);
@@ -16842,7 +16288,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         for (int i = 0; i < getDocumentsCount(); i++) {
           if (!getDocuments(i).isInitialized()) {
@@ -16852,7 +16297,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -17111,13 +16555,11 @@ public final class OCSProto {
         }
         return documentsBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -17139,12 +16581,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<GetReadRequestsReply>
         PARSER = new com.google.protobuf.AbstractParser<GetReadRequestsReply>() {
-      @java.lang.Override
       public GetReadRequestsReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GetReadRequestsReply(input, extensionRegistry);
+          return new GetReadRequestsReply(input, extensionRegistry);
       }
     };
 
@@ -17157,7 +16598,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.GetReadRequestsReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -17197,9 +16637,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
@@ -17234,7 +16671,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetBunchRequest_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetBunchRequest_fieldAccessorTable
@@ -17243,7 +16679,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -17253,13 +16688,11 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -17367,7 +16800,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -17375,7 +16807,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.GetBunchRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -17403,7 +16834,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetBunchRequest_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetBunchRequest_fieldAccessorTable
@@ -17426,24 +16856,20 @@ public final class OCSProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetBunchRequest_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetBunchRequest getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.GetBunchRequest.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetBunchRequest build() {
         ch.epfl.dedis.proto.OCSProto.GetBunchRequest result = buildPartial();
         if (!result.isInitialized()) {
@@ -17452,46 +16878,38 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetBunchRequest buildPartial() {
         ch.epfl.dedis.proto.OCSProto.GetBunchRequest result = new ch.epfl.dedis.proto.OCSProto.GetBunchRequest(this);
         onBuilt();
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.GetBunchRequest) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.GetBunchRequest)other);
@@ -17508,12 +16926,10 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -17531,13 +16947,11 @@ public final class OCSProto {
         }
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -17559,12 +16973,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<GetBunchRequest>
         PARSER = new com.google.protobuf.AbstractParser<GetBunchRequest>() {
-      @java.lang.Override
       public GetBunchRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GetBunchRequest(input, extensionRegistry);
+          return new GetBunchRequest(input, extensionRegistry);
       }
     };
 
@@ -17577,7 +16990,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.GetBunchRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -17642,9 +17054,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -17656,6 +17065,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 bunches_ = new java.util.ArrayList<ch.epfl.dedis.proto.SkipchainProto.SkipBlock>();
@@ -17663,13 +17079,6 @@ public final class OCSProto {
               }
               bunches_.add(
                   input.readMessage(ch.epfl.dedis.proto.SkipchainProto.SkipBlock.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -17692,7 +17101,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetBunchReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetBunchReply_fieldAccessorTable
@@ -17736,7 +17144,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -17752,7 +17159,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       for (int i = 0; i < bunches_.size(); i++) {
@@ -17761,7 +17167,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -17879,7 +17284,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -17887,7 +17291,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.GetBunchReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -17915,7 +17318,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetBunchReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetBunchReply_fieldAccessorTable
@@ -17939,7 +17341,6 @@ public final class OCSProto {
           getBunchesFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (bunchesBuilder_ == null) {
@@ -17951,18 +17352,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetBunchReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetBunchReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.GetBunchReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetBunchReply build() {
         ch.epfl.dedis.proto.OCSProto.GetBunchReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -17971,7 +17369,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetBunchReply buildPartial() {
         ch.epfl.dedis.proto.OCSProto.GetBunchReply result = new ch.epfl.dedis.proto.OCSProto.GetBunchReply(this);
         int from_bitField0_ = bitField0_;
@@ -17988,39 +17385,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.GetBunchReply) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.GetBunchReply)other);
@@ -18063,7 +17453,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         for (int i = 0; i < getBunchesCount(); i++) {
           if (!getBunches(i).isInitialized()) {
@@ -18073,7 +17462,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -18332,13 +17720,11 @@ public final class OCSProto {
         }
         return bunchesBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -18360,12 +17746,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<GetBunchReply>
         PARSER = new com.google.protobuf.AbstractParser<GetBunchReply>() {
-      @java.lang.Override
       public GetBunchReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GetBunchReply(input, extensionRegistry);
+          return new GetBunchReply(input, extensionRegistry);
       }
     };
 
@@ -18378,7 +17763,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.GetBunchReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -18439,9 +17823,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -18453,6 +17834,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               ocs_ = input.readBytes();
@@ -18461,13 +17849,6 @@ public final class OCSProto {
             case 18: {
               bitField0_ |= 0x00000002;
               darcid_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -18487,7 +17868,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetLatestDarc_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetLatestDarc_fieldAccessorTable
@@ -18527,7 +17907,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -18545,7 +17924,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -18557,7 +17935,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -18691,7 +18068,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -18699,7 +18075,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.GetLatestDarc prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -18728,7 +18103,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetLatestDarc_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetLatestDarc_fieldAccessorTable
@@ -18751,7 +18125,6 @@ public final class OCSProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         ocs_ = com.google.protobuf.ByteString.EMPTY;
@@ -18761,18 +18134,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetLatestDarc_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetLatestDarc getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.GetLatestDarc.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetLatestDarc build() {
         ch.epfl.dedis.proto.OCSProto.GetLatestDarc result = buildPartial();
         if (!result.isInitialized()) {
@@ -18781,7 +18151,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetLatestDarc buildPartial() {
         ch.epfl.dedis.proto.OCSProto.GetLatestDarc result = new ch.epfl.dedis.proto.OCSProto.GetLatestDarc(this);
         int from_bitField0_ = bitField0_;
@@ -18799,39 +18168,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.GetLatestDarc) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.GetLatestDarc)other);
@@ -18854,7 +18216,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasOcs()) {
           return false;
@@ -18865,7 +18226,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -18954,13 +18314,11 @@ public final class OCSProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -18982,12 +18340,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<GetLatestDarc>
         PARSER = new com.google.protobuf.AbstractParser<GetLatestDarc>() {
-      @java.lang.Override
       public GetLatestDarc parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GetLatestDarc(input, extensionRegistry);
+          return new GetLatestDarc(input, extensionRegistry);
       }
     };
 
@@ -19000,7 +18357,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.GetLatestDarc getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -19067,9 +18423,6 @@ public final class OCSProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -19081,6 +18434,13 @@ public final class OCSProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 darcs_ = new java.util.ArrayList<ch.epfl.dedis.proto.DarcOCSProto.Darc>();
@@ -19088,13 +18448,6 @@ public final class OCSProto {
               }
               darcs_.add(
                   input.readMessage(ch.epfl.dedis.proto.DarcOCSProto.Darc.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -19117,7 +18470,6 @@ public final class OCSProto {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetLatestDarcReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetLatestDarcReply_fieldAccessorTable
@@ -19161,7 +18513,6 @@ public final class OCSProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -19177,7 +18528,6 @@ public final class OCSProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       for (int i = 0; i < darcs_.size(); i++) {
@@ -19186,7 +18536,6 @@ public final class OCSProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -19304,7 +18653,6 @@ public final class OCSProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -19312,7 +18660,6 @@ public final class OCSProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OCSProto.GetLatestDarcReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -19342,7 +18689,6 @@ public final class OCSProto {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetLatestDarcReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetLatestDarcReply_fieldAccessorTable
@@ -19366,7 +18712,6 @@ public final class OCSProto {
           getDarcsFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (darcsBuilder_ == null) {
@@ -19378,18 +18723,15 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OCSProto.internal_static_ocs_GetLatestDarcReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetLatestDarcReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OCSProto.GetLatestDarcReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetLatestDarcReply build() {
         ch.epfl.dedis.proto.OCSProto.GetLatestDarcReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -19398,7 +18740,6 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OCSProto.GetLatestDarcReply buildPartial() {
         ch.epfl.dedis.proto.OCSProto.GetLatestDarcReply result = new ch.epfl.dedis.proto.OCSProto.GetLatestDarcReply(this);
         int from_bitField0_ = bitField0_;
@@ -19415,39 +18756,32 @@ public final class OCSProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OCSProto.GetLatestDarcReply) {
           return mergeFrom((ch.epfl.dedis.proto.OCSProto.GetLatestDarcReply)other);
@@ -19490,7 +18824,6 @@ public final class OCSProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         for (int i = 0; i < getDarcsCount(); i++) {
           if (!getDarcs(i).isInitialized()) {
@@ -19500,7 +18833,6 @@ public final class OCSProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -19759,13 +19091,11 @@ public final class OCSProto {
         }
         return darcsBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -19787,12 +19117,11 @@ public final class OCSProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<GetLatestDarcReply>
         PARSER = new com.google.protobuf.AbstractParser<GetLatestDarcReply>() {
-      @java.lang.Override
       public GetLatestDarcReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GetLatestDarcReply(input, extensionRegistry);
+          return new GetLatestDarcReply(input, extensionRegistry);
       }
     };
 
@@ -19805,7 +19134,6 @@ public final class OCSProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OCSProto.GetLatestDarcReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -19950,7 +19278,7 @@ public final class OCSProto {
       "\n\001e\030\004 \002(\014\022\t\n\001f\030\005 \002(\014\022\n\n\002cs\030\006 \003(\014\022\021\n\textr" +
       "adata\030\007 \001(\014\022\035\n\006reader\030\010 \002(\0132\r.darcOCS.Da" +
       "rc\022%\n\tsignature\030\t \001(\0132\022.darcOCS.Signatur" +
-      "e\"=\n\004Read\022\016\n\006dataid\030\001 \002(\014\022%\n\tsignature\030\002" +
+      "e\"=\n\004Read\022\016\n\006dataid\030\001 \002(\014\022%\n\tsignature\030\002",
       " \002(\0132\022.darcOCS.Signature\"L\n\007ReadDoc\022!\n\006r" +
       "eader\030\001 \002(\0132\021.darcOCS.Identity\022\016\n\006readid" +
       "\030\002 \002(\014\022\016\n\006dataid\030\003 \002(\014\"W\n\027CreateSkipchai" +
@@ -19960,7 +19288,7 @@ public final class OCSProto {
       "n.SkipBlock\022\t\n\001x\030\002 \002(\014\"a\n\013GetDarcPath\022\013\n" +
       "\003ocs\030\001 \002(\014\022\022\n\nbasedarcid\030\002 \002(\014\022#\n\010identi" +
       "ty\030\003 \002(\0132\021.darcOCS.Identity\022\014\n\004role\030\004 \002(" +
-      "\021\"/\n\020GetDarcPathReply\022\033\n\004path\030\001 \003(\0132\r.da" +
+      "\021\"/\n\020GetDarcPathReply\022\033\n\004path\030\001 \003(\0132\r.da",
       "rcOCS.Darc\"6\n\nUpdateDarc\022\013\n\003ocs\030\001 \002(\014\022\033\n" +
       "\004darc\030\002 \002(\0132\r.darcOCS.Darc\"3\n\017UpdateDarc" +
       "Reply\022 \n\002sb\030\001 \001(\0132\024.skipchain.SkipBlock\"" +
@@ -19970,7 +19298,7 @@ public final class OCSProto {
       "S.Darc\".\n\nWriteReply\022 \n\002sb\030\001 \001(\0132\024.skipc" +
       "hain.SkipBlock\"3\n\013ReadRequest\022\013\n\003ocs\030\001 \002" +
       "(\014\022\027\n\004read\030\002 \002(\0132\t.ocs.Read\"-\n\tReadReply" +
-      "\022 \n\002sb\030\001 \001(\0132\024.skipchain.SkipBlock\"&\n\023Sh" +
+      "\022 \n\002sb\030\001 \001(\0132\024.skipchain.SkipBlock\"&\n\023Sh",
       "aredPublicRequest\022\017\n\007genesis\030\001 \002(\014\"\036\n\021Sh" +
       "aredPublicReply\022\t\n\001x\030\001 \002(\014\"[\n\021DecryptKey" +
       "Request\022\014\n\004read\030\001 \002(\014\022\021\n\tephemeral\030\002 \001(\014" +
@@ -19980,7 +19308,7 @@ public final class OCSProto {
       "\005start\030\001 \002(\014\022\r\n\005count\030\002 \002(\021\"7\n\024GetReadRe" +
       "questsReply\022\037\n\tdocuments\030\001 \003(\0132\014.ocs.Rea" +
       "dDoc\"\021\n\017GetBunchRequest\"6\n\rGetBunchReply" +
-      "\022%\n\007bunches\030\001 \003(\0132\024.skipchain.SkipBlock\"" +
+      "\022%\n\007bunches\030\001 \003(\0132\024.skipchain.SkipBlock\"",
       ",\n\rGetLatestDarc\022\013\n\003ocs\030\001 \002(\014\022\016\n\006darcid\030" +
       "\002 \002(\014\"2\n\022GetLatestDarcReply\022\034\n\005darcs\030\001 \003" +
       "(\0132\r.darcOCS.DarcB\037\n\023ch.epfl.dedis.proto" +

--- a/external/java/src/main/java/ch/epfl/dedis/proto/OmniLedgerProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/proto/OmniLedgerProto.java
@@ -123,9 +123,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -137,6 +134,13 @@ public final class OmniLedgerProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               collectionroot_ = input.readBytes();
@@ -157,13 +161,6 @@ public final class OmniLedgerProto {
               timestamp_ = input.readSInt64();
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -181,7 +178,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_DataHeader_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_DataHeader_fieldAccessorTable
@@ -287,7 +283,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -313,7 +308,6 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -331,7 +325,6 @@ public final class OmniLedgerProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -492,7 +485,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -500,7 +492,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.DataHeader prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -528,7 +519,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_DataHeader_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_DataHeader_fieldAccessorTable
@@ -551,7 +541,6 @@ public final class OmniLedgerProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         collectionroot_ = com.google.protobuf.ByteString.EMPTY;
@@ -565,18 +554,15 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_DataHeader_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.DataHeader getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.DataHeader.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.DataHeader build() {
         ch.epfl.dedis.proto.OmniLedgerProto.DataHeader result = buildPartial();
         if (!result.isInitialized()) {
@@ -585,7 +571,6 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.DataHeader buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.DataHeader result = new ch.epfl.dedis.proto.OmniLedgerProto.DataHeader(this);
         int from_bitField0_ = bitField0_;
@@ -611,39 +596,32 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.DataHeader) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.DataHeader)other);
@@ -672,7 +650,6 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasCollectionroot()) {
           return false;
@@ -689,7 +666,6 @@ public final class OmniLedgerProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -917,13 +893,11 @@ public final class OmniLedgerProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -945,12 +919,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<DataHeader>
         PARSER = new com.google.protobuf.AbstractParser<DataHeader>() {
-      @java.lang.Override
       public DataHeader parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new DataHeader(input, extensionRegistry);
+          return new DataHeader(input, extensionRegistry);
       }
     };
 
@@ -963,7 +936,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.DataHeader getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -1029,9 +1001,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1043,6 +1012,13 @@ public final class OmniLedgerProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 transactions_ = new java.util.ArrayList<ch.epfl.dedis.proto.OmniLedgerProto.ClientTransaction>();
@@ -1050,13 +1026,6 @@ public final class OmniLedgerProto {
               }
               transactions_.add(
                   input.readMessage(ch.epfl.dedis.proto.OmniLedgerProto.ClientTransaction.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -1079,7 +1048,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_DataBody_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_DataBody_fieldAccessorTable
@@ -1123,7 +1091,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1139,7 +1106,6 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       for (int i = 0; i < transactions_.size(); i++) {
@@ -1148,7 +1114,6 @@ public final class OmniLedgerProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -1266,7 +1231,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -1274,7 +1238,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.DataBody prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -1303,7 +1266,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_DataBody_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_DataBody_fieldAccessorTable
@@ -1327,7 +1289,6 @@ public final class OmniLedgerProto {
           getTransactionsFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (transactionsBuilder_ == null) {
@@ -1339,18 +1300,15 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_DataBody_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.DataBody getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.DataBody.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.DataBody build() {
         ch.epfl.dedis.proto.OmniLedgerProto.DataBody result = buildPartial();
         if (!result.isInitialized()) {
@@ -1359,7 +1317,6 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.DataBody buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.DataBody result = new ch.epfl.dedis.proto.OmniLedgerProto.DataBody(this);
         int from_bitField0_ = bitField0_;
@@ -1376,39 +1333,32 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.DataBody) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.DataBody)other);
@@ -1451,7 +1401,6 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         for (int i = 0; i < getTransactionsCount(); i++) {
           if (!getTransactions(i).isInitialized()) {
@@ -1461,7 +1410,6 @@ public final class OmniLedgerProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1720,13 +1668,11 @@ public final class OmniLedgerProto {
         }
         return transactionsBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -1748,12 +1694,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<DataBody>
         PARSER = new com.google.protobuf.AbstractParser<DataBody>() {
-      @java.lang.Override
       public DataBody parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new DataBody(input, extensionRegistry);
+          return new DataBody(input, extensionRegistry);
       }
     };
 
@@ -1766,7 +1711,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.DataBody getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -1892,9 +1836,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1906,6 +1847,13 @@ public final class OmniLedgerProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 8: {
               bitField0_ |= 0x00000001;
               version_ = input.readSInt32();
@@ -1942,13 +1890,6 @@ public final class OmniLedgerProto {
               blockinterval_ = input.readSInt64();
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -1966,7 +1907,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_CreateGenesisBlock_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_CreateGenesisBlock_fieldAccessorTable
@@ -2088,7 +2028,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -2122,7 +2061,6 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -2140,7 +2078,6 @@ public final class OmniLedgerProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -2301,7 +2238,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -2309,7 +2245,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlock prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -2337,7 +2272,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_CreateGenesisBlock_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_CreateGenesisBlock_fieldAccessorTable
@@ -2362,7 +2296,6 @@ public final class OmniLedgerProto {
           getGenesisdarcFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         version_ = 0;
@@ -2384,18 +2317,15 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_CreateGenesisBlock_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlock getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlock.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlock build() {
         ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlock result = buildPartial();
         if (!result.isInitialized()) {
@@ -2404,7 +2334,6 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlock buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlock result = new ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlock(this);
         int from_bitField0_ = bitField0_;
@@ -2438,39 +2367,32 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlock) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlock)other);
@@ -2499,7 +2421,6 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasVersion()) {
           return false;
@@ -2522,7 +2443,6 @@ public final class OmniLedgerProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2945,13 +2865,11 @@ public final class OmniLedgerProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -2973,12 +2891,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<CreateGenesisBlock>
         PARSER = new com.google.protobuf.AbstractParser<CreateGenesisBlock>() {
-      @java.lang.Override
       public CreateGenesisBlock parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CreateGenesisBlock(input, extensionRegistry);
+          return new CreateGenesisBlock(input, extensionRegistry);
       }
     };
 
@@ -2991,7 +2908,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlock getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -3074,9 +2990,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -3088,6 +3001,13 @@ public final class OmniLedgerProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 8: {
               bitField0_ |= 0x00000001;
               version_ = input.readSInt32();
@@ -3104,13 +3024,6 @@ public final class OmniLedgerProto {
                 skipblock_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000002;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -3130,7 +3043,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_CreateGenesisBlockResponse_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_CreateGenesisBlockResponse_fieldAccessorTable
@@ -3196,7 +3108,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -3216,7 +3127,6 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -3228,7 +3138,6 @@ public final class OmniLedgerProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -3362,7 +3271,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -3370,7 +3278,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlockResponse prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -3398,7 +3305,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_CreateGenesisBlockResponse_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_CreateGenesisBlockResponse_fieldAccessorTable
@@ -3422,7 +3328,6 @@ public final class OmniLedgerProto {
           getSkipblockFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         version_ = 0;
@@ -3436,18 +3341,15 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_CreateGenesisBlockResponse_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlockResponse getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlockResponse.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlockResponse build() {
         ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlockResponse result = buildPartial();
         if (!result.isInitialized()) {
@@ -3456,7 +3358,6 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlockResponse buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlockResponse result = new ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlockResponse(this);
         int from_bitField0_ = bitField0_;
@@ -3478,39 +3379,32 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlockResponse) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlockResponse)other);
@@ -3533,7 +3427,6 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasVersion()) {
           return false;
@@ -3546,7 +3439,6 @@ public final class OmniLedgerProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -3767,13 +3659,11 @@ public final class OmniLedgerProto {
         }
         return skipblockBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -3795,12 +3685,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<CreateGenesisBlockResponse>
         PARSER = new com.google.protobuf.AbstractParser<CreateGenesisBlockResponse>() {
-      @java.lang.Override
       public CreateGenesisBlockResponse parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CreateGenesisBlockResponse(input, extensionRegistry);
+          return new CreateGenesisBlockResponse(input, extensionRegistry);
       }
     };
 
@@ -3813,7 +3702,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.CreateGenesisBlockResponse getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -3934,9 +3822,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -3948,6 +3833,13 @@ public final class OmniLedgerProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 8: {
               bitField0_ |= 0x00000001;
               version_ = input.readSInt32();
@@ -3976,13 +3868,6 @@ public final class OmniLedgerProto {
               inclusionwait_ = input.readSInt32();
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -4000,7 +3885,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_AddTxRequest_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_AddTxRequest_fieldAccessorTable
@@ -4114,7 +3998,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -4140,7 +4023,6 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -4158,7 +4040,6 @@ public final class OmniLedgerProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -4318,7 +4199,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -4326,7 +4206,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.AddTxRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -4354,7 +4233,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_AddTxRequest_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_AddTxRequest_fieldAccessorTable
@@ -4378,7 +4256,6 @@ public final class OmniLedgerProto {
           getTransactionFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         version_ = 0;
@@ -4396,18 +4273,15 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_AddTxRequest_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.AddTxRequest getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.AddTxRequest.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.AddTxRequest build() {
         ch.epfl.dedis.proto.OmniLedgerProto.AddTxRequest result = buildPartial();
         if (!result.isInitialized()) {
@@ -4416,7 +4290,6 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.AddTxRequest buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.AddTxRequest result = new ch.epfl.dedis.proto.OmniLedgerProto.AddTxRequest(this);
         int from_bitField0_ = bitField0_;
@@ -4446,39 +4319,32 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.AddTxRequest) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.AddTxRequest)other);
@@ -4507,7 +4373,6 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasVersion()) {
           return false;
@@ -4524,7 +4389,6 @@ public final class OmniLedgerProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -4848,13 +4712,11 @@ public final class OmniLedgerProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -4876,12 +4738,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<AddTxRequest>
         PARSER = new com.google.protobuf.AbstractParser<AddTxRequest>() {
-      @java.lang.Override
       public AddTxRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new AddTxRequest(input, extensionRegistry);
+          return new AddTxRequest(input, extensionRegistry);
       }
     };
 
@@ -4894,7 +4755,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.AddTxRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -4952,9 +4812,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -4966,16 +4823,16 @@ public final class OmniLedgerProto {
             case 0:
               done = true;
               break;
-            case 8: {
-              bitField0_ |= 0x00000001;
-              version_ = input.readSInt32();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              version_ = input.readSInt32();
               break;
             }
           }
@@ -4995,7 +4852,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_AddTxResponse_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_AddTxResponse_fieldAccessorTable
@@ -5028,7 +4884,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -5042,7 +4897,6 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -5051,7 +4905,6 @@ public final class OmniLedgerProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -5172,7 +5025,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -5180,7 +5032,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.AddTxResponse prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -5208,7 +5059,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_AddTxResponse_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_AddTxResponse_fieldAccessorTable
@@ -5231,7 +5081,6 @@ public final class OmniLedgerProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         version_ = 0;
@@ -5239,18 +5088,15 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_AddTxResponse_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.AddTxResponse getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.AddTxResponse.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.AddTxResponse build() {
         ch.epfl.dedis.proto.OmniLedgerProto.AddTxResponse result = buildPartial();
         if (!result.isInitialized()) {
@@ -5259,7 +5105,6 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.AddTxResponse buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.AddTxResponse result = new ch.epfl.dedis.proto.OmniLedgerProto.AddTxResponse(this);
         int from_bitField0_ = bitField0_;
@@ -5273,39 +5118,32 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.AddTxResponse) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.AddTxResponse)other);
@@ -5325,7 +5163,6 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasVersion()) {
           return false;
@@ -5333,7 +5170,6 @@ public final class OmniLedgerProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -5400,13 +5236,11 @@ public final class OmniLedgerProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -5428,12 +5262,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<AddTxResponse>
         PARSER = new com.google.protobuf.AbstractParser<AddTxResponse>() {
-      @java.lang.Override
       public AddTxResponse parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new AddTxResponse(input, extensionRegistry);
+          return new AddTxResponse(input, extensionRegistry);
       }
     };
 
@@ -5446,7 +5279,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.AddTxResponse getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -5542,9 +5374,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -5556,6 +5385,13 @@ public final class OmniLedgerProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 8: {
               bitField0_ |= 0x00000001;
               version_ = input.readSInt32();
@@ -5569,13 +5405,6 @@ public final class OmniLedgerProto {
             case 26: {
               bitField0_ |= 0x00000004;
               id_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -5595,7 +5424,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_GetProof_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_GetProof_fieldAccessorTable
@@ -5676,7 +5504,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -5698,7 +5525,6 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -5713,7 +5539,6 @@ public final class OmniLedgerProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -5860,7 +5685,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -5868,7 +5692,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.GetProof prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -5896,7 +5719,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_GetProof_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_GetProof_fieldAccessorTable
@@ -5919,7 +5741,6 @@ public final class OmniLedgerProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         version_ = 0;
@@ -5931,18 +5752,15 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_GetProof_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.GetProof getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.GetProof.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.GetProof build() {
         ch.epfl.dedis.proto.OmniLedgerProto.GetProof result = buildPartial();
         if (!result.isInitialized()) {
@@ -5951,7 +5769,6 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.GetProof buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.GetProof result = new ch.epfl.dedis.proto.OmniLedgerProto.GetProof(this);
         int from_bitField0_ = bitField0_;
@@ -5973,39 +5790,32 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.GetProof) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.GetProof)other);
@@ -6031,7 +5841,6 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasVersion()) {
           return false;
@@ -6045,7 +5854,6 @@ public final class OmniLedgerProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -6218,13 +6026,11 @@ public final class OmniLedgerProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -6246,12 +6052,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<GetProof>
         PARSER = new com.google.protobuf.AbstractParser<GetProof>() {
-      @java.lang.Override
       public GetProof parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GetProof(input, extensionRegistry);
+          return new GetProof(input, extensionRegistry);
       }
     };
 
@@ -6264,7 +6069,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.GetProof getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -6351,9 +6155,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -6365,6 +6166,13 @@ public final class OmniLedgerProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 8: {
               bitField0_ |= 0x00000001;
               version_ = input.readSInt32();
@@ -6381,13 +6189,6 @@ public final class OmniLedgerProto {
                 proof_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000002;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -6407,7 +6208,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_GetProofResponse_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_GetProofResponse_fieldAccessorTable
@@ -6476,7 +6276,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -6498,7 +6297,6 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -6510,7 +6308,6 @@ public final class OmniLedgerProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -6644,7 +6441,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -6652,7 +6448,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.GetProofResponse prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -6681,7 +6476,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_GetProofResponse_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_GetProofResponse_fieldAccessorTable
@@ -6705,7 +6499,6 @@ public final class OmniLedgerProto {
           getProofFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         version_ = 0;
@@ -6719,18 +6512,15 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_GetProofResponse_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.GetProofResponse getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.GetProofResponse.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.GetProofResponse build() {
         ch.epfl.dedis.proto.OmniLedgerProto.GetProofResponse result = buildPartial();
         if (!result.isInitialized()) {
@@ -6739,7 +6529,6 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.GetProofResponse buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.GetProofResponse result = new ch.epfl.dedis.proto.OmniLedgerProto.GetProofResponse(this);
         int from_bitField0_ = bitField0_;
@@ -6761,39 +6550,32 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.GetProofResponse) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.GetProofResponse)other);
@@ -6816,7 +6598,6 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasVersion()) {
           return false;
@@ -6830,7 +6611,6 @@ public final class OmniLedgerProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -7060,13 +6840,11 @@ public final class OmniLedgerProto {
         }
         return proofBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -7088,12 +6866,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<GetProofResponse>
         PARSER = new com.google.protobuf.AbstractParser<GetProofResponse>() {
-      @java.lang.Override
       public GetProofResponse parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GetProofResponse(input, extensionRegistry);
+          return new GetProofResponse(input, extensionRegistry);
       }
     };
 
@@ -7106,7 +6883,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.GetProofResponse getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -7171,9 +6947,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -7185,6 +6958,13 @@ public final class OmniLedgerProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 8: {
               bitField0_ |= 0x00000001;
               blockinterval_ = input.readSInt64();
@@ -7201,13 +6981,6 @@ public final class OmniLedgerProto {
                 roster_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000002;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -7227,7 +7000,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_ChainConfig_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_ChainConfig_fieldAccessorTable
@@ -7273,7 +7045,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -7295,7 +7066,6 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -7307,7 +7077,6 @@ public final class OmniLedgerProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -7442,7 +7211,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -7450,7 +7218,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.ChainConfig prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -7480,7 +7247,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_ChainConfig_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_ChainConfig_fieldAccessorTable
@@ -7504,7 +7270,6 @@ public final class OmniLedgerProto {
           getRosterFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         blockinterval_ = 0L;
@@ -7518,18 +7283,15 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_ChainConfig_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.ChainConfig getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.ChainConfig.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.ChainConfig build() {
         ch.epfl.dedis.proto.OmniLedgerProto.ChainConfig result = buildPartial();
         if (!result.isInitialized()) {
@@ -7538,7 +7300,6 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.ChainConfig buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.ChainConfig result = new ch.epfl.dedis.proto.OmniLedgerProto.ChainConfig(this);
         int from_bitField0_ = bitField0_;
@@ -7560,39 +7321,32 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.ChainConfig) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.ChainConfig)other);
@@ -7615,7 +7369,6 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasBlockinterval()) {
           return false;
@@ -7629,7 +7382,6 @@ public final class OmniLedgerProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -7798,13 +7550,11 @@ public final class OmniLedgerProto {
         }
         return rosterBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -7826,12 +7576,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<ChainConfig>
         PARSER = new com.google.protobuf.AbstractParser<ChainConfig>() {
-      @java.lang.Override
       public ChainConfig parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ChainConfig(input, extensionRegistry);
+          return new ChainConfig(input, extensionRegistry);
       }
     };
 
@@ -7844,7 +7593,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.ChainConfig getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -7996,9 +7744,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -8010,6 +7755,13 @@ public final class OmniLedgerProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.CollectionProto.Proof.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -8045,13 +7797,6 @@ public final class OmniLedgerProto {
                   input.readMessage(ch.epfl.dedis.proto.SkipchainProto.ForwardLink.PARSER, extensionRegistry));
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -8072,7 +7817,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Proof_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Proof_fieldAccessorTable
@@ -8213,7 +7957,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -8245,7 +7988,6 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -8260,7 +8002,6 @@ public final class OmniLedgerProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -8404,7 +8145,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -8412,7 +8152,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.Proof prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -8447,7 +8186,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Proof_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Proof_fieldAccessorTable
@@ -8473,7 +8211,6 @@ public final class OmniLedgerProto {
           getLinksFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (inclusionproofBuilder_ == null) {
@@ -8497,18 +8234,15 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Proof_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Proof getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.Proof.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Proof build() {
         ch.epfl.dedis.proto.OmniLedgerProto.Proof result = buildPartial();
         if (!result.isInitialized()) {
@@ -8517,7 +8251,6 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Proof buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.Proof result = new ch.epfl.dedis.proto.OmniLedgerProto.Proof(this);
         int from_bitField0_ = bitField0_;
@@ -8552,39 +8285,32 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.Proof) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.Proof)other);
@@ -8633,7 +8359,6 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasInclusionproof()) {
           return false;
@@ -8655,7 +8380,6 @@ public final class OmniLedgerProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -9330,13 +9054,11 @@ public final class OmniLedgerProto {
         }
         return linksBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -9358,12 +9080,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Proof>
         PARSER = new com.google.protobuf.AbstractParser<Proof>() {
-      @java.lang.Override
       public Proof parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Proof(input, extensionRegistry);
+          return new Proof(input, extensionRegistry);
       }
     };
 
@@ -9376,7 +9097,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.Proof getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -9618,9 +9338,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -9632,6 +9349,13 @@ public final class OmniLedgerProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               instanceid_ = input.readBytes();
@@ -9700,13 +9424,6 @@ public final class OmniLedgerProto {
                   input.readMessage(ch.epfl.dedis.proto.DarcProto.Signature.PARSER, extensionRegistry));
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -9727,7 +9444,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Instruction_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Instruction_fieldAccessorTable
@@ -9993,7 +9709,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -10037,7 +9752,6 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -10067,7 +9781,6 @@ public final class OmniLedgerProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -10276,7 +9989,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -10284,7 +9996,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.Instruction prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -10312,7 +10023,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Instruction_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Instruction_fieldAccessorTable
@@ -10339,7 +10049,6 @@ public final class OmniLedgerProto {
           getSignaturesFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         instanceid_ = com.google.protobuf.ByteString.EMPTY;
@@ -10377,18 +10086,15 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Instruction_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Instruction getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.Instruction.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Instruction build() {
         ch.epfl.dedis.proto.OmniLedgerProto.Instruction result = buildPartial();
         if (!result.isInitialized()) {
@@ -10397,7 +10103,6 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Instruction buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.Instruction result = new ch.epfl.dedis.proto.OmniLedgerProto.Instruction(this);
         int from_bitField0_ = bitField0_;
@@ -10456,39 +10161,32 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.Instruction) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.Instruction)other);
@@ -10552,7 +10250,6 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasInstanceid()) {
           return false;
@@ -10584,7 +10281,6 @@ public final class OmniLedgerProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -11595,13 +11291,11 @@ public final class OmniLedgerProto {
         }
         return signaturesBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -11623,12 +11317,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Instruction>
         PARSER = new com.google.protobuf.AbstractParser<Instruction>() {
-      @java.lang.Override
       public Instruction parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Instruction(input, extensionRegistry);
+          return new Instruction(input, extensionRegistry);
       }
     };
 
@@ -11641,7 +11334,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.Instruction getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -11753,9 +11445,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -11767,6 +11456,13 @@ public final class OmniLedgerProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
@@ -11780,13 +11476,6 @@ public final class OmniLedgerProto {
               }
               args_.add(
                   input.readMessage(ch.epfl.dedis.proto.OmniLedgerProto.Argument.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -11809,7 +11498,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Spawn_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Spawn_fieldAccessorTable
@@ -11928,7 +11616,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -11948,7 +11635,6 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -11960,7 +11646,6 @@ public final class OmniLedgerProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -12090,7 +11775,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -12098,7 +11782,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.Spawn prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -12126,7 +11809,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Spawn_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Spawn_fieldAccessorTable
@@ -12150,7 +11832,6 @@ public final class OmniLedgerProto {
           getArgsFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         contractid_ = "";
@@ -12164,18 +11845,15 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Spawn_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Spawn getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.Spawn.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Spawn build() {
         ch.epfl.dedis.proto.OmniLedgerProto.Spawn result = buildPartial();
         if (!result.isInitialized()) {
@@ -12184,7 +11862,6 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Spawn buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.Spawn result = new ch.epfl.dedis.proto.OmniLedgerProto.Spawn(this);
         int from_bitField0_ = bitField0_;
@@ -12207,39 +11884,32 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.Spawn) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.Spawn)other);
@@ -12287,7 +11957,6 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasContractid()) {
           return false;
@@ -12300,7 +11969,6 @@ public final class OmniLedgerProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -12731,13 +12399,11 @@ public final class OmniLedgerProto {
         }
         return argsBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -12759,12 +12425,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Spawn>
         PARSER = new com.google.protobuf.AbstractParser<Spawn>() {
-      @java.lang.Override
       public Spawn parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Spawn(input, extensionRegistry);
+          return new Spawn(input, extensionRegistry);
       }
     };
 
@@ -12777,7 +12442,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.Spawn getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -12890,9 +12554,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -12904,6 +12565,13 @@ public final class OmniLedgerProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
@@ -12917,13 +12585,6 @@ public final class OmniLedgerProto {
               }
               args_.add(
                   input.readMessage(ch.epfl.dedis.proto.OmniLedgerProto.Argument.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -12946,7 +12607,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Invoke_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Invoke_fieldAccessorTable
@@ -13065,7 +12725,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -13085,7 +12744,6 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -13097,7 +12755,6 @@ public final class OmniLedgerProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -13227,7 +12884,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -13235,7 +12891,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.Invoke prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -13264,7 +12919,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Invoke_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Invoke_fieldAccessorTable
@@ -13288,7 +12942,6 @@ public final class OmniLedgerProto {
           getArgsFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         command_ = "";
@@ -13302,18 +12955,15 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Invoke_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Invoke getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.Invoke.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Invoke build() {
         ch.epfl.dedis.proto.OmniLedgerProto.Invoke result = buildPartial();
         if (!result.isInitialized()) {
@@ -13322,7 +12972,6 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Invoke buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.Invoke result = new ch.epfl.dedis.proto.OmniLedgerProto.Invoke(this);
         int from_bitField0_ = bitField0_;
@@ -13345,39 +12994,32 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.Invoke) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.Invoke)other);
@@ -13425,7 +13067,6 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasCommand()) {
           return false;
@@ -13438,7 +13079,6 @@ public final class OmniLedgerProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -13869,13 +13509,11 @@ public final class OmniLedgerProto {
         }
         return argsBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -13897,12 +13535,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Invoke>
         PARSER = new com.google.protobuf.AbstractParser<Invoke>() {
-      @java.lang.Override
       public Invoke parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Invoke(input, extensionRegistry);
+          return new Invoke(input, extensionRegistry);
       }
     };
 
@@ -13915,7 +13552,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.Invoke getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -13956,9 +13592,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
@@ -13993,7 +13626,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Delete_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Delete_fieldAccessorTable
@@ -14002,7 +13634,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -14012,13 +13643,11 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -14126,7 +13755,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -14134,7 +13762,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.Delete prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -14163,7 +13790,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Delete_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Delete_fieldAccessorTable
@@ -14186,24 +13812,20 @@ public final class OmniLedgerProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Delete_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Delete getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.Delete.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Delete build() {
         ch.epfl.dedis.proto.OmniLedgerProto.Delete result = buildPartial();
         if (!result.isInitialized()) {
@@ -14212,46 +13834,38 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Delete buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.Delete result = new ch.epfl.dedis.proto.OmniLedgerProto.Delete(this);
         onBuilt();
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.Delete) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.Delete)other);
@@ -14268,12 +13882,10 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -14291,13 +13903,11 @@ public final class OmniLedgerProto {
         }
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -14319,12 +13929,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Delete>
         PARSER = new com.google.protobuf.AbstractParser<Delete>() {
-      @java.lang.Override
       public Delete parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Delete(input, extensionRegistry);
+          return new Delete(input, extensionRegistry);
       }
     };
 
@@ -14337,7 +13946,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.Delete getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -14422,9 +14030,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -14436,6 +14041,13 @@ public final class OmniLedgerProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
@@ -14445,13 +14057,6 @@ public final class OmniLedgerProto {
             case 18: {
               bitField0_ |= 0x00000002;
               value_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -14471,7 +14076,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Argument_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Argument_fieldAccessorTable
@@ -14558,7 +14162,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -14576,7 +14179,6 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -14588,7 +14190,6 @@ public final class OmniLedgerProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -14721,7 +14322,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -14729,7 +14329,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.Argument prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -14757,7 +14356,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Argument_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Argument_fieldAccessorTable
@@ -14780,7 +14378,6 @@ public final class OmniLedgerProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         name_ = "";
@@ -14790,18 +14387,15 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Argument_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Argument getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.Argument.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Argument build() {
         ch.epfl.dedis.proto.OmniLedgerProto.Argument result = buildPartial();
         if (!result.isInitialized()) {
@@ -14810,7 +14404,6 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Argument buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.Argument result = new ch.epfl.dedis.proto.OmniLedgerProto.Argument(this);
         int from_bitField0_ = bitField0_;
@@ -14828,39 +14421,32 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.Argument) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.Argument)other);
@@ -14885,7 +14471,6 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasName()) {
           return false;
@@ -14896,7 +14481,6 @@ public final class OmniLedgerProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -15066,13 +14650,11 @@ public final class OmniLedgerProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -15094,12 +14676,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Argument>
         PARSER = new com.google.protobuf.AbstractParser<Argument>() {
-      @java.lang.Override
       public Argument parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Argument(input, extensionRegistry);
+          return new Argument(input, extensionRegistry);
       }
     };
 
@@ -15112,7 +14693,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.Argument getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -15178,9 +14758,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -15192,6 +14769,13 @@ public final class OmniLedgerProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 instructions_ = new java.util.ArrayList<ch.epfl.dedis.proto.OmniLedgerProto.Instruction>();
@@ -15199,13 +14783,6 @@ public final class OmniLedgerProto {
               }
               instructions_.add(
                   input.readMessage(ch.epfl.dedis.proto.OmniLedgerProto.Instruction.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -15228,7 +14805,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_ClientTransaction_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_ClientTransaction_fieldAccessorTable
@@ -15272,7 +14848,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -15288,7 +14863,6 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       for (int i = 0; i < instructions_.size(); i++) {
@@ -15297,7 +14871,6 @@ public final class OmniLedgerProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -15415,7 +14988,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -15423,7 +14995,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.ClientTransaction prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -15452,7 +15023,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_ClientTransaction_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_ClientTransaction_fieldAccessorTable
@@ -15476,7 +15046,6 @@ public final class OmniLedgerProto {
           getInstructionsFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (instructionsBuilder_ == null) {
@@ -15488,18 +15057,15 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_ClientTransaction_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.ClientTransaction getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.ClientTransaction.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.ClientTransaction build() {
         ch.epfl.dedis.proto.OmniLedgerProto.ClientTransaction result = buildPartial();
         if (!result.isInitialized()) {
@@ -15508,7 +15074,6 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.ClientTransaction buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.ClientTransaction result = new ch.epfl.dedis.proto.OmniLedgerProto.ClientTransaction(this);
         int from_bitField0_ = bitField0_;
@@ -15525,39 +15090,32 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.ClientTransaction) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.ClientTransaction)other);
@@ -15600,7 +15158,6 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         for (int i = 0; i < getInstructionsCount(); i++) {
           if (!getInstructions(i).isInitialized()) {
@@ -15610,7 +15167,6 @@ public final class OmniLedgerProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -15869,13 +15425,11 @@ public final class OmniLedgerProto {
         }
         return instructionsBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -15897,12 +15451,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<ClientTransaction>
         PARSER = new com.google.protobuf.AbstractParser<ClientTransaction>() {
-      @java.lang.Override
       public ClientTransaction parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ClientTransaction(input, extensionRegistry);
+          return new ClientTransaction(input, extensionRegistry);
       }
     };
 
@@ -15915,7 +15468,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.ClientTransaction getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -16045,9 +15597,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -16059,6 +15608,13 @@ public final class OmniLedgerProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 8: {
               bitField0_ |= 0x00000001;
               stateaction_ = input.readSInt32();
@@ -16084,13 +15640,6 @@ public final class OmniLedgerProto {
               darcid_ = input.readBytes();
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -16108,7 +15657,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_StateChange_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_StateChange_fieldAccessorTable
@@ -16233,7 +15781,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -16263,7 +15810,6 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -16284,7 +15830,6 @@ public final class OmniLedgerProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -16457,7 +16002,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -16465,7 +16009,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.StateChange prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -16493,7 +16036,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_StateChange_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_StateChange_fieldAccessorTable
@@ -16516,7 +16058,6 @@ public final class OmniLedgerProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         stateaction_ = 0;
@@ -16532,18 +16073,15 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_StateChange_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.StateChange getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.StateChange.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.StateChange build() {
         ch.epfl.dedis.proto.OmniLedgerProto.StateChange result = buildPartial();
         if (!result.isInitialized()) {
@@ -16552,7 +16090,6 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.StateChange buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.StateChange result = new ch.epfl.dedis.proto.OmniLedgerProto.StateChange(this);
         int from_bitField0_ = bitField0_;
@@ -16582,39 +16119,32 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.StateChange) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.StateChange)other);
@@ -16646,7 +16176,6 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasStateaction()) {
           return false;
@@ -16666,7 +16195,6 @@ public final class OmniLedgerProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -16937,13 +16465,11 @@ public final class OmniLedgerProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -16965,12 +16491,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<StateChange>
         PARSER = new com.google.protobuf.AbstractParser<StateChange>() {
-      @java.lang.Override
       public StateChange parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new StateChange(input, extensionRegistry);
+          return new StateChange(input, extensionRegistry);
       }
     };
 
@@ -16983,7 +16508,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.StateChange getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -17060,9 +16584,6 @@ public final class OmniLedgerProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -17074,6 +16595,13 @@ public final class OmniLedgerProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               name_ = input.readBytes();
@@ -17082,13 +16610,6 @@ public final class OmniLedgerProto {
             case 16: {
               bitField0_ |= 0x00000002;
               value_ = input.readUInt64();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -17108,7 +16629,6 @@ public final class OmniLedgerProto {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Coin_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Coin_fieldAccessorTable
@@ -17164,7 +16684,6 @@ public final class OmniLedgerProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -17182,7 +16701,6 @@ public final class OmniLedgerProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -17194,7 +16712,6 @@ public final class OmniLedgerProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -17329,7 +16846,6 @@ public final class OmniLedgerProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -17337,7 +16853,6 @@ public final class OmniLedgerProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OmniLedgerProto.Coin prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -17366,7 +16881,6 @@ public final class OmniLedgerProto {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Coin_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Coin_fieldAccessorTable
@@ -17389,7 +16903,6 @@ public final class OmniLedgerProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         name_ = com.google.protobuf.ByteString.EMPTY;
@@ -17399,18 +16912,15 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.internal_static_omniledger_Coin_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Coin getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OmniLedgerProto.Coin.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Coin build() {
         ch.epfl.dedis.proto.OmniLedgerProto.Coin result = buildPartial();
         if (!result.isInitialized()) {
@@ -17419,7 +16929,6 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OmniLedgerProto.Coin buildPartial() {
         ch.epfl.dedis.proto.OmniLedgerProto.Coin result = new ch.epfl.dedis.proto.OmniLedgerProto.Coin(this);
         int from_bitField0_ = bitField0_;
@@ -17437,39 +16946,32 @@ public final class OmniLedgerProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OmniLedgerProto.Coin) {
           return mergeFrom((ch.epfl.dedis.proto.OmniLedgerProto.Coin)other);
@@ -17492,7 +16994,6 @@ public final class OmniLedgerProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasName()) {
           return false;
@@ -17503,7 +17004,6 @@ public final class OmniLedgerProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -17621,13 +17121,11 @@ public final class OmniLedgerProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -17649,12 +17147,11 @@ public final class OmniLedgerProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Coin>
         PARSER = new com.google.protobuf.AbstractParser<Coin>() {
-      @java.lang.Override
       public Coin parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Coin(input, extensionRegistry);
+          return new Coin(input, extensionRegistry);
       }
     };
 
@@ -17667,7 +17164,6 @@ public final class OmniLedgerProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OmniLedgerProto.Coin getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -17782,7 +17278,7 @@ public final class OmniLedgerProto {
       "omniledger.ClientTransaction\"{\n\022CreateGe" +
       "nesisBlock\022\017\n\007version\030\001 \002(\021\022\034\n\006roster\030\002 " +
       "\002(\0132\014.onet.Roster\022\037\n\013genesisdarc\030\003 \002(\0132\n" +
-      ".darc.Darc\022\025\n\rblockinterval\030\004 \002(\022\"V\n\032Cre" +
+      ".darc.Darc\022\025\n\rblockinterval\030\004 \002(\022\"V\n\032Cre",
       "ateGenesisBlockResponse\022\017\n\007version\030\001 \002(\021" +
       "\022\'\n\tskipblock\030\002 \001(\0132\024.skipchain.SkipBloc" +
       "k\"\177\n\014AddTxRequest\022\017\n\007version\030\001 \002(\021\022\023\n\013sk" +
@@ -17792,7 +17288,7 @@ public final class OmniLedgerProto {
       " \002(\021\"4\n\010GetProof\022\017\n\007version\030\001 \002(\021\022\013\n\003key" +
       "\030\002 \002(\014\022\n\n\002id\030\003 \002(\014\"E\n\020GetProofResponse\022\017" +
       "\n\007version\030\001 \002(\021\022 \n\005proof\030\002 \002(\0132\021.omniled" +
-      "ger.Proof\"B\n\013ChainConfig\022\025\n\rblockinterva" +
+      "ger.Proof\"B\n\013ChainConfig\022\025\n\rblockinterva",
       "l\030\001 \002(\022\022\034\n\006roster\030\002 \002(\0132\014.onet.Roster\"\177\n" +
       "\005Proof\022)\n\016inclusionproof\030\001 \002(\0132\021.collect" +
       "ion.Proof\022$\n\006latest\030\002 \002(\0132\024.skipchain.Sk" +
@@ -17802,7 +17298,7 @@ public final class OmniLedgerProto {
       "th\030\004 \002(\021\022 \n\005spawn\030\005 \001(\0132\021.omniledger.Spa" +
       "wn\022\"\n\006invoke\030\006 \001(\0132\022.omniledger.Invoke\022\"" +
       "\n\006delete\030\007 \001(\0132\022.omniledger.Delete\022#\n\nsi" +
-      "gnatures\030\010 \003(\0132\017.darc.Signature\"?\n\005Spawn" +
+      "gnatures\030\010 \003(\0132\017.darc.Signature\"?\n\005Spawn",
       "\022\022\n\ncontractid\030\001 \002(\t\022\"\n\004args\030\002 \003(\0132\024.omn" +
       "iledger.Argument\"=\n\006Invoke\022\017\n\007command\030\001 " +
       "\002(\t\022\"\n\004args\030\002 \003(\0132\024.omniledger.Argument\"" +
@@ -17812,7 +17308,7 @@ public final class OmniLedgerProto {
       "\n\013StateChange\022\023\n\013stateaction\030\001 \002(\021\022\022\n\nin" +
       "stanceid\030\002 \002(\014\022\022\n\ncontractid\030\003 \002(\014\022\r\n\005va" +
       "lue\030\004 \002(\014\022\016\n\006darcid\030\005 \002(\014\"#\n\004Coin\022\014\n\004nam" +
-      "e\030\001 \002(\014\022\r\n\005value\030\002 \002(\004B&\n\023ch.epfl.dedis." +
+      "e\030\001 \002(\014\022\r\n\005value\030\002 \002(\004B&\n\023ch.epfl.dedis.",
       "protoB\017OmniLedgerProto"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =

--- a/external/java/src/main/java/ch/epfl/dedis/proto/OnetProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/proto/OnetProto.java
@@ -88,9 +88,6 @@ public final class OnetProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -102,6 +99,13 @@ public final class OnetProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               id_ = input.readBytes();
@@ -119,13 +123,6 @@ public final class OnetProto {
             case 26: {
               bitField0_ |= 0x00000002;
               aggregate_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -148,7 +145,6 @@ public final class OnetProto {
       return ch.epfl.dedis.proto.OnetProto.internal_static_onet_Roster_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OnetProto.internal_static_onet_Roster_fieldAccessorTable
@@ -223,7 +219,6 @@ public final class OnetProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -243,7 +238,6 @@ public final class OnetProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -258,7 +252,6 @@ public final class OnetProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -402,7 +395,6 @@ public final class OnetProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -410,7 +402,6 @@ public final class OnetProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OnetProto.Roster prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -434,7 +425,6 @@ public final class OnetProto {
         return ch.epfl.dedis.proto.OnetProto.internal_static_onet_Roster_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OnetProto.internal_static_onet_Roster_fieldAccessorTable
@@ -458,7 +448,6 @@ public final class OnetProto {
           getListFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         id_ = com.google.protobuf.ByteString.EMPTY;
@@ -474,18 +463,15 @@ public final class OnetProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OnetProto.internal_static_onet_Roster_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OnetProto.Roster getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OnetProto.Roster.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OnetProto.Roster build() {
         ch.epfl.dedis.proto.OnetProto.Roster result = buildPartial();
         if (!result.isInitialized()) {
@@ -494,7 +480,6 @@ public final class OnetProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OnetProto.Roster buildPartial() {
         ch.epfl.dedis.proto.OnetProto.Roster result = new ch.epfl.dedis.proto.OnetProto.Roster(this);
         int from_bitField0_ = bitField0_;
@@ -521,39 +506,32 @@ public final class OnetProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OnetProto.Roster) {
           return mergeFrom((ch.epfl.dedis.proto.OnetProto.Roster)other);
@@ -602,7 +580,6 @@ public final class OnetProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasAggregate()) {
           return false;
@@ -615,7 +592,6 @@ public final class OnetProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -944,13 +920,11 @@ public final class OnetProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -972,12 +946,11 @@ public final class OnetProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Roster>
         PARSER = new com.google.protobuf.AbstractParser<Roster>() {
-      @java.lang.Override
       public Roster parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Roster(input, extensionRegistry);
+          return new Roster(input, extensionRegistry);
       }
     };
 
@@ -990,7 +963,6 @@ public final class OnetProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OnetProto.Roster getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -1060,9 +1032,6 @@ public final class OnetProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1074,6 +1043,13 @@ public final class OnetProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 field_ = com.google.protobuf.MapField.newMapField(
@@ -1085,13 +1061,6 @@ public final class OnetProto {
                   FieldDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
               field_.getMutableMap().put(
                   field__.getKey(), field__.getValue());
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -1112,7 +1081,6 @@ public final class OnetProto {
     }
 
     @SuppressWarnings({"rawtypes"})
-    @java.lang.Override
     protected com.google.protobuf.MapField internalGetMapField(
         int number) {
       switch (number) {
@@ -1123,7 +1091,6 @@ public final class OnetProto {
               "Invalid map field number: " + number);
       }
     }
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.OnetProto.internal_static_onet_Status_fieldAccessorTable
@@ -1208,7 +1175,6 @@ public final class OnetProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1218,7 +1184,6 @@ public final class OnetProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       com.google.protobuf.GeneratedMessageV3
@@ -1230,7 +1195,6 @@ public final class OnetProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -1354,7 +1318,6 @@ public final class OnetProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -1362,7 +1325,6 @@ public final class OnetProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.OnetProto.Status prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -1408,7 +1370,6 @@ public final class OnetProto {
                 "Invalid map field number: " + number);
         }
       }
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.OnetProto.internal_static_onet_Status_fieldAccessorTable
@@ -1431,25 +1392,21 @@ public final class OnetProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         internalGetMutableField().clear();
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.OnetProto.internal_static_onet_Status_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OnetProto.Status getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.OnetProto.Status.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OnetProto.Status build() {
         ch.epfl.dedis.proto.OnetProto.Status result = buildPartial();
         if (!result.isInitialized()) {
@@ -1458,7 +1415,6 @@ public final class OnetProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.OnetProto.Status buildPartial() {
         ch.epfl.dedis.proto.OnetProto.Status result = new ch.epfl.dedis.proto.OnetProto.Status(this);
         int from_bitField0_ = bitField0_;
@@ -1468,39 +1424,32 @@ public final class OnetProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.OnetProto.Status) {
           return mergeFrom((ch.epfl.dedis.proto.OnetProto.Status)other);
@@ -1519,12 +1468,10 @@ public final class OnetProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1666,13 +1613,11 @@ public final class OnetProto {
             .putAll(values);
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -1694,12 +1639,11 @@ public final class OnetProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Status>
         PARSER = new com.google.protobuf.AbstractParser<Status>() {
-      @java.lang.Override
       public Status parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Status(input, extensionRegistry);
+          return new Status(input, extensionRegistry);
       }
     };
 
@@ -1712,7 +1656,6 @@ public final class OnetProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.OnetProto.Status getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }

--- a/external/java/src/main/java/ch/epfl/dedis/proto/PoPProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/proto/PoPProto.java
@@ -76,9 +76,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -90,6 +87,13 @@ public final class PoPProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
@@ -109,13 +113,6 @@ public final class PoPProto {
               bitField0_ |= 0x00000002;
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -133,7 +130,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_ShortDesc_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_ShortDesc_fieldAccessorTable
@@ -206,7 +202,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -226,7 +221,6 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -238,7 +232,6 @@ public final class PoPProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -371,7 +364,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -379,7 +371,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.ShortDesc prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -408,7 +399,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_ShortDesc_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_ShortDesc_fieldAccessorTable
@@ -432,7 +422,6 @@ public final class PoPProto {
           getRosterFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         location_ = "";
@@ -446,18 +435,15 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_ShortDesc_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.ShortDesc getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.ShortDesc.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.ShortDesc build() {
         ch.epfl.dedis.proto.PoPProto.ShortDesc result = buildPartial();
         if (!result.isInitialized()) {
@@ -466,7 +452,6 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.ShortDesc buildPartial() {
         ch.epfl.dedis.proto.PoPProto.ShortDesc result = new ch.epfl.dedis.proto.PoPProto.ShortDesc(this);
         int from_bitField0_ = bitField0_;
@@ -488,39 +473,32 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.ShortDesc) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.ShortDesc)other);
@@ -545,7 +523,6 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasLocation()) {
           return false;
@@ -558,7 +535,6 @@ public final class PoPProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -771,13 +747,11 @@ public final class PoPProto {
         }
         return rosterBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -799,12 +773,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<ShortDesc>
         PARSER = new com.google.protobuf.AbstractParser<ShortDesc>() {
-      @java.lang.Override
       public ShortDesc parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ShortDesc(input, extensionRegistry);
+          return new ShortDesc(input, extensionRegistry);
       }
     };
 
@@ -817,7 +790,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.ShortDesc getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -1011,9 +983,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1025,6 +994,13 @@ public final class PoPProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
@@ -1065,13 +1041,6 @@ public final class PoPProto {
                   input.readMessage(ch.epfl.dedis.proto.PoPProto.ShortDesc.PARSER, extensionRegistry));
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -1092,7 +1061,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_PopDesc_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_PopDesc_fieldAccessorTable
@@ -1355,7 +1323,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1389,7 +1356,6 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -1410,7 +1376,6 @@ public final class PoPProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -1577,7 +1542,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -1585,7 +1549,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.PopDesc prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -1613,7 +1576,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_PopDesc_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_PopDesc_fieldAccessorTable
@@ -1638,7 +1600,6 @@ public final class PoPProto {
           getPartiesFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         name_ = "";
@@ -1662,18 +1623,15 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_PopDesc_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.PopDesc getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.PopDesc.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.PopDesc build() {
         ch.epfl.dedis.proto.PoPProto.PopDesc result = buildPartial();
         if (!result.isInitialized()) {
@@ -1682,7 +1640,6 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.PopDesc buildPartial() {
         ch.epfl.dedis.proto.PoPProto.PopDesc result = new ch.epfl.dedis.proto.PoPProto.PopDesc(this);
         int from_bitField0_ = bitField0_;
@@ -1721,39 +1678,32 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.PopDesc) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.PopDesc)other);
@@ -1814,7 +1764,6 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasName()) {
           return false;
@@ -1838,7 +1787,6 @@ public final class PoPProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2629,13 +2577,11 @@ public final class PoPProto {
         }
         return partiesBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -2657,12 +2603,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<PopDesc>
         PARSER = new com.google.protobuf.AbstractParser<PopDesc>() {
-      @java.lang.Override
       public PopDesc parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new PopDesc(input, extensionRegistry);
+          return new PopDesc(input, extensionRegistry);
       }
     };
 
@@ -2675,7 +2620,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.PopDesc getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -2803,9 +2747,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -2817,6 +2758,13 @@ public final class PoPProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.PoPProto.PopDesc.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -2848,13 +2796,6 @@ public final class PoPProto {
               merged_ = input.readBool();
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -2875,7 +2816,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FinalStatement_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FinalStatement_fieldAccessorTable
@@ -2998,7 +2938,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -3022,7 +2961,6 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -3040,7 +2978,6 @@ public final class PoPProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -3203,7 +3140,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -3211,7 +3147,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.FinalStatement prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -3240,7 +3175,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FinalStatement_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FinalStatement_fieldAccessorTable
@@ -3264,7 +3198,6 @@ public final class PoPProto {
           getDescFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (descBuilder_ == null) {
@@ -3282,18 +3215,15 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FinalStatement_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.FinalStatement getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.FinalStatement.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.FinalStatement build() {
         ch.epfl.dedis.proto.PoPProto.FinalStatement result = buildPartial();
         if (!result.isInitialized()) {
@@ -3302,7 +3232,6 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.FinalStatement buildPartial() {
         ch.epfl.dedis.proto.PoPProto.FinalStatement result = new ch.epfl.dedis.proto.PoPProto.FinalStatement(this);
         int from_bitField0_ = bitField0_;
@@ -3333,39 +3262,32 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.FinalStatement) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.FinalStatement)other);
@@ -3401,7 +3323,6 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasSignature()) {
           return false;
@@ -3417,7 +3338,6 @@ public final class PoPProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -3789,13 +3709,11 @@ public final class PoPProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -3817,12 +3735,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<FinalStatement>
         PARSER = new com.google.protobuf.AbstractParser<FinalStatement>() {
-      @java.lang.Override
       public FinalStatement parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new FinalStatement(input, extensionRegistry);
+          return new FinalStatement(input, extensionRegistry);
       }
     };
 
@@ -3835,7 +3752,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.FinalStatement getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -3899,9 +3815,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -3913,6 +3826,13 @@ public final class PoPProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               pophash_ = input.readBytes();
@@ -3924,13 +3844,6 @@ public final class PoPProto {
                 mutable_bitField0_ |= 0x00000002;
               }
               attendees_.add(input.readBytes());
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -3953,7 +3866,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_CheckConfig_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_CheckConfig_fieldAccessorTable
@@ -4000,7 +3912,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -4014,7 +3925,6 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -4026,7 +3936,6 @@ public final class PoPProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -4162,7 +4071,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -4170,7 +4078,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.CheckConfig prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -4198,7 +4105,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_CheckConfig_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_CheckConfig_fieldAccessorTable
@@ -4221,7 +4127,6 @@ public final class PoPProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         pophash_ = com.google.protobuf.ByteString.EMPTY;
@@ -4231,18 +4136,15 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_CheckConfig_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.CheckConfig getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.CheckConfig.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.CheckConfig build() {
         ch.epfl.dedis.proto.PoPProto.CheckConfig result = buildPartial();
         if (!result.isInitialized()) {
@@ -4251,7 +4153,6 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.CheckConfig buildPartial() {
         ch.epfl.dedis.proto.PoPProto.CheckConfig result = new ch.epfl.dedis.proto.PoPProto.CheckConfig(this);
         int from_bitField0_ = bitField0_;
@@ -4270,39 +4171,32 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.CheckConfig) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.CheckConfig)other);
@@ -4332,7 +4226,6 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasPophash()) {
           return false;
@@ -4340,7 +4233,6 @@ public final class PoPProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -4466,13 +4358,11 @@ public final class PoPProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -4494,12 +4384,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<CheckConfig>
         PARSER = new com.google.protobuf.AbstractParser<CheckConfig>() {
-      @java.lang.Override
       public CheckConfig parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CheckConfig(input, extensionRegistry);
+          return new CheckConfig(input, extensionRegistry);
       }
     };
 
@@ -4512,7 +4401,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.CheckConfig getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -4589,9 +4477,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -4603,6 +4488,13 @@ public final class PoPProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 8: {
               bitField0_ |= 0x00000001;
               popstatus_ = input.readSInt32();
@@ -4619,13 +4511,6 @@ public final class PoPProto {
                 mutable_bitField0_ |= 0x00000004;
               }
               attendees_.add(input.readBytes());
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -4648,7 +4533,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_CheckConfigReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_CheckConfigReply_fieldAccessorTable
@@ -4710,7 +4594,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -4728,7 +4611,6 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -4743,7 +4625,6 @@ public final class PoPProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -4892,7 +4773,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -4900,7 +4780,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.CheckConfigReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -4931,7 +4810,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_CheckConfigReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_CheckConfigReply_fieldAccessorTable
@@ -4954,7 +4832,6 @@ public final class PoPProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         popstatus_ = 0;
@@ -4966,18 +4843,15 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_CheckConfigReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.CheckConfigReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.CheckConfigReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.CheckConfigReply build() {
         ch.epfl.dedis.proto.PoPProto.CheckConfigReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -4986,7 +4860,6 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.CheckConfigReply buildPartial() {
         ch.epfl.dedis.proto.PoPProto.CheckConfigReply result = new ch.epfl.dedis.proto.PoPProto.CheckConfigReply(this);
         int from_bitField0_ = bitField0_;
@@ -5009,39 +4882,32 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.CheckConfigReply) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.CheckConfigReply)other);
@@ -5074,7 +4940,6 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasPopstatus()) {
           return false;
@@ -5085,7 +4950,6 @@ public final class PoPProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -5243,13 +5107,11 @@ public final class PoPProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -5271,12 +5133,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<CheckConfigReply>
         PARSER = new com.google.protobuf.AbstractParser<CheckConfigReply>() {
-      @java.lang.Override
       public CheckConfigReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CheckConfigReply(input, extensionRegistry);
+          return new CheckConfigReply(input, extensionRegistry);
       }
     };
 
@@ -5289,7 +5150,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.CheckConfigReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -5372,9 +5232,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -5386,6 +5243,13 @@ public final class PoPProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.PoPProto.FinalStatement.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -5402,13 +5266,6 @@ public final class PoPProto {
             case 18: {
               bitField0_ |= 0x00000002;
               id_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -5428,7 +5285,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_MergeConfig_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_MergeConfig_fieldAccessorTable
@@ -5494,7 +5350,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -5514,7 +5369,6 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -5526,7 +5380,6 @@ public final class PoPProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -5660,7 +5513,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -5668,7 +5520,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.MergeConfig prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -5696,7 +5547,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_MergeConfig_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_MergeConfig_fieldAccessorTable
@@ -5720,7 +5570,6 @@ public final class PoPProto {
           getFinalFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (finalBuilder_ == null) {
@@ -5734,18 +5583,15 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_MergeConfig_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.MergeConfig getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.MergeConfig.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.MergeConfig build() {
         ch.epfl.dedis.proto.PoPProto.MergeConfig result = buildPartial();
         if (!result.isInitialized()) {
@@ -5754,7 +5600,6 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.MergeConfig buildPartial() {
         ch.epfl.dedis.proto.PoPProto.MergeConfig result = new ch.epfl.dedis.proto.PoPProto.MergeConfig(this);
         int from_bitField0_ = bitField0_;
@@ -5776,39 +5621,32 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.MergeConfig) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.MergeConfig)other);
@@ -5831,7 +5669,6 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasId()) {
           return false;
@@ -5844,7 +5681,6 @@ public final class PoPProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -6068,13 +5904,11 @@ public final class PoPProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -6096,12 +5930,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<MergeConfig>
         PARSER = new com.google.protobuf.AbstractParser<MergeConfig>() {
-      @java.lang.Override
       public MergeConfig parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new MergeConfig(input, extensionRegistry);
+          return new MergeConfig(input, extensionRegistry);
       }
     };
 
@@ -6114,7 +5947,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.MergeConfig getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -6215,9 +6047,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -6229,6 +6058,13 @@ public final class PoPProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 8: {
               bitField0_ |= 0x00000001;
               popstatus_ = input.readSInt32();
@@ -6252,13 +6088,6 @@ public final class PoPProto {
               bitField0_ |= 0x00000004;
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -6276,7 +6105,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_MergeConfigReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_MergeConfigReply_fieldAccessorTable
@@ -6365,7 +6193,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -6389,7 +6216,6 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -6404,7 +6230,6 @@ public final class PoPProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -6551,7 +6376,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -6559,7 +6383,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.MergeConfigReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -6587,7 +6410,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_MergeConfigReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_MergeConfigReply_fieldAccessorTable
@@ -6611,7 +6433,6 @@ public final class PoPProto {
           getFinalFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         popstatus_ = 0;
@@ -6627,18 +6448,15 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_MergeConfigReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.MergeConfigReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.MergeConfigReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.MergeConfigReply build() {
         ch.epfl.dedis.proto.PoPProto.MergeConfigReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -6647,7 +6465,6 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.MergeConfigReply buildPartial() {
         ch.epfl.dedis.proto.PoPProto.MergeConfigReply result = new ch.epfl.dedis.proto.PoPProto.MergeConfigReply(this);
         int from_bitField0_ = bitField0_;
@@ -6673,39 +6490,32 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.MergeConfigReply) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.MergeConfigReply)other);
@@ -6731,7 +6541,6 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasPopstatus()) {
           return false;
@@ -6747,7 +6556,6 @@ public final class PoPProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -7019,13 +6827,11 @@ public final class PoPProto {
         }
         return finalBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -7047,12 +6853,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<MergeConfigReply>
         PARSER = new com.google.protobuf.AbstractParser<MergeConfigReply>() {
-      @java.lang.Override
       public MergeConfigReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new MergeConfigReply(input, extensionRegistry);
+          return new MergeConfigReply(input, extensionRegistry);
       }
     };
 
@@ -7065,7 +6870,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.MergeConfigReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -7132,9 +6936,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -7146,6 +6947,13 @@ public final class PoPProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
@@ -7155,13 +6963,6 @@ public final class PoPProto {
             case 18: {
               bitField0_ |= 0x00000002;
               public_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -7181,7 +6982,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_PinRequest_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_PinRequest_fieldAccessorTable
@@ -7248,7 +7048,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -7266,7 +7065,6 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -7278,7 +7076,6 @@ public final class PoPProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -7411,7 +7208,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -7419,7 +7215,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.PinRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -7449,7 +7244,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_PinRequest_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_PinRequest_fieldAccessorTable
@@ -7472,7 +7266,6 @@ public final class PoPProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         pin_ = "";
@@ -7482,18 +7275,15 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_PinRequest_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.PinRequest getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.PinRequest.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.PinRequest build() {
         ch.epfl.dedis.proto.PoPProto.PinRequest result = buildPartial();
         if (!result.isInitialized()) {
@@ -7502,7 +7292,6 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.PinRequest buildPartial() {
         ch.epfl.dedis.proto.PoPProto.PinRequest result = new ch.epfl.dedis.proto.PoPProto.PinRequest(this);
         int from_bitField0_ = bitField0_;
@@ -7520,39 +7309,32 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.PinRequest) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.PinRequest)other);
@@ -7577,7 +7359,6 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasPin()) {
           return false;
@@ -7588,7 +7369,6 @@ public final class PoPProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -7718,13 +7498,11 @@ public final class PoPProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -7746,12 +7524,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<PinRequest>
         PARSER = new com.google.protobuf.AbstractParser<PinRequest>() {
-      @java.lang.Override
       public PinRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new PinRequest(input, extensionRegistry);
+          return new PinRequest(input, extensionRegistry);
       }
     };
 
@@ -7764,7 +7541,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.PinRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -7827,9 +7603,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -7841,6 +7614,13 @@ public final class PoPProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.PoPProto.PopDesc.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -7857,13 +7637,6 @@ public final class PoPProto {
             case 18: {
               bitField0_ |= 0x00000002;
               signature_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -7883,7 +7656,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_StoreConfig_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_StoreConfig_fieldAccessorTable
@@ -7929,7 +7701,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -7949,7 +7720,6 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -7961,7 +7731,6 @@ public final class PoPProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -8095,7 +7864,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -8103,7 +7871,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.StoreConfig prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -8131,7 +7898,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_StoreConfig_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_StoreConfig_fieldAccessorTable
@@ -8155,7 +7921,6 @@ public final class PoPProto {
           getDescFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (descBuilder_ == null) {
@@ -8169,18 +7934,15 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_StoreConfig_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.StoreConfig getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.StoreConfig.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.StoreConfig build() {
         ch.epfl.dedis.proto.PoPProto.StoreConfig result = buildPartial();
         if (!result.isInitialized()) {
@@ -8189,7 +7951,6 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.StoreConfig buildPartial() {
         ch.epfl.dedis.proto.PoPProto.StoreConfig result = new ch.epfl.dedis.proto.PoPProto.StoreConfig(this);
         int from_bitField0_ = bitField0_;
@@ -8211,39 +7972,32 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.StoreConfig) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.StoreConfig)other);
@@ -8266,7 +8020,6 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasSignature()) {
           return false;
@@ -8279,7 +8032,6 @@ public final class PoPProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -8451,13 +8203,11 @@ public final class PoPProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -8479,12 +8229,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<StoreConfig>
         PARSER = new com.google.protobuf.AbstractParser<StoreConfig>() {
-      @java.lang.Override
       public StoreConfig parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new StoreConfig(input, extensionRegistry);
+          return new StoreConfig(input, extensionRegistry);
       }
     };
 
@@ -8497,7 +8246,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.StoreConfig getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -8549,9 +8297,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -8563,16 +8308,16 @@ public final class PoPProto {
             case 0:
               done = true;
               break;
-            case 10: {
-              bitField0_ |= 0x00000001;
-              id_ = input.readBytes();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              id_ = input.readBytes();
               break;
             }
           }
@@ -8592,7 +8337,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_StoreConfigReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_StoreConfigReply_fieldAccessorTable
@@ -8617,7 +8361,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -8631,7 +8374,6 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -8640,7 +8382,6 @@ public final class PoPProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -8761,7 +8502,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -8769,7 +8509,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.StoreConfigReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -8799,7 +8538,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_StoreConfigReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_StoreConfigReply_fieldAccessorTable
@@ -8822,7 +8560,6 @@ public final class PoPProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         id_ = com.google.protobuf.ByteString.EMPTY;
@@ -8830,18 +8567,15 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_StoreConfigReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.StoreConfigReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.StoreConfigReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.StoreConfigReply build() {
         ch.epfl.dedis.proto.PoPProto.StoreConfigReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -8850,7 +8584,6 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.StoreConfigReply buildPartial() {
         ch.epfl.dedis.proto.PoPProto.StoreConfigReply result = new ch.epfl.dedis.proto.PoPProto.StoreConfigReply(this);
         int from_bitField0_ = bitField0_;
@@ -8864,39 +8597,32 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.StoreConfigReply) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.StoreConfigReply)other);
@@ -8916,7 +8642,6 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasId()) {
           return false;
@@ -8924,7 +8649,6 @@ public final class PoPProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -8978,13 +8702,11 @@ public final class PoPProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -9006,12 +8728,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<StoreConfigReply>
         PARSER = new com.google.protobuf.AbstractParser<StoreConfigReply>() {
-      @java.lang.Override
       public StoreConfigReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new StoreConfigReply(input, extensionRegistry);
+          return new StoreConfigReply(input, extensionRegistry);
       }
     };
 
@@ -9024,7 +8745,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.StoreConfigReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -9098,9 +8818,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -9112,6 +8829,13 @@ public final class PoPProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               descid_ = input.readBytes();
@@ -9128,13 +8852,6 @@ public final class PoPProto {
             case 26: {
               bitField0_ |= 0x00000002;
               signature_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -9157,7 +8874,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FinalizeRequest_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FinalizeRequest_fieldAccessorTable
@@ -9219,7 +8935,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -9237,7 +8952,6 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -9252,7 +8966,6 @@ public final class PoPProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -9401,7 +9114,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -9409,7 +9121,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.FinalizeRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -9437,7 +9148,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FinalizeRequest_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FinalizeRequest_fieldAccessorTable
@@ -9460,7 +9170,6 @@ public final class PoPProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         descid_ = com.google.protobuf.ByteString.EMPTY;
@@ -9472,18 +9181,15 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FinalizeRequest_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.FinalizeRequest getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.FinalizeRequest.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.FinalizeRequest build() {
         ch.epfl.dedis.proto.PoPProto.FinalizeRequest result = buildPartial();
         if (!result.isInitialized()) {
@@ -9492,7 +9198,6 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.FinalizeRequest buildPartial() {
         ch.epfl.dedis.proto.PoPProto.FinalizeRequest result = new ch.epfl.dedis.proto.PoPProto.FinalizeRequest(this);
         int from_bitField0_ = bitField0_;
@@ -9515,39 +9220,32 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.FinalizeRequest) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.FinalizeRequest)other);
@@ -9580,7 +9278,6 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasDescid()) {
           return false;
@@ -9591,7 +9288,6 @@ public final class PoPProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -9752,13 +9448,11 @@ public final class PoPProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -9780,12 +9474,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<FinalizeRequest>
         PARSER = new com.google.protobuf.AbstractParser<FinalizeRequest>() {
-      @java.lang.Override
       public FinalizeRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new FinalizeRequest(input, extensionRegistry);
+          return new FinalizeRequest(input, extensionRegistry);
       }
     };
 
@@ -9798,7 +9491,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.FinalizeRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -9853,9 +9545,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -9867,6 +9556,13 @@ public final class PoPProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               ch.epfl.dedis.proto.PoPProto.FinalStatement.Builder subBuilder = null;
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -9878,13 +9574,6 @@ public final class PoPProto {
                 final_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000001;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -9904,7 +9593,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FinalizeResponse_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FinalizeResponse_fieldAccessorTable
@@ -9935,7 +9623,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -9951,7 +9638,6 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -9960,7 +9646,6 @@ public final class PoPProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -10081,7 +9766,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -10089,7 +9773,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.FinalizeResponse prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -10119,7 +9802,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FinalizeResponse_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FinalizeResponse_fieldAccessorTable
@@ -10143,7 +9825,6 @@ public final class PoPProto {
           getFinalFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (finalBuilder_ == null) {
@@ -10155,18 +9836,15 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FinalizeResponse_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.FinalizeResponse getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.FinalizeResponse.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.FinalizeResponse build() {
         ch.epfl.dedis.proto.PoPProto.FinalizeResponse result = buildPartial();
         if (!result.isInitialized()) {
@@ -10175,7 +9853,6 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.FinalizeResponse buildPartial() {
         ch.epfl.dedis.proto.PoPProto.FinalizeResponse result = new ch.epfl.dedis.proto.PoPProto.FinalizeResponse(this);
         int from_bitField0_ = bitField0_;
@@ -10193,39 +9870,32 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.FinalizeResponse) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.FinalizeResponse)other);
@@ -10245,7 +9915,6 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (hasFinal()) {
           if (!getFinal().isInitialized()) {
@@ -10255,7 +9924,6 @@ public final class PoPProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -10392,13 +10060,11 @@ public final class PoPProto {
         }
         return finalBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -10420,12 +10086,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<FinalizeResponse>
         PARSER = new com.google.protobuf.AbstractParser<FinalizeResponse>() {
-      @java.lang.Override
       public FinalizeResponse parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new FinalizeResponse(input, extensionRegistry);
+          return new FinalizeResponse(input, extensionRegistry);
       }
     };
 
@@ -10438,7 +10103,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.FinalizeResponse getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -10498,9 +10162,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -10512,6 +10173,13 @@ public final class PoPProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               id_ = input.readBytes();
@@ -10520,13 +10188,6 @@ public final class PoPProto {
             case 16: {
               bitField0_ |= 0x00000002;
               returnuncomplete_ = input.readBool();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -10546,7 +10207,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FetchRequest_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FetchRequest_fieldAccessorTable
@@ -10586,7 +10246,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -10600,7 +10259,6 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -10612,7 +10270,6 @@ public final class PoPProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -10747,7 +10404,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -10755,7 +10411,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.FetchRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -10783,7 +10438,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FetchRequest_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FetchRequest_fieldAccessorTable
@@ -10806,7 +10460,6 @@ public final class PoPProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         id_ = com.google.protobuf.ByteString.EMPTY;
@@ -10816,18 +10469,15 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_FetchRequest_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.FetchRequest getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.FetchRequest.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.FetchRequest build() {
         ch.epfl.dedis.proto.PoPProto.FetchRequest result = buildPartial();
         if (!result.isInitialized()) {
@@ -10836,7 +10486,6 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.FetchRequest buildPartial() {
         ch.epfl.dedis.proto.PoPProto.FetchRequest result = new ch.epfl.dedis.proto.PoPProto.FetchRequest(this);
         int from_bitField0_ = bitField0_;
@@ -10854,39 +10503,32 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.FetchRequest) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.FetchRequest)other);
@@ -10909,7 +10551,6 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasId()) {
           return false;
@@ -10917,7 +10558,6 @@ public final class PoPProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -11003,13 +10643,11 @@ public final class PoPProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -11031,12 +10669,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<FetchRequest>
         PARSER = new com.google.protobuf.AbstractParser<FetchRequest>() {
-      @java.lang.Override
       public FetchRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new FetchRequest(input, extensionRegistry);
+          return new FetchRequest(input, extensionRegistry);
       }
     };
 
@@ -11049,7 +10686,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.FetchRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -11109,9 +10745,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -11123,6 +10756,13 @@ public final class PoPProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               id_ = input.readBytes();
@@ -11131,13 +10771,6 @@ public final class PoPProto {
             case 18: {
               bitField0_ |= 0x00000002;
               signature_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -11157,7 +10790,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_MergeRequest_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_MergeRequest_fieldAccessorTable
@@ -11197,7 +10829,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -11215,7 +10846,6 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -11227,7 +10857,6 @@ public final class PoPProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -11361,7 +10990,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -11369,7 +10997,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.MergeRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -11397,7 +11024,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_MergeRequest_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_MergeRequest_fieldAccessorTable
@@ -11420,7 +11046,6 @@ public final class PoPProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         id_ = com.google.protobuf.ByteString.EMPTY;
@@ -11430,18 +11055,15 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_MergeRequest_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.MergeRequest getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.MergeRequest.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.MergeRequest build() {
         ch.epfl.dedis.proto.PoPProto.MergeRequest result = buildPartial();
         if (!result.isInitialized()) {
@@ -11450,7 +11072,6 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.MergeRequest buildPartial() {
         ch.epfl.dedis.proto.PoPProto.MergeRequest result = new ch.epfl.dedis.proto.PoPProto.MergeRequest(this);
         int from_bitField0_ = bitField0_;
@@ -11468,39 +11089,32 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.MergeRequest) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.MergeRequest)other);
@@ -11523,7 +11137,6 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasId()) {
           return false;
@@ -11534,7 +11147,6 @@ public final class PoPProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -11623,13 +11235,11 @@ public final class PoPProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -11651,12 +11261,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<MergeRequest>
         PARSER = new com.google.protobuf.AbstractParser<MergeRequest>() {
-      @java.lang.Override
       public MergeRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new MergeRequest(input, extensionRegistry);
+          return new MergeRequest(input, extensionRegistry);
       }
     };
 
@@ -11669,7 +11278,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.MergeRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -11711,9 +11319,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
@@ -11748,7 +11353,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_GetProposals_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_GetProposals_fieldAccessorTable
@@ -11757,7 +11361,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -11767,13 +11370,11 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -11881,7 +11482,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -11889,7 +11489,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.GetProposals prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -11919,7 +11518,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_GetProposals_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_GetProposals_fieldAccessorTable
@@ -11942,24 +11540,20 @@ public final class PoPProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_GetProposals_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.GetProposals getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.GetProposals.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.GetProposals build() {
         ch.epfl.dedis.proto.PoPProto.GetProposals result = buildPartial();
         if (!result.isInitialized()) {
@@ -11968,46 +11562,38 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.GetProposals buildPartial() {
         ch.epfl.dedis.proto.PoPProto.GetProposals result = new ch.epfl.dedis.proto.PoPProto.GetProposals(this);
         onBuilt();
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.GetProposals) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.GetProposals)other);
@@ -12024,12 +11610,10 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -12047,13 +11631,11 @@ public final class PoPProto {
         }
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -12075,12 +11657,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<GetProposals>
         PARSER = new com.google.protobuf.AbstractParser<GetProposals>() {
-      @java.lang.Override
       public GetProposals parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GetProposals(input, extensionRegistry);
+          return new GetProposals(input, extensionRegistry);
       }
     };
 
@@ -12093,7 +11674,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.GetProposals getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -12158,9 +11738,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -12172,6 +11749,13 @@ public final class PoPProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 proposals_ = new java.util.ArrayList<ch.epfl.dedis.proto.PoPProto.PopDesc>();
@@ -12179,13 +11763,6 @@ public final class PoPProto {
               }
               proposals_.add(
                   input.readMessage(ch.epfl.dedis.proto.PoPProto.PopDesc.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -12208,7 +11785,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_GetProposalsReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_GetProposalsReply_fieldAccessorTable
@@ -12252,7 +11828,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -12268,7 +11843,6 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       for (int i = 0; i < proposals_.size(); i++) {
@@ -12277,7 +11851,6 @@ public final class PoPProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -12395,7 +11968,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -12403,7 +11975,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.GetProposalsReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -12431,7 +12002,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_GetProposalsReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_GetProposalsReply_fieldAccessorTable
@@ -12455,7 +12025,6 @@ public final class PoPProto {
           getProposalsFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (proposalsBuilder_ == null) {
@@ -12467,18 +12036,15 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_GetProposalsReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.GetProposalsReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.GetProposalsReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.GetProposalsReply build() {
         ch.epfl.dedis.proto.PoPProto.GetProposalsReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -12487,7 +12053,6 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.GetProposalsReply buildPartial() {
         ch.epfl.dedis.proto.PoPProto.GetProposalsReply result = new ch.epfl.dedis.proto.PoPProto.GetProposalsReply(this);
         int from_bitField0_ = bitField0_;
@@ -12504,39 +12069,32 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.GetProposalsReply) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.GetProposalsReply)other);
@@ -12579,7 +12137,6 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         for (int i = 0; i < getProposalsCount(); i++) {
           if (!getProposals(i).isInitialized()) {
@@ -12589,7 +12146,6 @@ public final class PoPProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -12848,13 +12404,11 @@ public final class PoPProto {
         }
         return proposalsBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -12876,12 +12430,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<GetProposalsReply>
         PARSER = new com.google.protobuf.AbstractParser<GetProposalsReply>() {
-      @java.lang.Override
       public GetProposalsReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GetProposalsReply(input, extensionRegistry);
+          return new GetProposalsReply(input, extensionRegistry);
       }
     };
 
@@ -12894,7 +12447,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.GetProposalsReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -12944,9 +12496,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -12958,16 +12507,16 @@ public final class PoPProto {
             case 0:
               done = true;
               break;
-            case 10: {
-              bitField0_ |= 0x00000001;
-              public_ = input.readBytes();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              public_ = input.readBytes();
               break;
             }
           }
@@ -12987,7 +12536,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_VerifyLink_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_VerifyLink_fieldAccessorTable
@@ -13012,7 +12560,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -13026,7 +12573,6 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -13035,7 +12581,6 @@ public final class PoPProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -13156,7 +12701,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -13164,7 +12708,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.VerifyLink prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -13192,7 +12735,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_VerifyLink_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_VerifyLink_fieldAccessorTable
@@ -13215,7 +12757,6 @@ public final class PoPProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         public_ = com.google.protobuf.ByteString.EMPTY;
@@ -13223,18 +12764,15 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_VerifyLink_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.VerifyLink getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.VerifyLink.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.VerifyLink build() {
         ch.epfl.dedis.proto.PoPProto.VerifyLink result = buildPartial();
         if (!result.isInitialized()) {
@@ -13243,7 +12781,6 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.VerifyLink buildPartial() {
         ch.epfl.dedis.proto.PoPProto.VerifyLink result = new ch.epfl.dedis.proto.PoPProto.VerifyLink(this);
         int from_bitField0_ = bitField0_;
@@ -13257,39 +12794,32 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.VerifyLink) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.VerifyLink)other);
@@ -13309,7 +12839,6 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasPublic()) {
           return false;
@@ -13317,7 +12846,6 @@ public final class PoPProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -13371,13 +12899,11 @@ public final class PoPProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -13399,12 +12925,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<VerifyLink>
         PARSER = new com.google.protobuf.AbstractParser<VerifyLink>() {
-      @java.lang.Override
       public VerifyLink parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new VerifyLink(input, extensionRegistry);
+          return new VerifyLink(input, extensionRegistry);
       }
     };
 
@@ -13417,7 +12942,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.VerifyLink getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -13467,9 +12991,6 @@ public final class PoPProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -13481,16 +13002,16 @@ public final class PoPProto {
             case 0:
               done = true;
               break;
-            case 8: {
-              bitField0_ |= 0x00000001;
-              exists_ = input.readBool();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              exists_ = input.readBool();
               break;
             }
           }
@@ -13510,7 +13031,6 @@ public final class PoPProto {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_VerifyLinkReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.PoPProto.internal_static_pop_VerifyLinkReply_fieldAccessorTable
@@ -13535,7 +13055,6 @@ public final class PoPProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -13549,7 +13068,6 @@ public final class PoPProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -13558,7 +13076,6 @@ public final class PoPProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -13680,7 +13197,6 @@ public final class PoPProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -13688,7 +13204,6 @@ public final class PoPProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.PoPProto.VerifyLinkReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -13716,7 +13231,6 @@ public final class PoPProto {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_VerifyLinkReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_VerifyLinkReply_fieldAccessorTable
@@ -13739,7 +13253,6 @@ public final class PoPProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         exists_ = false;
@@ -13747,18 +13260,15 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.PoPProto.internal_static_pop_VerifyLinkReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.VerifyLinkReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.PoPProto.VerifyLinkReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.VerifyLinkReply build() {
         ch.epfl.dedis.proto.PoPProto.VerifyLinkReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -13767,7 +13277,6 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.PoPProto.VerifyLinkReply buildPartial() {
         ch.epfl.dedis.proto.PoPProto.VerifyLinkReply result = new ch.epfl.dedis.proto.PoPProto.VerifyLinkReply(this);
         int from_bitField0_ = bitField0_;
@@ -13781,39 +13290,32 @@ public final class PoPProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.PoPProto.VerifyLinkReply) {
           return mergeFrom((ch.epfl.dedis.proto.PoPProto.VerifyLinkReply)other);
@@ -13833,7 +13335,6 @@ public final class PoPProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasExists()) {
           return false;
@@ -13841,7 +13342,6 @@ public final class PoPProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -13892,13 +13392,11 @@ public final class PoPProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -13920,12 +13418,11 @@ public final class PoPProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<VerifyLinkReply>
         PARSER = new com.google.protobuf.AbstractParser<VerifyLinkReply>() {
-      @java.lang.Override
       public VerifyLinkReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new VerifyLinkReply(input, extensionRegistry);
+          return new VerifyLinkReply(input, extensionRegistry);
       }
     };
 
@@ -13938,7 +13435,6 @@ public final class PoPProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.PoPProto.VerifyLinkReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -14053,7 +13549,7 @@ public final class PoPProto {
       "\001 \001(\0132\014.pop.PopDesc\022\021\n\tattendees\030\002 \003(\014\022\021" +
       "\n\tsignature\030\003 \002(\014\022\016\n\006merged\030\004 \002(\010\"1\n\013Che" +
       "ckConfig\022\017\n\007pophash\030\001 \002(\014\022\021\n\tattendees\030\002" +
-      " \003(\014\"I\n\020CheckConfigReply\022\021\n\tpopstatus\030\001 " +
+      " \003(\014\"I\n\020CheckConfigReply\022\021\n\tpopstatus\030\001 ",
       "\002(\021\022\017\n\007pophash\030\002 \002(\014\022\021\n\tattendees\030\003 \003(\014\"" +
       "=\n\013MergeConfig\022\"\n\005final\030\001 \001(\0132\023.pop.Fina" +
       "lStatement\022\n\n\002id\030\002 \002(\014\"Z\n\020MergeConfigRep" +
@@ -14063,7 +13559,7 @@ public final class PoPProto {
       "\013StoreConfig\022\032\n\004desc\030\001 \001(\0132\014.pop.PopDesc" +
       "\022\021\n\tsignature\030\002 \002(\014\"\036\n\020StoreConfigReply\022" +
       "\n\n\002id\030\001 \002(\014\"G\n\017FinalizeRequest\022\016\n\006descid" +
-      "\030\001 \002(\014\022\021\n\tattendees\030\002 \003(\014\022\021\n\tsignature\030\003" +
+      "\030\001 \002(\014\022\021\n\tattendees\030\002 \003(\014\022\021\n\tsignature\030\003",
       " \002(\014\"6\n\020FinalizeResponse\022\"\n\005final\030\001 \001(\0132" +
       "\023.pop.FinalStatement\"4\n\014FetchRequest\022\n\n\002" +
       "id\030\001 \002(\014\022\030\n\020returnuncomplete\030\002 \001(\010\"-\n\014Me" +

--- a/external/java/src/main/java/ch/epfl/dedis/proto/SkipchainProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/proto/SkipchainProto.java
@@ -57,9 +57,6 @@ public final class SkipchainProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -71,16 +68,16 @@ public final class SkipchainProto {
             case 0:
               done = true;
               break;
-            case 10: {
-              bitField0_ |= 0x00000001;
-              id_ = input.readBytes();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              id_ = input.readBytes();
               break;
             }
           }
@@ -100,7 +97,6 @@ public final class SkipchainProto {
       return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_GetSingleBlock_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_GetSingleBlock_fieldAccessorTable
@@ -125,7 +121,6 @@ public final class SkipchainProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -139,7 +134,6 @@ public final class SkipchainProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -148,7 +142,6 @@ public final class SkipchainProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -269,7 +262,6 @@ public final class SkipchainProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -277,7 +269,6 @@ public final class SkipchainProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.SkipchainProto.GetSingleBlock prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -305,7 +296,6 @@ public final class SkipchainProto {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_GetSingleBlock_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_GetSingleBlock_fieldAccessorTable
@@ -328,7 +318,6 @@ public final class SkipchainProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         id_ = com.google.protobuf.ByteString.EMPTY;
@@ -336,18 +325,15 @@ public final class SkipchainProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_GetSingleBlock_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.GetSingleBlock getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.SkipchainProto.GetSingleBlock.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.GetSingleBlock build() {
         ch.epfl.dedis.proto.SkipchainProto.GetSingleBlock result = buildPartial();
         if (!result.isInitialized()) {
@@ -356,7 +342,6 @@ public final class SkipchainProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.GetSingleBlock buildPartial() {
         ch.epfl.dedis.proto.SkipchainProto.GetSingleBlock result = new ch.epfl.dedis.proto.SkipchainProto.GetSingleBlock(this);
         int from_bitField0_ = bitField0_;
@@ -370,39 +355,32 @@ public final class SkipchainProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.SkipchainProto.GetSingleBlock) {
           return mergeFrom((ch.epfl.dedis.proto.SkipchainProto.GetSingleBlock)other);
@@ -422,7 +400,6 @@ public final class SkipchainProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasId()) {
           return false;
@@ -430,7 +407,6 @@ public final class SkipchainProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -484,13 +460,11 @@ public final class SkipchainProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -512,12 +486,11 @@ public final class SkipchainProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<GetSingleBlock>
         PARSER = new com.google.protobuf.AbstractParser<GetSingleBlock>() {
-      @java.lang.Override
       public GetSingleBlock parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GetSingleBlock(input, extensionRegistry);
+          return new GetSingleBlock(input, extensionRegistry);
       }
     };
 
@@ -530,7 +503,6 @@ public final class SkipchainProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.SkipchainProto.GetSingleBlock getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -590,9 +562,6 @@ public final class SkipchainProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -604,16 +573,16 @@ public final class SkipchainProto {
             case 0:
               done = true;
               break;
-            case 10: {
-              bitField0_ |= 0x00000001;
-              latestID_ = input.readBytes();
-              break;
-            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
                 done = true;
               }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              latestID_ = input.readBytes();
               break;
             }
           }
@@ -633,7 +602,6 @@ public final class SkipchainProto {
       return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_GetUpdateChain_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_GetUpdateChain_fieldAccessorTable
@@ -666,7 +634,6 @@ public final class SkipchainProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -680,7 +647,6 @@ public final class SkipchainProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -689,7 +655,6 @@ public final class SkipchainProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -810,7 +775,6 @@ public final class SkipchainProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -818,7 +782,6 @@ public final class SkipchainProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.SkipchainProto.GetUpdateChain prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -848,7 +811,6 @@ public final class SkipchainProto {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_GetUpdateChain_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_GetUpdateChain_fieldAccessorTable
@@ -871,7 +833,6 @@ public final class SkipchainProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         latestID_ = com.google.protobuf.ByteString.EMPTY;
@@ -879,18 +840,15 @@ public final class SkipchainProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_GetUpdateChain_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.GetUpdateChain getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.SkipchainProto.GetUpdateChain.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.GetUpdateChain build() {
         ch.epfl.dedis.proto.SkipchainProto.GetUpdateChain result = buildPartial();
         if (!result.isInitialized()) {
@@ -899,7 +857,6 @@ public final class SkipchainProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.GetUpdateChain buildPartial() {
         ch.epfl.dedis.proto.SkipchainProto.GetUpdateChain result = new ch.epfl.dedis.proto.SkipchainProto.GetUpdateChain(this);
         int from_bitField0_ = bitField0_;
@@ -913,39 +870,32 @@ public final class SkipchainProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.SkipchainProto.GetUpdateChain) {
           return mergeFrom((ch.epfl.dedis.proto.SkipchainProto.GetUpdateChain)other);
@@ -965,7 +915,6 @@ public final class SkipchainProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasLatestID()) {
           return false;
@@ -973,7 +922,6 @@ public final class SkipchainProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1043,13 +991,11 @@ public final class SkipchainProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -1071,12 +1017,11 @@ public final class SkipchainProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<GetUpdateChain>
         PARSER = new com.google.protobuf.AbstractParser<GetUpdateChain>() {
-      @java.lang.Override
       public GetUpdateChain parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GetUpdateChain(input, extensionRegistry);
+          return new GetUpdateChain(input, extensionRegistry);
       }
     };
 
@@ -1089,7 +1034,6 @@ public final class SkipchainProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.SkipchainProto.GetUpdateChain getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -1180,9 +1124,6 @@ public final class SkipchainProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1194,6 +1135,13 @@ public final class SkipchainProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 update_ = new java.util.ArrayList<ch.epfl.dedis.proto.SkipchainProto.SkipBlock>();
@@ -1201,13 +1149,6 @@ public final class SkipchainProto {
               }
               update_.add(
                   input.readMessage(ch.epfl.dedis.proto.SkipchainProto.SkipBlock.PARSER, extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -1230,7 +1171,6 @@ public final class SkipchainProto {
       return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_GetUpdateChainReply_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_GetUpdateChainReply_fieldAccessorTable
@@ -1299,7 +1239,6 @@ public final class SkipchainProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1315,7 +1254,6 @@ public final class SkipchainProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       for (int i = 0; i < update_.size(); i++) {
@@ -1324,7 +1262,6 @@ public final class SkipchainProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -1442,7 +1379,6 @@ public final class SkipchainProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -1450,7 +1386,6 @@ public final class SkipchainProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.SkipchainProto.GetUpdateChainReply prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -1479,7 +1414,6 @@ public final class SkipchainProto {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_GetUpdateChainReply_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_GetUpdateChainReply_fieldAccessorTable
@@ -1503,7 +1437,6 @@ public final class SkipchainProto {
           getUpdateFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (updateBuilder_ == null) {
@@ -1515,18 +1448,15 @@ public final class SkipchainProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_GetUpdateChainReply_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.GetUpdateChainReply getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.SkipchainProto.GetUpdateChainReply.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.GetUpdateChainReply build() {
         ch.epfl.dedis.proto.SkipchainProto.GetUpdateChainReply result = buildPartial();
         if (!result.isInitialized()) {
@@ -1535,7 +1465,6 @@ public final class SkipchainProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.GetUpdateChainReply buildPartial() {
         ch.epfl.dedis.proto.SkipchainProto.GetUpdateChainReply result = new ch.epfl.dedis.proto.SkipchainProto.GetUpdateChainReply(this);
         int from_bitField0_ = bitField0_;
@@ -1552,39 +1481,32 @@ public final class SkipchainProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.SkipchainProto.GetUpdateChainReply) {
           return mergeFrom((ch.epfl.dedis.proto.SkipchainProto.GetUpdateChainReply)other);
@@ -1627,7 +1549,6 @@ public final class SkipchainProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         for (int i = 0; i < getUpdateCount(); i++) {
           if (!getUpdate(i).isInitialized()) {
@@ -1637,7 +1558,6 @@ public final class SkipchainProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1986,13 +1906,11 @@ public final class SkipchainProto {
         }
         return updateBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -2014,12 +1932,11 @@ public final class SkipchainProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<GetUpdateChainReply>
         PARSER = new com.google.protobuf.AbstractParser<GetUpdateChainReply>() {
-      @java.lang.Override
       public GetUpdateChainReply parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GetUpdateChainReply(input, extensionRegistry);
+          return new GetUpdateChainReply(input, extensionRegistry);
       }
     };
 
@@ -2032,7 +1949,6 @@ public final class SkipchainProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.SkipchainProto.GetUpdateChainReply getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -2238,9 +2154,6 @@ public final class SkipchainProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -2252,6 +2165,13 @@ public final class SkipchainProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 8: {
               bitField0_ |= 0x00000001;
               index_ = input.readInt32();
@@ -2343,13 +2263,6 @@ public final class SkipchainProto {
               payload_ = input.readBytes();
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -2379,7 +2292,6 @@ public final class SkipchainProto {
       return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_SkipBlock_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_SkipBlock_fieldAccessorTable
@@ -2646,7 +2558,6 @@ public final class SkipchainProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -2698,7 +2609,6 @@ public final class SkipchainProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -2746,7 +2656,6 @@ public final class SkipchainProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -3039,7 +2948,6 @@ public final class SkipchainProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -3047,7 +2955,6 @@ public final class SkipchainProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.SkipchainProto.SkipBlock prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -3071,7 +2978,6 @@ public final class SkipchainProto {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_SkipBlock_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_SkipBlock_fieldAccessorTable
@@ -3096,7 +3002,6 @@ public final class SkipchainProto {
           getForwardFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         index_ = 0;
@@ -3138,18 +3043,15 @@ public final class SkipchainProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_SkipBlock_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.SkipBlock getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.SkipchainProto.SkipBlock.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.SkipBlock build() {
         ch.epfl.dedis.proto.SkipchainProto.SkipBlock result = buildPartial();
         if (!result.isInitialized()) {
@@ -3158,7 +3060,6 @@ public final class SkipchainProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.SkipBlock buildPartial() {
         ch.epfl.dedis.proto.SkipchainProto.SkipBlock result = new ch.epfl.dedis.proto.SkipchainProto.SkipBlock(this);
         int from_bitField0_ = bitField0_;
@@ -3236,39 +3137,32 @@ public final class SkipchainProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.SkipchainProto.SkipBlock) {
           return mergeFrom((ch.epfl.dedis.proto.SkipchainProto.SkipBlock)other);
@@ -3371,7 +3265,6 @@ public final class SkipchainProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasIndex()) {
           return false;
@@ -3408,7 +3301,6 @@ public final class SkipchainProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -4304,13 +4196,11 @@ public final class SkipchainProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -4332,12 +4222,11 @@ public final class SkipchainProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<SkipBlock>
         PARSER = new com.google.protobuf.AbstractParser<SkipBlock>() {
-      @java.lang.Override
       public SkipBlock parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new SkipBlock(input, extensionRegistry);
+          return new SkipBlock(input, extensionRegistry);
       }
     };
 
@@ -4350,7 +4239,6 @@ public final class SkipchainProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.SkipchainProto.SkipBlock getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -4432,9 +4320,6 @@ public final class SkipchainProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -4446,6 +4331,13 @@ public final class SkipchainProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               from_ = input.readBytes();
@@ -4482,13 +4374,6 @@ public final class SkipchainProto {
               bitField0_ |= 0x00000008;
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -4506,7 +4391,6 @@ public final class SkipchainProto {
       return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_ForwardLink_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_ForwardLink_fieldAccessorTable
@@ -4588,7 +4472,6 @@ public final class SkipchainProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -4620,7 +4503,6 @@ public final class SkipchainProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -4638,7 +4520,6 @@ public final class SkipchainProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -4798,7 +4679,6 @@ public final class SkipchainProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -4806,7 +4686,6 @@ public final class SkipchainProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.SkipchainProto.ForwardLink prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -4830,7 +4709,6 @@ public final class SkipchainProto {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_ForwardLink_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_ForwardLink_fieldAccessorTable
@@ -4855,7 +4733,6 @@ public final class SkipchainProto {
           getSignatureFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         from_ = com.google.protobuf.ByteString.EMPTY;
@@ -4877,18 +4754,15 @@ public final class SkipchainProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_ForwardLink_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.ForwardLink getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.SkipchainProto.ForwardLink.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.ForwardLink build() {
         ch.epfl.dedis.proto.SkipchainProto.ForwardLink result = buildPartial();
         if (!result.isInitialized()) {
@@ -4897,7 +4771,6 @@ public final class SkipchainProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.ForwardLink buildPartial() {
         ch.epfl.dedis.proto.SkipchainProto.ForwardLink result = new ch.epfl.dedis.proto.SkipchainProto.ForwardLink(this);
         int from_bitField0_ = bitField0_;
@@ -4931,39 +4804,32 @@ public final class SkipchainProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.SkipchainProto.ForwardLink) {
           return mergeFrom((ch.epfl.dedis.proto.SkipchainProto.ForwardLink)other);
@@ -4992,7 +4858,6 @@ public final class SkipchainProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasFrom()) {
           return false;
@@ -5014,7 +4879,6 @@ public final class SkipchainProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -5339,13 +5203,11 @@ public final class SkipchainProto {
         }
         return signatureBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -5367,12 +5229,11 @@ public final class SkipchainProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<ForwardLink>
         PARSER = new com.google.protobuf.AbstractParser<ForwardLink>() {
-      @java.lang.Override
       public ForwardLink parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ForwardLink(input, extensionRegistry);
+          return new ForwardLink(input, extensionRegistry);
       }
     };
 
@@ -5385,7 +5246,6 @@ public final class SkipchainProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.SkipchainProto.ForwardLink getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -5441,9 +5301,6 @@ public final class SkipchainProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -5455,6 +5312,13 @@ public final class SkipchainProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               msg_ = input.readBytes();
@@ -5463,13 +5327,6 @@ public final class SkipchainProto {
             case 18: {
               bitField0_ |= 0x00000002;
               sig_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -5489,7 +5346,6 @@ public final class SkipchainProto {
       return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_ByzcoinSig_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_ByzcoinSig_fieldAccessorTable
@@ -5529,7 +5385,6 @@ public final class SkipchainProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -5547,7 +5402,6 @@ public final class SkipchainProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -5559,7 +5413,6 @@ public final class SkipchainProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -5693,7 +5546,6 @@ public final class SkipchainProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -5701,7 +5553,6 @@ public final class SkipchainProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.SkipchainProto.ByzcoinSig prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -5725,7 +5576,6 @@ public final class SkipchainProto {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_ByzcoinSig_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_ByzcoinSig_fieldAccessorTable
@@ -5748,7 +5598,6 @@ public final class SkipchainProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         msg_ = com.google.protobuf.ByteString.EMPTY;
@@ -5758,18 +5607,15 @@ public final class SkipchainProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_ByzcoinSig_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.ByzcoinSig getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.SkipchainProto.ByzcoinSig.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.ByzcoinSig build() {
         ch.epfl.dedis.proto.SkipchainProto.ByzcoinSig result = buildPartial();
         if (!result.isInitialized()) {
@@ -5778,7 +5624,6 @@ public final class SkipchainProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.ByzcoinSig buildPartial() {
         ch.epfl.dedis.proto.SkipchainProto.ByzcoinSig result = new ch.epfl.dedis.proto.SkipchainProto.ByzcoinSig(this);
         int from_bitField0_ = bitField0_;
@@ -5796,39 +5641,32 @@ public final class SkipchainProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.SkipchainProto.ByzcoinSig) {
           return mergeFrom((ch.epfl.dedis.proto.SkipchainProto.ByzcoinSig)other);
@@ -5851,7 +5689,6 @@ public final class SkipchainProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasMsg()) {
           return false;
@@ -5862,7 +5699,6 @@ public final class SkipchainProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -5951,13 +5787,11 @@ public final class SkipchainProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -5979,12 +5813,11 @@ public final class SkipchainProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<ByzcoinSig>
         PARSER = new com.google.protobuf.AbstractParser<ByzcoinSig>() {
-      @java.lang.Override
       public ByzcoinSig parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new ByzcoinSig(input, extensionRegistry);
+          return new ByzcoinSig(input, extensionRegistry);
       }
     };
 
@@ -5997,7 +5830,6 @@ public final class SkipchainProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.SkipchainProto.ByzcoinSig getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -6053,9 +5885,6 @@ public final class SkipchainProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -6067,6 +5896,13 @@ public final class SkipchainProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               bitField0_ |= 0x00000001;
               challenge_ = input.readBytes();
@@ -6075,13 +5911,6 @@ public final class SkipchainProto {
             case 18: {
               bitField0_ |= 0x00000002;
               response_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -6101,7 +5930,6 @@ public final class SkipchainProto {
       return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_SchnorrSig_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_SchnorrSig_fieldAccessorTable
@@ -6141,7 +5969,6 @@ public final class SkipchainProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -6159,7 +5986,6 @@ public final class SkipchainProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -6171,7 +5997,6 @@ public final class SkipchainProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -6305,7 +6130,6 @@ public final class SkipchainProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -6313,7 +6137,6 @@ public final class SkipchainProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.SkipchainProto.SchnorrSig prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -6337,7 +6160,6 @@ public final class SkipchainProto {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_SchnorrSig_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_SchnorrSig_fieldAccessorTable
@@ -6360,7 +6182,6 @@ public final class SkipchainProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         challenge_ = com.google.protobuf.ByteString.EMPTY;
@@ -6370,18 +6191,15 @@ public final class SkipchainProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_SchnorrSig_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.SchnorrSig getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.SkipchainProto.SchnorrSig.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.SchnorrSig build() {
         ch.epfl.dedis.proto.SkipchainProto.SchnorrSig result = buildPartial();
         if (!result.isInitialized()) {
@@ -6390,7 +6208,6 @@ public final class SkipchainProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.SchnorrSig buildPartial() {
         ch.epfl.dedis.proto.SkipchainProto.SchnorrSig result = new ch.epfl.dedis.proto.SkipchainProto.SchnorrSig(this);
         int from_bitField0_ = bitField0_;
@@ -6408,39 +6225,32 @@ public final class SkipchainProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.SkipchainProto.SchnorrSig) {
           return mergeFrom((ch.epfl.dedis.proto.SkipchainProto.SchnorrSig)other);
@@ -6463,7 +6273,6 @@ public final class SkipchainProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasChallenge()) {
           return false;
@@ -6474,7 +6283,6 @@ public final class SkipchainProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -6563,13 +6371,11 @@ public final class SkipchainProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -6591,12 +6397,11 @@ public final class SkipchainProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<SchnorrSig>
         PARSER = new com.google.protobuf.AbstractParser<SchnorrSig>() {
-      @java.lang.Override
       public SchnorrSig parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new SchnorrSig(input, extensionRegistry);
+          return new SchnorrSig(input, extensionRegistry);
       }
     };
 
@@ -6609,7 +6414,6 @@ public final class SkipchainProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.SkipchainProto.SchnorrSig getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -6665,9 +6469,6 @@ public final class SkipchainProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -6679,6 +6480,13 @@ public final class SkipchainProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 8: {
               bitField0_ |= 0x00000001;
               index_ = input.readInt32();
@@ -6687,13 +6495,6 @@ public final class SkipchainProto {
             case 18: {
               bitField0_ |= 0x00000002;
               commitment_ = input.readBytes();
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
               break;
             }
           }
@@ -6713,7 +6514,6 @@ public final class SkipchainProto {
       return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_Exception_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_Exception_fieldAccessorTable
@@ -6753,7 +6553,6 @@ public final class SkipchainProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -6771,7 +6570,6 @@ public final class SkipchainProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
@@ -6783,7 +6581,6 @@ public final class SkipchainProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -6917,7 +6714,6 @@ public final class SkipchainProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -6925,7 +6721,6 @@ public final class SkipchainProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.SkipchainProto.Exception prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -6949,7 +6744,6 @@ public final class SkipchainProto {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_Exception_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_Exception_fieldAccessorTable
@@ -6972,7 +6766,6 @@ public final class SkipchainProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         index_ = 0;
@@ -6982,18 +6775,15 @@ public final class SkipchainProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.SkipchainProto.internal_static_skipchain_Exception_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.Exception getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.SkipchainProto.Exception.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.Exception build() {
         ch.epfl.dedis.proto.SkipchainProto.Exception result = buildPartial();
         if (!result.isInitialized()) {
@@ -7002,7 +6792,6 @@ public final class SkipchainProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.SkipchainProto.Exception buildPartial() {
         ch.epfl.dedis.proto.SkipchainProto.Exception result = new ch.epfl.dedis.proto.SkipchainProto.Exception(this);
         int from_bitField0_ = bitField0_;
@@ -7020,39 +6809,32 @@ public final class SkipchainProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.SkipchainProto.Exception) {
           return mergeFrom((ch.epfl.dedis.proto.SkipchainProto.Exception)other);
@@ -7075,7 +6857,6 @@ public final class SkipchainProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasIndex()) {
           return false;
@@ -7086,7 +6867,6 @@ public final class SkipchainProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -7172,13 +6952,11 @@ public final class SkipchainProto {
         onChanged();
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -7200,12 +6978,11 @@ public final class SkipchainProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Exception>
         PARSER = new com.google.protobuf.AbstractParser<Exception>() {
-      @java.lang.Override
       public Exception parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Exception(input, extensionRegistry);
+          return new Exception(input, extensionRegistry);
       }
     };
 
@@ -7218,7 +6995,6 @@ public final class SkipchainProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.SkipchainProto.Exception getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -7283,7 +7059,7 @@ public final class SkipchainProto {
       "_height\030\004 \002(\005\022\021\n\tbacklinks\030\005 \003(\014\022\021\n\tveri" +
       "fiers\030\006 \003(\014\022\016\n\006parent\030\007 \001(\014\022\017\n\007genesis\030\010" +
       " \002(\014\022\014\n\004data\030\t \002(\014\022\034\n\006roster\030\n \002(\0132\014.one" +
-      "t.Roster\022\014\n\004hash\030\013 \002(\014\022\'\n\007forward\030\014 \003(\0132" +
+      "t.Roster\022\014\n\004hash\030\013 \002(\014\022\'\n\007forward\030\014 \003(\0132",
       "\026.skipchain.ForwardLink\022\020\n\010children\030\r \003(" +
       "\014\022\017\n\007payload\030\016 \001(\014\"r\n\013ForwardLink\022\014\n\004fro" +
       "m\030\001 \002(\014\022\n\n\002to\030\002 \002(\014\022\037\n\tnewRoster\030\003 \001(\0132\014" +

--- a/external/java/src/main/java/ch/epfl/dedis/proto/StatusProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/proto/StatusProto.java
@@ -47,9 +47,6 @@ public final class StatusProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
@@ -84,7 +81,6 @@ public final class StatusProto {
       return ch.epfl.dedis.proto.StatusProto.internal_static_status_Request_descriptor;
     }
 
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.StatusProto.internal_static_status_Request_fieldAccessorTable
@@ -93,7 +89,6 @@ public final class StatusProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -103,13 +98,11 @@ public final class StatusProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -217,7 +210,6 @@ public final class StatusProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -225,7 +217,6 @@ public final class StatusProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.StatusProto.Request prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -253,7 +244,6 @@ public final class StatusProto {
         return ch.epfl.dedis.proto.StatusProto.internal_static_status_Request_descriptor;
       }
 
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.StatusProto.internal_static_status_Request_fieldAccessorTable
@@ -276,24 +266,20 @@ public final class StatusProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.StatusProto.internal_static_status_Request_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.StatusProto.Request getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.StatusProto.Request.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.StatusProto.Request build() {
         ch.epfl.dedis.proto.StatusProto.Request result = buildPartial();
         if (!result.isInitialized()) {
@@ -302,46 +288,38 @@ public final class StatusProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.StatusProto.Request buildPartial() {
         ch.epfl.dedis.proto.StatusProto.Request result = new ch.epfl.dedis.proto.StatusProto.Request(this);
         onBuilt();
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.StatusProto.Request) {
           return mergeFrom((ch.epfl.dedis.proto.StatusProto.Request)other);
@@ -358,12 +336,10 @@ public final class StatusProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -381,13 +357,11 @@ public final class StatusProto {
         }
         return this;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -409,12 +383,11 @@ public final class StatusProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Request>
         PARSER = new com.google.protobuf.AbstractParser<Request>() {
-      @java.lang.Override
       public Request parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Request(input, extensionRegistry);
+          return new Request(input, extensionRegistry);
       }
     };
 
@@ -427,7 +400,6 @@ public final class StatusProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.StatusProto.Request getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
@@ -514,9 +486,6 @@ public final class StatusProto {
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -528,6 +497,13 @@ public final class StatusProto {
             case 0:
               done = true;
               break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
                 status_ = com.google.protobuf.MapField.newMapField(
@@ -554,13 +530,6 @@ public final class StatusProto {
               bitField0_ |= 0x00000001;
               break;
             }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -579,7 +548,6 @@ public final class StatusProto {
     }
 
     @SuppressWarnings({"rawtypes"})
-    @java.lang.Override
     protected com.google.protobuf.MapField internalGetMapField(
         int number) {
       switch (number) {
@@ -590,7 +558,6 @@ public final class StatusProto {
               "Invalid map field number: " + number);
       }
     }
-    @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return ch.epfl.dedis.proto.StatusProto.internal_static_status_Response_fieldAccessorTable
@@ -697,7 +664,6 @@ public final class StatusProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -713,7 +679,6 @@ public final class StatusProto {
       return true;
     }
 
-    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       com.google.protobuf.GeneratedMessageV3
@@ -728,7 +693,6 @@ public final class StatusProto {
       unknownFields.writeTo(output);
     }
 
-    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -865,7 +829,6 @@ public final class StatusProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
@@ -873,7 +836,6 @@ public final class StatusProto {
     public static Builder newBuilder(ch.epfl.dedis.proto.StatusProto.Response prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
@@ -923,7 +885,6 @@ public final class StatusProto {
                 "Invalid map field number: " + number);
         }
       }
-      @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return ch.epfl.dedis.proto.StatusProto.internal_static_status_Response_fieldAccessorTable
@@ -947,7 +908,6 @@ public final class StatusProto {
           getServeridentityFieldBuilder();
         }
       }
-      @java.lang.Override
       public Builder clear() {
         super.clear();
         internalGetMutableStatus().clear();
@@ -960,18 +920,15 @@ public final class StatusProto {
         return this;
       }
 
-      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
         return ch.epfl.dedis.proto.StatusProto.internal_static_status_Response_descriptor;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.StatusProto.Response getDefaultInstanceForType() {
         return ch.epfl.dedis.proto.StatusProto.Response.getDefaultInstance();
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.StatusProto.Response build() {
         ch.epfl.dedis.proto.StatusProto.Response result = buildPartial();
         if (!result.isInitialized()) {
@@ -980,7 +937,6 @@ public final class StatusProto {
         return result;
       }
 
-      @java.lang.Override
       public ch.epfl.dedis.proto.StatusProto.Response buildPartial() {
         ch.epfl.dedis.proto.StatusProto.Response result = new ch.epfl.dedis.proto.StatusProto.Response(this);
         int from_bitField0_ = bitField0_;
@@ -1000,39 +956,32 @@ public final class StatusProto {
         return result;
       }
 
-      @java.lang.Override
       public Builder clone() {
         return (Builder) super.clone();
       }
-      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.setField(field, value);
       }
-      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return (Builder) super.clearField(field);
       }
-      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return (Builder) super.clearOneof(oneof);
       }
-      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
         return (Builder) super.setRepeatedField(field, index, value);
       }
-      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
         return (Builder) super.addRepeatedField(field, value);
       }
-      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
         if (other instanceof ch.epfl.dedis.proto.StatusProto.Response) {
           return mergeFrom((ch.epfl.dedis.proto.StatusProto.Response)other);
@@ -1054,7 +1003,6 @@ public final class StatusProto {
         return this;
       }
 
-      @java.lang.Override
       public final boolean isInitialized() {
         if (hasServeridentity()) {
           if (!getServeridentity().isInitialized()) {
@@ -1064,7 +1012,6 @@ public final class StatusProto {
         return true;
       }
 
-      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1324,13 +1271,11 @@ public final class StatusProto {
         }
         return serveridentityBuilder_;
       }
-      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -1352,12 +1297,11 @@ public final class StatusProto {
 
     @java.lang.Deprecated public static final com.google.protobuf.Parser<Response>
         PARSER = new com.google.protobuf.AbstractParser<Response>() {
-      @java.lang.Override
       public Response parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new Response(input, extensionRegistry);
+          return new Response(input, extensionRegistry);
       }
     };
 
@@ -1370,7 +1314,6 @@ public final class StatusProto {
       return PARSER;
     }
 
-    @java.lang.Override
     public ch.epfl.dedis.proto.StatusProto.Response getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }

--- a/external/proto/darc.proto
+++ b/external/proto/darc.proto
@@ -99,7 +99,7 @@ message Request {
   repeated bytes signatures = 5;
 }
 
-// Rules are action-expression associations.
+// Rules is a list of action-expression associations.
 message Rules {
   repeated Rule list = 1;
 }

--- a/omniledger/service/service_test.go
+++ b/omniledger/service/service_test.go
@@ -61,6 +61,17 @@ func TestService_CreateSkipchain(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, CurrentVersion, resp.Version)
 	assert.NotNil(t, resp.Skipblock)
+
+	proof, err := s.service().GetProof(&GetProof{
+		Version: CurrentVersion,
+		Key:     genesisMsg.GenesisDarc.GetID(),
+		ID:      resp.Skipblock.SkipChainID(),
+	})
+	require.Nil(t, err)
+	require.Nil(t, proof.Proof.Verify(resp.Skipblock.SkipChainID()))
+	k, _, err := proof.Proof.KeyValue()
+	require.Nil(t, err)
+	require.EqualValues(t, genesisMsg.GenesisDarc.GetID(), k)
 }
 
 func padDarc(key []byte) []byte {


### PR DESCRIPTION
Added missing java API calls for OmniLedger structures.
Added some more documentation.

- Make sure all `omniledger/contracts` correctly make use of `sendTransactionAndWait` instead of `sleep`ing.
- `sendTransactionAndWait` should throw `CothorityProcessingException` if transaction has not been included, and `CothorityCommunicationException` if network fails.

Closes #1407 