### PR TITLE
Fix Go 1.11 build break.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ matrix:
   include:
     - language: go
 
+      go:
+	    - "1.11.x"
+
       install:
         - go get -t ./...
         - go get github.com/dedis/Coding || true

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -550,7 +550,7 @@ func (s *Service) updateCollectionCallback(sbID skipchain.SkipBlockID) error {
 				s.pollChanWG.Add(1)
 				s.pollChan[k] = s.startPolling(sb.SkipChainID(), interval)
 			} else {
-				log.Warnf("%s we are a new leader but we were already polling for", s.ServerIdentity(), sb.SkipChainID())
+				log.Warnf("%s we are a new leader but we were already polling for %x", s.ServerIdentity(), sb.SkipChainID())
 			}
 		} else {
 			if c, ok := s.pollChan[k]; ok {

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -550,7 +550,7 @@ func (s *Service) updateCollectionCallback(sbID skipchain.SkipBlockID) error {
 				s.pollChanWG.Add(1)
 				s.pollChan[k] = s.startPolling(sb.SkipChainID(), interval)
 			} else {
-				log.Warn("%s we are a new leader but we were already polling for", s.ServerIdentity(), sb.SkipChainID())
+				log.Warnf("%s we are a new leader but we were already polling for", s.ServerIdentity(), sb.SkipChainID())
 			}
 		} else {
 			if c, ok := s.pollChan[k]; ok {

--- a/cosi/client.go
+++ b/cosi/client.go
@@ -53,7 +53,7 @@ func signFile(c *cli.Context) error {
 	}
 	writeSigAsJSON(sig, outFile)
 	if outFileName != "" {
-		log.Lvl2("Signature written to: %s", outFile.Name())
+		log.Lvl2("Signature written to:", outFile.Name())
 	} // else keep the Stdout empty
 	return nil
 }

--- a/ftcosi/client.go
+++ b/ftcosi/client.go
@@ -58,7 +58,7 @@ func signFile(c *cli.Context) error {
 	}
 	writeSigAsJSON(sig, outFile)
 	if outFileName != "" {
-		log.Lvl2("Signature written to: %s", outFile.Name())
+		log.Lvlf2("Signature written to: %s", outFile.Name())
 	} // else keep the Stdout empty
 	return nil
 }

--- a/scmgr/app.go
+++ b/scmgr/app.go
@@ -242,7 +242,7 @@ func followDel(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	log.Infof("Successfully deleted following of skipchain", scid, link.Conode)
+	log.Infof("Successfully deleted following of skipchain %x in conode %v.", scid, link.Conode)
 	return nil
 }
 func followList(c *cli.Context) error {
@@ -272,7 +272,7 @@ func followList(c *cli.Context) error {
 		}
 	}
 	if list.FollowIDs != nil && list.Follow != nil {
-		log.Infof("Conode %s doesn't follow any skipchain and allows everything.")
+		log.Info("Conode doesn't follow any skipchain and allows everything.")
 	}
 	return nil
 }


### PR DESCRIPTION
Go 1.11 is more careful about detecting % strings, and we had some mistakes.