### PR TITLE
Database Versioning

### DIFF
--- a/conode/Dockerfile-dev
+++ b/conode/Dockerfile-dev
@@ -1,12 +1,12 @@
 FROM golang:1.10
 WORKDIR /root/
-COPY exe/conode.Linux.x86_64 ./conode
 COPY setup-then-start.sh .
 COPY run_conode.sh .
 RUN mkdir /conode_data
 RUN mkdir -p .local/share .config
 RUN ln -s /conode_data .local/share/conode
 RUN ln -s /conode_data .config/conode
+COPY exe/conode.Linux.x86_64 ./conode
 
 EXPOSE 6879 6880
 

--- a/evoting/service/service.go
+++ b/evoting/service/service.go
@@ -46,6 +46,7 @@ var serviceID onet.ServiceID
 
 // storageKey identifies the on-disk storage.
 var storageKey = []byte("storage")
+var dbVersion = 1
 
 // Service is the core structure of the application.
 type Service struct {
@@ -738,6 +739,9 @@ func (s *Service) save() {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	if err := s.Save(storageKey, s.storage); err != nil {
+		log.Error(err)
+	}
+	if err := s.SaveVersion(dbVersion); err != nil {
 		log.Error(err)
 	}
 }

--- a/identity/api_test.go
+++ b/identity/api_test.go
@@ -325,7 +325,7 @@ func TestCrashAfterRevocation(t *testing.T) {
 	for _, srvc := range services {
 		s := srvc.(*Service)
 		log.Lvl3(s.Storage.Identities)
-		s.Storage.Auth.Sets = append(s.Storage.Auth.Sets, anonSet{Set: set})
+		s.Storage.Auth.Sets = append(s.Storage.Auth.Sets, anonSet1{Set: set})
 	}
 
 	c1 := NewIdentity(roster, 2, "one", kp1)
@@ -439,7 +439,7 @@ func createIdentity(l *onet.LocalTest, services []onet.Service, roster *onet.Ros
 	set := anon.Set([]kyber.Point{kp1.Public, kp2.Public})
 	for _, srvc := range services {
 		s := srvc.(*Service)
-		s.Storage.Auth.Sets = append(s.Storage.Auth.Sets, anonSet{Set: set})
+		s.Storage.Auth.Sets = append(s.Storage.Auth.Sets, anonSet1{Set: set})
 	}
 
 	c := NewTestIdentity(roster, 50, name, l, kp1)

--- a/identity/db.go
+++ b/identity/db.go
@@ -1,0 +1,180 @@
+package identity
+
+import (
+	"sync"
+
+	"github.com/dedis/cothority"
+	"github.com/dedis/cothority/skipchain"
+	"github.com/dedis/kyber"
+	"github.com/dedis/kyber/sign/anon"
+	"github.com/dedis/kyber/util/key"
+	"github.com/dedis/onet"
+	"github.com/dedis/onet/network"
+	"github.com/dedis/protobuf"
+)
+
+// DB-versioning, allows propoer passage from one version to another. This example
+// shows how to handle the case where there was no previous versioning in the
+// database, and we already have two possible incompatible versions out there,
+// version 0a and 0b. Version 1 will be the correct one.
+//
+// loadVersion starts trying to get version 1, but only if the database returns
+// the correct version. If the version is 0 (or nonexistant), then it calls first
+// updateFrom0a, if that fails it tries updateFrom0b and if all fails it returns an error.
+//
+// In case of a future incompatible change, one would have to add `updateFrom1` which
+// would call `updateFrom0` if the version < 1. `updateFrom1` would return `storage2`.
+// And the `Service` structure would use `storage2` for the up-to-date storage
+// version.
+
+const dbVersion = 1
+
+var storageKey = []byte("storage")
+var versionKey = []byte("version")
+
+func loadVersion(l onet.ContextDB) (*storage1, error) {
+	vers, err := l.LoadVersion()
+	if err != nil {
+		return nil, err
+	}
+	if vers < dbVersion {
+		storage, err := updateFrom0(l, vers)
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO: this is really ugly...
+		if c, ok := l.(*onet.Context); ok {
+			err = c.Save(storageKey, storage)
+		}
+		err = l.SaveVersion(dbVersion)
+		return storage, err
+	}
+	sInt, err := l.Load(storageKey)
+	if err != nil {
+		return nil, err
+	}
+	if sInt == nil {
+		return &storage1{}, nil
+	}
+	return sInt.(*storage1), err
+}
+
+// storage1 holds the map to the storages so it can be marshaled.
+type storage1 struct {
+	Identities map[string]*IDBlock
+	// The key that is stored in the skipchain service to authenticate
+	// new blocks.
+	SkipchainKeyPair *key.Pair
+	// Auth is a list of all authentications allowed for this service
+	Auth *authData1
+}
+
+type authData1 struct {
+	// set of Pins and keys
+	Pins map[string]bool
+	// Sets of public keys to verify linkable ring signatures
+	Sets []anonSet1
+	// list of public Keys to verify simple authentication with Schnorr sig
+	Keys []kyber.Point
+	// list of AdminKeys
+	AdminKeys []kyber.Point
+	// set of Nonces
+	Nonces map[string]bool
+}
+
+type anonSet1 struct {
+	Set anon.Set
+}
+
+// updateFrom0 tries first to load the oldest version of the database, then the
+// somewhat newer one.
+func updateFrom0(l onet.ContextDB, vers int) (*storage1, error) {
+	s := &storage1{}
+	err := updateFrom0a(l, s)
+	if err == nil {
+		return s, nil
+	}
+	return s, updateFrom0b(l, s)
+}
+
+//
+// This is the oldest version of the database.
+//
+
+type storage0a struct {
+	Identities map[string]*idBlock0
+	// OldSkipchainKey is a placeholder for protobuf being able to read old config-files
+	OldSkipchainKey kyber.Scalar
+	// The key that is stored in the skipchain service to authenticate
+	// new blocks.
+	SkipchainKeyPair *key.Pair
+	// Auth is a list of all authentications allowed for this service
+	Auth *authData1
+}
+
+type idBlock0 struct {
+	sync.Mutex
+	Latest          *Data
+	Proposed        *Data
+	LatestSkipblock *skipchain.SkipBlock
+}
+
+func updateFrom0a(l onet.ContextDB, s *storage1) error {
+	s0Buf, err := l.LoadRaw(storageKey)
+	if err != nil {
+		return err
+	}
+	if len(s0Buf) <= 16 {
+		return nil
+	}
+	s0 := &storage0a{}
+	err = protobuf.DecodeWithConstructors(s0Buf[16:], s0, network.DefaultConstructors(cothority.Suite))
+	if err != nil {
+		return err
+	}
+	s.Identities = make(map[string]*IDBlock)
+	for k, v := range s0.Identities {
+		s.Identities[k] = &IDBlock{
+			Latest:          v.Latest,
+			Proposed:        v.Proposed,
+			LatestSkipblock: v.LatestSkipblock,
+		}
+	}
+	s.SkipchainKeyPair = s0.SkipchainKeyPair
+	return nil
+}
+
+//
+// This is a somewhat newer version of the database.
+//
+
+type storage0b struct {
+	Identities map[string]*IDBlock
+	// OldSkipchainKey is a placeholder for protobuf being able to read old config-files
+	OldSkipchainKey kyber.Scalar
+	// The key that is stored in the skipchain service to authenticate
+	// new blocks.
+	SkipchainKeyPair *key.Pair
+	// Auth is a list of all authentications allowed for this service
+	Auth *authData1
+}
+
+func updateFrom0b(l onet.ContextDB, s *storage1) error {
+	s0Buf, err := l.LoadRaw(storageKey)
+	if err != nil {
+		return err
+	}
+	if len(s0Buf) <= 16 {
+		return nil
+	}
+	s0 := &storage0b{}
+	err = protobuf.DecodeWithConstructors(s0Buf[16:], s0, network.DefaultConstructors(cothority.Suite))
+	if err != nil {
+		return err
+	}
+	s.Identities = s0.Identities
+	s.SkipchainKeyPair = s0.SkipchainKeyPair
+	s.Auth = s0.Auth
+	return nil
+}

--- a/identity/db_test.go
+++ b/identity/db_test.go
@@ -1,0 +1,104 @@
+package identity
+
+import (
+	"testing"
+
+	"github.com/dedis/cothority"
+	"github.com/dedis/cothority/skipchain"
+	"github.com/dedis/kyber/util/key"
+	"github.com/dedis/onet/network"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	network.RegisterMessages(&storage0a{}, &storage0b{})
+}
+
+func TestLoadVersion(t *testing.T) {
+	ml := myLoader{
+		data: make(map[string][]byte),
+	}
+
+	// Test that storage0a is correctly recognized
+	s0a := &storage0a{
+		Identities: map[string]*idBlock0{"abc": &idBlock0{
+			Latest: &Data{
+				Threshold: 10,
+			},
+			LatestSkipblock: &skipchain.SkipBlock{
+				SkipBlockFix: &skipchain.SkipBlockFix{
+					Height: 3,
+				},
+			},
+		}},
+		OldSkipchainKey:  cothority.Suite.Scalar().One(),
+		SkipchainKeyPair: key.NewKeyPair(cothority.Suite),
+		Auth:             &authData1{},
+	}
+	s0aBuf, err := network.Marshal(s0a)
+	require.Nil(t, err)
+	ml.data[string(storageKey)] = s0aBuf
+
+	storage, err := loadVersion(ml)
+	require.Nil(t, err)
+	require.True(t, s0a.SkipchainKeyPair.Public.Equal(storage.SkipchainKeyPair.Public))
+	require.Equal(t, s0a.Identities["abc"].Latest.Threshold,
+		storage.Identities["abc"].Latest.Threshold)
+	require.Equal(t, s0a.Identities["abc"].LatestSkipblock.Height,
+		storage.Identities["abc"].LatestSkipblock.Height)
+
+	// Test that storage0b is correctly recognized
+	s0b := &storage0b{
+		Identities: map[string]*IDBlock{"abc": &IDBlock{
+			Latest: &Data{
+				Threshold: 10,
+			},
+			LatestSkipblock: &skipchain.SkipBlock{
+				SkipBlockFix: &skipchain.SkipBlockFix{
+					Height: 3,
+				},
+			},
+		}},
+		OldSkipchainKey:  cothority.Suite.Scalar().One(),
+		SkipchainKeyPair: key.NewKeyPair(cothority.Suite),
+		Auth:             &authData1{},
+	}
+	s0bBuf, err := network.Marshal(s0b)
+	require.Nil(t, err)
+	ml.data[string(storageKey)] = s0bBuf
+	ml.SaveVersion(0)
+
+	storage, err = loadVersion(ml)
+	require.Nil(t, err)
+	require.True(t, s0b.SkipchainKeyPair.Public.Equal(storage.SkipchainKeyPair.Public))
+	require.Equal(t, s0b.Identities["abc"].Latest.Threshold,
+		storage.Identities["abc"].Latest.Threshold)
+	require.Equal(t, s0b.Identities["abc"].LatestSkipblock.Height,
+		storage.Identities["abc"].LatestSkipblock.Height)
+}
+
+type myLoader struct {
+	data map[string][]byte
+}
+
+func (ml myLoader) Load(key []byte) (interface{}, error) {
+	_, i, err := network.Unmarshal(ml.data[string(key)], cothority.Suite)
+	return i, err
+}
+
+func (ml myLoader) LoadRaw(key []byte) ([]byte, error) {
+	return ml.data[string(key)], nil
+}
+
+func (ml myLoader) LoadVersion() (int, error) {
+	v, ok := ml.data["version"]
+	if !ok {
+		return 0, nil
+	}
+	return int(v[0]), nil
+}
+
+func (ml myLoader) SaveVersion(v int) error {
+	ml.data["version"] = []byte{byte(v)}
+	return nil
+}

--- a/identity/service_test.go
+++ b/identity/service_test.go
@@ -26,7 +26,7 @@ func TestService_CreateIdentity2(t *testing.T) {
 	kp := key.NewKeyPair(tSuite)
 	kp2 := key.NewKeyPair(tSuite)
 	set := anon.Set([]kyber.Point{kp.Public, kp2.Public})
-	service.Storage.Auth.Sets = append(service.Storage.Auth.Sets, anonSet{Set: set})
+	service.Storage.Auth.Sets = append(service.Storage.Auth.Sets, anonSet1{Set: set})
 
 	da := NewData(ro, 50, kp.Public, "one")
 	ci := &CreateIdentity{}

--- a/ocs/service/service.go
+++ b/ocs/service/service.go
@@ -38,6 +38,7 @@ const timestampRange = 60
 
 var storageKey = []byte("storage")
 var darcsKey = []byte("darcs")
+var dbVersion = 1
 
 func init() {
 	network.RegisterMessages(Storage{}, vData{})
@@ -854,6 +855,7 @@ func (s *Service) save() {
 	if err != nil {
 		log.Error("Couldn't save file:", err)
 	}
+	s.SaveVersion(dbVersion)
 }
 
 // Tries to load the configuration and updates if a configuration

--- a/pop/service/service.go
+++ b/pop/service/service.go
@@ -82,6 +82,7 @@ var mergeCheckID network.MessageTypeID
 var mergeCheckReplyID network.MessageTypeID
 
 var storageKey = []byte("storage")
+var dbVersion = 1
 
 // Service represents data needed for one pop-party.
 type Service struct {
@@ -974,6 +975,7 @@ func (s *Service) save() {
 	if err != nil {
 		log.Error("Couldn't save data:", err)
 	}
+	s.SaveVersion(dbVersion)
 }
 
 // Tries to load the configuration and updates if a configuration

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -39,6 +39,7 @@ const bftNewBlock = "SkipchainBFTNew"
 const bftFollowBlock = "SkipchainBFTFollow"
 
 var storageKey = []byte("skipchainconfig")
+var dbVersion = 1
 
 // If this flag is set, then we relax our forward-link signature verification
 // to accept the aggregate signature by the public keys of the rotated roster.
@@ -1409,6 +1410,7 @@ func (s *Service) save() {
 	if err != nil {
 		log.Error("Couldn't save file:", err)
 	}
+	s.SaveVersion(dbVersion)
 }
 
 // Tries to load the configuration and updates the data in the service


### PR DESCRIPTION
First shot at adding a database versioning for the Identity and the OmniLedger
services. The idea is to add an additional bucket with an integer in it, that
can be used to get older versions of the database. In the Identity service,
`db.go` holds an example that does try different versions before giving up.

This depends on dedis/onet#464