### PR TITLE
Get proof sanity check

### DIFF
--- a/calypso/service_test.go
+++ b/calypso/service_test.go
@@ -171,19 +171,22 @@ func newTS(t *testing.T, nodes int) ts {
 	s := ts{}
 	s.local = onet.NewLocalTestT(cothority.Suite, t)
 
+	// Create the service
 	s.servers, s.roster, _ = s.local.GenTree(nodes, true)
 	services := s.local.GetServices(s.servers, calypsoID)
 	for _, ser := range services {
 		s.services = append(s.services, ser.(*Service))
 	}
-	log.Lvl2("Starting dkg for", nodes, "nodes")
-	var err error
-	s.ltsReply, err = s.services[0].CreateLTS(&CreateLTS{Roster: *s.roster})
-	require.Nil(t, err)
-	log.Lvl2("Done setting up dkg")
-	s.signer = darc.NewSignerEd25519(nil, nil)
 
+	// Create the skipchain
+	s.signer = darc.NewSignerEd25519(nil, nil)
 	s.createGenesis(t)
+
+	// Start DKG
+	var err error
+	s.ltsReply, err = s.services[0].CreateLTS(&CreateLTS{Roster: *s.roster, OLID: s.gbReply.Skipblock.Hash})
+	require.Nil(t, err)
+
 	return s
 }
 

--- a/omniledger/service/proof.go
+++ b/omniledger/service/proof.go
@@ -14,10 +14,10 @@ import (
 // NewProof creates a proof for key in the skipchain with the given id. It uses
 // the collectionDB to look up the key and the skipblockdb to create the correct
 // proof for the forward links.
-func NewProof(c *collectionDB, s *skipchain.SkipBlockDB, id skipchain.SkipBlockID,
+func NewProof(c CollectionView, s *skipchain.SkipBlockDB, id skipchain.SkipBlockID,
 	key []byte) (p *Proof, err error) {
 	p = &Proof{}
-	p.InclusionProof, err = c.coll.Get(key).Proof()
+	p.InclusionProof, err = c.Get(key).Proof()
 	if err != nil {
 		return
 	}

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -284,37 +284,18 @@ func (s *Service) GetProof(req *GetProof) (resp *GetProofResponse, err error) {
 		return nil, errors.New("version mismatch")
 	}
 	log.Lvlf2("%s Getting proof for key %x on sc %x", s.ServerIdentity(), req.Key, req.ID)
-
-	// Get the collection database and the latest skipblock, if the latest
-	// skipblock does not have the same index as the one in the collection
-	// then we look back for one that does.
-	sb, err := s.db().GetLatestByID(req.ID)
-	if err != nil && sb == nil {
+	sb := s.db().GetByID(req.ID)
+	if sb == nil {
+		err = errors.New("cannot find skipblock while getting proof")
 		return
 	}
-	cdb := s.getCollection(req.ID)
-	if cdb.getIndex() > sb.Index {
-		err = errors.New("invalid index while getting proof")
-		return
-	}
-	// TODO can cdb.getIndex change in this loop?
-	for cdb.getIndex() != -1 && sb.Index > cdb.getIndex() {
-		if len(sb.BackLinkIDs) < 1 || sb.BackLinkIDs[0] == nil {
-			break
-		}
-		sb = s.db().GetByID(sb.BackLinkIDs[0])
-		if sb == nil {
-			err = errors.New("invalid back link")
-			return
-		}
-	}
-	if sb.Index != cdb.getIndex() {
-		err = errors.New("couldn't find block with matching index")
-		return
-	}
-
-	proof, err := NewProof(cdb, s.db(), sb.Hash, req.Key)
+	proof, err := NewProof(s.GetCollectionView(sb.SkipChainID()), s.db(), req.ID, req.Key)
 	if err != nil {
+		return
+	}
+
+	// Sanity check
+	if err = proof.Verify(req.ID); err != nil {
 		return
 	}
 	resp = &GetProofResponse{

--- a/omniledger/service/service_test.go
+++ b/omniledger/service/service_test.go
@@ -380,7 +380,12 @@ func txResultsFromBlock(sb *skipchain.SkipBlock) (TxResults, error) {
 }
 
 func TestService_WaitInclusion(t *testing.T) {
-	for i := 0; i < 3; i++ {
+	n := 3
+	if testing.Short() {
+		n = 1
+	}
+
+	for i := 0; i < n; i++ {
 		log.Lvl1("Testing inclusion when sending to service", i)
 		waitInclusion(t, i)
 	}


### PR DESCRIPTION
The previous technique of looking back to find the correct skipblock
does not work. We still have the inconsistency problem collection versus
skipchain DB. So remove the attempt to find the right skipblock and add
a sanity check.