### PR TITLE
Fix Closing in Test

### DIFF
--- a/messaging/propagate.go
+++ b/messaging/propagate.go
@@ -149,11 +149,18 @@ func (p *Propagate) Start() error {
 // Dispatch can handle timeouts
 func (p *Propagate) Dispatch() error {
 	process := true
+	var received int
 	log.Lvl4(p.ServerIdentity(), "Start dispatch")
 	defer p.Done()
+	defer func() {
+		if p.IsRoot() {
+			if p.onDoneCb != nil {
+				p.onDoneCb(received + 1)
+			}
+		}
+	}()
 
 	var gotSendData bool
-	var received int
 	var errs []error
 	subtreeCount := p.TreeNode().SubtreeCount()
 
@@ -226,11 +233,6 @@ func (p *Propagate) Dispatch() error {
 		}
 	}
 	log.Lvl3(p.ServerIdentity(), "done, isroot:", p.IsRoot())
-	if p.IsRoot() {
-		if p.onDoneCb != nil {
-			p.onDoneCb(received + 1)
-		}
-	}
 	return nil
 }
 

--- a/omniledger/service/service_test.go
+++ b/omniledger/service/service_test.go
@@ -428,6 +428,8 @@ func waitInclusion(t *testing.T, client int) {
 	require.NoError(t, err)
 	require.Equal(t, len(txr), 2)
 
+	log.Lvl1("done with test")
+
 	// TODO: This sleep is required for the same reason as the problem
 	// documented in TestService_CloseAllDeadlock. How to fix it correctly?
 	time.Sleep(s.interval)
@@ -1182,7 +1184,6 @@ func newSerN(t *testing.T, step int, interval time.Duration, n int, viewchange b
 		signer: darc.NewSignerEd25519(nil, nil),
 	}
 	s.hosts, s.roster, _ = s.local.GenTree(n, true)
-
 	for _, sv := range s.local.GetServices(s.hosts, OmniledgerID) {
 		service := sv.(*Service)
 		s.services = append(s.services, service)


### PR DESCRIPTION
When Server.Close is called, the skipchain sometimes tried to finish
transactions and start new ones. This is fixed by adding a
TestClose method to the skipchain service.

The propagation protocol did not correctly handle errors, which is fixed
by always returning how many actual confirmations we get, even in the
case of errors.