### PR TITLE
Add WaitProof to Calypso API

### DIFF
--- a/calypso/api.go
+++ b/calypso/api.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dedis/cothority/darc"
 	"github.com/dedis/onet"
 	"github.com/dedis/protobuf"
+	"time"
 )
 
 // Client is a class to communicate to the calypso service.
@@ -59,6 +60,12 @@ func (c *Client) DecryptKey(dkr *DecryptKey) (reply *DecryptKeyReply, err error)
 		return nil, err
 	}
 	return reply, nil
+}
+
+// WaitProof calls the byzcoin client's wait proof
+func (c *Client) WaitProof(id byzcoin.InstanceID, interval time.Duration,
+	value []byte) (*byzcoin.Proof, error) {
+		return c.bcClient.WaitProof(id, interval, value)
 }
 
 // AddWrite creates a Write Instance by adding a transaction on the byzcoin client.

--- a/calypso/api.go
+++ b/calypso/api.go
@@ -65,7 +65,7 @@ func (c *Client) DecryptKey(dkr *DecryptKey) (reply *DecryptKeyReply, err error)
 // WaitProof calls the byzcoin client's wait proof
 func (c *Client) WaitProof(id byzcoin.InstanceID, interval time.Duration,
 	value []byte) (*byzcoin.Proof, error) {
-		return c.bcClient.WaitProof(id, interval, value)
+	return c.bcClient.WaitProof(id, interval, value)
 }
 
 // AddWrite creates a Write Instance by adding a transaction on the byzcoin client.

--- a/calypso/api_test.go
+++ b/calypso/api_test.go
@@ -107,13 +107,13 @@ func TestClient_Calypso(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, wr1.InstanceID)
 	//Get the write proof
-	prWr1, err := calypsoClient.bcClient.WaitProof(wr1.InstanceID, time.Second, nil)
+	prWr1, err := calypsoClient.WaitProof(wr1.InstanceID, time.Second, nil)
 	require.Nil(t, err)
 	require.NotNil(t, prWr1)
 
 	re1, err := calypsoClient.AddRead(prWr1, reader1, *darc1, 10)
 	require.Nil(t, err)
-	prRe1, err := calypsoClient.bcClient.WaitProof(re1.InstanceID, time.Second, nil)
+	prRe1, err := calypsoClient.WaitProof(re1.InstanceID, time.Second, nil)
 	require.Nil(t, err)
 	require.True(t, prRe1.InclusionProof.Match())
 
@@ -123,12 +123,12 @@ func TestClient_Calypso(t *testing.T) {
 		darc2.GetBaseID(), calypsoClient.ltsReply.X, key2)
 	wr2, err := calypsoClient.AddWrite(write2, provider2, *darc2, 10)
 	require.Nil(t, err)
-	prWr2, err := calypsoClient.bcClient.WaitProof(wr2.InstanceID, time.Second, nil)
+	prWr2, err := calypsoClient.WaitProof(wr2.InstanceID, time.Second, nil)
 	require.Nil(t, err)
 	require.True(t, prWr2.InclusionProof.Match())
 	re2, err := calypsoClient.AddRead(prWr2, reader2, *darc2, 10)
 	require.Nil(t, err)
-	prRe2, err := calypsoClient.bcClient.WaitProof(re2.InstanceID, time.Second, nil)
+	prRe2, err := calypsoClient.WaitProof(re2.InstanceID, time.Second, nil)
 	require.Nil(t, err)
 	require.True(t, prRe2.InclusionProof.Match())
 


### PR DESCRIPTION
A small patch to the Calypso API [PR#1526](https://github.com/dedis/cothority/pull/1526)

where a function WaitProof is created.