### PR TITLE
Add status RCP call

### DIFF
--- a/external/java/src/main/java/ch/epfl/dedis/lib/status/StatusRPC.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/status/StatusRPC.java
@@ -1,0 +1,31 @@
+package ch.epfl.dedis.lib.status;
+
+import ch.epfl.dedis.lib.ServerIdentity;
+import ch.epfl.dedis.lib.exception.CothorityCommunicationException;
+import ch.epfl.dedis.proto.OnetProto;
+import ch.epfl.dedis.proto.StatusProto;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import java.util.Map;
+
+/**
+ * The RPC to get the status of a conode.
+ */
+public class StatusRPC {
+    /**
+     * Make an RPC to the conode identified by its server identity (sid) to get its status.
+     * @param sid The server identity of the conode.
+     */
+    public static Map<String, OnetProto.Status> getStatus(ServerIdentity sid) throws CothorityCommunicationException {
+        StatusProto.Request.Builder b = StatusProto.Request.newBuilder();
+        ByteString msg = ByteString.copyFrom(sid.SendMessage("Status/Request", b.build().toByteArray()));
+
+        try {
+            StatusProto.Response resp = StatusProto.Response.parseFrom(msg);
+            return resp.getStatusMap();
+        } catch (InvalidProtocolBufferException e) {
+            throw new CothorityCommunicationException(e);
+        }
+    }
+}

--- a/external/java/src/test/java/ch/epfl/dedis/integration/DockerTestServerController.java
+++ b/external/java/src/test/java/ch/epfl/dedis/integration/DockerTestServerController.java
@@ -63,15 +63,11 @@ public class DockerTestServerController extends TestServerController {
     }
 
     @Override
-    public int countRunningConodes() throws IOException, InterruptedException {
-        Container.ExecResult psResults = blockchainContainer.execInContainer("ps", "-o", "pid=", "-C", "conode");
-        return psResults.getStdout().split("\\n").length;
-    }
-
-    @Override
     public void startConode(int nodeNumber) throws InterruptedException {
         logger.info("Starting container {}", nodeNumber);
         runCmdInBackground(blockchainContainer, "conode", "-d", "2", "-c", "co" + nodeNumber + "/private.toml", "server");
+        // Wait a bit for the server to actually start.
+        Thread.sleep(1000);
     }
 
     @Override

--- a/external/java/src/test/java/ch/epfl/dedis/integration/ManualTestServerController.java
+++ b/external/java/src/test/java/ch/epfl/dedis/integration/ManualTestServerController.java
@@ -13,16 +13,6 @@ import java.util.stream.Collectors;
 
 public class ManualTestServerController extends TestServerController {
     @Override
-    public int countRunningConodes() throws IOException, InterruptedException {
-        Process p = Runtime.getRuntime().exec("pgrep conode");
-        int returnCode = p.waitFor();
-        if (returnCode != 0) {
-            throw new IllegalStateException("unable to count running conodes");
-        }
-        return countLines(inputStreamToString(p.getInputStream()));
-    }
-
-    @Override
     public void startConode(int nodeNumber) throws InterruptedException, IOException {
         Runtime.getRuntime().exec("../scripts/start_4th_conode.sh");
         Thread.sleep(1000);

--- a/external/java/src/test/java/ch/epfl/dedis/integration/TestServerController.java
+++ b/external/java/src/test/java/ch/epfl/dedis/integration/TestServerController.java
@@ -3,6 +3,8 @@ package ch.epfl.dedis.integration;
 import ch.epfl.dedis.byzgen.OcsFactory;
 import ch.epfl.dedis.lib.Roster;
 import ch.epfl.dedis.lib.ServerIdentity;
+import ch.epfl.dedis.lib.exception.CothorityCommunicationException;
+import ch.epfl.dedis.lib.status.StatusRPC;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -17,7 +19,21 @@ public abstract class TestServerController {
     protected static final String CONODE_PUB_3 = "7f47f33084c3ecc233f8b05b8f408bbd1c2e4a129aae126f92becacc73576bc7";
     protected static final String CONODE_PUB_4 = "8b25f8ac70b85b2e9aa7faf65507d4f7555af1c872240305117b7659b1e58a1e";
 
-    public abstract int countRunningConodes() throws IOException, InterruptedException;
+    /**
+     * Counts the number of conodes that are running by making a status request to all nodes in the roster. Note that it
+     * will not include nodes that are not in the roster.
+     */
+    public int countRunningConodes() {
+        int failures = 0;
+        for (ServerIdentity sid : this.getRoster().getNodes()) {
+            try {
+                StatusRPC.getStatus(sid);
+            } catch (CothorityCommunicationException e) {
+                failures++;
+            }
+        }
+        return getRoster().getNodes().size() - failures;
+    }
 
     public abstract void startConode(int nodeNumber) throws InterruptedException, IOException;
 

--- a/external/java/src/test/java/ch/epfl/dedis/lib/status/StatusRPCTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/lib/status/StatusRPCTest.java
@@ -1,0 +1,17 @@
+package ch.epfl.dedis.lib.status;
+
+import ch.epfl.dedis.integration.TestServerController;
+import ch.epfl.dedis.integration.TestServerInit;
+import ch.epfl.dedis.lib.ServerIdentity;
+import org.junit.jupiter.api.Test;
+
+class StatusRPCTest {
+    @Test
+    void getStatus() throws Exception {
+        TestServerController testInstanceController = TestServerInit.getInstance();
+        for (ServerIdentity sid: testInstanceController.getRoster().getNodes()) {
+            // If the RPC call fails then an exception is thrown, test passes if there are no exceptions.
+            StatusRPC.getStatus(sid);
+        }
+    }
+}


### PR DESCRIPTION
Instead of using ps to count the number of conodes, make a status
request to make sure it is online.