### PR TITLE
Keep block index with the database

### DIFF
--- a/omniledger/service/proof_test.go
+++ b/omniledger/service/proof_test.go
@@ -92,7 +92,7 @@ func createSC(t *testing.T) (s sc) {
 
 	s.key = []byte("key")
 	s.value = []byte("value")
-	s.c.Store(&StateChange{StateAction: Create, InstanceID: s.key, Value: s.value})
+	s.c.StoreAll([]StateChange{{StateAction: Create, InstanceID: s.key, Value: s.value}}, 0)
 
 	s.genesis = skipchain.NewSkipBlock()
 	s.genesis.Roster, s.genesisPrivs = genRoster(1)

--- a/omniledger/service/service_test.go
+++ b/omniledger/service/service_test.go
@@ -175,6 +175,9 @@ func testAddTransaction(t *testing.T, sendToIdx int, failure bool) {
 			_, vs, err := pr.KeyValue()
 			require.Nil(t, err)
 			require.True(t, bytes.Equal(tx.Instructions[0].Spawn.Args[0].Value, vs[0]))
+
+			// check that the database has this new block's index recorded
+			require.Equal(t, pr.Latest.Index, s.services[0].getCollection(pr.Latest.SkipChainID()).getIndex())
 		}
 	}
 
@@ -188,6 +191,8 @@ func testAddTransaction(t *testing.T, sendToIdx int, failure bool) {
 			_, vs, err := pr.KeyValue()
 			require.Nil(t, err)
 			require.True(t, bytes.Equal(tx.Instructions[0].Spawn.Args[0].Value, vs[0]))
+			// check that the database has this new block's index recorded
+			require.Equal(t, pr.Latest.Index, s.services[len(s.hosts)-1].getCollection(pr.Latest.SkipChainID()).getIndex())
 		}
 		// Try to add a new transaction to the node that failed (but is
 		// now running) and it should work.

--- a/omniledger/service/service_test.go
+++ b/omniledger/service/service_test.go
@@ -629,12 +629,12 @@ func TestService_StateChange(t *testing.T) {
 
 	// Manually create the add contract
 	inst := genID()
-	err := cdb.Store(&StateChange{
+	err := cdb.StoreAll([]StateChange{{
 		StateAction: Create,
 		InstanceID:  inst.Slice(),
 		ContractID:  []byte("add"),
 		Value:       make([]byte, 8),
-	})
+	}}, 0)
 	require.Nil(t, err)
 
 	n := 5
@@ -984,12 +984,12 @@ func TestService_StateChangeCache(t *testing.T) {
 
 	scID := s.sb.SkipChainID()
 	collDB := s.service().getCollection(scID)
-	collDB.Store(&StateChange{
+	collDB.StoreAll([]StateChange{{
 		StateAction: Create,
 		InstanceID:  NewInstanceID(s.darc.GetBaseID()).Slice(),
 		ContractID:  []byte(contractID),
 		Value:       []byte{},
-	})
+	}}, 0)
 	coll := collDB.coll
 	tx1, err := createOneClientTx(s.darc.GetBaseID(), contractID, []byte{}, s.signer)
 	require.Nil(t, err)

--- a/omniledger/service/struct_test.go
+++ b/omniledger/service/struct_test.go
@@ -25,12 +25,12 @@ func TestCollectionDBStrange(t *testing.T) {
 	key := []byte("first")
 	value := []byte("value")
 	contract := "mycontract"
-	err = cdb.Store(&StateChange{
+	err = cdb.StoreAll([]StateChange{{
 		StateAction: Create,
 		InstanceID:  key,
 		Value:       value,
 		ContractID:  []byte(contract),
-	})
+	}}, 0)
 	require.Nil(t, err)
 	v, c, _, err := cdb.GetValues([]byte("first"))
 	require.Nil(t, err)
@@ -58,13 +58,13 @@ func TestCollectionDB(t *testing.T) {
 
 	// Store all key/value pairs
 	for k, v := range pairs {
-		sc := &StateChange{
+		sc := StateChange{
 			StateAction: Create,
 			InstanceID:  []byte(k),
 			Value:       []byte(v),
 			ContractID:  []byte(myContract),
 		}
-		require.Nil(t, cdb.Store(sc))
+		require.Nil(t, cdb.StoreAll([]StateChange{sc}, 0))
 	}
 
 	// Verify it's all there
@@ -90,13 +90,13 @@ func TestCollectionDB(t *testing.T) {
 		pairs[k] = v + "-2"
 	}
 	for k, v := range pairs {
-		sc := &StateChange{
+		sc := StateChange{
 			StateAction: Update,
 			InstanceID:  []byte(k),
 			Value:       []byte(v),
 			ContractID:  []byte(myContract),
 		}
-		require.Nil(t, cdb2.Store(sc), k)
+		require.Nil(t, cdb2.StoreAll([]StateChange{sc}, 0), k)
 	}
 	for k, v := range pairs {
 		stored, contract, _, err := cdb2.GetValues([]byte(k))
@@ -107,12 +107,12 @@ func TestCollectionDB(t *testing.T) {
 
 	// Delete
 	for c := range pairs {
-		sc := &StateChange{
+		sc := StateChange{
 			StateAction: Remove,
 			InstanceID:  []byte(c),
 			ContractID:  []byte(myContract),
 		}
-		require.Nil(t, cdb2.Store(sc))
+		require.Nil(t, cdb2.StoreAll([]StateChange{sc}, 0))
 	}
 	for c := range pairs {
 		_, _, _, err := cdb2.GetValues([]byte(c))
@@ -150,8 +150,8 @@ func TestCollectionDBtryHash(t *testing.T) {
 	require.EqualError(t, err, "no match found")
 	_, _, _, err = cdb.GetValues([]byte("key2"))
 	require.EqualError(t, err, "no match found")
-	cdb.Store(&scs[0])
-	cdb.Store(&scs[1])
+	cdb.StoreAll([]StateChange{scs[0]}, 0)
+	cdb.StoreAll([]StateChange{scs[1]}, 0)
 	mrReal := cdb.RootHash()
 	require.Equal(t, mrTrial, mrReal)
 }


### PR DESCRIPTION
The last applied block index should be kept alongside the data
itself, not in a runtime state structure that will be lost on
server restart.

Fixes #1425.