### PR TITLE
Java warning 1325

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -7,6 +7,8 @@ do-java:
 		protoc -I=proto --java_out=java/src/main/java $$i ; \
 	done
 
+	./clean_proto_deprecation.sh
+
 do-js:
 	cd js/cothority; npm run protobuf
 

--- a/external/clean_proto_deprecation.sh
+++ b/external/clean_proto_deprecation.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Because Protobuf uses its own deprecated references, this script will replace
+# them by the correct public getter
+
+echo "Fixing PARSER deprecation by using the public getter"
+
+PROTO_PATH=java/src/main/java/ch/epfl/dedis/lib/proto
+
+for filename in $PROTO_PATH/*.java; do
+	sed -i 's/\.PARSER/.parser()/g' $filename
+done
+

--- a/external/clean_proto_deprecation.sh
+++ b/external/clean_proto_deprecation.sh
@@ -8,6 +8,6 @@ echo "Fixing PARSER deprecation by using the public getter"
 PROTO_PATH=java/src/main/java/ch/epfl/dedis/lib/proto
 
 for filename in $PROTO_PATH/*.java; do
-	sed -i 's/\.PARSER/.parser()/g' $filename
+	sed -i 's/\.PARSER\b/.parser()/g' $filename
 done
 

--- a/external/java/src/main/java/ch/epfl/dedis/byzgen/EpflPermission.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzgen/EpflPermission.java
@@ -21,7 +21,7 @@ public enum EpflPermission {
     }
 
     public static EnumSet<EpflPermission> setOf(EpflPermission ... permissions) {
-        EnumSet enumSet = EnumSet.noneOf(EpflPermission.class);
+        EnumSet<EpflPermission> enumSet = EnumSet.noneOf(EpflPermission.class);
         Collections.addAll(enumSet, permissions);
         return enumSet;
     }
@@ -35,7 +35,7 @@ public enum EpflPermission {
     }
 
     public static EnumSet<EpflPermission> setOf(int bitmask) {
-        EnumSet enumSet = EnumSet.noneOf(EpflPermission.class);
+        EnumSet<EpflPermission> enumSet = EnumSet.noneOf(EpflPermission.class);
 
         for (EpflPermission permission : EpflPermission.values()) {
             if (0 != (bitmask & permission.getBitRepresentation())) {

--- a/external/java/src/main/java/ch/epfl/dedis/eventlog/EventLogInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/eventlog/EventLogInstance.java
@@ -247,6 +247,6 @@ public class EventLogInstance {
             idx++;
         }
         ClientTransaction tx = new ClientTransaction(instrs);
-        return new Pair(tx, keys);
+        return new Pair<>(tx, keys);
     }
 }

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/ByzCoinProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/ByzCoinProto.java
@@ -1049,7 +1049,7 @@ public final class ByzCoinProto {
                 mutable_bitField0_ |= 0x00000001;
               }
               txresults_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.TxResult.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.TxResult.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -1934,7 +1934,7 @@ public final class ByzCoinProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = roster_.toBuilder();
               }
-              roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.PARSER, extensionRegistry);
+              roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(roster_);
                 roster_ = subBuilder.buildPartial();
@@ -1947,7 +1947,7 @@ public final class ByzCoinProto {
               if (((bitField0_ & 0x00000004) == 0x00000004)) {
                 subBuilder = genesisdarc_.toBuilder();
               }
-              genesisdarc_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Darc.PARSER, extensionRegistry);
+              genesisdarc_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Darc.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(genesisdarc_);
                 genesisdarc_ = subBuilder.buildPartial();
@@ -3217,7 +3217,7 @@ public final class ByzCoinProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = skipblock_.toBuilder();
               }
-              skipblock_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.PARSER, extensionRegistry);
+              skipblock_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(skipblock_);
                 skipblock_ = subBuilder.buildPartial();
@@ -4082,7 +4082,7 @@ public final class ByzCoinProto {
               if (((bitField0_ & 0x00000004) == 0x00000004)) {
                 subBuilder = transaction_.toBuilder();
               }
-              transaction_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction.PARSER, extensionRegistry);
+              transaction_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(transaction_);
                 transaction_ = subBuilder.buildPartial();
@@ -6494,7 +6494,7 @@ public final class ByzCoinProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = proof_.toBuilder();
               }
-              proof_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.PARSER, extensionRegistry);
+              proof_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(proof_);
                 proof_ = subBuilder.buildPartial();
@@ -7400,7 +7400,7 @@ public final class ByzCoinProto {
                 mutable_bitField0_ |= 0x00000008;
               }
               identities_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Identity.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Identity.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -9241,7 +9241,7 @@ public final class ByzCoinProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = roster_.toBuilder();
               }
-              roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.PARSER, extensionRegistry);
+              roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(roster_);
                 roster_ = subBuilder.buildPartial();
@@ -10145,7 +10145,7 @@ public final class ByzCoinProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = inclusionproof_.toBuilder();
               }
-              inclusionproof_ = input.readMessage(ch.epfl.dedis.lib.proto.CollectionProto.Proof.PARSER, extensionRegistry);
+              inclusionproof_ = input.readMessage(ch.epfl.dedis.lib.proto.CollectionProto.Proof.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(inclusionproof_);
                 inclusionproof_ = subBuilder.buildPartial();
@@ -10158,7 +10158,7 @@ public final class ByzCoinProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = latest_.toBuilder();
               }
-              latest_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.PARSER, extensionRegistry);
+              latest_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(latest_);
                 latest_ = subBuilder.buildPartial();
@@ -10172,7 +10172,7 @@ public final class ByzCoinProto {
                 mutable_bitField0_ |= 0x00000004;
               }
               links_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -11787,7 +11787,7 @@ public final class ByzCoinProto {
               if (((bitField0_ & 0x00000010) == 0x00000010)) {
                 subBuilder = spawn_.toBuilder();
               }
-              spawn_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Spawn.PARSER, extensionRegistry);
+              spawn_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Spawn.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(spawn_);
                 spawn_ = subBuilder.buildPartial();
@@ -11800,7 +11800,7 @@ public final class ByzCoinProto {
               if (((bitField0_ & 0x00000020) == 0x00000020)) {
                 subBuilder = invoke_.toBuilder();
               }
-              invoke_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Invoke.PARSER, extensionRegistry);
+              invoke_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Invoke.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(invoke_);
                 invoke_ = subBuilder.buildPartial();
@@ -11813,7 +11813,7 @@ public final class ByzCoinProto {
               if (((bitField0_ & 0x00000040) == 0x00000040)) {
                 subBuilder = delete_.toBuilder();
               }
-              delete_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Delete.PARSER, extensionRegistry);
+              delete_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Delete.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(delete_);
                 delete_ = subBuilder.buildPartial();
@@ -11827,7 +11827,7 @@ public final class ByzCoinProto {
                 mutable_bitField0_ |= 0x00000080;
               }
               signatures_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Signature.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Signature.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -13909,7 +13909,7 @@ public final class ByzCoinProto {
                 mutable_bitField0_ |= 0x00000002;
               }
               args_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Argument.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Argument.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -15046,7 +15046,7 @@ public final class ByzCoinProto {
                 mutable_bitField0_ |= 0x00000002;
               }
               args_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Argument.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Argument.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -17328,7 +17328,7 @@ public final class ByzCoinProto {
                 mutable_bitField0_ |= 0x00000001;
               }
               instructions_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Instruction.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Instruction.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -18127,7 +18127,7 @@ public final class ByzCoinProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = clienttransaction_.toBuilder();
               }
-              clienttransaction_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction.PARSER, extensionRegistry);
+              clienttransaction_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(clienttransaction_);
                 clienttransaction_ = subBuilder.buildPartial();
@@ -21128,7 +21128,7 @@ public final class ByzCoinProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = block_.toBuilder();
               }
-              block_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.PARSER, extensionRegistry);
+              block_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(block_);
                 block_ = subBuilder.buildPartial();

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/Calypso.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/Calypso.java
@@ -2306,7 +2306,7 @@ public final class Calypso {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = roster_.toBuilder();
               }
-              roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.PARSER, extensionRegistry);
+              roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(roster_);
                 roster_ = subBuilder.buildPartial();
@@ -3828,7 +3828,7 @@ public final class Calypso {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = read_.toBuilder();
               }
-              read_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.PARSER, extensionRegistry);
+              read_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(read_);
                 read_ = subBuilder.buildPartial();
@@ -3841,7 +3841,7 @@ public final class Calypso {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = write_.toBuilder();
               }
-              write_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.PARSER, extensionRegistry);
+              write_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(write_);
                 write_ = subBuilder.buildPartial();

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/CiscProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/CiscProto.java
@@ -105,7 +105,7 @@ public final class CiscProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = latest_.toBuilder();
               }
-              latest_ = input.readMessage(ch.epfl.dedis.lib.proto.CiscProto.Data.PARSER, extensionRegistry);
+              latest_ = input.readMessage(ch.epfl.dedis.lib.proto.CiscProto.Data.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(latest_);
                 latest_ = subBuilder.buildPartial();
@@ -118,7 +118,7 @@ public final class CiscProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = proposed_.toBuilder();
               }
-              proposed_ = input.readMessage(ch.epfl.dedis.lib.proto.CiscProto.Data.PARSER, extensionRegistry);
+              proposed_ = input.readMessage(ch.epfl.dedis.lib.proto.CiscProto.Data.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(proposed_);
                 proposed_ = subBuilder.buildPartial();
@@ -131,7 +131,7 @@ public final class CiscProto {
               if (((bitField0_ & 0x00000004) == 0x00000004)) {
                 subBuilder = latestskipblock_.toBuilder();
               }
-              latestskipblock_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.PARSER, extensionRegistry);
+              latestskipblock_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(latestskipblock_);
                 latestskipblock_ = subBuilder.buildPartial();
@@ -1369,7 +1369,7 @@ public final class CiscProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = roster_.toBuilder();
               }
-              roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.PARSER, extensionRegistry);
+              roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(roster_);
                 roster_ = subBuilder.buildPartial();
@@ -4348,7 +4348,7 @@ public final class CiscProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = final_.toBuilder();
               }
-              final_ = input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.FinalStatement.PARSER, extensionRegistry);
+              final_ = input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.FinalStatement.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(final_);
                 final_ = subBuilder.buildPartial();
@@ -5378,7 +5378,7 @@ public final class CiscProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = data_.toBuilder();
               }
-              data_ = input.readMessage(ch.epfl.dedis.lib.proto.CiscProto.Data.PARSER, extensionRegistry);
+              data_ = input.readMessage(ch.epfl.dedis.lib.proto.CiscProto.Data.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(data_);
                 data_ = subBuilder.buildPartial();
@@ -6510,7 +6510,7 @@ public final class CiscProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = genesis_.toBuilder();
               }
-              genesis_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.PARSER, extensionRegistry);
+              genesis_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(genesis_);
                 genesis_ = subBuilder.buildPartial();
@@ -7670,7 +7670,7 @@ public final class CiscProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = data_.toBuilder();
               }
-              data_ = input.readMessage(ch.epfl.dedis.lib.proto.CiscProto.Data.PARSER, extensionRegistry);
+              data_ = input.readMessage(ch.epfl.dedis.lib.proto.CiscProto.Data.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(data_);
                 data_ = subBuilder.buildPartial();
@@ -8322,7 +8322,7 @@ public final class CiscProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = propose_.toBuilder();
               }
-              propose_ = input.readMessage(ch.epfl.dedis.lib.proto.CiscProto.Data.PARSER, extensionRegistry);
+              propose_ = input.readMessage(ch.epfl.dedis.lib.proto.CiscProto.Data.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(propose_);
                 propose_ = subBuilder.buildPartial();
@@ -9564,7 +9564,7 @@ public final class CiscProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = propose_.toBuilder();
               }
-              propose_ = input.readMessage(ch.epfl.dedis.lib.proto.CiscProto.Data.PARSER, extensionRegistry);
+              propose_ = input.readMessage(ch.epfl.dedis.lib.proto.CiscProto.Data.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(propose_);
                 propose_ = subBuilder.buildPartial();
@@ -10995,7 +10995,7 @@ public final class CiscProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = data_.toBuilder();
               }
-              data_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.PARSER, extensionRegistry);
+              data_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(data_);
                 data_ = subBuilder.buildPartial();
@@ -11662,7 +11662,7 @@ public final class CiscProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = idblock_.toBuilder();
               }
-              idblock_ = input.readMessage(ch.epfl.dedis.lib.proto.CiscProto.IDBlock.PARSER, extensionRegistry);
+              idblock_ = input.readMessage(ch.epfl.dedis.lib.proto.CiscProto.IDBlock.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(idblock_);
                 idblock_ = subBuilder.buildPartial();
@@ -12627,7 +12627,7 @@ public final class CiscProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = latest_.toBuilder();
               }
-              latest_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.PARSER, extensionRegistry);
+              latest_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(latest_);
                 latest_ = subBuilder.buildPartial();

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/CollectionProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/CollectionProto.java
@@ -122,7 +122,7 @@ public final class CollectionProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = children_.toBuilder();
               }
-              children_ = input.readMessage(ch.epfl.dedis.lib.proto.CollectionProto.Children.PARSER, extensionRegistry);
+              children_ = input.readMessage(ch.epfl.dedis.lib.proto.CollectionProto.Children.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(children_);
                 children_ = subBuilder.buildPartial();
@@ -1679,7 +1679,7 @@ public final class CollectionProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = left_.toBuilder();
               }
-              left_ = input.readMessage(ch.epfl.dedis.lib.proto.CollectionProto.Dump.PARSER, extensionRegistry);
+              left_ = input.readMessage(ch.epfl.dedis.lib.proto.CollectionProto.Dump.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(left_);
                 left_ = subBuilder.buildPartial();
@@ -1692,7 +1692,7 @@ public final class CollectionProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = right_.toBuilder();
               }
-              right_ = input.readMessage(ch.epfl.dedis.lib.proto.CollectionProto.Dump.PARSER, extensionRegistry);
+              right_ = input.readMessage(ch.epfl.dedis.lib.proto.CollectionProto.Dump.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(right_);
                 right_ = subBuilder.buildPartial();
@@ -2594,7 +2594,7 @@ public final class CollectionProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = root_.toBuilder();
               }
-              root_ = input.readMessage(ch.epfl.dedis.lib.proto.CollectionProto.Dump.PARSER, extensionRegistry);
+              root_ = input.readMessage(ch.epfl.dedis.lib.proto.CollectionProto.Dump.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(root_);
                 root_ = subBuilder.buildPartial();
@@ -2608,7 +2608,7 @@ public final class CollectionProto {
                 mutable_bitField0_ |= 0x00000004;
               }
               steps_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.CollectionProto.Step.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.CollectionProto.Step.parser(), extensionRegistry));
               break;
             }
             default: {

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/DarcProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/DarcProto.java
@@ -303,7 +303,7 @@ public final class DarcProto {
               if (((bitField0_ & 0x00000010) == 0x00000010)) {
                 subBuilder = rules_.toBuilder();
               }
-              rules_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Rules.PARSER, extensionRegistry);
+              rules_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Rules.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(rules_);
                 rules_ = subBuilder.buildPartial();
@@ -317,7 +317,7 @@ public final class DarcProto {
                 mutable_bitField0_ |= 0x00000020;
               }
               signatures_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Signature.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Signature.parser(), extensionRegistry));
               break;
             }
             case 58: {
@@ -326,7 +326,7 @@ public final class DarcProto {
                 mutable_bitField0_ |= 0x00000040;
               }
               verificationdarcs_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Darc.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Darc.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -2476,7 +2476,7 @@ public final class DarcProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = darc_.toBuilder();
               }
-              darc_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.IdentityDarc.PARSER, extensionRegistry);
+              darc_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.IdentityDarc.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(darc_);
                 darc_ = subBuilder.buildPartial();
@@ -2489,7 +2489,7 @@ public final class DarcProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = ed25519_.toBuilder();
               }
-              ed25519_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.IdentityEd25519.PARSER, extensionRegistry);
+              ed25519_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.IdentityEd25519.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(ed25519_);
                 ed25519_ = subBuilder.buildPartial();
@@ -2502,7 +2502,7 @@ public final class DarcProto {
               if (((bitField0_ & 0x00000004) == 0x00000004)) {
                 subBuilder = x509Ec_.toBuilder();
               }
-              x509Ec_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.IdentityX509EC.PARSER, extensionRegistry);
+              x509Ec_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.IdentityX509EC.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(x509Ec_);
                 x509Ec_ = subBuilder.buildPartial();
@@ -5290,7 +5290,7 @@ public final class DarcProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = signer_.toBuilder();
               }
-              signer_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Identity.PARSER, extensionRegistry);
+              signer_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Identity.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(signer_);
                 signer_ = subBuilder.buildPartial();
@@ -6097,7 +6097,7 @@ public final class DarcProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = ed25519_.toBuilder();
               }
-              ed25519_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.SignerEd25519.PARSER, extensionRegistry);
+              ed25519_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.SignerEd25519.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(ed25519_);
                 ed25519_ = subBuilder.buildPartial();
@@ -6110,7 +6110,7 @@ public final class DarcProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = x509Ec_.toBuilder();
               }
-              x509Ec_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.SignerX509EC.PARSER, extensionRegistry);
+              x509Ec_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.SignerX509EC.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(x509Ec_);
                 x509Ec_ = subBuilder.buildPartial();
@@ -8153,7 +8153,7 @@ public final class DarcProto {
                 mutable_bitField0_ |= 0x00000008;
               }
               identities_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Identity.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Identity.parser(), extensionRegistry));
               break;
             }
             case 42: {
@@ -9412,7 +9412,7 @@ public final class DarcProto {
                 mutable_bitField0_ |= 0x00000001;
               }
               list_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Rule.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Rule.parser(), extensionRegistry));
               break;
             }
             default: {

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/EventLogProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/EventLogProto.java
@@ -1214,7 +1214,7 @@ public final class EventLogProto {
                 mutable_bitField0_ |= 0x00000001;
               }
               events_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.EventLogProto.Event.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.EventLogProto.Event.parser(), extensionRegistry));
               break;
             }
             case 16: {

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/OnetProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/OnetProto.java
@@ -113,7 +113,7 @@ public final class OnetProto {
                 mutable_bitField0_ |= 0x00000002;
               }
               list_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity.parser(), extensionRegistry));
               break;
             }
             case 26: {

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/Personhood.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/Personhood.java
@@ -80,7 +80,7 @@ public final class Personhood {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = party_.toBuilder();
               }
-              party_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.Party.PARSER, extensionRegistry);
+              party_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.Party.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(party_);
                 party_ = subBuilder.buildPartial();
@@ -828,7 +828,7 @@ public final class Personhood {
               if (((bitField0_ & 0x00000004) == 0x00000004)) {
                 subBuilder = finalstatement_.toBuilder();
               }
-              finalstatement_ = input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.FinalStatement.PARSER, extensionRegistry);
+              finalstatement_ = input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.FinalStatement.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(finalstatement_);
                 finalstatement_ = subBuilder.buildPartial();
@@ -841,7 +841,7 @@ public final class Personhood {
               if (((bitField0_ & 0x00000008) == 0x00000008)) {
                 subBuilder = darc_.toBuilder();
               }
-              darc_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Darc.PARSER, extensionRegistry);
+              darc_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Darc.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(darc_);
                 darc_ = subBuilder.buildPartial();
@@ -854,7 +854,7 @@ public final class Personhood {
               if (((bitField0_ & 0x00000010) == 0x00000010)) {
                 subBuilder = signer_.toBuilder();
               }
-              signer_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Signer.PARSER, extensionRegistry);
+              signer_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Signer.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(signer_);
                 signer_ = subBuilder.buildPartial();
@@ -5091,7 +5091,7 @@ public final class Personhood {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = questionnaire_.toBuilder();
               }
-              questionnaire_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.Questionnaire.PARSER, extensionRegistry);
+              questionnaire_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.Questionnaire.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(questionnaire_);
                 questionnaire_ = subBuilder.buildPartial();
@@ -6493,7 +6493,7 @@ public final class Personhood {
                 mutable_bitField0_ |= 0x00000001;
               }
               questionnaires_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.Personhood.Questionnaire.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.Personhood.Questionnaire.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -10611,7 +10611,7 @@ public final class Personhood {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = message_.toBuilder();
               }
-              message_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.Message.PARSER, extensionRegistry);
+              message_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.Message.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(message_);
                 message_ = subBuilder.buildPartial();
@@ -14471,7 +14471,7 @@ public final class Personhood {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = message_.toBuilder();
               }
-              message_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.Message.PARSER, extensionRegistry);
+              message_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.Message.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(message_);
                 message_ = subBuilder.buildPartial();

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/PoPProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/PoPProto.java
@@ -101,7 +101,7 @@ public final class PoPProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = roster_.toBuilder();
               }
-              roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.PARSER, extensionRegistry);
+              roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(roster_);
                 roster_ = subBuilder.buildPartial();
@@ -1048,7 +1048,7 @@ public final class PoPProto {
               if (((bitField0_ & 0x00000008) == 0x00000008)) {
                 subBuilder = roster_.toBuilder();
               }
-              roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.PARSER, extensionRegistry);
+              roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(roster_);
                 roster_ = subBuilder.buildPartial();
@@ -1062,7 +1062,7 @@ public final class PoPProto {
                 mutable_bitField0_ |= 0x00000010;
               }
               parties_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.ShortDesc.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.ShortDesc.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -2822,7 +2822,7 @@ public final class PoPProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = desc_.toBuilder();
               }
-              desc_ = input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.PopDesc.PARSER, extensionRegistry);
+              desc_ = input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.PopDesc.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(desc_);
                 desc_ = subBuilder.buildPartial();
@@ -5391,7 +5391,7 @@ public final class PoPProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = final_.toBuilder();
               }
-              final_ = input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.FinalStatement.PARSER, extensionRegistry);
+              final_ = input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.FinalStatement.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(final_);
                 final_ = subBuilder.buildPartial();
@@ -6244,7 +6244,7 @@ public final class PoPProto {
               if (((bitField0_ & 0x00000004) == 0x00000004)) {
                 subBuilder = final_.toBuilder();
               }
-              final_ = input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.FinalStatement.PARSER, extensionRegistry);
+              final_ = input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.FinalStatement.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(final_);
                 final_ = subBuilder.buildPartial();
@@ -7846,7 +7846,7 @@ public final class PoPProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = desc_.toBuilder();
               }
-              desc_ = input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.PopDesc.PARSER, extensionRegistry);
+              desc_ = input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.PopDesc.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(desc_);
                 desc_ = subBuilder.buildPartial();
@@ -9872,7 +9872,7 @@ public final class PoPProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = final_.toBuilder();
               }
-              final_ = input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.FinalStatement.PARSER, extensionRegistry);
+              final_ = input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.FinalStatement.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(final_);
                 final_ = subBuilder.buildPartial();
@@ -12178,7 +12178,7 @@ public final class PoPProto {
                 mutable_bitField0_ |= 0x00000001;
               }
               proposals_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.PopDesc.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.PopDesc.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -18215,7 +18215,7 @@ public final class PoPProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = signer_.toBuilder();
               }
-              signer_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Signer.PARSER, extensionRegistry);
+              signer_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Signer.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(signer_);
                 signer_ = subBuilder.buildPartial();
@@ -19879,7 +19879,7 @@ public final class PoPProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = signer_.toBuilder();
               }
-              signer_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Signer.PARSER, extensionRegistry);
+              signer_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Signer.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(signer_);
                 signer_ = subBuilder.buildPartial();
@@ -23132,7 +23132,7 @@ public final class PoPProto {
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
                 subBuilder = finalstatement_.toBuilder();
               }
-              finalstatement_ = input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.FinalStatement.PARSER, extensionRegistry);
+              finalstatement_ = input.readMessage(ch.epfl.dedis.lib.proto.PoPProto.FinalStatement.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(finalstatement_);
                 finalstatement_ = subBuilder.buildPartial();

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/SkipchainProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/SkipchainProto.java
@@ -2721,7 +2721,7 @@ public final class SkipchainProto {
                 mutable_bitField0_ |= 0x00000001;
               }
               update_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -3829,7 +3829,7 @@ public final class SkipchainProto {
               if (((bitField0_ & 0x00000080) == 0x00000080)) {
                 subBuilder = roster_.toBuilder();
               }
-              roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.PARSER, extensionRegistry);
+              roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(roster_);
                 roster_ = subBuilder.buildPartial();
@@ -3848,7 +3848,7 @@ public final class SkipchainProto {
                 mutable_bitField0_ |= 0x00000800;
               }
               forward_.add(
-                  input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink.PARSER, extensionRegistry));
+                  input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink.parser(), extensionRegistry));
               break;
             }
             case 106: {
@@ -5982,7 +5982,7 @@ public final class SkipchainProto {
               if (((bitField0_ & 0x00000004) == 0x00000004)) {
                 subBuilder = newRoster_.toBuilder();
               }
-              newRoster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.PARSER, extensionRegistry);
+              newRoster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(newRoster_);
                 newRoster_ = subBuilder.buildPartial();
@@ -5995,7 +5995,7 @@ public final class SkipchainProto {
               if (((bitField0_ & 0x00000008) == 0x00000008)) {
                 subBuilder = signature_.toBuilder();
               }
-              signature_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.ByzcoinSig.PARSER, extensionRegistry);
+              signature_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.ByzcoinSig.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(signature_);
                 signature_ = subBuilder.buildPartial();

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/StatusProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/StatusProto.java
@@ -546,7 +546,7 @@ public final class StatusProto {
               if (((bitField0_ & 0x00000001) == 0x00000001)) {
                 subBuilder = serveridentity_.toBuilder();
               }
-              serveridentity_ = input.readMessage(ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity.PARSER, extensionRegistry);
+              serveridentity_ = input.readMessage(ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(serveridentity_);
                 serveridentity_ = subBuilder.buildPartial();

--- a/external/java/src/test/java/ch/epfl/dedis/integration/DockerTestServerController.java
+++ b/external/java/src/test/java/ch/epfl/dedis/integration/DockerTestServerController.java
@@ -9,7 +9,7 @@ import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.FrameConsumerResultCallback;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.Wait;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import java.io.IOException;
@@ -22,7 +22,7 @@ public class DockerTestServerController extends TestServerController {
     private static final String TEST_SERVER_IMAGE_NAME = "dedis/conode-test:latest";
     private static final String TEMPORARY_DOCKER_IMAGE = "conode-test-run";
 
-    private final GenericContainer blockchainContainer;
+    private final GenericContainer<?> blockchainContainer;
 
     protected DockerTestServerController() {
         logger.warn("local docker will be started for tests.");
@@ -31,13 +31,11 @@ public class DockerTestServerController extends TestServerController {
         logger.info("For a test run this code will create additional docker image with name " + TEMPORARY_DOCKER_IMAGE +
                 ", at the end this additional image will be automatically deleted");
         try {
-            blockchainContainer = new GenericContainer(
+            blockchainContainer = new GenericContainer<>(
                     new ImageFromDockerfile(TEMPORARY_DOCKER_IMAGE, true)
-                            .withDockerfileFromBuilder(builder -> {
-                                builder
-                                        .from(TEST_SERVER_IMAGE_NAME)
-                                        .expose(7002, 7003, 7004, 7005, 7006, 7007, 7008, 7009);
-                            })
+                            .withDockerfileFromBuilder(builder -> builder
+                                    .from(TEST_SERVER_IMAGE_NAME)
+                                    .expose(7002, 7003, 7004, 7005, 7006, 7007, 7008, 7009))
             );
 
             blockchainContainer.setPortBindings(Arrays.asList(


### PR DESCRIPTION
Fix Java build warnings

One thing to note is the script to clean the Protobuf generated code. I made it that way because it's the solution with the less impact but we should consider a more final solution like using proto3 or spending some time to fix this in the Protobuf repository. Let me know if you see a better way.