### PR TITLE
Remove DeriveID as much as possible

### DIFF
--- a/eventlog/api.go
+++ b/eventlog/api.go
@@ -64,7 +64,7 @@ func (c *Client) Create() error {
 		return err
 	}
 
-	c.Instance = instr.DeriveID("eventlog")
+	c.Instance = omniledger.NewInstanceID(instr.Hash())
 	return nil
 }
 
@@ -165,7 +165,7 @@ func makeTx(darcID darc.ID, id omniledger.InstanceID, msgs []Event, signers []da
 			}
 		}
 		tx.Instructions[i].Signatures = darcSigs
-		keys[i] = LogID(tx.Instructions[i].DeriveID("event").Slice())
+		keys[i] = LogID(tx.Instructions[i].Hash())
 	}
 	return &tx, keys, nil
 }

--- a/eventlog/service.go
+++ b/eventlog/service.go
@@ -186,8 +186,7 @@ func (s *Service) invoke(v omniledger.CollectionView, inst omniledger.Instructio
 		return nil, nil, err
 	}
 
-	// Get a new instance ID for storing this event.
-	eventID := inst.DeriveID("event")
+	eventID := omniledger.NewInstanceID(inst.Hash())
 
 	sc = append(sc, omniledger.NewStateChange(omniledger.Create, eventID, cid, eventBuf, darcID))
 
@@ -297,7 +296,7 @@ func (s *Service) spawn(v omniledger.CollectionView, inst omniledger.Instruction
 	// Store zeros as the pointer to the first bucket because there are not yet
 	// any events in this event log.
 	return []omniledger.StateChange{
-		omniledger.NewStateChange(omniledger.Create, inst.DeriveID("eventlog"),
+		omniledger.NewStateChange(omniledger.Create, omniledger.NewInstanceID(inst.Hash()),
 			cid, make([]byte, 32), darcID),
 	}, nil, nil
 }

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/Instruction.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/Instruction.java
@@ -195,31 +195,6 @@ public class Instruction {
         }
     }
 
-    /**
-     * This function derives an instance ID from the instruction with the given string. The derived instance ID if
-     * useful as a key to this instruction.
-     * @param what - the string that gets mixed into the derived instance ID
-     * @return the instance ID
-     * @throws CothorityCryptoException
-     */
-    public InstanceId deriveId(String what) throws CothorityCryptoException {
-        final byte zero = 0;
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            digest.update(this.hash());
-            digest.update(zero);
-            for (Signature sig : this.signatures) {
-                digest.update(sig.signature);
-                digest.update(zero);
-            }
-            digest.update(what.getBytes());
-            digest.update(zero);
-            return new InstanceId(digest.digest());
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     private static byte[] intToArr4(int x) {
         ByteBuffer b = ByteBuffer.allocate(4);
         b.order(ByteOrder.LITTLE_ENDIAN);

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/DarcInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/DarcInstance.java
@@ -193,7 +193,7 @@ public class DarcInstance {
         Instruction inst = spawnContractInstruction(contractID, s, args, 0, 1);
         ClientTransaction ct = new ClientTransaction(Arrays.asList(inst));
         ol.sendTransactionAndWait(ct, wait);
-        InstanceId iid = inst.deriveId("value");
+        InstanceId iid = new InstanceId(inst.hash());
         if (contractID.equals("darc")) {
             // Special case for a darc, then the resulting instanceId is based
             // on the darc itself.

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/EventLogInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/EventLogInstance.java
@@ -187,7 +187,7 @@ public class EventLogInstance {
         ClientTransaction tx = new ClientTransaction(Arrays.asList(instr));
         ol.sendTransaction(tx);
 
-        return instr.deriveId("eventlog");
+        return new InstanceId(instr.hash());
     }
 
 
@@ -223,7 +223,7 @@ public class EventLogInstance {
             Instruction instr = new Instruction(instance.getId(), Instruction.genNonce(), idx, events.size(), invoke);
             instr.signBy(darcId, signers);
             instrs.add(instr);
-            keys.add(instr.deriveId("event"));
+            keys.add(new InstanceId(instr.hash()));
             idx++;
         }
         ClientTransaction tx = new ClientTransaction(instrs);

--- a/omniledger/Contracts.md
+++ b/omniledger/Contracts.md
@@ -158,6 +158,10 @@ to create a new instance with the given ContractID, which can be different from
 the Darc itself. The client must be able to authenticate against a
 `Spawn_contractid` rule defined in the Darc instance.
 
+The new instance spawned will have an instance ID equal to the hash of
+the Spawn instruction. The client can remember this instance ID in order
+to invoke methods on it later.
+
 ### Invoke
 
 The only method that a client can invoke on a Darc instance is `Evolve`, which

--- a/omniledger/contracts/value.go
+++ b/omniledger/contracts/value.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/dedis/cothority/omniledger/darc"
-	"github.com/dedis/cothority/omniledger/service"
+	omniledger "github.com/dedis/cothority/omniledger/service"
 )
 
 // The value contract can simply store a value in an instance and serves
@@ -20,7 +20,7 @@ var ContractValueID = "value"
 // It can spawn new value instances and will store the "value" argument in these
 // new instances.
 // Existing value instances can be "update"d and deleted.
-func ContractValue(cdb service.CollectionView, inst service.Instruction, c []service.Coin) (sc []service.StateChange, cOut []service.Coin, err error) {
+func ContractValue(cdb omniledger.CollectionView, inst omniledger.Instruction, c []omniledger.Coin) (sc []omniledger.StateChange, cOut []omniledger.Coin, err error) {
 	cOut = c
 
 	var darcID darc.ID
@@ -31,21 +31,21 @@ func ContractValue(cdb service.CollectionView, inst service.Instruction, c []ser
 
 	switch {
 	case inst.Spawn != nil:
-		return []service.StateChange{
-			service.NewStateChange(service.Create, inst.DeriveID(ContractValueID),
+		return []omniledger.StateChange{
+			omniledger.NewStateChange(omniledger.Create, omniledger.NewInstanceID(inst.Hash()),
 				ContractValueID, inst.Spawn.Args.Search("value"), darcID),
 		}, c, nil
 	case inst.Invoke != nil:
 		if inst.Invoke.Command != "update" {
 			return nil, nil, errors.New("Value contract can only update")
 		}
-		return []service.StateChange{
-			service.NewStateChange(service.Update, inst.InstanceID,
+		return []omniledger.StateChange{
+			omniledger.NewStateChange(omniledger.Update, inst.InstanceID,
 				ContractValueID, inst.Invoke.Args.Search("value"), darcID),
 		}, c, nil
 	case inst.Delete != nil:
-		return service.StateChanges{
-			service.NewStateChange(service.Remove, inst.InstanceID, ContractValueID, nil, darcID),
+		return omniledger.StateChanges{
+			omniledger.NewStateChange(omniledger.Remove, inst.InstanceID, ContractValueID, nil, darcID),
 		}, c, nil
 	}
 	return nil, nil, errors.New("didn't find any instruction")

--- a/omniledger/contracts/value_test.go
+++ b/omniledger/contracts/value_test.go
@@ -49,7 +49,7 @@ func TestValue_Spawn(t *testing.T) {
 
 	_, err = cl.AddTransaction(ctx)
 	require.Nil(t, err)
-	pr, err := cl.WaitProof(ctx.Instructions[0].DeriveID(ContractValueID), genesisMsg.BlockInterval, myvalue)
+	pr, err := cl.WaitProof(omniledger.NewInstanceID(ctx.Instructions[0].Hash()), genesisMsg.BlockInterval, myvalue)
 	require.Nil(t, err)
 	require.True(t, pr.InclusionProof.Match())
 	values, err := pr.InclusionProof.RawValues()

--- a/omniledger/service/transaction.go
+++ b/omniledger/service/transaction.go
@@ -105,8 +105,12 @@ func (instr Instruction) Hash() []byte {
 	return h.Sum(nil)
 }
 
-// DeriveID derives a new InstanceID from the instruction's
-// InstanceID, the given string, and the hash of the Instruction.
+// DeriveID derives a new InstanceID from the hash of the instruction, its signatures,
+// and the given string.
+//
+// DeriveID is used inside of contracts that need to create additional keys in
+// the collection. Newly spawned instances should, by convention, always use the
+// Hash() of the instruction as the new InstanceID.
 func (instr Instruction) DeriveID(what string) InstanceID {
 	h := sha256.New()
 	h.Write(instr.Hash())

--- a/omniledger/simulation/coins.go
+++ b/omniledger/simulation/coins.go
@@ -243,5 +243,11 @@ func (s *SimulationService) Run(config *onet.SimulationConfig) error {
 		// skipblock propagation to fail.
 		time.Sleep(blockInterval)
 	}
+	// We wait a bit before closing because c.GetProof is sent to the
+	// leader, but at this point some of the children might still be doing
+	// updateCollection. If we stop the simulation immediately, then the
+	// database gets closed and updateCollection on the children fails to
+	// complete.
+	time.Sleep(time.Second)
 	return nil
 }


### PR DESCRIPTION
In accordance with the (new) documentation on DeriveID, it should
ONLY be used inside a contract that needs to create new keys to
store additional information. All other instance ID's should come
from spawning new instances, and those should be inst.Hash().

The ida for DeriveID came from the legitimate need of eventlog
to get keys to store its time buckets. So it is still using
DeriveID.

Remove deriveId from Java, since if contracts are using
it correctly (i.e. only for their own use) then Omniledger
clients will never need to look up those keys.