### PR TITLE
Adding pop-contract - depends on #1463

### DIFF
--- a/conode/conode.go
+++ b/conode/conode.go
@@ -27,7 +27,6 @@ import (
 	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/ftcosi/check"
 	_ "github.com/dedis/cothority/ftcosi/service"
-	_ "github.com/dedis/cothority/identity"
 	_ "github.com/dedis/cothority/skipchain"
 	_ "github.com/dedis/cothority/status/service"
 	"github.com/dedis/kyber/util/encoding"

--- a/conode/experimental.go
+++ b/conode/experimental.go
@@ -8,6 +8,7 @@ stable branch.
 import (
 	_ "github.com/dedis/cothority/eventlog"
 	_ "github.com/dedis/cothority/evoting/service"
+	_ "github.com/dedis/cothority/identity"
 	_ "github.com/dedis/cothority/ocs/service"
 	_ "github.com/dedis/cothority/omniledger/contracts"
 	_ "github.com/dedis/cothority/omniledger/service"

--- a/evoting/protocol/decrypt.go
+++ b/evoting/protocol/decrypt.go
@@ -153,7 +153,7 @@ func (d *Decrypt) HandlePrompt(prompt MessagePromptDecrypt) error {
 		return nil
 	}
 	// report to root
-	d.Done()
+	defer d.Done()
 	return d.SendTo(d.Root(), &TerminateDecrypt{})
 }
 

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -1181,7 +1181,6 @@ func (s *Service) registerContract(contractID string, c OmniLedgerContract) erro
 // other nodes.
 func (s *Service) startAllChains() error {
 	s.SetPropagationTimeout(120 * time.Second)
-
 	msg, err := s.Load(storageID)
 	if err != nil {
 		return err

--- a/pop/service/api.go
+++ b/pop/service/api.go
@@ -170,6 +170,23 @@ func (c *Client) GetFinalStatements(dst network.Address) (map[string]*FinalState
 	return res.FinalStatements, nil
 }
 
+// StoreKeys asks the service to store public keys for a party.
+func (c *Client) StoreKeys(dst network.Address, partyID []byte, keys []kyber.Point) error {
+	si := &network.ServerIdentity{Address: dst}
+	ret := &StoreKeysReply{}
+
+	return c.SendProtobuf(si, &StoreKeys{partyID, keys, nil}, ret)
+}
+
+// GetKeys asks the service for the public keys for a party.
+func (c *Client) GetKeys(dst network.Address, partyID []byte) ([]kyber.Point, error) {
+	si := &network.ServerIdentity{Address: dst}
+	ret := &GetKeysReply{}
+
+	err := c.SendProtobuf(si, &GetKeys{partyID}, ret)
+	return ret.Keys, err
+}
+
 // StoreInstanceID asks the service to store an instanceID for a given party.
 func (c *Client) StoreInstanceID(dst network.Address, partyID []byte, instanceID ol.InstanceID) error {
 	si := &network.ServerIdentity{Address: dst}

--- a/pop/service/api.go
+++ b/pop/service/api.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/dedis/cothority"
+	"github.com/dedis/cothority/omniledger/darc"
+	ol "github.com/dedis/cothority/omniledger/service"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/sign/eddsa"
 	"github.com/dedis/kyber/sign/schnorr"
@@ -107,7 +109,7 @@ func (c *Client) Finalize(dst network.Address, p *PopDesc, attendees []kyber.Poi
 	req := &FinalizeRequest{}
 	req.DescID = p.Hash()
 	req.Attendees = attendees
-	hash, err := req.hash()
+	hash, err := req.Hash()
 	if err != nil {
 		return nil, err
 	}
@@ -142,6 +144,64 @@ func (c *Client) Merge(dst network.Address, p *PopDesc, priv kyber.Scalar) (
 		return nil, e
 	}
 	return res.Final, nil
+}
+
+// GetLink returns the link of the organizer, if available.
+func (c *Client) GetLink(dst network.Address) (kyber.Point, error) {
+	si := &network.ServerIdentity{Address: dst}
+	res := &GetLinkReply{}
+
+	e := c.SendProtobuf(si, &GetLink{}, res)
+	if e != nil {
+		return nil, e
+	}
+	return res.Public, nil
+}
+
+// GetFinalStatements returns a map of all final statements.
+func (c *Client) GetFinalStatements(dst network.Address) (map[string]*FinalStatement, error) {
+	si := &network.ServerIdentity{Address: dst}
+	res := &GetFinalStatementsReply{}
+
+	e := c.SendProtobuf(si, &GetFinalStatements{}, res)
+	if e != nil {
+		return nil, e
+	}
+	return res.FinalStatements, nil
+}
+
+// StoreInstanceID asks the service to store an instanceID for a given party.
+func (c *Client) StoreInstanceID(dst network.Address, partyID []byte, instanceID ol.InstanceID) error {
+	si := &network.ServerIdentity{Address: dst}
+	ret := &StoreInstanceIDReply{}
+
+	return c.SendProtobuf(si, &StoreInstanceID{partyID, instanceID}, ret)
+}
+
+// GetInstanceID asks the service for an instanceID for a given party.
+func (c *Client) GetInstanceID(dst network.Address, partyID []byte) (ol.InstanceID, error) {
+	si := &network.ServerIdentity{Address: dst}
+	ret := &GetInstanceIDReply{}
+
+	err := c.SendProtobuf(si, &GetInstanceID{partyID}, ret)
+	return ret.InstanceID, err
+}
+
+// StoreSigner asks the service to store an Signer for a given party.
+func (c *Client) StoreSigner(dst network.Address, partyID []byte, Signer darc.Signer) error {
+	si := &network.ServerIdentity{Address: dst}
+	ret := &StoreSignerReply{}
+
+	return c.SendProtobuf(si, &StoreSigner{partyID, Signer}, ret)
+}
+
+// GetSigner asks the service for an Signer for a given party.
+func (c *Client) GetSigner(dst network.Address, partyID []byte) (darc.Signer, error) {
+	si := &network.ServerIdentity{Address: dst}
+	ret := &GetSignerReply{}
+
+	err := c.SendProtobuf(si, &GetSigner{partyID}, ret)
+	return ret.Signer, err
 }
 
 // The toml-structure for (un)marshaling with toml

--- a/pop/service/api_test.go
+++ b/pop/service/api_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/dedis/cothority"
+	"github.com/dedis/cothority/omniledger/darc"
+	ol "github.com/dedis/cothority/omniledger/service"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/sign/eddsa"
 	"github.com/dedis/kyber/util/key"
@@ -79,4 +81,128 @@ func TestFinalStatement_Verify(t *testing.T) {
 	require.Nil(t, fs.Verify())
 	fs.Attendees = append(fs.Attendees, eddsa.Public)
 	require.NotNil(t, fs.Verify())
+}
+
+func TestClient_GetLink(t *testing.T) {
+	ts := newTSer(t)
+	defer ts.Close()
+
+	glr, err := NewClient().GetLink(ts.addr)
+	require.Nil(t, err)
+	kp := key.NewKeyPair(cothority.Suite)
+	ts.services[0].data.Public = kp.Public
+	glr, err = NewClient().GetLink(ts.addr)
+	require.Nil(t, err)
+	require.True(t, glr.Equal(kp.Public))
+}
+
+func TestClient_GetFinalStatement(t *testing.T) {
+	ts := newTSer(t)
+	defer ts.Close()
+
+	fss, err := NewClient().GetFinalStatements(ts.addr)
+	require.Nil(t, err)
+	require.Equal(t, 0, len(fss))
+
+	ts.services[0].data.Finals[ts.fsIDstr] = ts.fs
+
+	fss, err = NewClient().GetFinalStatements(ts.addr)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(fss))
+	require.NotNil(t, fss[ts.fsIDstr])
+	fsIDC, err := fss[ts.fsIDstr].Hash()
+	require.Nil(t, err)
+	require.Equal(t, ts.fsID, fsIDC)
+}
+
+func TestClient_StoreGetKeys(t *testing.T) {
+	ts := newTSer(t)
+	defer ts.Close()
+
+	gkr, err := NewClient().GetKeys(ts.addr, ts.fsID)
+	require.NotNil(t, err)
+	require.Equal(t, 0, len(gkr))
+
+	var keys []kyber.Point
+	for i := 0; i < 4; i++ {
+		kp := key.NewKeyPair(cothority.Suite)
+		keys = append(keys, kp.Public)
+	}
+
+	err = NewClient().StoreKeys(ts.addr, ts.fsID, keys)
+	require.Nil(t, err)
+	gkr, err = NewClient().GetKeys(ts.addr, ts.fsID)
+	require.Nil(t, err)
+	for i, p := range gkr {
+		require.True(t, keys[i].Equal(p))
+	}
+}
+
+func TestClient_StoreGetInstanceID(t *testing.T) {
+	ts := newTSer(t)
+	defer ts.Close()
+
+	iid := ol.NewInstanceID(random.Bits(256, true, random.New()))
+	err := NewClient().StoreInstanceID(ts.addr, ts.fsID, iid)
+	require.Nil(t, err)
+
+	gii, err := NewClient().GetInstanceID(ts.addr, ts.fsID)
+	require.Nil(t, err)
+	require.True(t, gii.Equal(iid))
+}
+
+func TestClient_StoreGetSigner(t *testing.T) {
+	ts := newTSer(t)
+	defer ts.Close()
+
+	gs, err := NewClient().GetSigner(ts.addr, ts.fsID)
+	require.NotNil(t, err)
+
+	kp := key.NewKeyPair(cothority.Suite)
+	signer := darc.NewSignerEd25519(kp.Public, kp.Private)
+
+	err = NewClient().StoreSigner(ts.addr, ts.fsID, signer)
+	require.Nil(t, err)
+	gs, err = NewClient().GetSigner(ts.addr, ts.fsID)
+	require.Nil(t, err)
+	p, err := gs.GetPrivate()
+	require.Nil(t, err)
+	require.True(t, p.Equal(kp.Private))
+}
+
+type tSer struct {
+	local    *onet.LocalTest
+	servers  []*onet.Server
+	roster   *onet.Roster
+	services []*Service
+	addr     network.Address
+	fs       *FinalStatement
+	fsID     []byte
+	fsIDstr  string
+}
+
+func newTSer(t *testing.T) (ts tSer) {
+	ts.local = onet.NewTCPTest(cothority.Suite)
+	ts.servers, ts.roster, _ = ts.local.GenTree(1, true)
+	ts.addr = ts.roster.List[0].Address
+	services := ts.local.GetServices(ts.servers, onet.ServiceFactory.ServiceID(Name))
+	for _, s := range services {
+		ts.services = append(ts.services, s.(*Service))
+	}
+
+	ts.fs = &FinalStatement{
+		Desc: &PopDesc{
+			Name:   "test",
+			Roster: ts.roster,
+		},
+	}
+	var err error
+	ts.fsID, err = ts.fs.Hash()
+	require.Nil(t, err)
+	ts.fsIDstr = string(ts.fsID)
+	return
+}
+
+func (ts *tSer) Close() {
+	ts.local.CloseAll()
 }

--- a/pop/service/contract.go
+++ b/pop/service/contract.go
@@ -28,6 +28,15 @@ var ContractPopParty = "popParty"
 // ContractPopCoinAccount holds popcoins of an attendee or a service.
 var ContractPopCoinAccount = "popCoinAccount"
 
+// PoPCoinName is the identifier of the popcoins.
+var PoPCoinName ol.InstanceID
+
+func init() {
+	h := sha256.New()
+	h.Write([]byte("popcoin"))
+	PoPCoinName = ol.NewInstanceID(h.Sum(nil))
+}
+
 // ContractPopParty represents a pop-party on OmniLedger. It has the following
 // functionalities:
 //   * Spawn - takes a "FinalStatement" argument with the binary representation
@@ -190,9 +199,9 @@ func createCoin(inst ol.Instruction, d *darc.Darc, pub kyber.Point, balance uint
 		return
 	}
 	iid.Write(pubBuf)
-	cci := contracts.CoinInstance{
-		Type:    []byte("popcoins"),
-		Balance: balance,
+	cci := ol.Coin{
+		Name:  PoPCoinName,
+		Value: balance,
 	}
 	cciBuf, err := protobuf.Encode(&cci)
 	if err != nil {

--- a/pop/service/contract.go
+++ b/pop/service/contract.go
@@ -53,6 +53,12 @@ func init() {
 //         the service to use.
 func (s *Service) ContractPopParty(cdb ol.CollectionView, inst ol.Instruction, coins []ol.Coin) (scs []ol.StateChange, cOut []ol.Coin, err error) {
 	cOut = coins
+
+	err = inst.VerifyDarcSignature(cdb)
+	if err != nil {
+		return
+	}
+
 	var darcID darc.ID
 	var ppi PopPartyInstance
 	if inst.Spawn == nil {

--- a/pop/service/contract.go
+++ b/pop/service/contract.go
@@ -1,0 +1,206 @@
+package service
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+
+	"github.com/dedis/cothority"
+	"github.com/dedis/cothority/omniledger/contracts"
+	"github.com/dedis/cothority/omniledger/darc"
+	"github.com/dedis/cothority/omniledger/darc/expression"
+	ol "github.com/dedis/cothority/omniledger/service"
+	"github.com/dedis/kyber"
+	"github.com/dedis/onet/log"
+	"github.com/dedis/onet/network"
+	"github.com/dedis/protobuf"
+)
+
+// This file holds the contracts for the pop-party. The following contracts
+// are defined here:
+//   - PopParty - holds the Configuration and later the FinalStatement
+//   - PopCoinAccount - represents an account of popcoins
+
+// ContractPopParty represents a pop-party that holds either a configuration
+// or a final statement.
+var ContractPopParty = "popParty"
+
+// ContractPopCoinAccount holds popcoins of an attendee or a service.
+var ContractPopCoinAccount = "popCoinAccount"
+
+// ContractPopParty represents a pop-party on OmniLedger. It has the following
+// functionalities:
+//   * Spawn - takes a "FinalStatement" argument with the binary representation
+//     of the final statement to store.
+//   * Invoke - hast the following Command
+//     * "Finalize" - that stores a final statement and doesn't let it be
+//       changed afterwards. It will also create a darc for every attendee
+//       and bind that darc to a coin account, putting an initial 1.000.000
+//       popCoins in it.
+//        This command has the following arguments:
+//       * "FinalStatement" - mandatory, to give the new final statement. It
+//         needs to be correctly finalized by the pop-service.
+//       * "Service" - when given, will create a darc and a coin-account for
+//         the service to use.
+func (s *Service) ContractPopParty(cdb ol.CollectionView, inst ol.Instruction, coins []ol.Coin) (scs []ol.StateChange, cOut []ol.Coin, err error) {
+	cOut = coins
+	var darcID darc.ID
+	var ppi PopPartyInstance
+	if inst.Spawn == nil {
+		var ppiBuf []byte
+		ppiBuf, _, darcID, err = cdb.GetValues(inst.InstanceID.Slice())
+		if err != nil {
+			return nil, nil, errors.New("couldn't get instance data: " + err.Error())
+		}
+		err = protobuf.DecodeWithConstructors(ppiBuf, &ppi, network.DefaultConstructors(cothority.Suite))
+		if err != nil {
+			return nil, nil, errors.New("couldn't unmarshal existing PopPartyInstance: " + err.Error())
+		}
+	} else {
+		darcID = inst.InstanceID.Slice()
+	}
+	switch {
+	case inst.Spawn != nil:
+		fsBuf := inst.Spawn.Args.Search("FinalStatement")
+		if fsBuf == nil {
+			return nil, nil, errors.New("need FinalStatement argument")
+		}
+		ppData := &PopPartyInstance{
+			State:          1,
+			FinalStatement: &FinalStatement{},
+		}
+		err = protobuf.DecodeWithConstructors(fsBuf, ppData.
+			FinalStatement, network.DefaultConstructors(cothority.Suite))
+		if err != nil {
+			return nil, nil, errors.New("couldn't unmarshal the final statement: " + err.Error())
+		}
+		ppiBuf, err := protobuf.Encode(ppData)
+		if err != nil {
+			return nil, nil, errors.New("couldn't marshal PopPartyInstance: " + err.Error())
+		}
+		// partyID, err := ppData.FinalStatement.Hash()
+		// if err != nil {
+		// 	return nil, nil, errors.New("couldn't get party id: " + err.Error())
+		// }
+		// log.Printf("New party: %x", partyID)
+		return ol.StateChanges{
+			ol.NewStateChange(ol.Create, inst.DeriveID(""), inst.Spawn.ContractID, ppiBuf, darc.ID(inst.InstanceID[:])),
+		}, cOut, nil
+	case inst.Invoke != nil:
+		switch inst.Invoke.Command {
+		case "Finalize":
+			if ppi.State != 1 {
+				return nil, nil, fmt.Errorf("can only finalize party with state 1, but current state is %d",
+					ppi.State)
+			}
+			fsBuf := inst.Invoke.Args.Search("FinalStatement")
+			if fsBuf == nil {
+				return nil, nil, errors.New("missing argument: FinalStatement")
+			}
+			fs := FinalStatement{}
+			err = protobuf.DecodeWithConstructors(fsBuf, &fs, network.DefaultConstructors(cothority.Suite))
+			if err != nil {
+				return nil, nil, errors.New("argument is not a valid FinalStatement")
+			}
+
+			// TODO: check for aggregate signature of all organizers
+			ppi := PopPartyInstance{
+				State:          2,
+				FinalStatement: &fs,
+			}
+
+			for i, pub := range fs.Attendees {
+				log.Lvlf3("Creating darc for attendee %d %s", i, pub)
+				d, sc, err := createDarc(darcID, pub)
+				if err != nil {
+					return nil, nil, err
+				}
+				scs = append(scs, sc)
+
+				sc, err = createCoin(inst, d, pub, 1000000)
+				if err != nil {
+					return nil, nil, err
+				}
+				scs = append(scs, sc)
+			}
+
+			// And add a service if the argument is given
+			sBuf := inst.Invoke.Args.Search("Service")
+			if sBuf != nil {
+				ppi.Service = cothority.Suite.Point()
+				err = ppi.Service.UnmarshalBinary(sBuf)
+				if err != nil {
+					return nil, nil, errors.New("couldn't unmarshal point: " + err.Error())
+				}
+				log.Lvlf3("Appending service-darc and account for %s", ppi.Service)
+				d, sc, err := createDarc(darcID, ppi.Service)
+				if err != nil {
+					return nil, nil, err
+				}
+				scs = append(scs, sc)
+				sc, err = createCoin(inst, d, ppi.Service, 0)
+				if err != nil {
+					return nil, nil, err
+				}
+				scs = append(scs, sc)
+			}
+
+			ppiBuf, err := protobuf.Encode(&ppi)
+			if err != nil {
+				return nil, nil, errors.New("couldn't marshal PopPartyInstance: " + err.Error())
+			}
+
+			// Update existing final statement
+			scs = append(scs, ol.NewStateChange(ol.Update, inst.InstanceID, ContractPopParty, ppiBuf, darcID))
+
+			return scs, coins, nil
+		case "AddParty":
+			return nil, nil, errors.New("not yet implemented")
+		default:
+			return nil, nil, errors.New("can only finalize Pop-party contract")
+		}
+
+	default:
+		return nil, nil, errors.New("Only invoke and spawn are defined yet")
+	}
+}
+
+func createDarc(darcID darc.ID, pub kyber.Point) (d *darc.Darc, sc ol.StateChange, err error) {
+	id := darc.NewIdentityEd25519(pub)
+	rules := darc.InitRules([]darc.Identity{id}, []darc.Identity{id})
+	rules.AddRule(darc.Action("invoke:transfer"), expression.Expr(id.String()))
+	d = darc.NewDarc(rules, []byte("Attendee darc for pop-party"))
+	darcBuf, err := d.ToProto()
+	if err != nil {
+		err = errors.New("couldn't marshal darc: " + err.Error())
+		return
+	}
+	log.Lvlf3("Final %x/%x", d.GetBaseID(), sha256.Sum256(darcBuf))
+	sc = ol.NewStateChange(ol.Create, ol.NewInstanceID(d.GetBaseID()),
+		ol.ContractDarcID, darcBuf, darcID)
+	return
+}
+
+func createCoin(inst ol.Instruction, d *darc.Darc, pub kyber.Point, balance uint64) (sc ol.StateChange, err error) {
+	iid := sha256.New()
+	iid.Write(inst.InstanceID.Slice())
+	pubBuf, err := pub.MarshalBinary()
+	if err != nil {
+		err = errors.New("couldn't marshal public key: " + err.Error())
+		return
+	}
+	iid.Write(pubBuf)
+	cci := contracts.CoinInstance{
+		Type:    []byte("popcoins"),
+		Balance: balance,
+	}
+	cciBuf, err := protobuf.Encode(&cci)
+	if err != nil {
+		err = errors.New("couldn't encode CoinInstance: " + err.Error())
+		return
+	}
+	coinID := iid.Sum(nil)
+	log.Lvlf3("Creating account %x", coinID)
+	return ol.NewStateChange(ol.Create, ol.NewInstanceID(coinID),
+		contracts.ContractCoinID, cciBuf, d.GetBaseID()), nil
+}

--- a/pop/service/proto.go
+++ b/pop/service/proto.go
@@ -6,7 +6,7 @@ This holds the messages used to communicate with the service over the network.
 
 import (
 	"github.com/dedis/cothority/omniledger/darc"
-	omniledger "github.com/dedis/cothority/omniledger/service"
+	ol "github.com/dedis/cothority/omniledger/service"
 	"github.com/dedis/kyber"
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/network"
@@ -192,7 +192,7 @@ type GetFinalStatementsReply struct {
 // StoreInstanceID writes an InstanceID from OmniLedger to a FinalStatement.
 type StoreInstanceID struct {
 	PartyID    []byte
-	InstanceID omniledger.InstanceID
+	InstanceID ol.InstanceID
 }
 
 // StoreInstanceIDReply is an empty reply
@@ -206,7 +206,7 @@ type GetInstanceID struct {
 
 // GetInstanceIDReply is the InstanceID for the party
 type GetInstanceIDReply struct {
-	InstanceID omniledger.InstanceID
+	InstanceID ol.InstanceID
 }
 
 // StoreSigner writes an Signer from OmniLedger to a FinalStatement.
@@ -267,10 +267,10 @@ type PopPartyInstance struct {
 	FinalStatement *FinalStatement
 	// Previous is the link to the instanceID of the previous party, it can be
 	// nil for the first party.
-	Previous omniledger.InstanceID
+	Previous ol.InstanceID
 	// Next is a link to the omniledger instanceID of the next party. It can be
 	// nil if there is no next party.
-	Next omniledger.InstanceID
+	Next ol.InstanceID
 	// Public key of service - can be nil.
 	Service kyber.Point `protobuf:"opt"`
 }

--- a/pop/service/service.go
+++ b/pop/service/service.go
@@ -35,6 +35,8 @@ import (
 	"github.com/dedis/cothority/byzcoinx"
 	"github.com/dedis/cothority/ftcosi/protocol"
 	"github.com/dedis/cothority/messaging"
+	"github.com/dedis/cothority/omniledger/darc"
+	"github.com/dedis/cothority/omniledger/service"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/sign/schnorr"
 	"github.com/dedis/kyber/suites"
@@ -110,6 +112,13 @@ type Service struct {
 	// all proposed configurations - they don't need to be saved. Every time they
 	// are retrived, they will be deleted.
 	proposedDescription []PopDesc
+	// storedKeys is a temporary storage for saving keys of attendees while
+	// scanning.
+	storedKeys map[string]*keyList
+}
+
+type keyList struct {
+	Keys []kyber.Point
 }
 
 type saveData struct {
@@ -120,6 +129,10 @@ type saveData struct {
 	// The final statements
 	// key of map is ID of party
 	Finals map[string]*FinalStatement
+	// InstanceIDs stores a map of partyID to InstanceID
+	InstanceIDs map[string]*service.InstanceID
+	// Signers stores a map of partyID to Signer
+	Signers map[string]*darc.Signer
 	// The info used in merge process
 	// key is ID of party
 	merges map[string]*merge
@@ -240,12 +253,12 @@ func (s *Service) GetProposals(req *GetProposals) (*GetProposalsReply, error) {
 // FinalizeRequest returns the FinalStatement if all conodes already received
 // a PopDesc and signed off. The FinalStatement holds the updated PopDesc, the
 // pruned attendees-public-key-list and the collective signature.
-func (s *Service) FinalizeRequest(req *FinalizeRequest) (network.Message, error) {
+func (s *Service) FinalizeRequest(req *FinalizeRequest) (*FinalizeResponse, error) {
 	log.Lvlf2("Finalize: %s %+v", s.Context.ServerIdentity(), req)
 	if s.data.Public == nil {
 		return nil, errors.New("Not linked yet")
 	}
-	hash, err := req.hash()
+	hash, err := req.Hash()
 	if err != nil {
 		return nil, err
 	}
@@ -401,6 +414,69 @@ func (s *Service) MergeRequest(req *MergeRequest) (network.Message,
 
 	s.save()
 	return &FinalizeResponse{newFinal}, nil
+}
+
+// GetLink returns the public key of the linked organizer.
+func (s *Service) GetLink(req *GetLink) (*GetLinkReply, error) {
+	return &GetLinkReply{s.data.Public}, nil
+}
+
+// GetFinalStatements returns all final statements stored in this service.
+func (s *Service) GetFinalStatements(req *GetFinalStatements) (*GetFinalStatementsReply, error) {
+	rep := &GetFinalStatementsReply{
+		FinalStatements: make(map[string]*FinalStatement),
+	}
+	for k, v := range s.data.Finals {
+		rep.FinalStatements[k] = v
+	}
+	return rep, nil
+}
+
+// StoreKeys stores the given keys in the service to be retrieved by the users.
+func (s *Service) StoreKeys(req *StoreKeys) (*StoreKeysReply, error) {
+	// TODO: verify signature
+	s.storedKeys[string(req.ID)] = &keyList{req.Keys}
+	return &StoreKeysReply{}, nil
+}
+
+// GetKeys will return the keys stored for that party.
+func (s *Service) GetKeys(req *GetKeys) (*GetKeysReply, error) {
+	return &GetKeysReply{
+		ID:   req.ID,
+		Keys: s.storedKeys[string(req.ID)].Keys,
+	}, nil
+}
+
+// StoreInstanceID will store the instanceID in a given final statement
+func (s *Service) StoreInstanceID(req *StoreInstanceID) (*StoreInstanceIDReply, error) {
+	s.data.InstanceIDs[string(req.PartyID)] = &req.InstanceID
+	s.save()
+	return &StoreInstanceIDReply{}, nil
+}
+
+// GetInstanceID will return the instanceID of a final statement
+func (s *Service) GetInstanceID(req *GetInstanceID) (*GetInstanceIDReply, error) {
+	iid, ok := s.data.InstanceIDs[string(req.PartyID)]
+	if !ok {
+		return nil, errors.New("no such instanceID stored")
+	}
+	return &GetInstanceIDReply{*iid}, nil
+}
+
+// StoreSigner will store the Signer in a given final statement
+func (s *Service) StoreSigner(req *StoreSigner) (*StoreSignerReply, error) {
+	s.data.Signers[string(req.PartyID)] = &req.Signer
+	s.save()
+	return &StoreSignerReply{}, nil
+}
+
+// GetSigner will return the Signer of a final statement
+func (s *Service) GetSigner(req *GetSigner) (*GetSignerReply, error) {
+	sig, ok := s.data.Signers[string(req.PartyID)]
+	if !ok {
+		return nil, errors.New("no such Signer stored")
+	}
+	return &GetSignerReply{*sig}, nil
 }
 
 // MergeConfig receives a final statement of requesting party,
@@ -599,6 +675,11 @@ func (final *FinalStatement) VerifyMergeStatement(mergeFinal *FinalStatement) in
 	}
 
 	return PopStatusOK
+}
+
+// StoreLink can be used by tests to directly store a pin.
+func (s *Service) StoreLink(pub kyber.Point) {
+	s.data.Public = pub
 }
 
 // Verification function for signing during Finalization
@@ -1054,9 +1135,12 @@ func newService(c *onet.Context) (onet.Service, error) {
 	s := &Service{
 		ServiceProcessor: onet.NewServiceProcessor(c),
 		data:             &saveData{},
+		storedKeys:       map[string]*keyList{},
 	}
 	err := s.RegisterHandlers(s.PinRequest, s.VerifyLink, s.StoreConfig, s.FinalizeRequest,
-		s.FetchFinal, s.MergeRequest, s.GetProposals)
+		s.FetchFinal, s.MergeRequest, s.GetProposals, s.GetLink, s.GetFinalStatements,
+		s.StoreKeys, s.StoreInstanceID, s.GetInstanceID,
+		s.StoreSigner, s.GetSigner)
 	if err != nil {
 		return nil, err
 	}
@@ -1068,6 +1152,12 @@ func newService(c *onet.Context) (onet.Service, error) {
 	}
 	if s.data.merges == nil {
 		s.data.merges = make(map[string]*merge)
+	}
+	if len(s.data.InstanceIDs) == 0 {
+		s.data.InstanceIDs = map[string]*service.InstanceID{}
+	}
+	if len(s.data.Signers) == 0 {
+		s.data.Signers = map[string]*darc.Signer{}
 	}
 	s.syncs = make(map[string]*syncChans)
 	s.propagateFinalize, err = messaging.NewPropagationFunc(c, propagFinal, s.PropagateFinal, 0)
@@ -1091,5 +1181,8 @@ func newService(c *onet.Context) (onet.Service, error) {
 		s.bftVerifyMerge, s.bftVerifyMergeAck, bftSignMerge); err != nil {
 		return nil, err
 	}
+
+	service.RegisterContract(c, ContractPopParty, s.ContractPopParty)
+
 	return s, nil
 }

--- a/pop/service/service.go
+++ b/pop/service/service.go
@@ -441,9 +441,13 @@ func (s *Service) StoreKeys(req *StoreKeys) (*StoreKeysReply, error) {
 
 // GetKeys will return the keys stored for that party.
 func (s *Service) GetKeys(req *GetKeys) (*GetKeysReply, error) {
+	ks := s.storedKeys[string(req.ID)]
+	if ks == nil {
+		return nil, errors.New("no keys stored for this party")
+	}
 	return &GetKeysReply{
 		ID:   req.ID,
-		Keys: s.storedKeys[string(req.ID)].Keys,
+		Keys: ks.Keys,
 	}, nil
 }
 
@@ -1140,7 +1144,7 @@ func newService(c *onet.Context) (onet.Service, error) {
 	err := s.RegisterHandlers(s.PinRequest, s.VerifyLink, s.StoreConfig, s.FinalizeRequest,
 		s.FetchFinal, s.MergeRequest, s.GetProposals, s.GetLink, s.GetFinalStatements,
 		s.StoreKeys, s.StoreInstanceID, s.GetInstanceID,
-		s.StoreSigner, s.GetSigner)
+		s.StoreSigner, s.GetSigner, s.GetKeys, s.StoreKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/pop/service/service_test.go
+++ b/pop/service/service_test.go
@@ -222,7 +222,7 @@ func TestService_FinalizeRequest(t *testing.T) {
 		fr := &FinalizeRequest{}
 		fr.DescID = descHash
 		fr.Attendees = atts
-		hash, err := fr.hash()
+		hash, err := fr.Hash()
 		log.ErrFatal(err)
 		// Send a request to all services
 		for i, s := range services {
@@ -258,9 +258,7 @@ func TestService_FinalizeRequest(t *testing.T) {
 		final, err := services[0].FinalizeRequest(fr)
 		require.Nil(t, err)
 		require.NotNil(t, final)
-		fin, ok := final.(*FinalizeResponse)
-		require.True(t, ok)
-		require.Nil(t, fin.Final.Verify())
+		require.Nil(t, final.Final.Verify())
 	}
 }
 
@@ -281,7 +279,7 @@ func TestService_FetchFinal(t *testing.T) {
 		fr := &FinalizeRequest{}
 		fr.DescID = descHash
 		fr.Attendees = atts
-		hash, err := fr.hash()
+		hash, err := fr.Hash()
 		sg, err := schnorr.Sign(tSuite, priv[0], hash)
 		log.ErrFatal(err)
 		fr.Signature = sg
@@ -306,8 +304,6 @@ func TestService_FetchFinal(t *testing.T) {
 		msg, err := services[1].FinalizeRequest(fr)
 		require.Nil(t, err)
 		require.NotNil(t, msg)
-		_, ok := msg.(*FinalizeResponse)
-		require.True(t, ok)
 	}
 	for _, desc := range descs {
 		// Fetch final
@@ -360,7 +356,7 @@ func TestService_MergeConfig(t *testing.T) {
 		fr := &FinalizeRequest{}
 		fr.DescID = descHash
 		fr.Attendees = atts[2*i : 2*i+2]
-		hash, err := fr.hash()
+		hash, err := fr.Hash()
 		sg, err := schnorr.Sign(tSuite, priv[2*i], hash)
 		log.ErrFatal(err)
 		fr.Signature = sg
@@ -373,8 +369,6 @@ func TestService_MergeConfig(t *testing.T) {
 		msg, err := srvcs[2*i+1].FinalizeRequest(fr)
 		require.Nil(t, err)
 		require.NotNil(t, msg)
-		_, ok := msg.(*FinalizeResponse)
-		require.True(t, ok)
 	}
 
 	log.Lvl2("Group 1, Server:", srvcs[0].ServerIdentity())
@@ -450,7 +444,7 @@ func TestService_MergeRequest(t *testing.T) {
 		fr := &FinalizeRequest{}
 		fr.DescID = []byte(hash[i])
 		fr.Attendees = atts[2*i : 2*i+2]
-		hash_fr, err := fr.hash()
+		hash_fr, err := fr.Hash()
 		sg, err := schnorr.Sign(tSuite, priv[2*i], hash_fr)
 		log.ErrFatal(err)
 		fr.Signature = sg
@@ -463,8 +457,6 @@ func TestService_MergeRequest(t *testing.T) {
 		msg, err := srvcs[2*i+1].FinalizeRequest(fr)
 		require.Nil(t, err)
 		require.NotNil(t, msg)
-		_, ok := msg.(*FinalizeResponse)
-		require.True(t, ok)
 	}
 	// wrong Signature
 	mr.ID = []byte(hash[0])
@@ -503,6 +495,17 @@ func TestService_MergeRequest(t *testing.T) {
 			fmt.Sprintf("Signature in node %d is not created", i))
 	}
 
+}
+
+func TestService_GetFinalStatement(t *testing.T) {
+	suiteSkip(t)
+	local := onet.NewTCPTest(tSuite)
+	defer local.CloseAll()
+	nodes, r, _ := local.GenTree(2, true)
+	svcs := local.GetServices(nodes, serviceID)
+	_, _, srvcs, _ := storeDesc(svcs, r, 2, 2)
+	_, err := srvcs[0].GetFinalStatements(nil)
+	require.Nil(t, err)
 }
 
 func storeDesc(srvcs []onet.Service, el *onet.Roster, nbr int,

--- a/pop/service/struct.go
+++ b/pop/service/struct.go
@@ -18,7 +18,9 @@ func init() {
 		PinRequest{}, FetchRequest{}, MergeRequest{},
 		StoreConfig{}, StoreConfigReply{},
 		GetProposals{}, GetProposalsReply{},
-		VerifyLink{}, VerifyLinkReply{})
+		VerifyLink{}, VerifyLinkReply{},
+		GetLink{}, GetLinkReply{},
+		GetFinalStatements{}, GetFinalStatementsReply{})
 }
 
 func newMerge() *merge {
@@ -71,7 +73,8 @@ const (
 	PopStatusOK
 )
 
-func (fr *FinalizeRequest) hash() ([]byte, error) {
+// Hash calculates the hash for the FinalizeRequest.
+func (fr *FinalizeRequest) Hash() ([]byte, error) {
 	h := cothority.Suite.Hash()
 	_, err := h.Write(fr.DescID)
 	if err != nil {

--- a/skipchain/protocol.go
+++ b/skipchain/protocol.go
@@ -51,16 +51,10 @@ type ExtendRoster struct {
 	// previous roster in one block back
 	allowedFailures int
 	doneChan        chan int
-}
 
-// GetBlocks is used for conodes to get blocks from each other.
-type GetBlocks struct {
-	*onet.TreeNodeInstance
-
-	GetBlocks      *ProtoGetBlocks
-	GetBlocksReply chan []*SkipBlock
-	DB             *SkipBlockDB
-	replies        int
+	closingMutex sync.Mutex
+	closed       bool
+	closing      chan bool
 }
 
 // NewProtocolExtendRoster prepares for a protocol that checks if a roster can
@@ -71,18 +65,10 @@ func NewProtocolExtendRoster(n *onet.TreeNodeInstance) (onet.ProtocolInstance, e
 		ExtendRosterReply: make(chan []ProtoExtendSignature),
 		// it's hardcoded at the moment, maybe the caller can specify
 		allowedFailures: (len(n.Roster().List) - 1) / 3,
-		doneChan:        make(chan int, 0),
+		closing:         make(chan bool),
+		doneChan:        make(chan int, 1),
 	}
 	return t, t.RegisterHandlers(t.HandleExtendRoster, t.HandleExtendRosterReply)
-}
-
-// NewProtocolGetBlocks prepares for a protocol that fetches blocks.
-func NewProtocolGetBlocks(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-	t := &GetBlocks{
-		TreeNodeInstance: n,
-		GetBlocksReply:   make(chan []*SkipBlock),
-	}
-	return t, t.RegisterHandlers(t.HandleGetBlocks, t.HandleGetBlocksReply)
 }
 
 // Start sends the extend roster request to all of the children.
@@ -92,18 +78,6 @@ func (p *ExtendRoster) Start() error {
 		errs := p.SendToChildrenInParallel(p.ExtendRoster)
 		if len(errs) > p.allowedFailures {
 			log.Errorf("Send to children failed: %v", errs)
-		}
-	}()
-	return nil
-}
-
-// Start sends the block request to all of the children.
-func (p *GetBlocks) Start() error {
-	log.Lvl3("Starting Protocol GetBlocks")
-	go func() {
-		errs := p.SendToChildrenInParallel(p.GetBlocks)
-		if len(errs) > 0 {
-			log.Lvlf1("Error while sending to children: %+v", errs)
 		}
 	}()
 	return nil
@@ -194,6 +168,8 @@ func (p *ExtendRoster) HandleExtendRosterReply(r ProtoStructExtendRosterReply) e
 				} else {
 					p.ExtendRosterReply <- []ProtoExtendSignature{}
 				}
+			case <-p.closing:
+				return
 			}
 		}()
 	}
@@ -224,6 +200,46 @@ func (p *ExtendRoster) HandleExtendRosterReply(r ProtoStructExtendRosterReply) e
 			p.doneChan <- 1
 		}
 	}
+	return nil
+}
+
+// Shutdown makes sure the protocol stops if the server goes down. This is
+// mostly in testing.
+func (p *ExtendRoster) Shutdown() error {
+	close(p.closing)
+	return nil
+}
+
+// GetBlocks is used for conodes to get blocks from each other.
+type GetBlocks struct {
+	*onet.TreeNodeInstance
+
+	GetBlocks      *ProtoGetBlocks
+	GetBlocksReply chan []*SkipBlock
+	DB             *SkipBlockDB
+	replies        int
+	closing        chan bool
+}
+
+// NewProtocolGetBlocks prepares for a protocol that fetches blocks.
+func NewProtocolGetBlocks(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
+	t := &GetBlocks{
+		TreeNodeInstance: n,
+		GetBlocksReply:   make(chan []*SkipBlock),
+		closing:          make(chan bool),
+	}
+	return t, t.RegisterHandlers(t.HandleGetBlocks, t.HandleGetBlocksReply)
+}
+
+// Start sends the block request to all of the children.
+func (p *GetBlocks) Start() error {
+	log.Lvl3("Starting Protocol GetBlocks")
+	go func() {
+		errs := p.SendToChildrenInParallel(p.GetBlocks)
+		if len(errs) > 0 {
+			log.Lvlf1("Error while sending to children: %+v", errs)
+		}
+	}()
 	return nil
 }
 
@@ -275,5 +291,11 @@ func (p *GetBlocks) HandleGetBlocksReply(msg ProtoStructGetBlocksReply) error {
 		p.GetBlocksReply <- blocksReply
 		p.Done()
 	}
+	return nil
+}
+
+// Shutdown closes the channel to indicate that the protocol should stop.
+func (p *GetBlocks) Shutdown() error {
+	close(p.closing)
 	return nil
 }

--- a/skipchain/protocol.go
+++ b/skipchain/protocol.go
@@ -218,7 +218,6 @@ type GetBlocks struct {
 	GetBlocksReply chan []*SkipBlock
 	DB             *SkipBlockDB
 	replies        int
-	closing        chan bool
 }
 
 // NewProtocolGetBlocks prepares for a protocol that fetches blocks.
@@ -226,7 +225,6 @@ func NewProtocolGetBlocks(n *onet.TreeNodeInstance) (onet.ProtocolInstance, erro
 	t := &GetBlocks{
 		TreeNodeInstance: n,
 		GetBlocksReply:   make(chan []*SkipBlock),
-		closing:          make(chan bool),
 	}
 	return t, t.RegisterHandlers(t.HandleGetBlocks, t.HandleGetBlocksReply)
 }
@@ -291,11 +289,5 @@ func (p *GetBlocks) HandleGetBlocksReply(msg ProtoStructGetBlocksReply) error {
 		p.GetBlocksReply <- blocksReply
 		p.Done()
 	}
-	return nil
-}
-
-// Shutdown closes the channel to indicate that the protocol should stop.
-func (p *GetBlocks) Shutdown() error {
-	close(p.closing)
 	return nil
 }

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -724,6 +724,7 @@ func (s *Service) AddFollow(add *AddFollow) (*EmptyReply, error) {
 						FollowChainType{
 							Block:    last,
 							NewChain: add.NewChain,
+							closing:  make(chan bool),
 						})
 					found = true
 					break
@@ -744,6 +745,7 @@ func (s *Service) AddFollow(add *AddFollow) (*EmptyReply, error) {
 			FollowChainType{
 				Block:    last,
 				NewChain: add.NewChain,
+				closing:  make(chan bool),
 			})
 		log.Lvlf2("%s FollowLookup %x", s.ServerIdentity(), add.SkipchainID)
 	default:
@@ -867,6 +869,9 @@ func (s *Service) TestClose() {
 	s.closedMutex.Lock()
 	if !s.closed {
 		s.closed = true
+		for _, fct := range s.Storage.Follow {
+			fct.Shutdown()
+		}
 		s.closedMutex.Unlock()
 		s.working.Wait()
 	} else {
@@ -1476,6 +1481,9 @@ func (s *Service) tryLoad() error {
 	s.Storage, ok = msg.(*Storage)
 	if !ok {
 		return errors.New("data of wrong type")
+	}
+	for i := range s.Storage.Follow {
+		s.Storage.Follow[i].closing = make(chan bool)
 	}
 	return nil
 }

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -673,6 +673,7 @@ func TestService_AddFollow(t *testing.T) {
 	services[1].Storage.Follow = []FollowChainType{{
 		Block:    master0.Latest,
 		NewChain: NewChainAnyNode,
+		closing:  make(chan bool),
 	}}
 	sig, err = schnorr.Sign(cothority.Suite, priv0, ssb.NewBlock.CalculateHash())
 	log.ErrFatal(err)
@@ -685,6 +686,7 @@ func TestService_AddFollow(t *testing.T) {
 	services[2].Storage.Follow = []FollowChainType{{
 		Block:    master0.Latest,
 		NewChain: NewChainAnyNode,
+		closing:  make(chan bool),
 	}}
 	sb = sb.Copy()
 	sb.Roster = onet.NewRoster([]*network.ServerIdentity{ro.List[1], ro.List[0], ro.List[2]})
@@ -935,8 +937,14 @@ func setupFollow(s *Service) kyber.Scalar {
 	s.Storage.Clients = []kyber.Point{kp.Public}
 	s.Storage.FollowIDs = []SkipBlockID{{0}, {1}}
 	s.Storage.Follow = []FollowChainType{
-		{Block: &SkipBlock{SkipBlockFix: &SkipBlockFix{Index: 0, Data: []byte{}}, Hash: []byte{2}}},
-		{Block: &SkipBlock{SkipBlockFix: &SkipBlockFix{Index: 0, Data: []byte{}}, Hash: []byte{3}}},
+		{
+			Block:   &SkipBlock{SkipBlockFix: &SkipBlockFix{Index: 0, Data: []byte{}}, Hash: []byte{2}},
+			closing: make(chan bool),
+		},
+		{
+			Block:   &SkipBlock{SkipBlockFix: &SkipBlockFix{Index: 0, Data: []byte{}}, Hash: []byte{3}},
+			closing: make(chan bool),
+		},
 	}
 	return kp.Private
 }

--- a/stable/directories
+++ b/stable/directories
@@ -1,7 +1,6 @@
 .
 bftcosi
 byzcoinx
-cisc
 conode
 cosi
 cosi/check
@@ -14,13 +13,9 @@ ftcosi/check
 ftcosi/protocol
 ftcosi/service
 ftcosi/simulation
-identity
 messaging
-pop
-pop/service
 randhound
 randhound/simulation
-scmgr
 skipchain
 status
 status/service


### PR DESCRIPTION
Adding pop-contract First step in having pop in omniledger by adding a simple contract that can save the party-proposition and the final statement. Once the final statement is accepted, the contract will create a new coin-account for every attendee of the party.

Before merging: change commit-base in #1460 
Please also squash this PR.