### PR TITLE
Wait for nodes to finish propagation in simulation

### DIFF
--- a/omniledger/simulation/coins.go
+++ b/omniledger/simulation/coins.go
@@ -236,12 +236,12 @@ func (s *SimulationService) Run(config *onet.SimulationConfig) error {
 		}
 		confirm.Record()
 		roundM.Record()
+
+		// This sleep is needed to wait for the propagation to finish
+		// on all the nodes. Otherwise the simulation manager
+		// (runsimul.go in onet) might close some nodes and cause
+		// skipblock propagation to fail.
+		time.Sleep(blockInterval)
 	}
-	// We wait a bit before closing because c.GetProof is sent to the
-	// leader, but at this point some of the children might still be doing
-	// updateCollection. If we stop the simulation immediately, then the
-	// database gets closed and updateCollection on the children fails to
-	// complete.
-	time.Sleep(time.Second)
 	return nil
 }


### PR DESCRIPTION
Without this change the simulation may fail for a large number of nodes.
Further, we remove the final sleep because updateCollection is gone and
it is now a callback in skipchain.