### PR TITLE
Adding GenesisDarc to Omniledger.Client

### DIFF
--- a/eventlog/api_test.go
+++ b/eventlog/api_test.go
@@ -364,7 +364,7 @@ func newSer(t *testing.T) (*ser, *Client) {
 	s.id = resp.Skipblock.Hash
 
 	ol := omniledger.NewClient()
-	ol.Roster = s.roster
+	ol.Roster = *s.roster
 	ol.ID = s.id
 
 	c := NewClient(ol)

--- a/omniledger/ol/main.go
+++ b/omniledger/ol/main.go
@@ -166,7 +166,7 @@ func show(c *cli.Context) error {
 
 	cfg := &ol.Config{
 		ID:     cl.ID,
-		Roster: *cl.Roster,
+		Roster: cl.Roster,
 	}
 
 	fmt.Fprintln(c.App.Writer, cfg)

--- a/omniledger/service/api_test.go
+++ b/omniledger/service/api_test.go
@@ -29,7 +29,7 @@ func TestClient_GetProof(t *testing.T) {
 	c := NewClient()
 	csr, err := c.CreateGenesisBlock(msg)
 	require.Nil(t, err)
-	c.Roster = roster
+	c.Roster = *roster
 	c.ID = csr.Skipblock.SkipChainID()
 
 	// Create a new transaction.

--- a/omniledger/service/service_test.go
+++ b/omniledger/service/service_test.go
@@ -584,8 +584,8 @@ func TestService_StateChange(t *testing.T) {
 
 		zeroBuf := make([]byte, 8)
 		switch inst.GetType() {
-		// create the object if it doesn't exist
 		case SpawnType:
+			// create the object if it doesn't exist
 			if inst.Spawn.ContractID != "add" {
 				return nil, nil, errors.New("can only spawn add contracts")
 			}
@@ -598,8 +598,8 @@ func TestService_StateChange(t *testing.T) {
 					Value:       zeroBuf,
 				},
 			}, nil, nil
-		case InvokeType:
 
+		case InvokeType:
 			// increment the object value
 			vals, err := rec.Values()
 			if err != nil {


### PR DESCRIPTION
Retrieving the GenesisDarc directly when creating a DefaultGenesisMsg is useful when accessing the api.

Before merging: change commit-base in #1457 