### PR TITLE
Implement view-change.v2

### DIFF
--- a/external/java/src/test/java/ch/epfl/dedis/lib/omniledger/contracts/EventLogInstanceTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/lib/omniledger/contracts/EventLogInstanceTest.java
@@ -45,7 +45,7 @@ class EventLogInstanceTest {
         rules.addRule("invoke:eventlog", admin.getIdentity().toString().getBytes());
         Darc genesisDarc = new Darc(rules, "genesis".getBytes());
 
-        ol = new OmniledgerRPC(testInstanceController.getRoster(), genesisDarc, Duration.of(100, MILLIS));
+        ol = new OmniledgerRPC(testInstanceController.getRoster(), genesisDarc, Duration.of(500, MILLIS));
         if (!ol.checkLiveness()) {
             throw new CothorityCommunicationException("liveness check failed");
         }
@@ -57,7 +57,7 @@ class EventLogInstanceTest {
     void log() throws Exception {
         Event e = new Event("hello", "goodbye");
         InstanceId key = el.log(e, ol.getGenesisDarc().getBaseId(), Arrays.asList(admin));
-        Thread.sleep(2 * ol.getConfig().getBlockInterval().toMillis());
+        Thread.sleep(5 * ol.getConfig().getBlockInterval().toMillis());
         Event loggedEvent = el.get(key);
         assertEquals(loggedEvent, e);
     }
@@ -75,7 +75,7 @@ class EventLogInstanceTest {
         boolean allOK = true;
         for (int i = 0; i < 4; i++) {
             allOK = true;
-            Thread.sleep(2 * ol.getConfig().getBlockInterval().toMillis());
+            Thread.sleep(5 * ol.getConfig().getBlockInterval().toMillis());
             for (InstanceId key : keys) {
                 try {
                     logger.info("ok");
@@ -100,7 +100,7 @@ class EventLogInstanceTest {
         Event event = new Event(now, "login", "alice");
         el.log(event, ol.getGenesisDarc().getBaseId(), Arrays.asList(admin));
 
-        Thread.sleep(2 * ol.getConfig().getBlockInterval().toMillis());
+        Thread.sleep(5 * ol.getConfig().getBlockInterval().toMillis());
 
         // finds the event under any topic
         SearchResponse resp = el.search("", now - 1000, now + 1000);

--- a/omniledger/README.md
+++ b/omniledger/README.md
@@ -57,27 +57,17 @@ remaining to be run, they will be prepended to the next collected set of
 transactions when the next block interval expires.
 
 A "view change" (change of leader) is needed when the leader stops performing
-its duties correctly. Followers notice the need for a new leader by way of a
-heartbeat mechanism triggering on the absence of new blocks.
+its duties correctly. Followers notice the need for a new leader if the leader
+stops sending heartbeat messages within some time window or detect a malicious
+behaviour (not implemented yet).
 
-We implement a simple view-change that re-uses all of existing functionalities 
-in OmniLedger (e.g., block creation and smart contracts). However, it does not
-prevent Byzantine leaders yet. We assume the roster is ordered and every node
-observes the same order. Further, the leader polls the followers once every
-`blockInterval`. Using these assumptions, when the current leader stops polling,
-then next leader (according to the roster list) will send out a new
-transaction. This transaction contains the `invoke:view_change` action which
-shifts the order of the roster by one. As a result, the failed leader moves to
-the end of the roster and the new leader becomes the first. In the contract,
-every node should verify that the new node is the correct next leader and
-enough time has past since the current leader stopped responding.
-
-The current implementation has some limitations. The system makes progress when
-only one leader node fails, we have not tested the scenario where multiple
-nodes fail. We have not implemented the "catch-up" functionality for when a
-node comes back up. For these reasons, view-change is disabled by default. To
-enable view-change, refer to the `EnableViewChange` function in the OmniLedger
-service package.
+The design is similar to the view-change protocol in PBFT (OSDI99). We keep the
+view-change message that followers send when they detect an anomaly. But we
+replace the new-view message with the ftcosi protocol and block creation. The
+result of ftcosi is an aggregate signature of all the nodes that agree to
+perform the view-change. The signature is included in the block which nodes
+accept if the aggregate signature is correct. This technique enables nodes to
+synchronise and replay blocks to compute the most up-to-date leader.
 
 # Structure Definitions
 

--- a/omniledger/service/contracts.go
+++ b/omniledger/service/contracts.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/omniledger/darc"
+	"github.com/dedis/cothority/omniledger/viewchange"
+	"github.com/dedis/kyber/sign/cosi"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
@@ -101,15 +103,15 @@ func (s *Service) ContractConfig(cdb CollectionView, inst Instruction, coins []C
 	}
 	switch inst.GetType() {
 	case SpawnType:
-		return s.spawnContractConfig(cdb, inst, coins)
+		return spawnContractConfig(cdb, inst, coins)
 	case InvokeType:
-		return s.invokeContractConfig(cdb, inst, coins)
+		return invokeContractConfig(cdb, inst, coins)
 	default:
 		return nil, coins, errors.New("unsupported instruction type")
 	}
 }
 
-func (s *Service) invokeContractConfig(cdb CollectionView, inst Instruction, coins []Coin) (sc []StateChange, cOut []Coin, err error) {
+func invokeContractConfig(cdb CollectionView, inst Instruction, coins []Coin) (sc []StateChange, cOut []Coin, err error) {
 	cOut = coins
 
 	// Find the darcID for this instance.
@@ -141,24 +143,21 @@ func (s *Service) invokeContractConfig(cdb CollectionView, inst Instruction, coi
 		}
 		return
 	} else if inst.Invoke.Command == "view_change" {
-		config := &ChainConfig{}
-		config, err = LoadConfigFromColl(cdb)
+		var req viewchange.NewViewReq
+		err = protobuf.DecodeWithConstructors(inst.Invoke.Args.Search("newview"), &req, network.DefaultConstructors(cothority.Suite))
 		if err != nil {
 			return
 		}
-		newRosterBuf := inst.Invoke.Args.Search("roster")
-		newRoster := onet.Roster{}
-		err = protobuf.DecodeWithConstructors(newRosterBuf, &newRoster, network.DefaultConstructors(cothority.Suite))
+		// If everything is correctly signed, then we trust it, no need
+		// to do additional verification.
+		sigBuf := inst.Invoke.Args.Search("multisig")
+		err = cosi.Verify(cothority.Suite, req.Roster.Publics(),
+			req.Hash(), sigBuf, cosi.NewThresholdPolicy(len(req.Roster.List)-len(req.Roster.List)/3))
 		if err != nil {
 			return
 		}
-		if err = validRotation(config.Roster, newRoster); err != nil {
-			return
-		}
-		if err = s.withinInterval(darcID, inst.Signatures[0].Signer.Ed25519.Point); err != nil {
-			return
-		}
-		sc, err = updateRosterScs(cdb, darcID, newRoster)
+
+		sc, err = updateRosterScs(cdb, darcID, req.Roster)
 		return
 	}
 	err = errors.New("invalid invoke command: " + inst.Invoke.Command)
@@ -195,7 +194,7 @@ func validRotation(oldRoster, newRoster onet.Roster) error {
 	return nil
 }
 
-func (s *Service) spawnContractConfig(cdb CollectionView, inst Instruction, coins []Coin) (sc []StateChange, c []Coin, err error) {
+func spawnContractConfig(cdb CollectionView, inst Instruction, coins []Coin) (sc []StateChange, c []Coin, err error) {
 	c = coins
 	darcBuf := inst.Spawn.Args.Search("darc")
 	d, err := darc.NewFromProtobuf(darcBuf)

--- a/omniledger/service/heartbeat.go
+++ b/omniledger/service/heartbeat.go
@@ -60,15 +60,7 @@ func (r *heartbeats) closeAll() {
 		c.closeChan <- true
 	}
 	r.wg.Wait()
-}
-
-func (r *heartbeats) enabled() bool {
-	r.Lock()
-	defer r.Unlock()
-	if r.heartbeatMap == nil {
-		return false
-	}
-	return true
+	r.heartbeatMap = make(map[string]heartbeat)
 }
 
 func (r *heartbeats) exists(key string) bool {

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -11,9 +11,11 @@ import (
 	"time"
 
 	"github.com/dedis/cothority"
+	cosiprotocol "github.com/dedis/cothority/ftcosi/protocol"
 	"github.com/dedis/cothority/messaging"
 	"github.com/dedis/cothority/omniledger/collection"
 	"github.com/dedis/cothority/omniledger/darc"
+	"github.com/dedis/cothority/omniledger/viewchange"
 	"github.com/dedis/cothority/skipchain"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/util/random"
@@ -32,6 +34,11 @@ const noTimeout time.Duration = 0
 
 const collectTxProtocol = "CollectTxProtocol"
 
+const viewChangeSubFtCosi = "viewchange_sub_ftcosi"
+const viewChangeFtCosi = "viewchange_ftcosi"
+
+var viewChangeMsgID network.MessageTypeID
+
 // OmniledgerID can be used to refer to this service
 var OmniledgerID onet.ServiceID
 
@@ -42,6 +49,7 @@ func init() {
 	OmniledgerID, err = onet.RegisterNewService(ServiceName, newService)
 	log.ErrFatal(err)
 	network.RegisterMessages(&omniStorage{}, &DataHeader{}, &DataBody{})
+	viewChangeMsgID = network.RegisterMessage(&viewchange.InitReq{})
 }
 
 // GenNonce returns a random nonce.
@@ -75,9 +83,9 @@ type Service struct {
 	// restarting after shutdown, answer getTxs requests and so on.
 	txBuffer txBuffer
 
-	heartbeats        heartbeats
-	heartbeatsTimeout chan string
-	heartbeatsClose   chan bool
+	heartbeats             heartbeats
+	heartbeatsTimeout      chan string
+	closeLeaderMonitorChan chan bool
 
 	// contracts map kinds to kind specific verification functions
 	contracts map[string]OmniLedgerContract
@@ -93,9 +101,10 @@ type Service struct {
 
 	stateChangeCache stateChangeCache
 
-	closed      bool
-	closedMutex sync.Mutex
-	working     sync.WaitGroup
+	closed        bool
+	closedMutex   sync.Mutex
+	working       sync.WaitGroup
+	viewChangeMan viewChangeManager
 }
 
 // storageID reflects the data we're storing - we could store more
@@ -233,7 +242,7 @@ func (s *Service) GetProof(req *GetProof) (resp *GetProofResponse, err error) {
 	if req.Version != CurrentVersion {
 		return nil, errors.New("version mismatch")
 	}
-	log.Lvlf2("%s: Getting proof for key %x on sc %x", s.ServerIdentity(), req.Key, req.ID)
+	log.Lvlf2("%s Getting proof for key %x on sc %x", s.ServerIdentity(), req.Key, req.ID)
 	latest, err := s.db().GetLatestByID(req.ID)
 	if err != nil && latest == nil {
 		return
@@ -347,7 +356,7 @@ func (s *Service) createNewBlock(scID skipchain.SkipBlockID, r *onet.Roster, tx 
 // Hence, we need to figure out when a new block is added. This can be done by
 // looking at the latest skipblock cache from Service.state.
 func (s *Service) updateCollectionCallback(sbID skipchain.SkipBlockID) error {
-	log.Lvlf4("%s: callback on %x", s.ServerIdentity(), sbID)
+	log.Lvlf4("%s callback on %x", s.ServerIdentity(), sbID)
 	if !s.isOurChain(sbID) {
 		log.Lvl4("Not our chain...")
 		return nil
@@ -381,10 +390,10 @@ func (s *Service) updateCollectionCallback(sbID skipchain.SkipBlockID) error {
 		return errors.New("couldn't unmarshal body")
 	}
 
-	log.Lvlf2("%s: Updating transactions for %x", s.ServerIdentity(), sb.SkipChainID())
+	log.Lvlf2("%s Updating transactions for %x", s.ServerIdentity(), sb.SkipChainID())
 	_, _, scs := s.createStateChanges(cdb.coll, sb.SkipChainID(), body.TxResults, noTimeout)
 
-	log.Lvlf3("%s: Storing %d state changes %v", s.ServerIdentity(), len(scs), scs.ShortStrings())
+	log.Lvlf3("%s Storing %d state changes %v", s.ServerIdentity(), len(scs), scs.ShortStrings())
 	if err = cdb.StoreAll(scs, sb.Index); err != nil {
 		return err
 	}
@@ -404,28 +413,17 @@ func (s *Service) updateCollectionCallback(sbID skipchain.SkipBlockID) error {
 	if err != nil {
 		return err
 	}
-	if s.heartbeats.enabled() && sb.Index == 0 {
+	if sb.Index == 0 {
 		if s.heartbeats.exists(string(sb.SkipChainID())) {
 			panic("This is a new genesis block, but we're already running " +
 				"the heartbeat monitor, it should never happen.")
 		}
-		log.Lvlf2("%s: started heartbeat monitor for %x", s.ServerIdentity(), sb.SkipChainID())
+		log.Lvlf2("%s started heartbeat monitor for %x", s.ServerIdentity(), sb.SkipChainID())
 		s.heartbeats.start(string(sb.SkipChainID()), interval*rotationWindow, s.heartbeatsTimeout)
 	}
 
-	// if we are the new leader, then start polling
-	if sb.Roster.List[0].Equal(s.ServerIdentity()) {
-		s.pollChanMut.Lock()
-		if _, ok := s.pollChan[string(sb.SkipChainID())]; !ok {
-			log.Lvlf2("%s: new leader started polling for %x", s.ServerIdentity(), sb.SkipChainID())
-			s.pollChanWG.Add(1)
-			s.pollChan[string(sb.SkipChainID())] = s.startPolling(sb.SkipChainID(), interval)
-		}
-		s.pollChanMut.Unlock()
-	}
-
 	// If we are adding a genesis block, then look into it for the darc ID
-	// and add it to the darcToSc hash map.
+	// and add it to the darcToSc hash map. Start polling if necessary.
 	if sb.Index == 0 {
 		// the information should already be in the collections
 		d, err := s.LoadGenesisDarc(sb.SkipChainID())
@@ -435,8 +433,62 @@ func (s *Service) updateCollectionCallback(sbID skipchain.SkipBlockID) error {
 		s.darcToScMut.Lock()
 		s.darcToSc[string(d.GetBaseID())] = sb.SkipChainID()
 		s.darcToScMut.Unlock()
+		// create the view-change manager entry
+		s.viewChangeMan.add(s.sendViewChangeReq, s.sendNewView, s.isLeader, string(sb.Hash))
+		s.viewChangeMan.start(s.ServerIdentity().ID, sb.SkipChainID(), s.computeInitialDuration(sb.Hash), s.getFaultThreshold(sb.Hash), string(sb.Hash)) // TODO fault threshold might change
+
+		s.pollChanMut.Lock()
+		k := string(sb.SkipChainID())
+		if sb.Roster.List[0].Equal(s.ServerIdentity()) {
+			if _, ok := s.pollChan[k]; !ok {
+				log.Lvlf2("%s genesis leader started polling for %x", s.ServerIdentity(), sb.SkipChainID())
+				s.pollChanWG.Add(1)
+				s.pollChan[k] = s.startPolling(sb.SkipChainID(), interval)
+			}
+		}
+		s.pollChanMut.Unlock()
+	}
+
+	// If it is a view-change transaction, then
+	// (1) inform the view-change manager
+	// (2) if we are the new leader, then start polling; if we got demoted, then stop polling
+	view := isViewChangeTx(body.TxResults)
+	if view != nil {
+		s.viewChangeMan.done(*view)
+		s.pollChanMut.Lock()
+		k := string(sb.SkipChainID())
+		if sb.Roster.List[0].Equal(s.ServerIdentity()) {
+			if _, ok := s.pollChan[k]; !ok {
+				log.Lvlf2("%s new leader started polling for %x", s.ServerIdentity(), sb.SkipChainID())
+				s.pollChanWG.Add(1)
+				s.pollChan[k] = s.startPolling(sb.SkipChainID(), interval)
+			}
+		} else {
+			if c, ok := s.pollChan[k]; ok {
+				log.Lvlf2("%s old leader stopped polling for %x", s.ServerIdentity(), sb.SkipChainID())
+				close(c)
+				delete(s.pollChan, k)
+			}
+		}
+		s.pollChanMut.Unlock()
 	}
 	return nil
+}
+
+func isViewChangeTx(txs TxResults) *viewchange.View {
+	invoke := txs[0].ClientTransaction.Instructions[0].Invoke
+	if invoke == nil {
+		return nil
+	}
+	if invoke.Command != "view_change" {
+		return nil
+	}
+	var req viewchange.NewViewReq
+	if err := protobuf.DecodeWithConstructors(invoke.Args.Search("newview"), &req, network.DefaultConstructors(cothority.Suite)); err != nil {
+		log.Error("failed to decode new-view req")
+		return nil
+	}
+	return req.GetView()
 }
 
 // GetCollectionView returns a read-only accessor to the collection
@@ -460,6 +512,12 @@ func (s *Service) getCollection(id skipchain.SkipBlockID) *collectionDB {
 // interface to skipchain.Service
 func (s *Service) skService() *skipchain.Service {
 	return s.Service(skipchain.ServiceName).(*skipchain.Service)
+}
+
+func (s *Service) isLeader(view viewchange.View) bool {
+	sb := s.db().GetByID(view.ID)
+	sid := sb.Roster.List[view.LeaderIndex]
+	return sid.ID.Equal(s.ServerIdentity().ID)
 }
 
 // gives us access to the skipchain's database, so we can get blocks by ID
@@ -491,16 +549,6 @@ func (s *Service) LoadBlockInterval(scID skipchain.SkipBlockID) (time.Duration, 
 	return LoadBlockIntervalFromColl(&roCollection{collDb.coll})
 }
 
-// EnableViewChange enables the view-change functionality. View-change is
-// highly time sensitive, if the block interval is very low (e.g., when using
-// tests), then we may see unexpected view-change requests while transactions
-// are still being processed if it is enabled in tests.
-func (s *Service) EnableViewChange() {
-	s.skService().EnableViewChange()
-	s.heartbeats = newHeartbeats()
-	s.monitorLeaderFailure()
-}
-
 func (s *Service) startPolling(scID skipchain.SkipBlockID, interval time.Duration) chan bool {
 	closeSignal := make(chan bool)
 	go func() {
@@ -527,14 +575,6 @@ func (s *Service) startPolling(scID skipchain.SkipBlockID, interval time.Duratio
 				}
 
 				log.Lvl3("Starting new block", sb.Index+1)
-				leader, err := s.getLeader(scID)
-				if err != nil {
-					panic("getLeader should not return an error if roster is initialised.")
-				}
-				if !leader.Equal(s.ServerIdentity()) {
-					panic("startPolling should always be called by the leader," +
-						" if it isn't, then it did not start or shutdown properly.")
-				}
 				tree := sb.Roster.GenerateNaryTree(len(sb.Roster.List))
 
 				proto, err := s.CreateProtocol(collectTxProtocol, tree)
@@ -616,13 +656,13 @@ func (s *Service) startPolling(scID skipchain.SkipBlockID, interval time.Duratio
 func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool {
 	start := time.Now()
 	defer func() {
-		log.Lvlf3("%s: Verify done after %s", s.ServerIdentity(), time.Now().Sub(start))
+		log.Lvlf3("%s Verify done after %s", s.ServerIdentity(), time.Now().Sub(start))
 	}()
 
 	var header DataHeader
 	err := protobuf.DecodeWithConstructors(newSB.Data, &header, network.DefaultConstructors(cothority.Suite))
 	if err != nil {
-		log.Error("verifySkipblock: couldn't unmarshal header")
+		log.Error(s.ServerIdentity(), "verifySkipblock: couldn't unmarshal header")
 		return false
 	}
 
@@ -653,6 +693,11 @@ func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool
 		return false
 	}
 
+	if s.viewChangeMan.waiting(string(newSB.SkipChainID())) && isViewChangeTx(body.TxResults) == nil {
+		log.Error(s.ServerIdentity(), "we are not accepting blocks when a view-change is in progress")
+		return false
+	}
+
 	cdb := s.getCollection(newSB.SkipChainID())
 	mtr, txOut, scs := s.createStateChanges(cdb.coll, newSB.SkipChainID(), body.TxResults, noTimeout)
 
@@ -662,6 +707,7 @@ func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool
 		log.Lvl2(s.ServerIdentity(), "transaction list length mismatch after execution")
 		return false
 	}
+
 	for i := range txOut {
 		if txOut[i].Accepted != body.TxResults[i].Accepted {
 			log.Lvl2(s.ServerIdentity(), "Client Transaction accept mistmatch on tx", i)
@@ -689,22 +735,22 @@ func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool
 	collClone := s.getCollection(newSB.SkipChainID()).coll.Clone()
 	for _, sc := range scs {
 		if err := storeInColl(collClone, &sc); err != nil {
-			log.Error(err)
+			log.Error(s.ServerIdentity(), err)
 			return false
 		}
 	}
 	config, err := LoadConfigFromColl(&roCollection{collClone})
 	if err != nil {
-		log.Error(err)
+		log.Error(s.ServerIdentity(), err)
 		return false
 	}
 	if !config.Roster.ID.Equal(newSB.Roster.ID) {
-		log.Error("rosters have unequal IDs")
+		log.Error(s.ServerIdentity(), "rosters have unequal IDs")
 		return false
 	}
 	for i := range config.Roster.List {
 		if !newSB.Roster.List[i].Equal(config.Roster.List[i]) {
-			log.Error("roster in config is not equal to the one in skipblock")
+			log.Error(s.ServerIdentity(), "roster in config is not equal to the one in skipblock")
 			return false
 		}
 	}
@@ -773,14 +819,14 @@ clientTransactions:
 		for _, instr := range tx.ClientTransaction.Instructions {
 			scs, cout, err := s.executeInstruction(cdbI, cin, instr)
 			if err != nil {
-				log.Errorf("%s: Call to contract returned error: %s", s.ServerIdentity(), err)
+				log.Errorf("%s Call to contract returned error: %s", s.ServerIdentity(), err)
 				tx.Accepted = false
 				txOut = append(txOut, tx)
 				continue clientTransactions
 			}
 			for _, sc := range scs {
 				if err := storeInColl(cdbI.c, &sc); err != nil {
-					log.Error("failed to add to collections with error: " + err.Error())
+					log.Error(s.ServerIdentity(), "failed to add to collections with error: "+err.Error())
 					tx.Accepted = false
 					txOut = append(txOut, tx)
 					continue clientTransactions
@@ -829,7 +875,7 @@ func (s *Service) executeInstruction(cdbI CollectionView, cin []Coin, instr Inst
 		return
 	}
 	// Now we call the contract function with the data of the key.
-	log.Lvlf3("%s: Calling contract %s", s.ServerIdentity(), contractID)
+	log.Lvlf3("%s Calling contract %s", s.ServerIdentity(), contractID)
 	return contract(cdbI, instr, cin)
 }
 
@@ -866,9 +912,7 @@ func (s *Service) getTxs(leader *network.ServerIdentity, roster *onet.Roster, sc
 		log.Warn(s.ServerIdentity(), "getTxs came from a wrong leader")
 		return []ClientTransaction{}
 	}
-	if s.heartbeats.enabled() {
-		s.heartbeats.beat(string(scID))
-	}
+	s.heartbeats.beat(string(scID))
 
 	// If the leader's latestID is something we do not know about, then we
 	// need to synchronise.
@@ -910,107 +954,56 @@ func (s *Service) TestClose() {
 }
 
 func (s *Service) cleanupGoroutines() {
+	log.Lvl4(s.ServerIdentity(), "closing go-routines")
 	s.pollChanMut.Lock()
 	for k, c := range s.pollChan {
 		close(c)
 		delete(s.pollChan, k)
 	}
 	s.pollChanMut.Unlock()
-	if s.heartbeats.enabled() {
-		s.heartbeats.closeAll()
-		s.heartbeatsClose <- true
-	}
-
 	s.pollChanWG.Wait()
+
+	s.heartbeats.closeAll()
+	s.closeLeaderMonitorChan <- true
+	s.viewChangeMan.closeAll()
 }
 
 func (s *Service) monitorLeaderFailure() {
-	go func() {
-		s.closedMutex.Lock()
-		if s.closed {
-			s.closedMutex.Unlock()
+	s.closedMutex.Lock()
+	if s.closed {
+		s.closedMutex.Unlock()
+		return
+	}
+	s.working.Add(1)
+	s.closedMutex.Unlock()
+	defer s.working.Done()
+	select {
+	case <-s.closeLeaderMonitorChan:
+	default:
+	}
+	for {
+		select {
+		case key := <-s.heartbeatsTimeout:
+			log.Lvl3(s.ServerIdentity(), "missed heartbeat")
+			gen := []byte(key)
+			latest, err := s.db().GetLatestByID(gen)
+			if err != nil {
+				panic("err")
+			}
+			req := viewchange.InitReq{
+				SignerID: s.ServerIdentity().ID,
+				View: viewchange.View{
+					ID:          latest.Hash,
+					Gen:         gen,
+					LeaderIndex: 1,
+				},
+			}
+			s.viewChangeMan.addAnomaly(req)
+		case <-s.closeLeaderMonitorChan:
+			log.Lvl2(s.ServerIdentity(), "closing heartbeat timeout monitor")
 			return
 		}
-		s.working.Add(1)
-		s.closedMutex.Unlock()
-		defer s.working.Done()
-		// Here we empty the messages in heartbeatsClose. This is
-		// needed because tests may try to close the heartbeat monitor
-		// multiple times. Further, if there's already something in the
-		// close channel, and then we try to start the heartbeat
-		// monitor, it will close immediately which would cause
-		// confussion.
-	emptyMessagesLabel:
-		for {
-			select {
-			case <-s.heartbeatsClose:
-			default:
-				break emptyMessagesLabel
-			}
-		}
-		for {
-			select {
-			case key := <-s.heartbeatsTimeout:
-				log.Lvlf2("%s: heartbeat timeout at %d for %x", s.ServerIdentity(), time.Now().Unix(), []byte(key))
-				scID := []byte(key)
-				if err := s.startViewChange(scID); err != nil {
-					log.Error(s.ServerIdentity(), err)
-				}
-			case <-s.heartbeatsClose:
-				log.Lvl2(s.ServerIdentity(), "closing heartbeat timeout monitor")
-				return
-			}
-		}
-	}()
-}
-
-func (s *Service) startViewChange(scID skipchain.SkipBlockID) error {
-	sb, err := s.db().GetLatestByID(scID)
-	if err != nil {
-		return err
 	}
-	if len(sb.Roster.List) < 2 {
-		return errors.New("roster size is too small")
-	}
-	if !sb.Roster.List[1].Equal(s.ServerIdentity()) {
-		// i'm not the next leader, do nothing
-		return nil
-	}
-
-	_, _, genDarcID, err := s.GetCollectionView(scID).GetValues(NewInstanceID(nil).Slice())
-	if err != nil {
-		return err
-	}
-
-	newRoster := onet.NewRoster(append(sb.Roster.List[1:], sb.Roster.List[0]))
-	newRosterBuf, err := protobuf.Encode(newRoster)
-	if err != nil {
-		return err
-	}
-
-	ctx := ClientTransaction{
-		Instructions: []Instruction{{
-			InstanceID: NewInstanceID(nil),
-			Nonce:      GenNonce(),
-			Index:      0,
-			Length:     1,
-			Invoke: &Invoke{
-				Command: "view_change",
-				Args: []Argument{{
-					Name:  "roster",
-					Value: newRosterBuf,
-				}},
-			},
-		}},
-	}
-	signer := darc.NewSignerEd25519(s.ServerIdentity().Public, s.getPrivateKey())
-	if err = ctx.Instructions[0].SignBy(genDarcID, signer); err != nil {
-		return err
-	}
-
-	log.Lvlf2("%s: proposing view-change for %x", s.ServerIdentity(), scID)
-	_, err = s.createNewBlock(scID, newRoster, []TxResult{{ClientTransaction: ctx}})
-	return err
 }
 
 // getPrivateKey is a hack that creates a temporary TreeNodeInstance and gets
@@ -1125,8 +1118,8 @@ func (s *Service) tryLoad() error {
 
 	// Recreate the polling channles.
 	s.pollChanMut.Lock()
-	defer s.pollChanMut.Unlock()
 	s.pollChan = make(map[string]chan bool)
+	s.pollChanMut.Unlock()
 
 	gas := &skipchain.GetAllSkipChainIDs{}
 	gasr, err := s.skService().GetAllSkipChainIDs(gas)
@@ -1138,9 +1131,10 @@ func (s *Service) tryLoad() error {
 		if !s.isOurChain(gen) {
 			continue
 		}
+
 		interval, err := s.LoadBlockInterval(gen)
 		if err != nil {
-			log.Errorf("Ignoring chain %x because we can't load blockInterval: %s", gen, err)
+			log.Errorf("%s Ignoring chain %x because we can't load blockInterval: %s", s.ServerIdentity(), gen, err)
 			continue
 		}
 
@@ -1149,8 +1143,10 @@ func (s *Service) tryLoad() error {
 			panic("getLeader should not return an error if roster is initialised.")
 		}
 		if leader.Equal(s.ServerIdentity()) {
+			s.pollChanMut.Lock()
 			s.pollChanWG.Add(1)
 			s.pollChan[string(gen)] = s.startPolling(gen, interval)
+			s.pollChanMut.Unlock()
 		}
 
 		// populate the darcID to skipchainID mapping
@@ -1161,7 +1157,21 @@ func (s *Service) tryLoad() error {
 		s.darcToScMut.Lock()
 		s.darcToSc[string(d.GetBaseID())] = gen
 		s.darcToScMut.Unlock()
+
+		// start the heartbeat
+		if s.heartbeats.exists(string(gen)) {
+			panic("we are just starting the service, there should be no existing heartbeat monitors")
+		}
+		log.Lvlf2("%s started heartbeat monitor for %x", s.ServerIdentity(), gen)
+		s.heartbeats.start(string(gen), interval*rotationWindow, s.heartbeatsTimeout)
+
+		// initiate the view-change manager
+		s.viewChangeMan.add(s.sendViewChangeReq, s.sendNewView, s.isLeader, string(gen))
+		s.viewChangeMan.start(s.ServerIdentity().ID, gen, s.computeInitialDuration(gen), s.getFaultThreshold(gen), string(gen)) // TODO fault threshold might change
 	}
+
+	s.trySyncAll()
+	go s.monitorLeaderFailure()
 
 	return nil
 }
@@ -1188,7 +1198,27 @@ func (s *Service) save() {
 	defer s.storage.Unlock()
 	err := s.Save(storageID, s.storage)
 	if err != nil {
-		log.Error("Couldn't save file:", err)
+		log.Error(s.ServerIdentity(), "Couldn't save file:", err)
+	}
+}
+
+func (s *Service) trySyncAll() {
+	gas := &skipchain.GetAllSkipChainIDs{}
+	gasr, err := s.skService().GetAllSkipChainIDs(gas)
+	if err != nil {
+		log.Error(s.ServerIdentity(), err)
+		return
+	}
+	for _, scID := range gasr.IDs {
+		sb, err := s.db().GetLatestByID(scID)
+		if err != nil {
+			log.Error(s.ServerIdentity(), err)
+			continue
+		}
+		err = s.skService().SyncChain(sb.Roster, sb.Hash)
+		if err != nil {
+			log.Error(s.ServerIdentity(), err)
+		}
 	}
 }
 
@@ -1198,23 +1228,22 @@ func (s *Service) save() {
 // deployments.
 func newService(c *onet.Context) (onet.Service, error) {
 	s := &Service{
-		ServiceProcessor:  onet.NewServiceProcessor(c),
-		contracts:         make(map[string]OmniLedgerContract),
-		txBuffer:          newTxBuffer(),
-		heartbeatsTimeout: make(chan string, 1),
-		heartbeatsClose:   make(chan bool, 1),
-		storage:           &omniStorage{},
-		darcToSc:          make(map[string]skipchain.SkipBlockID),
-		stateChangeCache:  newStateChangeCache(),
+		ServiceProcessor:       onet.NewServiceProcessor(c),
+		contracts:              make(map[string]OmniLedgerContract),
+		txBuffer:               newTxBuffer(),
+		storage:                &omniStorage{},
+		darcToSc:               make(map[string]skipchain.SkipBlockID),
+		stateChangeCache:       newStateChangeCache(),
+		heartbeatsTimeout:      make(chan string, 1),
+		closeLeaderMonitorChan: make(chan bool, 1),
+		heartbeats:             newHeartbeats(),
+		viewChangeMan:          newViewChangeManager(),
 	}
 	if err := s.RegisterHandlers(s.CreateGenesisBlock, s.AddTransaction,
 		s.GetProof); err != nil {
 		log.ErrFatal(err, "Couldn't register messages")
 	}
-	if err := s.tryLoad(); err != nil {
-		log.Error(err)
-		return nil, err
-	}
+	s.RegisterProcessorFunc(viewChangeMsgID, s.handleViewChangeReq)
 
 	s.registerContract(ContractConfigID, s.ContractConfig)
 	s.registerContract(ContractDarcID, s.ContractDarc)
@@ -1223,5 +1252,26 @@ func newService(c *onet.Context) (onet.Service, error) {
 		return nil, err
 	}
 	s.skService().RegisterStoreSkipblockCallback(s.updateCollectionCallback)
+	s.skService().EnableViewChange()
+
+	// Register the view-change cosi protocols.
+	var err error
+	_, err = s.ProtocolRegister(viewChangeSubFtCosi, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
+		return cosiprotocol.NewSubFtCosi(n, s.verifyViewChange, cothority.Suite)
+	})
+	if err != nil {
+		return nil, err
+	}
+	_, err = s.ProtocolRegister(viewChangeFtCosi, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
+		return cosiprotocol.NewFtCosi(n, s.verifyViewChange, viewChangeSubFtCosi, cothority.Suite)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.tryLoad(); err != nil {
+		log.Error(err)
+		return nil, err
+	}
 	return s, nil
 }

--- a/omniledger/service/viewchange.go
+++ b/omniledger/service/viewchange.go
@@ -1,0 +1,371 @@
+package service
+
+import (
+	"bytes"
+	"errors"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/dedis/cothority"
+	cosiprotocol "github.com/dedis/cothority/ftcosi/protocol"
+	"github.com/dedis/cothority/omniledger/darc"
+	"github.com/dedis/cothority/omniledger/viewchange"
+	"github.com/dedis/cothority/skipchain"
+	"github.com/dedis/kyber/sign/schnorr"
+	"github.com/dedis/onet"
+	"github.com/dedis/onet/log"
+	"github.com/dedis/onet/network"
+	"github.com/dedis/protobuf"
+)
+
+type viewChangeManager struct {
+	sync.Mutex
+	controllers map[string]*viewchange.Controller
+}
+
+func newViewChangeManager() viewChangeManager {
+	return viewChangeManager{
+		controllers: make(map[string]*viewchange.Controller),
+	}
+}
+
+func (m *viewChangeManager) add(sendVC viewchange.SendInitReqFunc,
+	sendNV viewchange.SendNewViewReqFunc, isLeader viewchange.IsLeaderFunc, k string) {
+	m.Lock()
+	defer m.Unlock()
+	c := viewchange.NewController(sendVC, sendNV, isLeader)
+	m.controllers[k] = &c
+}
+
+func (m *viewChangeManager) start(myID network.ServerIdentityID, scID skipchain.SkipBlockID, initialDuration time.Duration, f int, k string) {
+	m.Lock()
+	defer m.Unlock()
+	c := m.controllers[k]
+	go c.Start(myID, scID, initialDuration, f)
+}
+
+func (m *viewChangeManager) addReq(req viewchange.InitReq) {
+	m.Lock()
+	defer m.Unlock()
+	c := m.controllers[string(req.View.Gen)]
+	c.AddReq(req)
+}
+
+func (m *viewChangeManager) addAnomaly(req viewchange.InitReq) {
+	m.Lock()
+	defer m.Unlock()
+	c := m.controllers[string(req.View.Gen)]
+	c.AddAnomaly(req)
+}
+
+func (m *viewChangeManager) done(view viewchange.View) {
+	m.Lock()
+	defer m.Unlock()
+	c := m.controllers[string(view.Gen)]
+	c.Done(view)
+	log.Lvl3("view-change done for " + view.String())
+}
+
+func (m *viewChangeManager) waiting(k string) bool {
+	m.Lock()
+	defer m.Unlock()
+	c := m.controllers[k]
+	return c.Waiting()
+}
+
+func (m *viewChangeManager) closeAll() {
+	m.Lock()
+	defer m.Unlock()
+	for _, c := range m.controllers {
+		c.Stop()
+	}
+	m.controllers = make(map[string]*viewchange.Controller)
+}
+
+// sendViewChangeReq is called when the node detects that a view change is
+// needed. It uses SendRaw to send the message to all other nodes. This
+// function should only be used as a callback in ViewChangeLog.
+func (s *Service) sendViewChangeReq(view viewchange.View) error {
+	log.Lvl2(s.ServerIdentity(), "sending view-change request for view:", view)
+	latest, err := s.db().GetLatestByID(view.ID)
+	if err != nil {
+		return err
+	}
+	req := viewchange.InitReq{
+		SignerID: s.ServerIdentity().ID,
+		View:     view,
+	}
+	if err := req.Sign(s.getPrivateKey()); err != nil {
+		return err
+	}
+	for _, sid := range latest.Roster.List {
+		if sid.Equal(s.ServerIdentity()) {
+			continue
+		}
+		if err := s.SendRaw(sid, &req); err != nil {
+			// Having an error here is fine because not all the
+			// nodes are guaranteed to be online. So we log a
+			// warning instead of returning an error.
+			log.Warn(s.ServerIdentity(), err)
+		}
+	}
+	return nil
+}
+
+func (s *Service) sendNewView(proof []viewchange.InitReq) {
+
+	if len(proof) == 0 {
+		log.Error(s.ServerIdentity(), "not enough proofs")
+	}
+	log.Lvl2(s.ServerIdentity(), "sending new-view request for view:", proof[0].View)
+
+	// Our own proof might not be signed, so sign it.
+	for i := range proof {
+		if proof[i].SignerID.Equal(s.ServerIdentity().ID) && len(proof[i].Signature) == 0 {
+			proof[i].Sign(s.getPrivateKey())
+		}
+	}
+
+	sb := s.db().GetByID(proof[0].View.ID)
+	req := viewchange.NewViewReq{
+		Roster: *rotateRoster(sb.Roster, proof[0].View.LeaderIndex),
+		Proof:  proof,
+	}
+
+	go func() {
+		// This go-routine eventually exists because both cosi and
+		// block creation have a timeout.
+		sig, err := s.startViewChangeCosi(req)
+		if err != nil {
+			log.Error(s.ServerIdentity(), err)
+			return
+		}
+		if len(sig) == 0 {
+			log.Error(s.ServerIdentity(), "empty viewchange cosi signature")
+			return
+		}
+		if err := s.createViewChangeBlock(req, sig); err != nil {
+			log.Error(s.ServerIdentity(), err)
+		}
+	}()
+}
+
+func (s *Service) computeInitialDuration(scID skipchain.SkipBlockID) time.Duration {
+	interval, err := s.LoadBlockInterval(scID)
+	if err != nil {
+		panic("we should only computer the interval on a known block," +
+			" otherwise it is a progarmmer error: " + err.Error())
+	}
+	return rotationWindow * interval
+}
+
+func (s *Service) getFaultThreshold(sbID skipchain.SkipBlockID) int {
+	sb := s.db().GetByID(sbID)
+	return len(sb.Roster.List) / 3
+}
+
+// handleViewChangeReq should be registered as a handler for viewchange.InitReq
+// messages.
+func (s *Service) handleViewChangeReq(env *network.Envelope) {
+	// Parse message.
+	req, ok := env.Msg.(*viewchange.InitReq)
+	if !ok {
+		log.Error(s.ServerIdentity(), "failed to cast to viewchange.ViewChangeReq")
+		return
+	}
+	// Should not be sending to ourselves.
+	if req.SignerID.Equal(s.ServerIdentity().ID) {
+		log.Error(s.ServerIdentity(), "should not send to ourselve")
+		return
+	}
+
+	// Check that the genesis exists and the view is valid.
+	_, err := s.db().GetLatestByID(req.View.Gen)
+	if err != nil {
+		log.Error(s.ServerIdentity(), err)
+		return
+	}
+	reqLatest := s.db().GetByID(req.View.ID)
+	if reqLatest == nil {
+		// NOTE: If we don't know about the this view, it might be that
+		// we are not up-do-date, which should not happen because the
+		// delay for triggering view-change should be longer than the
+		// time it takes to create and propagate a new block. Hence,
+		// somebody is sending bogus views.
+		log.Error(s.ServerIdentity(), "we do not know this view")
+		return
+	}
+	actualLatest, err := s.db().GetLatest(reqLatest)
+	if err != nil || !actualLatest.Hash.Equal(reqLatest.Hash) {
+		log.Error(s.ServerIdentity(), "viewchange should not happen for earlier blocks", err)
+		return
+	}
+
+	// Check signature.
+	_, signerSID := actualLatest.Roster.Search(req.SignerID)
+	if signerSID == nil {
+		log.Error(s.ServerIdentity(), "signer does not exist")
+		return
+	}
+	if err := schnorr.Verify(cothority.Suite, signerSID.Public, req.Hash(), req.Signature); err != nil {
+		log.Error(s.ServerIdentity(), err)
+		return
+	}
+
+	// Store it in our log.
+	s.viewChangeMan.addReq(*req)
+}
+
+func (s *Service) startViewChangeCosi(req viewchange.NewViewReq) ([]byte, error) {
+	defer log.Lvl2(s.ServerIdentity(), "finished view-change ftcosi")
+	sb := s.db().GetByID(req.GetView().ID)
+	newRoster := rotateRoster(sb.Roster, req.GetView().LeaderIndex)
+	if !newRoster.List[0].Equal(s.ServerIdentity()) {
+		panic("startViewChangeCosi should not be called by non-leader")
+	}
+	proto, err := s.CreateProtocol(viewChangeFtCosi, newRoster.GenerateBinaryTree())
+	if err != nil {
+		panic(err)
+	}
+	payload, err := protobuf.Encode(&req)
+	if err != nil {
+		panic(err)
+	}
+
+	interval, err := s.LoadBlockInterval(req.GetView().ID)
+	if err != nil {
+		panic(err)
+	}
+
+	n := len(sb.Roster.List)
+	cosiProto := proto.(*cosiprotocol.FtCosi)
+	cosiProto.Msg = req.Hash()
+	cosiProto.Data = payload
+	cosiProto.CreateProtocol = s.CreateProtocol
+	cosiProto.Timeout = interval / 2
+	cosiProto.Threshold = n - n/3
+	cosiProto.NSubtrees = int(math.Pow(float64(n), 1.0/3.0))
+	if err := cosiProto.Start(); err != nil {
+		return nil, err
+	}
+	// The protocol should always send FinalSignature because it has a
+	// timeout, so we don't need a select.
+	return <-cosiProto.FinalSignature, nil
+}
+
+// verifyViewChange is registered in the view-change ftcosi.
+func (s *Service) verifyViewChange(msg []byte, data []byte) bool {
+	// Parse message and check hash.
+	var req viewchange.NewViewReq
+	if err := protobuf.DecodeWithConstructors(data, &req, network.DefaultConstructors(cothority.Suite)); err != nil {
+		log.Error(s.ServerIdentity(), err)
+		return false
+	}
+	if !bytes.Equal(msg, req.Hash()) {
+		log.Error(s.ServerIdentity(), "digest doesn't verify")
+		return false
+	}
+	// Check that we know about the view and the new roster in the request
+	// matches the view-change proofs.
+	sb := s.db().GetByID(req.GetView().ID)
+	if sb == nil {
+		log.Error(s.ServerIdentity(), "view does not exist")
+		return false
+	}
+	newRosterID := rotateRoster(sb.Roster, req.GetView().LeaderIndex).ID
+	if !newRosterID.Equal(req.Roster.ID) {
+		log.Error(s.ServerIdentity(), "invalid roster in request")
+		return false
+	}
+	// Check the signers are unique, they are in the roster and the
+	// signatures are correct.
+	uniqueSigners, uniqueViews := func() (int, int) {
+		signers := make(map[[16]byte]bool)
+		views := make(map[string]bool)
+		for _, p := range req.Proof {
+			signers[p.SignerID] = true
+			views[string(p.View.Hash())] = true
+		}
+		return len(signers), len(views)
+	}()
+	f := len(sb.Roster.List) / 3
+	if uniqueSigners < 2*f+1 {
+		log.Error(s.ServerIdentity(), "not enough proofs")
+		return false
+	}
+	if uniqueViews != 1 {
+		log.Error(s.ServerIdentity(), "conflicting views")
+		return false
+	}
+	for _, p := range req.Proof {
+		_, sid := sb.Roster.Search(p.SignerID)
+		if sid == nil {
+			log.Error(s.ServerIdentity(), "the signer is not in the roster")
+			return false
+		}
+		// Check that the signature is correct.
+		if err := schnorr.Verify(cothority.Suite, sid.Public, p.Hash(), p.Signature); err != nil {
+			log.Error(s.ServerIdentity(), err)
+			return false
+		}
+	}
+	log.Lvl2(s.ServerIdentity(), "view-change verification OK")
+	return true
+}
+
+// createViewChangeBlock creates a new block to record the successful
+// view-change operation.
+func (s *Service) createViewChangeBlock(req viewchange.NewViewReq, multisig []byte) error {
+	defer log.Lvl2(s.ServerIdentity(), "created view-change block")
+	sb, err := s.db().GetLatestByID(req.GetGen())
+	if err != nil {
+		return err
+	}
+	if len(sb.Roster.List) < 2 {
+		return errors.New("roster size is too small")
+	}
+
+	_, _, genDarcID, err := s.GetCollectionView(req.GetGen()).GetValues(NewInstanceID(nil).Slice())
+	if err != nil {
+		return err
+	}
+
+	reqBuf, err := protobuf.Encode(&req)
+	if err != nil {
+		return err
+	}
+
+	ctx := ClientTransaction{
+		Instructions: []Instruction{{
+			InstanceID: NewInstanceID(nil),
+			Nonce:      GenNonce(),
+			Index:      0,
+			Length:     1,
+			Invoke: &Invoke{
+				Command: "view_change",
+				Args: []Argument{
+					{
+						Name:  "newview",
+						Value: reqBuf,
+					},
+					{
+						Name:  "multisig",
+						Value: multisig,
+					},
+				},
+			},
+		}},
+	}
+	signer := darc.NewSignerEd25519(s.ServerIdentity().Public, s.getPrivateKey())
+	if err = ctx.Instructions[0].SignBy(genDarcID, signer); err != nil {
+		return err
+	}
+
+	_, err = s.createNewBlock(req.GetGen(), rotateRoster(sb.Roster, req.GetView().LeaderIndex), []TxResult{TxResult{ctx, false}})
+	return err
+}
+
+func rotateRoster(roster *onet.Roster, i int) *onet.Roster {
+	return onet.NewRoster(append(roster.List[i:], roster.List[:i]...))
+}

--- a/omniledger/viewchange/viewchange.go
+++ b/omniledger/viewchange/viewchange.go
@@ -1,0 +1,531 @@
+// Package viewchange implements the view-change algorithm found in the PBFT
+// paper (OSDI99). The implementation is specific our use-case, meaning that
+// our views are represented by skipblocks. However, it is possible to create
+// an interface that abstracts the underlying data-structure of a view.
+//
+// The key component is the Controller. It acts as a finite state machine (FSM)
+// that reacts to incoming messages. Under normal operation, the FSM waits for
+// 2f+1 valid InitReq messages (also known as view-change messages in the
+// paper) and then starts a timer. If the timer expires before the view-change
+// is completed, then the FSM goes back to the initial state. Please see the
+// paper to see how it handles other scenarios.
+package viewchange
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"github.com/dedis/cothority"
+	"github.com/dedis/cothority/skipchain"
+	"github.com/dedis/kyber"
+	"github.com/dedis/kyber/sign/schnorr"
+	"github.com/dedis/onet"
+	"github.com/dedis/onet/log"
+	"github.com/dedis/onet/network"
+)
+
+// View assume that the context are the same.
+type View struct {
+	ID          skipchain.SkipBlockID
+	Gen         skipchain.SkipBlockID
+	LeaderIndex int
+}
+
+// Equal checks whether the receiver equals to other.
+func (v View) Equal(other View) bool {
+	return v.ID.Equal(other.ID) && v.Gen.Equal(other.Gen) && v.LeaderIndex == other.LeaderIndex
+}
+
+func (v View) String() string {
+	return fmt.Sprintf("ID: %x, Gen: %x, Leader: %d", v.ID, v.Gen, v.LeaderIndex)
+}
+
+// Hash computes the of the view.
+func (v View) Hash() []byte {
+	h := sha256.New()
+	h.Write(v.ID)
+	h.Write(v.Gen)
+
+	idxBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(idxBuf, uint32(v.LeaderIndex))
+	h.Write(idxBuf)
+
+	return h.Sum(nil)
+}
+
+// SendInitReqFunc is a callback that must be registered in Controller. It is
+// called when the Controller decides to multicast a view-change message.
+type SendInitReqFunc func(view View) error
+
+// SendNewViewReqFunc is a callback that must be registered in Controller. It
+// is called when the Controller decides to propose itself as the new leader.
+// The function should not block. The successful execution of this function
+// should send a signal back to the Controller by calling Done.
+type SendNewViewReqFunc func(proof []InitReq)
+
+// IsLeaderFunc is a callback that must be registered in Controller. It should
+// say whether the node itself is the leader in the given view.
+type IsLeaderFunc func(view View) bool
+
+// Controller accepts three types of messages from the outside - (1) a
+// view-change message from another node, (2) an anomaly message from myself
+// and (3) a notification of the completion of a view-change. There are three
+// states in the controller, (1) the initial state, (2) the sent request state
+// and (3) the started timer state. Depending on the messages that the
+// controller receives, the state might be moved forward or reset.
+// The caller of the controller is expected to behave correctly. That is, it
+// should not send views from a different context (i.e., from a different
+// skipchain) to the controller.
+type Controller struct {
+	reqChan          chan InitReq
+	anomalyChan      chan InitReq
+	doneChan         chan View
+	waiting          chan chan bool
+	closeMonitorChan chan bool
+	sendInitReq      SendInitReqFunc
+	sendNewViewReq   SendNewViewReqFunc
+	isLeader         IsLeaderFunc
+
+	// The following channels are for testing the internal state.
+	expireTimerChan chan int
+	startTimerChan  chan int
+	stopTimerChan   chan int
+}
+
+// NewController creates a new Controller. Upon creation, the controller is not
+// active, Start must be called to activate it.
+func NewController(sendVC SendInitReqFunc, sendNV SendNewViewReqFunc, isLeader IsLeaderFunc) Controller {
+	return Controller{
+		reqChan:          make(chan InitReq, 1),
+		anomalyChan:      make(chan InitReq, 1),
+		doneChan:         make(chan View, 1),
+		waiting:          make(chan chan bool, 1),
+		closeMonitorChan: make(chan bool),
+		sendInitReq:      sendVC,
+		sendNewViewReq:   sendNV,
+		isLeader:         isLeader,
+
+		expireTimerChan: make(chan int),
+		startTimerChan:  make(chan int),
+		stopTimerChan:   make(chan int),
+	}
+}
+
+// Stop should only be called from the test, it blocks until the controller is
+// closed.
+func (c *Controller) Stop() {
+	c.closeMonitorChan <- true
+}
+
+// Start begins a blocking process that processes incoming view-requests.
+func (c *Controller) Start(myID network.ServerIdentityID, genesis skipchain.SkipBlockID, initialDuration time.Duration, f int) {
+	meta := newStateLogs()
+	// Timer is only valid for the current ctr. It starts in the stopped
+	// state, we can't set it to nil because it gets de-referenced in
+	// select.
+	timer := time.NewTimer(time.Second)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	var ctr int
+	// The loop below implements the view-change state machine. It can be
+	// in one of three states (defined in state) and four transitions
+	// (close is not a transition) defined in the case statements below.
+	for {
+		select {
+		case req := <-c.reqChan:
+			// Transition: received a view-change request, start
+			// the timer and move the state if there are 2f+1 valid
+			// requests.
+			meta.addOther(req)
+			log.Lvl4("adding req:", req.View)
+			if meta.highest() > ctr && meta.countOf(meta.highest()) > f {
+				// To avoid starting view-change too late, if
+				// another honest node detects an anomaly,
+				// we'll report it too.
+				stopTimer(timer, c.stopTimerChan, ctr)
+				reqNew := InitReq{
+					View:     req.View,
+					SignerID: myID,
+				}
+				c.anomalyChan <- reqNew
+			}
+			if meta.countOf(ctr) > 2*f && meta.stateOf(ctr) < startedTimerState && meta.acceptOf(ctr) {
+				// To avoid starting the next view-change too
+				// soon, start view-change timer after
+				// receiving 2*f+1 view-change messages.
+				timer.Reset(time.Duration(pow(2, ctr)) * initialDuration)
+				meta.nextStateFor(ctr)
+				select {
+				case c.startTimerChan <- ctr:
+				default:
+				}
+				// If i am the leader, send the new-view
+				// message, which means starting ftcosi.
+				if c.isLeader(meta.currOf(ctr)) {
+					c.sendNewViewReq(meta.getProof(ctr))
+				}
+			}
+		case req := <-c.anomalyChan:
+			// Transition: anomaly detected, this should be the
+			// only way to increment ctr and it should move the
+			// state forward.
+			if !myID.Equal(req.SignerID) {
+				// The anomaly is only triggered by myself.
+				// The caller should make sure of it.
+				panic("only accept our own ID")
+			}
+			meta.addMyself(req)
+			log.Lvl4("adding anomaly:", req.View)
+			if req.View.LeaderIndex > ctr {
+				// We detected a new anomaly, so send a new
+				// view-change message.
+				ctr = req.View.LeaderIndex
+				if meta.stateOf(ctr) < sentReqState {
+					if err := c.sendInitReq(meta.currOf(ctr)); err != nil {
+						log.Error("failed to send request", err)
+					} else {
+						meta.nextStateFor(ctr)
+					}
+				}
+			} else {
+				// We blackhole the anomaly if the leader index
+				// is less or equal to the counter. This
+				// situation only happens if we detect an
+				// anomaly for an earlier view. But the
+				// controller has already moved on and it will
+				// only wait for relevant messages for its
+				// current or later view.
+				log.Warn("Controller is not accepting anomalies for earlier views")
+			}
+		case view := <-c.doneChan:
+			// Transition: view-change completed successfully, go
+			// back to the initial state.
+			if meta.empty() {
+				log.Warn("doing nothing because the controller is in an empty state for view:", view)
+				continue
+			}
+			if view.Equal(meta.currOf(ctr)) {
+				log.Lvl3("view-change completed successfully for view: ", view)
+			} else {
+				// Usually this should not happen, if it does,
+				// that means the controller decided to move on
+				// to a later view too soon. But if this
+				// section of the code is execute, that means
+				// the majority of the nodes agreed, so we'll
+				// accept the view.
+				log.Warn("view-change completed an earlier view: ", view, "the current view is: ", meta.currOf(ctr))
+			}
+			ctr = 0
+			stopTimer(timer, c.stopTimerChan, ctr)
+			meta = newStateLogs()
+		case <-timer.C:
+			select {
+			case c.expireTimerChan <- ctr:
+			default:
+			}
+			// Transition: timer expired, view-change did not
+			// complete, so increase the timer multiplier.
+			view := View{
+				ID:          meta.currOf(ctr).ID,
+				Gen:         genesis,
+				LeaderIndex: ctr + 1,
+			}
+			log.Lvl4("view-change timer expired, creating new view:", view)
+			req := InitReq{
+				View:     view,
+				SignerID: myID,
+			}
+			c.anomalyChan <- req
+			meta.clean(ctr)
+		case ch := <-c.waiting:
+			if meta.stateOf(ctr) == startedTimerState {
+				ch <- true
+			} else {
+				ch <- false
+			}
+		case <-c.closeMonitorChan:
+			stopTimer(timer, c.stopTimerChan, ctr)
+			return
+		}
+	}
+}
+
+// AddReq adds the request to the log. It assumes the caller is correct and
+// does not add bogus requests. We first check that the current view is the
+// same as the one in our request. If it is, then we need to update the current
+// view in the receiver. Finally, we add the request.
+func (c *Controller) AddReq(req InitReq) {
+	c.reqChan <- req
+}
+
+// AddAnomaly should be called when an anomaly is detected, e.g., then the
+// current leader is offline or is sending erroneous messages.
+func (c *Controller) AddAnomaly(req InitReq) {
+	c.anomalyChan <- req
+}
+
+// Done should be called when a view-change is completed.
+func (c *Controller) Done(view View) {
+	c.doneChan <- view
+}
+
+// Waiting returns true if the controller is waiting for the view-change
+// procedure to complete.
+func (c *Controller) Waiting() bool {
+	ch := make(chan bool, 1)
+	c.waiting <- ch
+	return <-ch
+}
+
+func (c *Controller) diagnoseStartTimer(f func()) chan int {
+	outChan := make(chan int)
+	syncChan := make(chan bool)
+	go func() {
+		syncChan <- true
+		outChan <- <-c.startTimerChan
+	}()
+	<-syncChan
+	f()
+	return outChan
+}
+
+func (c *Controller) diagnoseExpireTimer() chan int {
+	ch := make(chan int)
+	go func() {
+		ch <- <-c.expireTimerChan
+	}()
+	return ch
+}
+
+func (c *Controller) diagnoseStopTimer(f func()) chan int {
+	outChan := make(chan int)
+	syncChan := make(chan bool)
+	go func() {
+		syncChan <- true
+		outChan <- <-c.stopTimerChan
+	}()
+	<-syncChan
+	f()
+	return outChan
+}
+
+// InitReq is the request that is sent by SendInitReqFunc. It is the
+// "view-change" message from the PBFT paper.
+type InitReq struct {
+	// SignerID is the ID of the request sender.
+	View      View
+	SignerID  network.ServerIdentityID
+	Signature []byte
+}
+
+// Hash computes the digest of the request.
+func (req InitReq) Hash() []byte {
+	h := sha256.New()
+	h.Write(req.SignerID[:])
+	h.Write(req.View.ID)
+
+	idxBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(idxBuf, uint32(req.View.LeaderIndex))
+	h.Write(idxBuf)
+	return h.Sum(nil)
+}
+
+// Sign signs the request.
+func (req *InitReq) Sign(sk kyber.Scalar) error {
+	sig, err := schnorr.Sign(cothority.Suite, sk, req.Hash())
+	if err != nil {
+		return err
+	}
+	req.Signature = sig
+	return nil
+}
+
+// NewViewReq is the message that is created and sent out by SendNewViewReqFunc.
+type NewViewReq struct {
+	Roster onet.Roster
+	Proof  []InitReq
+}
+
+// Hash computes the digest of the request.
+func (req NewViewReq) Hash() []byte {
+	h := sha256.New()
+	h.Write(req.Roster.ID[:])
+	for _, p := range req.Proof {
+		h.Write(p.Hash())
+	}
+	return h.Sum(nil)
+}
+
+// GetGen gets the first genesis block in the list, if the list is empty it
+// returns nil. It assumes all the genesis blocks are the same.
+func (req NewViewReq) GetGen() []byte {
+	for _, p := range req.Proof {
+		return p.View.Gen
+	}
+	return nil
+}
+
+// GetView gets the first view in the list, if the list is empty it returns
+// nil. It assumes all the views are the same.
+func (req NewViewReq) GetView() *View {
+	for _, p := range req.Proof {
+		return &p.View
+	}
+	return nil
+}
+
+type state int
+
+const (
+	initialState state = iota
+	sentReqState
+	startedTimerState
+)
+
+type stateLog struct {
+	curr     View
+	received map[network.ServerIdentityID]InitReq
+	state    state
+	accept   bool // set to true if we received a message for ourself
+}
+
+func newStateLog() stateLog {
+	return stateLog{
+		received: make(map[network.ServerIdentityID]InitReq),
+	}
+}
+
+func (m *stateLog) add(req InitReq) {
+	// Invariant: requests must have the same view
+	for _, v := range m.received {
+		if !v.View.Equal(req.View) {
+			panic("view is not equal")
+		}
+	}
+	m.curr = req.View
+	m.received[req.SignerID] = req
+}
+
+func (m *stateLog) nextState() {
+	switch m.state {
+	case initialState:
+		m.state = sentReqState
+	case sentReqState:
+		m.state = startedTimerState
+	default:
+		panic("there is no more next state")
+	}
+}
+
+func (m stateLog) count() int {
+	return len(m.received)
+}
+
+type stateLogs struct {
+	m map[int]stateLog
+}
+
+func newStateLogs() stateLogs {
+	return stateLogs{
+		m: make(map[int]stateLog),
+	}
+}
+
+func (m *stateLogs) addOther(req InitReq) {
+	if _, ok := m.m[req.View.LeaderIndex]; !ok {
+		m.m[req.View.LeaderIndex] = newStateLog()
+	}
+	tmp := m.m[req.View.LeaderIndex]
+	tmp.add(req)
+	m.m[req.View.LeaderIndex] = tmp
+}
+
+func (m *stateLogs) addMyself(req InitReq) {
+	m.addOther(req)
+	tmp := m.m[req.View.LeaderIndex]
+	tmp.accept = true
+	m.m[req.View.LeaderIndex] = tmp
+}
+
+func (m stateLogs) highest() int {
+	i := -1
+	for k := range m.m {
+		if k > i {
+			i = k
+		}
+	}
+	return i
+}
+
+func (m *stateLogs) nextStateFor(i int) {
+	tmp := m.m[i]
+	tmp.nextState()
+	m.m[i] = tmp
+}
+
+func (m stateLogs) countOf(i int) int {
+	return m.m[i].count()
+}
+
+func (m stateLogs) stateOf(i int) state {
+	return m.m[i].state
+}
+
+func (m stateLogs) currOf(i int) View {
+	return m.m[i].curr
+}
+
+func (m stateLogs) acceptOf(i int) bool {
+	return m.m[i].accept
+}
+
+func (m stateLogs) getProof(viewIdx int) []InitReq {
+	reqs := make([]InitReq, len(m.m[viewIdx].received))
+	var i int
+	for _, req := range m.m[viewIdx].received {
+		reqs[i] = req
+		i++
+	}
+	return reqs
+}
+
+func (m stateLogs) empty() bool {
+	return len(m.m) == 0
+}
+
+func (m *stateLogs) clean(i int) {
+	for k := range m.m {
+		if k < i {
+			delete(m.m, k)
+		}
+	}
+}
+
+func stopTimer(timer *time.Timer, c chan int, i int) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	select {
+	case c <- i:
+	default:
+	}
+}
+
+// NOTE: this might overflow but this function is local in this package and is
+// only used for computing the next timeout duration and should not be used for
+// general computation.
+func pow(base, exponent int) int64 {
+	x := int64(1)
+	b := int64(base)
+	for exponent > 0 {
+		x = x * b
+		exponent--
+	}
+	return x
+}

--- a/omniledger/viewchange/viewchange_test.go
+++ b/omniledger/viewchange/viewchange_test.go
@@ -81,6 +81,9 @@ func TestViewChange_Normal(t *testing.T) {
 	_, view, vcl := testSetupViewChange2F1(t, mySignerID, dur, f)
 	defer vcl.Stop()
 
+	// Check that view-change is in progress.
+	require.True(t, vcl.Waiting())
+
 	// If we signal that the view-change completed successfully, then
 	// everything should be reset.
 	ctrChan := vcl.diagnoseStopTimer(func() {
@@ -92,6 +95,9 @@ func TestViewChange_Normal(t *testing.T) {
 	case <-time.After(dur):
 		require.Fail(t, "timer should have stopped on done")
 	}
+
+	// Check that view-change is finsihed.
+	require.False(t, vcl.Waiting())
 }
 
 func TestViewChange_Timeout(t *testing.T) {

--- a/omniledger/viewchange/viewchange_test.go
+++ b/omniledger/viewchange/viewchange_test.go
@@ -1,0 +1,168 @@
+package viewchange
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dedis/cothority/skipchain"
+	"github.com/stretchr/testify/require"
+)
+
+// testSetupViewChangeF1 sets up the view-change log and sends f view-change
+// messages. If anomaly is set then it sends one more message to the anomaly
+// channel.
+func testSetupViewChangeF1(t *testing.T, signerID [16]byte, dur time.Duration, f int, anomaly bool) (chan bool, View, *Controller) {
+	view := View{
+		ID:          skipchain.SkipBlockID([]byte{42}),
+		LeaderIndex: 1,
+	}
+	vcChan := make(chan bool, 1)
+	vcF := func(view View) error {
+		vcChan <- true
+		return nil
+	}
+	nvF := func(proof []InitReq) {
+	}
+	vcl := NewController(vcF, nvF, func(v View) bool { return true })
+	go vcl.Start(signerID, []byte{}, dur, f)
+
+	// We receive view-change requests and send our own because we detected
+	// an anomaly.
+	for i := 0; i < f; i++ {
+		req := InitReq{
+			SignerID: [16]byte{byte(i)},
+			View:     view,
+		}
+		vcl.AddReq(req)
+	}
+	if anomaly {
+		vcl.AddAnomaly(InitReq{
+			SignerID: signerID,
+			View:     view,
+		})
+		select {
+		case <-vcChan:
+		case <-time.After(10 * time.Millisecond):
+			require.Fail(t, "view change function should have been called")
+		}
+	}
+	return vcChan, view, &vcl
+}
+
+// testSetupViewChange2F1 sets up the view-change log and sends 2f+1 messages
+// including one from myself. Hence by the time this function returns the timer
+// should have started and the state should be at startedTimerState.
+func testSetupViewChange2F1(t *testing.T, signerID [16]byte, dur time.Duration, f int) (chan bool, View, *Controller) {
+	vcChan, view, vcl := testSetupViewChangeF1(t, signerID, dur, f, true)
+	// Suppose more view-change message arrive, until there are 2f+1 of
+	// them, then a timer should start.
+	ctrChan := vcl.diagnoseStartTimer(func() {
+		for i := f + 1; i < 2*f+1; i++ {
+			req := InitReq{
+				SignerID: [16]byte{byte(i)},
+				View:     view,
+			}
+			vcl.AddReq(req)
+		}
+	})
+	select {
+	case ctr := <-ctrChan:
+		require.Equal(t, 1, ctr)
+	case <-time.After(dur):
+		require.Fail(t, "timer should have started")
+	}
+	return vcChan, view, vcl
+}
+
+func TestViewChange_Normal(t *testing.T) {
+	dur := 100 * time.Millisecond
+	f := 2
+	mySignerID := [16]byte{byte(255)}
+	_, view, vcl := testSetupViewChange2F1(t, mySignerID, dur, f)
+	defer vcl.Stop()
+
+	// If we signal that the view-change completed successfully, then
+	// everything should be reset.
+	ctrChan := vcl.diagnoseStopTimer(func() {
+		vcl.Done(view)
+	})
+	select {
+	case ctr := <-ctrChan:
+		require.Equal(t, 0, ctr)
+	case <-time.After(dur):
+		require.Fail(t, "timer should have stopped on done")
+	}
+}
+
+func TestViewChange_Timeout(t *testing.T) {
+	dur := 100 * time.Millisecond
+	f := 2
+	mySignerID := [16]byte{byte(255)}
+	vcChan, view, vcl := testSetupViewChange2F1(t, mySignerID, dur, f)
+	defer vcl.Stop()
+
+	// If the view-change did not complete successfully, the timer should
+	// expire and we should move to the next view.
+	select {
+	case ctr := <-vcl.diagnoseExpireTimer():
+		require.Equal(t, 1, ctr)
+	case <-time.After(2*dur + dur/2):
+		require.Fail(t, "expected timer to expire")
+	}
+
+	// Add more requests to trigger the second timer. We only need to add
+	// 2*f because the anomaly request is automatically send upon timer
+	// expiration.
+	newView := view
+	newView.LeaderIndex++
+	startCtrChan := vcl.diagnoseStartTimer(func() {
+		for i := 0; i < 2*f; i++ {
+			req := InitReq{
+				SignerID: [16]byte{byte(i)},
+				View:     newView,
+			}
+			vcl.AddReq(req)
+		}
+		select {
+		case <-vcChan:
+		case <-time.After(100 * time.Millisecond):
+			require.Fail(t, "view change function should have been called")
+		}
+	})
+	select {
+	case ctr := <-startCtrChan:
+		require.Equal(t, newView.LeaderIndex, ctr)
+	case <-time.After(dur + dur/2):
+		require.Fail(t, "timer should have started")
+	}
+
+	// Another timer should expire if we do not see anything for 4*dur.
+	select {
+	case i := <-vcl.diagnoseExpireTimer():
+		require.Equal(t, 2, i)
+	case <-time.After(4*dur + dur/2):
+		require.Fail(t, "expected timer to expire")
+	}
+}
+
+// TestViewChange_AutoStart checks that we can start view-change not from
+// sending in an anomaly (e.g., detected a timeout) but from receiving many
+// view-change messages from other nodes.
+func TestViewChange_AutoStart(t *testing.T) {
+	dur := 100 * time.Millisecond
+	f := 2
+	mySignerID := [16]byte{byte(255)}
+	vcChan, view, vcl := testSetupViewChangeF1(t, mySignerID, dur, f, false)
+	defer vcl.Stop()
+	// Send a in regular request instead of an anomaly should trigger the
+	// anomaly case.
+	vcl.AddReq(InitReq{
+		SignerID: [16]byte{byte(f)},
+		View:     view,
+	})
+	select {
+	case <-vcChan:
+	case <-time.After(10 * time.Millisecond):
+		require.Fail(t, "view change function should have been called")
+	}
+}


### PR DESCRIPTION
The new version of view-change replaces the previous version, which had
difficulty handling corner cases.

The design is similar to the view-change protocol in PBFT (OSDI99). We
keep the view-change message that replicas send when they detect an
anomaly. But we replace the new-view message with the ftcosi protocol
and block creation. The result of ftcosi is an aggregate signature of
all the nodes that agree to perform the view-change. The signature is
included in the block which nodes accept if the aggregate signature is
correct.

The technique above enables nodes to replay blocks to compute the most
up-to-date leader, which was not possible with the previous
implementation. Additionally, we are able to tolerate multiple failures,
which was also not possible previously. Finally, we enable view-change
by default and remove the possibility of switching it off because the
improvements above demonstrate its robustness.