### PR TITLE
Protocol fails when subleader of the same tree continuosly fail more than 2 times

### DIFF
--- a/ftcosi/protocol/protocol.go
+++ b/ftcosi/protocol/protocol.go
@@ -334,7 +334,7 @@ func (p *FtCosi) startSubProtocol(tree *onet.Tree) (*SubFtCosi, error) {
 	cosiSubProtocol.Data = p.Data
 	// We allow for one subleader failure during the commit phase, and thus
 	// only allocate one third of the ftcosi budget to the subprotocol.
-	cosiSubProtocol.Timeout = p.Timeout / time.Duration(len(tree.List()))
+	cosiSubProtocol.Timeout = p.Timeout / 3
 
 	// the Threshold (minus root node) is divided evenly among the subtrees
 	subThreshold := int(math.Ceil(float64(p.Threshold-1) / float64(p.NSubtrees)))

--- a/ftcosi/protocol/protocol.go
+++ b/ftcosi/protocol/protocol.go
@@ -334,7 +334,7 @@ func (p *FtCosi) startSubProtocol(tree *onet.Tree) (*SubFtCosi, error) {
 	cosiSubProtocol.Data = p.Data
 	// We allow for one subleader failure during the commit phase, and thus
 	// only allocate one third of the ftcosi budget to the subprotocol.
-	cosiSubProtocol.Timeout = p.Timeout / 3
+	cosiSubProtocol.Timeout = p.Timeout / time.Duration(len(tree.List()))
 
 	// the Threshold (minus root node) is divided evenly among the subtrees
 	subThreshold := int(math.Ceil(float64(p.Threshold-1) / float64(p.NSubtrees)))

--- a/ftcosi/protocol/protocol_commitments.go
+++ b/ftcosi/protocol/protocol_commitments.go
@@ -45,7 +45,7 @@ func (p *FtCosi) collectCommitments(trees []*onet.Tree,
 					for _, child := range trees[i].Root.Children[0].Children {
 						nodes = append(nodes, child.RosterIndex)
 					}
-					if subleaderID > nodes[len(nodes)-1] {
+					if len(nodes) < 2 || subleaderID > nodes[1] {
 						errChan <- fmt.Errorf("(subprotocol %v) failed with every subleader, ignoring this subtree",
 							i)
 						return


### PR DESCRIPTION
If the current subleader of a tree is unresponsive we choose the next subleader as the first child and append the current subleader to the last position.
Eg: [0,1,2,3,4]->[0,2,3,4,1](currently fails here)->[0,3,4,1,2]->[0,4,1,2,3](should fail here)