### PR TITLE
Test instructions that depend on each other

### DIFF
--- a/omniledger/darc/darc.go
+++ b/omniledger/darc/darc.go
@@ -898,11 +898,10 @@ func (r Request) MsgToDarc(darcBuf []byte) (*Darc, error) {
 	return d, nil
 }
 
-// InitRequest initialises a request, the caller must provide all the fields of
+// NewRequest initialises a request, the caller must provide all the fields of
 // the request. There is no guarantee that this request is valid, please see
 // InitAndSignRequest is a valid request needs to be created.
-// TODO: rename to NewRequest
-func InitRequest(baseID ID, action Action, msg []byte, ids []Identity, sigs [][]byte) Request {
+func NewRequest(baseID ID, action Action, msg []byte, ids []Identity, sigs [][]byte) Request {
 	req := Request{
 		BaseID:     baseID,
 		Action:     action,

--- a/omniledger/service/contracts.go
+++ b/omniledger/service/contracts.go
@@ -299,8 +299,9 @@ func (s *Service) ContractDarc(cdb CollectionView, inst Instruction, coins []Coi
 		default:
 			return nil, nil, errors.New("invalid command: " + inst.Invoke.Command)
 		}
-
+	case DeleteType:
+		return nil, nil, errors.New("delete on a Darc instance is not supported")
 	default:
-		return nil, nil, errors.New("Only invoke and spawn are defined yet")
+		return nil, nil, errors.New("unknown instruction type")
 	}
 }

--- a/omniledger/service/transaction.go
+++ b/omniledger/service/transaction.go
@@ -200,7 +200,7 @@ func (instr Instruction) Action() string {
 	case InvokeType:
 		a = "invoke:" + instr.Invoke.Command
 	case DeleteType:
-		a = "Delete"
+		a = "delete"
 	}
 	return a
 }
@@ -273,9 +273,9 @@ func (instr Instruction) ToDarcRequest(baseID darc.ID) (*darc.Request, error) {
 		if err != nil {
 			return nil, err
 		}
-		req = darc.InitRequest(baseID, darc.Action(action), d.GetID(), ids, sigs)
+		req = darc.NewRequest(baseID, darc.Action(action), d.GetID(), ids, sigs)
 	} else {
-		req = darc.InitRequest(baseID, darc.Action(action), instr.Hash(), ids, sigs)
+		req = darc.NewRequest(baseID, darc.Action(action), instr.Hash(), ids, sigs)
 	}
 	return &req, nil
 }


### PR DESCRIPTION
This change un-disables a test that I wrote in the past
to prove a problem existed. Recent changes fixed this problem
so now we'll re-enable this test. Doing so uncovered other
problems with how Delete is implemented, which are fixed here.

Fixes #1379.