### PR TITLE
Make invalid protobuf test more intelligent

### DIFF
--- a/omniledger/collection/proof_test.go
+++ b/omniledger/collection/proof_test.go
@@ -521,7 +521,7 @@ func TestProofSerialization(test *testing.T) {
 		}
 	}
 
-	_, err := collection.Deserialize([]byte("definitelynotaproof"))
+	_, err := collection.Deserialize([]byte{0})
 
 	if err == nil {
 		test.Error("[proof.go]", "[serialization]", "Deserialize() does not yield an error when provided with an invalid byte slice.")


### PR DESCRIPTION
With the latest protobuf changes, we discard unknown fields (like protobuf3)
and don't throw an error anymore. So we need to be more intelligent in
creating invalid input.