### PR TITLE
Fix state change caching in the case of bad tx

### DIFF
--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -768,9 +768,10 @@ func (s *Service) createStateChanges(coll *collection.Collection, scID skipchain
 	// ignore the error and compute the state changes.
 	merkleRoot, ctsOK, ctsBad, states, err = s.stateChangeCache.get(scID, cts.Hash())
 	if err == nil {
-		log.Lvl3(s.ServerIdentity(), "loaded state changes from cache")
+		log.Lvl4(s.ServerIdentity(), "state changes from cache: HIT")
 		return
 	}
+	log.Lvl4(s.ServerIdentity(), "state changes from cache: MISS")
 	err = nil
 
 	deadline := time.Now().Add(timeout)
@@ -818,7 +819,7 @@ clientTransactions:
 
 	// Store the result in the cache before returning.
 	merkleRoot = cdbTemp.GetRoot()
-	s.stateChangeCache.update(scID, cts.Hash(), merkleRoot, ctsOK, ctsBad, states)
+	s.stateChangeCache.update(scID, ctsOK.Hash(), merkleRoot, ctsOK, ctsBad, states)
 	return
 }
 

--- a/omniledger/service/statechange_cache.go
+++ b/omniledger/service/statechange_cache.go
@@ -13,7 +13,7 @@ import (
 // should only happen at block interval boundaries. So we do not expect
 // interleaving state changes for the same skipchain. The advantage of this
 // approach is that we do not need to worry about deleting used cache because
-// the memory useage stays constant per skipchain.
+// the memory usage stays constant at one entry per Skipchain.
 type stateChangeCache struct {
 	sync.Mutex
 	cache map[string]*stateChangeValue


### PR DESCRIPTION
Previously, if a tx is removed because it is bad, the
state changes generated by the remaining tx's would be
cached under the wrong key. The result would be that
an attacker could disable the state change caching by
intentionally sending invalid transactions.

This was found by code inspection, but then I decided
to prove it was really happening by adding the hit/miss
monitoring mechanism.