### PR TITLE
Omniledger stability improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ install:
 
 script: cd external/js/$TEST_DIR && npm install && npm run test && npm run build
 
+cache:
+  directories:
+    - $HOME/.cache/go-build
+    - $HOME/.m2
 
 after_success:
   - npm run coveralls
@@ -40,7 +44,6 @@ matrix:
         - cd $TRAVIS_BUILD_DIR
 
       script:
-        - (cd conode/; make docker)
         - make test
 
     - language: java

--- a/omniledger/service/transaction.go
+++ b/omniledger/service/transaction.go
@@ -132,6 +132,7 @@ func (instr Instruction) DeriveID(what string) InstanceID {
 		binary.LittleEndian.PutUint32(b[:], uint32(len(s.Signature)))
 		h.Write(b[:])
 		h.Write(s.Signature)
+		// TODO: Why not h.Write(s.Signer)
 	}
 	// Because there is no attacker-controlled input after what, we do not need
 	// domain separation here.


### PR DESCRIPTION
Using `go test -run WaitInclus -count 100 -failfast`
let us flush out lots of reliability problems, especially
related to start/shutdown, and to fast block pace.

Also: Try to turn on travis caching, see if it is helpful or
annoying.