### PR TITLE
Unlock close mutex

### DIFF
--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -904,6 +904,8 @@ func (s *Service) TestClose() {
 		s.closedMutex.Unlock()
 		s.cleanupGoroutines()
 		s.working.Wait()
+	} else {
+		s.closedMutex.Unlock()
 	}
 }
 


### PR DESCRIPTION
Fix a missing unlock which may cause deadlock when calling TestClose
more than once.