### PR TITLE
Transactions 1402

### DIFF
--- a/external/java/src/main/java/ch/epfl/dedis/lib/SkipBlock.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/SkipBlock.java
@@ -2,10 +2,13 @@ package ch.epfl.dedis.lib;
 
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 import ch.epfl.dedis.lib.exception.CothorityException;
+import ch.epfl.dedis.lib.skipchain.ForwardLink;
 import ch.epfl.dedis.proto.SkipchainProto;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * SkipBlock is a wrapper around the protobuf SkipBlock class. It is mainly used to serialize the genesis block for
@@ -64,6 +67,17 @@ public class SkipBlock {
     }
 
     /**
+     * @return a list of forwardlinks to next blocks. If the list is empty, then this is the last block of the chain.
+     */
+    public List<ForwardLink>getForwardLinks(){
+        List<ForwardLink> ret = new ArrayList<>();
+        skipBlock.getForwardList().forEach(fl ->{
+            ret.add(new ForwardLink(fl));
+        });
+        return ret;
+    }
+
+    /**
      * Gets the roster from the skipblock.
      */
     public Roster getRoster() throws CothorityException {
@@ -71,6 +85,23 @@ public class SkipBlock {
             return new Roster(skipBlock.getRoster());
         } catch (URISyntaxException e) {
             throw new CothorityException(e);
+        }
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (!(obj instanceof SkipBlock)) {
+            return super.equals(obj);
+        }
+        SkipBlock other = (SkipBlock) obj;
+
+        try {
+            return other.getId().equals(this.getId());
+        } catch (CothorityCryptoException e){
+            return false;
         }
     }
 }

--- a/external/java/src/main/java/ch/epfl/dedis/lib/byzcoin/Block.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/byzcoin/Block.java
@@ -2,11 +2,13 @@ package ch.epfl.dedis.lib.byzcoin;
 
 import ch.epfl.dedis.lib.Sha256id;
 import ch.epfl.dedis.lib.SkipBlock;
+import ch.epfl.dedis.lib.SkipblockId;
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 import ch.epfl.dedis.proto.ByzCoinProto;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -18,6 +20,7 @@ import java.util.List;
 public class Block {
     private ByzCoinProto.DataHeader dataHeader;
     private DataBody dataBody;
+    private SkipblockId sbId;
 
     /**
      * Instantiates a new OmniBlock given a skipblock.
@@ -30,6 +33,7 @@ public class Block {
             // TODO: check that it is actually an OmniBlock by looking at the verifiers
             dataHeader = ByzCoinProto.DataHeader.parseFrom(sb.getData());
             dataBody = new DataBody(ByzCoinProto.DataBody.parseFrom(sb.getPayload()));
+            sbId = sb.getId();
         } catch (InvalidProtocolBufferException e) {
             throw new CothorityCryptoException(e.getMessage());
         }
@@ -78,6 +82,17 @@ public class Block {
     }
 
     /**
+     * @return a list of ClientTransactions stored in this block.
+     */
+    public List<ClientTransaction> getClientTransactions(){
+        List<ClientTransaction> result = new ArrayList<>();
+        dataBody.txResults.forEach(txr ->{
+            result.add(txr.getClientTransaction());
+        });
+        return result;
+    }
+
+    /**
      * @return the unix-timestamp in nanoseconds of the block creation time.
      */
     public long getTimestampNano() {
@@ -97,5 +112,18 @@ public class Block {
      */
     public List<TxResult> getTxResults() {
         return dataBody.txResults;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (!(obj instanceof Block)) {
+            return super.equals(obj);
+        }
+        Block other = (Block) obj;
+
+        return other.sbId.equals(this.sbId);
     }
 }

--- a/external/java/src/main/java/ch/epfl/dedis/lib/byzcoin/ByzCoinRPC.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/byzcoin/ByzCoinRPC.java
@@ -36,6 +36,7 @@ public class ByzCoinRPC {
     private SkipBlock genesis;
     private SkipBlock latest;
     private SkipchainRPC skipchain;
+    private Subscription subscription;
     public static final int currentVersion = 1;
 
     private final Logger logger = LoggerFactory.getLogger(ByzCoinRPC.class);
@@ -71,6 +72,7 @@ public class ByzCoinRPC {
         config = new Config(blockInterval);
         roster = r;
         genesisDarc = d;
+        subscription = new Subscription(skipchain, blockInterval.toMillis());
     }
 
     /**
@@ -99,6 +101,7 @@ public class ByzCoinRPC {
         this.roster = roster;
         genesis = skipchain.getSkipblock(skipchainId);
         latest = skipchain.getLatestSkipblock();
+        subscription = new Subscription(skipchain, config.getBlockInterval().toMillis());
     }
 
     /**
@@ -266,6 +269,23 @@ public class ByzCoinRPC {
     public SkipchainRPC getSkipchain() {
         logger.warn("usually you should not need this - please tell us why you do anyway.");
         return skipchain;
+    }
+
+    /**
+     * Subscribes to all new skipBlocks that might arrive. The subscription is implemented using a polling
+     * approach until we have a working streaming solution.
+     * @param sbr is a SkipBlockReceiver that will be called with any new block(s) available.
+     */
+    public void subscribeSkipBlock(Subscription.SkipBlockReceiver sbr){
+        subscription.subscribeSkipBlock(sbr);
+    }
+
+    /**
+     * Unsubscribes a BlockReceiver.
+     * @param sbr the SkipBlockReceiver to unsubscribe.
+     */
+    public void unsubscribeBlock(Subscription.SkipBlockReceiver sbr){
+        subscription.unsubscribeSkipBlock(sbr);
     }
 
    /**

--- a/external/java/src/main/java/ch/epfl/dedis/lib/byzcoin/Subscription.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/byzcoin/Subscription.java
@@ -1,0 +1,126 @@
+package ch.epfl.dedis.lib.byzcoin;
+
+import ch.epfl.dedis.lib.SkipBlock;
+import ch.epfl.dedis.lib.exception.CothorityException;
+import ch.epfl.dedis.lib.skipchain.SkipchainRPC;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * Subscription class for ByzCoin. A listener can subscribe to different events and then get notified
+ * whenever something happens. This first implementation uses polling to fetch latest blocks and then
+ * calls the appropriate receivers. Once we have a streaming service, it will directly connect to the
+ * streaming service.
+ * <p>
+ * - The polling only starts if at least one receiver subscribes.
+ * - The polling stops, once the last receiver has been unsubscribed.
+ * - Only blocks arriving after the subscription will be passed to the receiver(s).
+ * - If more than one block has been received during the subscription period, they will be given in
+ * a list to the receiver(s).
+ */
+public class Subscription {
+    /**
+     * A SkipBlockReceiver will be informed on any new block arriving.
+     */
+    @FunctionalInterface
+    public interface SkipBlockReceiver {
+        void receive(List<SkipBlock> blocks);
+    }
+
+    private SkipchainRPC sc;
+    private Set<SkipBlockReceiver> blockReceivers = new HashSet<>();
+    private final ScheduledExecutorService scheduler =
+            Executors.newScheduledThreadPool(1);
+    private Runnable pollRunnable;
+    private ScheduledFuture<?> pollHandle;
+    private SkipBlock latestBlock;
+    private long millis;
+
+    /**
+     * Starts a subscription service, but doesn't call the polling yet.
+     *
+     * @param sc     a reference to the instantiated skipchainRPC
+     * @param millis how many millisecond to wait between two polling events.
+     * @throws CothorityException
+     */
+    public Subscription(SkipchainRPC sc, long millis) throws CothorityException {
+        this.sc = sc;
+        this.millis = millis;
+        pollRunnable = () -> poll();
+    }
+
+    /**
+     * Subscribes the receiver to the service. After the receiver has been subscribed, every new block will
+     * be sent to it. Previously received blocks will not be sent to the receiver.
+     *
+     * @param br the receiver that wants to be informed of new blocks.
+     */
+    public void subscribeSkipBlock(SkipBlockReceiver br) {
+        blockReceivers.add(br);
+        if (blockReceivers.size() == 1) {
+            startPolling();
+        }
+    }
+
+    /**
+     * Unsubscribes an existing receiver from the system. If it was the last receiver, then the polling will
+     * stop.
+     *
+     * @param br the receiver to unsubscribe.
+     */
+    public void unsubscribeSkipBlock(SkipBlockReceiver br) {
+        blockReceivers.remove(br);
+        if (blockReceivers.size() == 0) {
+            stopPolling();
+        }
+    }
+
+    private void poll() {
+        List<SkipBlock> newBlocks = new ArrayList<>();
+        try {
+            // Update the latest block
+            latestBlock = sc.getSkipblock(latestBlock.getId());
+            while (latestBlock.getForwardLinks().size() > 0) {
+                // Get next block with link-height 0
+                latestBlock = sc.getSkipblock(latestBlock.getForwardLinks().get(0).getTo());
+                newBlocks.add(latestBlock);
+            }
+        } catch (CothorityException e) {
+            return;
+        }
+        if (newBlocks.size() > 0) {
+            blockReceivers.forEach(br -> br.receive(newBlocks));
+        }
+    }
+
+    private void startPolling() {
+        if (pollHandle == null) {
+            try {
+                latestBlock = sc.getLatestSkipblock();
+            } catch (CothorityException e) {
+            }
+            pollHandle = scheduler.scheduleWithFixedDelay(pollRunnable, 0,
+                    this.millis, MILLISECONDS);
+        }
+    }
+
+    private void stopPolling() {
+        if (pollHandle == null) {
+            return;
+        }
+        pollHandle.cancel(false);
+        try {
+            pollHandle.wait();
+            pollHandle = null;
+        } catch (InterruptedException e) {
+        }
+    }
+}


### PR DESCRIPTION
Implementation of the subscription to new SkipBlocks. Every SkipBlock can easily be transformed to a ByzCoin-`Block` and from there the `ClientTransactions` can be retrieved and looked if they are new.

Closes #1402 