### PR TITLE
Updating Omniledger to behave

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,49 @@
-notifications:
-  email: false
+language: node_js
+sudo: required
+dist: trusty
 
-language: go
+node_js:
+  - "lts/*"
+  - "8"
+
+env:
+  - TEST_DIR=cothority
+  - TEST_DIR=kyber
 
 install:
   - gimme 1.9
   - . $HOME/.gimme/envs/go1.9.env
   - go get github.com/dedis/Coding || true
-  - go get -t ./...
+  # Because we are using "language: node_js" the "git clone" is not in the
+  # GOPATH. So make a copy of it over where it is supposed to be.
+  - git clone . `go env GOPATH`/src/github.com/dedis/cothority
+  - (cd `go env GOPATH`/src/github.com/dedis/cothority && go get -t ./... )
 
-before_install:
-  - cd $TRAVIS_BUILD_DIR
+script: cd external/js/$TEST_DIR && npm install && npm run test && npm run build
 
-script:
-  - (cd conode/; make docker)
-  - make test_playground
+
+after_success:
+  - npm run coveralls
+
+notifications:
+  email: false
+
+matrix:
+  include:
+    - language: go
+
+      install:
+        - go get -t ./...
+        - go get github.com/dedis/Coding || true
+
+      before_install:
+        - cd $TRAVIS_BUILD_DIR
+
+      script:
+        - (cd conode/; make docker)
+        - make test
+
+    - language: java
+
+      script:
+        - make test_java

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,49 +1,17 @@
-language: node_js
-sudo: required
-dist: trusty
+notifications:
+  email: false
 
-node_js:
-  - "lts/*"
-  - "8"
-
-env:
-  - TEST_DIR=cothority
-  - TEST_DIR=kyber
+language: go
 
 install:
   - gimme 1.9
   - . $HOME/.gimme/envs/go1.9.env
   - go get github.com/dedis/Coding || true
-  # Because we are using "language: node_js" the "git clone" is not in the
-  # GOPATH. So make a copy of it over where it is supposed to be.
-  - git clone . `go env GOPATH`/src/github.com/dedis/cothority
-  - (cd `go env GOPATH`/src/github.com/dedis/cothority && go get -t ./... )
+  - go get -t ./...
 
-script: cd external/js/$TEST_DIR && npm install && npm run test && npm run build
+before_install:
+  - cd $TRAVIS_BUILD_DIR
 
-
-after_success:
-  - npm run coveralls
-
-notifications:
-  email: false
-
-matrix:
-  include:
-    - language: go
-
-      install:
-        - go get -t ./...
-        - go get github.com/dedis/Coding || true
-
-      before_install:
-        - cd $TRAVIS_BUILD_DIR
-
-      script:
-        - (cd conode/; make docker)
-        - make test
-
-    - language: java
-
-      script:
-        - make test_java
+script:
+  - (cd conode/; make docker)
+  - make test_playground

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ EXCLUDE_LINT = "should be.*UI|_test.go"
 test_playground:
 	cd omniledger/simulation; \
 	for a in $$( seq 100 ); do \
-		if DEBUG_TIME=true go test -v -race > log.txt 2>&1; then \
+		# if DEBUG_TIME=true go test -v -race > log.txt 2>&1; then \
+		if DEBUG_TIME=true go test -v -race; then \
 			echo Successfully ran \#$$a at $$(date); \
 		else \
 			echo Failed at $$(date); \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ EXCLUDE_LINT = "should be.*UI|_test.go"
 # for more than once in Travis. Change `make test` in .travis.yml
 # to `make test_playground`.
 test_playground:
-	cd omniledger/service; \
+	cd omniledger/simulation; \
 	for a in $$( seq 100 ); do \
 		if DEBUG_TIME=true go test -v -race > log.txt 2>&1; then \
 			echo Successfully ran \#$$a at $$(date); \

--- a/eventlog/api.go
+++ b/eventlog/api.go
@@ -50,9 +50,10 @@ func AddWriter(r darc.Rules, expr expression.Expr) darc.Rules {
 // a timeout). Upon non-error return, c.Instance will be correctly set.
 func (c *Client) Create() error {
 	instr := omniledger.Instruction{
-		Index:  0,
-		Length: 1,
-		Spawn:  &omniledger.Spawn{ContractID: contractName},
+		InstanceID: omniledger.NewInstanceID(c.DarcID),
+		Index:      0,
+		Length:     1,
+		Spawn:      &omniledger.Spawn{ContractID: contractName},
 	}
 	if err := instr.SignBy(c.DarcID, c.Signers...); err != nil {
 		return err

--- a/eventlog/service.go
+++ b/eventlog/service.go
@@ -304,6 +304,12 @@ func (s *Service) spawn(v omniledger.CollectionView, inst omniledger.Instruction
 // contractFunction is the function that runs to process a transaction of
 // type "eventlog"
 func (s *Service) contractFunction(v omniledger.CollectionView, inst omniledger.Instruction, c []omniledger.Coin) ([]omniledger.StateChange, []omniledger.Coin, error) {
+
+	err := inst.VerifyDarcSignature(v)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	switch inst.GetType() {
 	case omniledger.InvokeType:
 		return s.invoke(v, inst, c)

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/Instruction.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/Instruction.java
@@ -33,8 +33,8 @@ public class Instruction {
      * @param length The length of the atomic set.
      * @param spawn The spawn object, which contains the value and the argument.
      */
-    public Instruction(byte[] nonce, int index, int length, Spawn spawn) {
-        this.instId = InstanceId.zero();
+    public Instruction(InstanceId instId, byte[] nonce, int index, int length, Spawn spawn) {
+        this.instId = instId;
         this.nonce = nonce;
         this.index = index;
         this.length = length;

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/DarcInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/DarcInstance.java
@@ -193,7 +193,7 @@ public class DarcInstance {
         Instruction inst = spawnContractInstruction(contractID, s, args, 0, 1);
         ClientTransaction ct = new ClientTransaction(Arrays.asList(inst));
         ol.sendTransactionAndWait(ct, wait);
-        InstanceId iid = new InstanceId(inst.hash());
+        InstanceId iid = inst.deriveId(contractID);
         if (contractID.equals("darc")) {
             // Special case for a darc, then the resulting instanceId is based
             // on the darc itself.

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/DarcInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/DarcInstance.java
@@ -152,7 +152,7 @@ public class DarcInstance {
     public Instruction spawnContractInstruction(String contractID, Signer s, List<Argument> args, int pos, int len)
             throws CothorityCryptoException {
         Spawn sp = new Spawn(contractID, args);
-        Instruction inst = new Instruction(Instruction.genNonce(), pos, len, sp);
+        Instruction inst = new Instruction(new InstanceId(darc.getBaseId().getId()), Instruction.genNonce(), pos, len, sp);
         try {
             Request r = new Request(darc.getBaseId(), "spawn:" + contractID, inst.hash(),
                     Arrays.asList(s.getIdentity()), null);

--- a/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/EventLogInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/omniledger/contracts/EventLogInstance.java
@@ -181,7 +181,7 @@ public class EventLogInstance {
             throw new CothorityException("already have an instance");
         }
         Spawn spawn = new Spawn("eventlog", new ArrayList<>());
-        Instruction instr = new Instruction(Instruction.genNonce(), 0, 1, spawn);
+        Instruction instr = new Instruction(new InstanceId(darcId.getId()), Instruction.genNonce(), 0, 1, spawn);
         instr.signBy(darcId, signers);
 
         ClientTransaction tx = new ClientTransaction(Arrays.asList(instr));

--- a/external/java/src/test/java/ch/epfl/dedis/lib/omniledger/OmniledgerRPCTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/lib/omniledger/OmniledgerRPCTest.java
@@ -83,7 +83,6 @@ public class OmniledgerRPCTest {
 
     @Test
     void spawnDarc() throws Exception{
-        SkipBlock previous = ol.getLatest();
         DarcInstance dc = new DarcInstance(ol, genesisDarc);
         Darc darc2 = genesisDarc.copy();
         darc2.setRule("spawn:darc", admin.getIdentity().toString().getBytes());
@@ -106,7 +105,6 @@ public class OmniledgerRPCTest {
 
     @Test
     void spawnValue() throws Exception{
-        SkipBlock previous = ol.getLatest();
         DarcInstance dc = new DarcInstance(ol, genesisDarc);
         Darc darc2 = genesisDarc.copy();
         darc2.setRule("spawn:value", admin.getIdentity().toString().getBytes());

--- a/omniledger/contracts/coins.go
+++ b/omniledger/contracts/coins.go
@@ -60,6 +60,11 @@ func (s safeUint64) sub(a uint64) (safeUint64, error) {
 func ContractCoin(cdb omniledger.CollectionView, inst omniledger.Instruction, c []omniledger.Coin) (sc []omniledger.StateChange, cOut []omniledger.Coin, err error) {
 	cOut = c
 
+	err = inst.VerifyDarcSignature(cdb)
+	if err != nil {
+		return
+	}
+
 	var value []byte
 	var darcID darc.ID
 	value, _, darcID, err = cdb.GetValues(inst.InstanceID.Slice())

--- a/omniledger/contracts/value.go
+++ b/omniledger/contracts/value.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/dedis/cothority/omniledger/darc"
-	omniledger "github.com/dedis/cothority/omniledger/service"
+	ol "github.com/dedis/cothority/omniledger/service"
 )
 
 // The value contract can simply store a value in an instance and serves
@@ -20,8 +20,13 @@ var ContractValueID = "value"
 // It can spawn new value instances and will store the "value" argument in these
 // new instances.
 // Existing value instances can be "update"d and deleted.
-func ContractValue(cdb omniledger.CollectionView, inst omniledger.Instruction, c []omniledger.Coin) (sc []omniledger.StateChange, cOut []omniledger.Coin, err error) {
+func ContractValue(cdb ol.CollectionView, inst ol.Instruction, c []ol.Coin) (sc []ol.StateChange, cOut []ol.Coin, err error) {
 	cOut = c
+
+	err = inst.VerifyDarcSignature(cdb)
+	if err != nil {
+		return
+	}
 
 	var darcID darc.ID
 	_, _, darcID, err = cdb.GetValues(inst.InstanceID.Slice())
@@ -29,23 +34,23 @@ func ContractValue(cdb omniledger.CollectionView, inst omniledger.Instruction, c
 		return
 	}
 
-	switch {
-	case inst.Spawn != nil:
-		return []omniledger.StateChange{
-			omniledger.NewStateChange(omniledger.Create, omniledger.NewInstanceID(inst.Hash()),
+	switch inst.GetType() {
+	case ol.SpawnType:
+		return []ol.StateChange{
+			ol.NewStateChange(ol.Create, inst.DeriveID(ContractValueID),
 				ContractValueID, inst.Spawn.Args.Search("value"), darcID),
 		}, c, nil
-	case inst.Invoke != nil:
+	case ol.InvokeType:
 		if inst.Invoke.Command != "update" {
 			return nil, nil, errors.New("Value contract can only update")
 		}
-		return []omniledger.StateChange{
-			omniledger.NewStateChange(omniledger.Update, inst.InstanceID,
+		return []ol.StateChange{
+			ol.NewStateChange(ol.Update, inst.InstanceID,
 				ContractValueID, inst.Invoke.Args.Search("value"), darcID),
 		}, c, nil
-	case inst.Delete != nil:
-		return omniledger.StateChanges{
-			omniledger.NewStateChange(omniledger.Remove, inst.InstanceID, ContractValueID, nil, darcID),
+	case ol.DeleteType:
+		return ol.StateChanges{
+			ol.NewStateChange(ol.Remove, inst.InstanceID, ContractValueID, nil, darcID),
 		}, c, nil
 	}
 	return nil, nil, errors.New("didn't find any instruction")

--- a/omniledger/contracts/value_test.go
+++ b/omniledger/contracts/value_test.go
@@ -49,7 +49,7 @@ func TestValue_Spawn(t *testing.T) {
 
 	_, err = cl.AddTransaction(ctx)
 	require.Nil(t, err)
-	pr, err := cl.WaitProof(omniledger.NewInstanceID(ctx.Instructions[0].Hash()), genesisMsg.BlockInterval, myvalue)
+	pr, err := cl.WaitProof(omniledger.NewInstanceID(ctx.Instructions[0].DeriveID(ContractValueID).Slice()), genesisMsg.BlockInterval, myvalue)
 	require.Nil(t, err)
 	require.True(t, pr.InclusionProof.Match())
 	values, err := pr.InclusionProof.RawValues()

--- a/omniledger/service/api.go
+++ b/omniledger/service/api.go
@@ -291,12 +291,12 @@ func DefaultGenesisMsg(v Version, r *onet.Roster, rules []string, ids ...darc.Id
 func SignInstruction(inst *Instruction, darcID darc.ID, signers ...darc.Signer) error {
 	inst.Signatures = make([]darc.Signature, 0)
 	var action string
-	switch {
-	case inst.Spawn != nil:
+	switch inst.GetType() {
+	case SpawnType:
 		action = "spawn:" + inst.Spawn.ContractID
-	case inst.Invoke != nil:
+	case InvokeType:
 		action = "invoke:" + inst.Invoke.Command
-	case inst.Delete != nil:
+	case DeleteType:
 		action = "delete"
 	}
 	req, err := darc.InitAndSignRequest(darcID, darc.Action(action),

--- a/omniledger/service/contracts.go
+++ b/omniledger/service/contracts.go
@@ -19,6 +19,9 @@ var ContractConfigID = "config"
 // ContractDarcID denotes a darc-contract
 var ContractDarcID = "darc"
 
+// ConfigInstanceID represents the 0-id of the configuration instance.
+var ConfigInstanceID = InstanceID{}
+
 // CmdDarcEvolve is needed to evolve a darc.
 var CmdDarcEvolve = "evolve"
 
@@ -85,11 +88,23 @@ func LoadDarcFromColl(coll CollectionView, key []byte) (*darc.Darc, error) {
 // ContractConfig can only be instantiated once per skipchain, and only for
 // the genesis block.
 func (s *Service) ContractConfig(cdb CollectionView, inst Instruction, coins []Coin) (sc []StateChange, c []Coin, err error) {
-	if inst.GetType() == SpawnType {
+	// Verify the darc signature if the config instance does not exist yet.
+	pr, err := cdb.Get(ConfigInstanceID.Slice()).Proof()
+	if err != nil {
+		return
+	}
+	if pr.Match() {
+		err = inst.VerifyDarcSignature(cdb)
+		if err != nil {
+			return
+		}
+	}
+	switch inst.GetType() {
+	case SpawnType:
 		return s.spawnContractConfig(cdb, inst, coins)
-	} else if inst.GetType() == InvokeType {
+	case InvokeType:
 		return s.invokeContractConfig(cdb, inst, coins)
-	} else {
+	default:
 		return nil, coins, errors.New("unsupported instruction type")
 	}
 }
@@ -223,7 +238,7 @@ func (s *Service) spawnContractConfig(cdb CollectionView, inst Instruction, coin
 
 	id := d.GetBaseID()
 	return []StateChange{
-		NewStateChange(Create, NewInstanceID(nil), ContractConfigID, configBuf, id),
+		NewStateChange(Create, ConfigInstanceID, ContractConfigID, configBuf, id),
 		NewStateChange(Create, NewInstanceID(id), ContractDarcID, darcBuf, id),
 	}, c, nil
 
@@ -234,8 +249,12 @@ func (s *Service) spawnContractConfig(cdb CollectionView, inst Instruction, coin
 //   - Invoke.Evolve - evolves an existing darc
 func (s *Service) ContractDarc(cdb CollectionView, inst Instruction, coins []Coin) (sc []StateChange, cOut []Coin, err error) {
 	cOut = coins
-	switch {
-	case inst.Spawn != nil:
+	err = inst.VerifyDarcSignature(cdb)
+	if err != nil {
+		return
+	}
+	switch inst.GetType() {
+	case SpawnType:
 		if inst.Spawn.ContractID == ContractDarcID {
 			darcBuf := inst.Spawn.Args.Search("darc")
 			d, err := darc.NewFromProtobuf(darcBuf)
@@ -247,17 +266,14 @@ func (s *Service) ContractDarc(cdb CollectionView, inst Instruction, coins []Coi
 				NewStateChange(Create, NewInstanceID(id), ContractDarcID, darcBuf, id),
 			}, coins, nil
 		}
-		// TODO The code below will never get called because this
-		// contract is used only when tx.Spawn.ContractID is "darc", so
-		// the if statement above gets executed and this contract
-		// returns. Why do we need this part, if we do, how should we
-		// fix it?
+
 		c, found := s.contracts[inst.Spawn.ContractID]
 		if !found {
 			return nil, nil, errors.New("couldn't find this contract type")
 		}
 		return c(cdb, inst, coins)
-	case inst.Invoke != nil:
+
+	case InvokeType:
 		switch inst.Invoke.Command {
 		case "evolve":
 			var darcID darc.ID
@@ -284,6 +300,7 @@ func (s *Service) ContractDarc(cdb CollectionView, inst Instruction, coins []Coi
 		default:
 			return nil, nil, errors.New("invalid command: " + inst.Invoke.Command)
 		}
+
 	default:
 		return nil, nil, errors.New("Only invoke and spawn are defined yet")
 	}

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -609,6 +609,10 @@ func (s *Service) startPolling(scID skipchain.SkipBlockID, interval time.Duratio
 // We use the OmniLedger as a receiver (as is done in the identity service),
 // so we can access e.g. the collectionDBs of the service.
 func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool {
+	start := time.Now()
+	defer func() {
+		log.Lvlf3("%s: Verify done after %s", s.ServerIdentity(), time.Now().Sub(start))
+	}()
 	_, headerI, err := network.Unmarshal(newSB.Data, cothority.Suite)
 	header, ok := headerI.(*DataHeader)
 	if err != nil || !ok {

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -4,7 +4,6 @@ package service
 import (
 	"bytes"
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"sync"
@@ -166,7 +165,7 @@ func (s *Service) CreateGenesisBlock(req *CreateGenesisBlock) (
 	// reference to the actual genesis transaction.
 	transaction := []ClientTransaction{{
 		Instructions: []Instruction{{
-			InstanceID: NewInstanceID(req.GenesisDarc.GetID()),
+			InstanceID: ConfigInstanceID,
 			Nonce:      Nonce{},
 			Index:      0,
 			Length:     1,
@@ -258,61 +257,6 @@ func (s *Service) SetPropagationTimeout(p time.Duration) {
 	s.skService().SetPropTimeout(p)
 }
 
-func (s *Service) verifyAndFilterTxs(scID skipchain.SkipBlockID, ts []ClientTransaction) []ClientTransaction {
-	var validTxs []ClientTransaction
-	for i, t := range ts {
-		if err := s.verifyClientTx(scID, t); err != nil {
-			log.Errorf("%v tx #%v, %v", s.ServerIdentity(), i, err)
-			continue
-		}
-		validTxs = append(validTxs, t)
-	}
-	return validTxs
-}
-
-func (s *Service) verifyClientTx(scID skipchain.SkipBlockID, tx ClientTransaction) error {
-	for i, instr := range tx.Instructions {
-		if err := s.verifyInstruction(scID, instr); err != nil {
-			log.Errorf("%v instr #%v, %v", s.ServerIdentity(), i, err)
-			return err
-		}
-	}
-	return nil
-}
-
-func (s *Service) verifyInstruction(scID skipchain.SkipBlockID, instr Instruction) error {
-	d, err := s.loadLatestDarc(scID, instr.InstanceID)
-	if err != nil {
-		return errors.New("darc not found: " + err.Error())
-	}
-	req, err := instr.ToDarcRequest(d.GetBaseID())
-	if err != nil {
-		return errors.New("couldn't create darc request: " + err.Error())
-	}
-	// Verify the request is signed by appropriate identities.
-	// A callback is required to get any delegated DARC(s) during
-	// expression evaluation.
-	view := s.GetCollectionView(scID)
-	err = req.VerifyWithCB(d, func(str string, latest bool) *darc.Darc {
-		if len(str) < 5 || string(str[0:5]) != "darc:" {
-			return nil
-		}
-		darcID, err := hex.DecodeString(str[5:])
-		if err != nil {
-			return nil
-		}
-		d, err := LoadDarcFromColl(view, darcID)
-		if err != nil {
-			return nil
-		}
-		return d
-	})
-	if err != nil {
-		return errors.New("request verification failed: " + err.Error())
-	}
-	return nil
-}
-
 // createNewBlock creates a new block and proposes it to the
 // skipchain-service. Once the block has been created, we
 // inform all nodes to update their internal collections
@@ -350,10 +294,6 @@ func (s *Service) createNewBlock(scID skipchain.SkipBlockID, r *onet.Roster, cts
 			sb.Roster = r
 		}
 
-		cts = s.verifyAndFilterTxs(sb.SkipChainID(), cts)
-		if len(cts) == 0 {
-			return nil, errors.New("no valid transaction")
-		}
 		coll = s.getCollection(scID).coll
 	}
 
@@ -544,15 +484,7 @@ func (s *Service) LoadConfig(scID skipchain.SkipBlockID) (*ChainConfig, error) {
 // LoadGenesisDarc loads the genesis darc of the given skipchain ID.
 func (s *Service) LoadGenesisDarc(scID skipchain.SkipBlockID) (*darc.Darc, error) {
 	coll := s.GetCollectionView(scID)
-	// Find the genesis-darc ID.
-	_, contract, darcID, err := getValueContract(coll, NewInstanceID(nil).Slice())
-	if err != nil {
-		return nil, err
-	}
-	if string(contract) != ContractConfigID {
-		return nil, errors.New("did not get " + ContractConfigID)
-	}
-	return s.loadLatestDarc(scID, NewInstanceID(darcID))
+	return getInstanceDarc(coll, ConfigInstanceID)
 }
 
 // LoadBlockInterval loads the block interval from the skipchain ID.
@@ -572,31 +504,6 @@ func (s *Service) EnableViewChange() {
 	s.skService().EnableViewChange()
 	s.heartbeats = newHeartbeats()
 	s.monitorLeaderFailure()
-}
-
-func (s *Service) loadLatestDarc(scID skipchain.SkipBlockID, iid InstanceID) (*darc.Darc, error) {
-	colldb := s.getCollection(scID)
-	if colldb == nil {
-		return nil, fmt.Errorf("collection for skipchain ID %s does not exist", scID.Short())
-	}
-	coll := &roCollection{colldb.coll}
-
-	// From instance ID, find the darcID that controls access to it.
-	_, _, dID, err := coll.GetValues(iid.Slice())
-	if err != nil {
-		return nil, err
-	}
-
-	// Fetch the darc itself.
-	value, contract, _, err := coll.GetValues(dID)
-	if err != nil {
-		return nil, err
-	}
-
-	if string(contract) != ContractDarcID {
-		return nil, fmt.Errorf("for instance %v, expected Kind to be 'darc' but got '%v'", iid, string(contract))
-	}
-	return darc.NewFromProtobuf(value)
 }
 
 func (s *Service) startPolling(scID skipchain.SkipBlockID, interval time.Duration) chan bool {
@@ -773,10 +680,10 @@ func (s *Service) createStateChanges(coll *collection.Collection, scID skipchain
 	// ignore the error and compute the state changes.
 	merkleRoot, ctsOK, ctsBad, states, err = s.stateChangeCache.get(scID, cts.Hash())
 	if err == nil {
-		log.Lvl4(s.ServerIdentity(), "state changes from cache: HIT")
+		log.Lvl3(s.ServerIdentity(), "loaded state changes from cache")
 		return
 	}
-	log.Lvl4(s.ServerIdentity(), "state changes from cache: MISS")
+	log.Lvl3(s.ServerIdentity(), "state changes from cache: MISS")
 	err = nil
 
 	deadline := time.Now().Add(timeout)

--- a/omniledger/service/service_test.go
+++ b/omniledger/service/service_test.go
@@ -80,7 +80,10 @@ func TestService_AddTransaction_WithFailure(t *testing.T) {
 }
 
 func TestService_AddTransaction_WithFailure_OnFollower(t *testing.T) {
+	// for {
+	// 	log.Print("Starting test")
 	testAddTransaction(t, 1, true)
+	// }
 }
 
 func testAddTransaction(t *testing.T, sendToIdx int, failure bool) {
@@ -88,7 +91,7 @@ func testAddTransaction(t *testing.T, sendToIdx int, failure bool) {
 	if failure {
 		s = newSerN(t, 1, time.Second, 4, false)
 		for _, service := range s.services {
-			service.SetPropagationTimeout(time.Second)
+			service.SetPropagationTimeout(2 * time.Second)
 		}
 	} else {
 		s = newSer(t, 1, testInterval)
@@ -464,57 +467,64 @@ func TestService_StateChange(t *testing.T) {
 			return nil, nil, err
 		}
 
+		zeroBuf := make([]byte, 8)
+		switch inst.GetType() {
 		// create the object if it doesn't exist
-		if !rec.Match() {
-			if inst.Spawn == nil {
-				return nil, nil, errors.New("expected spawn")
+		case SpawnType:
+			if inst.Spawn.ContractID != "add" {
+				return nil, nil, errors.New("can only spawn add contracts")
 			}
-			zeroBuf := make([]byte, 8)
 			binary.PutVarint(zeroBuf, 0)
 			return []StateChange{
 				StateChange{
 					StateAction: Create,
-					InstanceID:  inst.InstanceID.Slice(),
+					InstanceID:  inst.DeriveID("add").Slice(),
 					ContractID:  []byte(cid),
 					Value:       zeroBuf,
 				},
 			}, nil, nil
+		case InvokeType:
+
+			// increment the object value
+			vals, err := rec.Values()
+			if err != nil {
+				return nil, nil, err
+			}
+			v, _ := binary.Varint(vals[0].([]byte))
+			v++
+
+			// we read v back to check later in the test
+			latest = v
+
+			vBuf := make([]byte, 8)
+			binary.PutVarint(vBuf, v)
+			return []StateChange{
+				StateChange{
+					StateAction: Update,
+					InstanceID:  inst.InstanceID.Slice(),
+					ContractID:  []byte(cid),
+					Value:       vBuf,
+				},
+			}, nil, nil
 		}
-
-		if inst.Invoke == nil {
-			return nil, nil, errors.New("expected invoke")
-		}
-
-		// increment the object value
-		vals, err := rec.Values()
-		if err != nil {
-			return nil, nil, err
-		}
-		v, _ := binary.Varint(vals[0].([]byte))
-		v++
-
-		// we read v back to check later in the test
-		latest = v
-
-		vBuf := make([]byte, 8)
-		binary.PutVarint(vBuf, v)
-		return []StateChange{
-			StateChange{
-				StateAction: Update,
-				InstanceID:  inst.InstanceID.Slice(),
-				ContractID:  []byte(cid),
-				Value:       vBuf,
-			},
-		}, nil, nil
-
+		return nil, nil, errors.New("need spawn or invoke")
 	}
 	RegisterContract(s.hosts[0], "add", f)
 
 	cdb := s.service().getCollection(s.sb.SkipChainID())
 	require.NotNil(t, cdb)
 
-	n := 5
+	// Manually create the add contract
 	inst := genID()
+	err := cdb.Store(&StateChange{
+		StateAction: Create,
+		InstanceID:  inst.Slice(),
+		ContractID:  []byte("add"),
+		Value:       make([]byte, 8),
+	})
+	require.Nil(t, err)
+
+	n := 5
 	nonce := GenNonce()
 	instrs := make([]Instruction, n)
 	for i := range instrs {
@@ -529,6 +539,7 @@ func TestService_StateChange(t *testing.T) {
 				ContractID: "add",
 			}
 		} else {
+			instrs[i].InstanceID = instrs[0].DeriveID("add")
 			instrs[i].Invoke = &Invoke{}
 		}
 	}
@@ -855,7 +866,14 @@ func TestService_StateChangeCache(t *testing.T) {
 	s.service().registerContract(contractID, contract)
 
 	scID := s.sb.SkipChainID()
-	coll := s.service().getCollection(scID).coll
+	collDB := s.service().getCollection(scID)
+	collDB.Store(&StateChange{
+		StateAction: Create,
+		InstanceID:  NewInstanceID(s.darc.GetBaseID()).Slice(),
+		ContractID:  []byte(contractID),
+		Value:       []byte{},
+	})
+	coll := collDB.coll
 	tx1, err := createOneClientTx(s.darc.GetBaseID(), contractID, []byte{}, s.signer)
 	require.Nil(t, err)
 
@@ -1065,7 +1083,7 @@ func newSerN(t *testing.T, step int, interval time.Duration, n int, viewchange b
 	}
 
 	genesisMsg, err := DefaultGenesisMsg(CurrentVersion, s.roster,
-		[]string{"spawn:dummy", "spawn:invalid", "spawn:panic", "spawn:darc", "invoke:update_config", "spawn:slow"}, s.signer.Identity())
+		[]string{"spawn:dummy", "spawn:invalid", "spawn:panic", "spawn:darc", "invoke:update_config", "spawn:slow", "spawn:stateShangeCacheTest"}, s.signer.Identity())
 	require.Nil(t, err)
 	s.darc = &genesisMsg.GenesisDarc
 

--- a/omniledger/service/struct.go
+++ b/omniledger/service/struct.go
@@ -325,6 +325,25 @@ func (c *collectionDB) tryHash(ts []StateChange) (mr []byte, rerr error) {
 	return
 }
 
+func getInstanceDarc(c CollectionView, iid InstanceID) (*darc.Darc, error) {
+	// From instance ID, find the darcID that controls access to it.
+	_, _, dID, err := c.GetValues(iid.Slice())
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch the darc itself.
+	value, contract, _, err := c.GetValues(dID)
+	if err != nil {
+		return nil, err
+	}
+
+	if string(contract) != ContractDarcID {
+		return nil, fmt.Errorf("for instance %v, expected Kind to be 'darc' but got '%v'", iid, string(contract))
+	}
+	return darc.NewFromProtobuf(value)
+}
+
 // RegisterContract stores the contract in a map and will
 // call it whenever a contract needs to be done.
 // GetService makes it possible to give either an `onet.Context` or

--- a/omniledger/simulation/coins.toml
+++ b/omniledger/simulation/coins.toml
@@ -8,6 +8,6 @@ Suite = "Ed25519"
 # of tests
 
 Keep,   Transactions, BatchSize,  Hosts,  Delay, BlockInterval
-true,   200,          5,          10,     10,    "2s"
+true,   200,          5,          5,     10,    "1s"
 # true,   200,          10,         10,     10,    "2s"
 # true,   200,          20,         10,     10,    "2s"


### PR DESCRIPTION
There were a couple of things astray in Omniledger land:
- verification of signatures on instructions were done _after_ the contract has been run
  -> verification of signatures is done in contracts, so they can do whatever seems fit
- instructions sent to an instance didn't call that instance if it was a 'spawn' instruction
  -> all instructions call now the instance in the 'InstanceID' field
  -> fixed tests that sent instructions to non-existent instances
- followers didn't verify the signatures of instructions
  -> verification is done in contracts, so this is taken care of
- updated java and added `deriveID` again