### PR TITLE
Cleanup cl* and co* files

### DIFF
--- a/libtest.sh
+++ b/libtest.sh
@@ -389,8 +389,10 @@ cleanup(){
   pkill -9 conode 2> /dev/null
   pkill -9 ^${APP}$ 2> /dev/null
   sleep .5
+  rm -f co*/*bin
+  rm -f cl*/*bin
   if [ -z "$KEEP_DB" ]; then
-	  rm -rf $CONODE_SERVICE_PATH
+    rm -rf $CONODE_SERVICE_PATH
   fi
 }
 


### PR DESCRIPTION
I'm not sure why co* and cl* were removed, but bring them back fixes the pop integration test. 