### PR TITLE
allow view change flag per skipchain cothority-1474

### DIFF
--- a/byzcoin/proof.go
+++ b/byzcoin/proof.go
@@ -81,7 +81,7 @@ func (p Proof) Verify(scID skipchain.SkipBlockID) error {
 			publics = l.NewRoster.Publics()
 			continue
 		}
-		if err = l.Verify(cothority.Suite, publics); err != nil {
+		if err = l.Verify(cothority.Suite, publics, true); err != nil {
 			return ErrorVerifySkipchain
 		}
 		if !l.From.Equal(sbID) {

--- a/byzcoin/proof_test.go
+++ b/byzcoin/proof_test.go
@@ -107,13 +107,13 @@ func createSC(t *testing.T) (s sc) {
 	s.sb2.Hash = s.sb2.CalculateHash()
 	s.genesis.ForwardLink = genForwardLink(t, s.genesis, s.sb2, s.genesisPrivs)
 
-	_, err = s.s.StoreBlocks([]*skipchain.SkipBlock{s.genesis, s.sb2})
+	_, err = s.s.StoreBlocks([]*skipchain.SkipBlock{s.genesis, s.sb2}, nil)
 	require.Nil(t, err)
 
 	s.genesis2 = skipchain.NewSkipBlock()
 	s.genesis2.Roster, _ = genRoster(2)
 	s.genesis2.Hash = s.genesis2.CalculateHash()
-	s.s.Store(s.genesis2)
+	s.s.Store(s.genesis2, nil)
 	return
 }
 

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -75,6 +75,7 @@ func TestService_CreateGenesisBlock(t *testing.T) {
 	// finally passing
 	resp, err = s.service().CreateGenesisBlock(genesisMsg)
 	require.Nil(t, err)
+	require.True(t, s.service().skService().CheckViewChangeAllowed(resp.Skipblock.SkipChainID()))
 	assert.Equal(t, CurrentVersion, resp.Version)
 	assert.NotNil(t, resp.Skipblock)
 
@@ -487,7 +488,7 @@ func TestService_FloodLedger(t *testing.T) {
 	defer s.local.CloseAll()
 
 	// Store the latest block
-	reply, err := skipchain.NewClient().GetUpdateChain(s.sb.Roster, s.sb.SkipChainID())
+	reply, err := skipchain.NewClient().GetUpdateChain(s.sb.Roster, s.sb.SkipChainID(), nil)
 	require.Nil(t, err)
 	before := reply.Update[len(reply.Update)-1]
 
@@ -499,7 +500,7 @@ func TestService_FloodLedger(t *testing.T) {
 	sendTransaction(t, s, 0, dummyContract, 100)
 
 	// Suppose we need at least 2 blocks (slowContract waits 1/5 interval for each execution)
-	reply, err = skipchain.NewClient().GetUpdateChain(s.sb.Roster, s.sb.SkipChainID())
+	reply, err = skipchain.NewClient().GetUpdateChain(s.sb.Roster, s.sb.SkipChainID(), nil)
 	require.Nil(t, err)
 	latest := reply.Update[len(reply.Update)-1]
 	if latest.Index-before.Index < 2 {
@@ -515,7 +516,7 @@ func TestService_BigTx(t *testing.T) {
 	defer s.local.CloseAll()
 
 	// Check block number before.
-	reply, err := skipchain.NewClient().GetUpdateChain(s.sb.Roster, s.sb.SkipChainID())
+	reply, err := skipchain.NewClient().GetUpdateChain(s.sb.Roster, s.sb.SkipChainID(), nil)
 	require.Nil(t, err)
 	latest := reply.Update[len(reply.Update)-1]
 	require.Equal(t, 0, latest.Index)

--- a/skipchain/api.go
+++ b/skipchain/api.go
@@ -185,7 +185,7 @@ func (c *Client) CreateRootControl(elRoot, elControl *onet.Roster,
 // GetUpdateChain will return the chain of SkipBlocks going from the 'latest' to
 // the most current SkipBlock of the chain. It takes a roster that knows the
 // 'latest' skipblock and the id (=hash) of the latest skipblock.
-func (c *Client) GetUpdateChain(roster *onet.Roster, latest SkipBlockID) (reply *GetUpdateChainReply, err error) {
+func (c *Client) GetUpdateChain(roster *onet.Roster, latest SkipBlockID, service *Service) (reply *GetUpdateChainReply, err error) {
 	const retries = 3
 	delay := 1 * time.Second
 
@@ -228,7 +228,7 @@ func (c *Client) GetUpdateChain(roster *onet.Roster, latest SkipBlockID) (reply 
 				}
 			}
 
-			if err := b.VerifyForwardSignatures(); err != nil {
+			if err := b.VerifyForwardSignatures(service); err != nil {
 				return nil, err
 			}
 			// Cannot check back links until we've confirmed the first one

--- a/skipchain/long_test.go
+++ b/skipchain/long_test.go
@@ -92,7 +92,7 @@ func TestClient_ParallelGetUpdateChain(t *testing.T) {
 	for i := range [128]byte{} {
 		wg.Add(1)
 		go func(i int) {
-			_, err := clients[i%8].GetUpdateChain(inter.Roster, inter.Hash)
+			_, err := clients[i%8].GetUpdateChain(inter.Roster, inter.Hash, nil)
 			log.ErrFatal(err)
 			wg.Done()
 		}(i)

--- a/skipchain/protocol_test.go
+++ b/skipchain/protocol_test.go
@@ -69,9 +69,9 @@ func TestGB(t *testing.T) {
 	ts1.Db = NewSkipBlockDB(db, bucket)
 	ts2.Db = NewSkipBlockDB(db, bucket)
 	blocks := []*SkipBlock{sb0, sb1, sb2, sb3}
-	_, err := ts0.Db.StoreBlocks(blocks)
+	_, err := ts0.Db.StoreBlocks(blocks, nil)
 	require.Nil(t, err)
-	_, err = ts1.Db.StoreBlocks(blocks)
+	_, err = ts1.Db.StoreBlocks(blocks, nil)
 	require.Nil(t, err)
 	// do not save anything into ts2 so that
 	// it is totally out of date, and cannot answer anything

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -27,15 +27,15 @@ func TestSkipBlock_GetResponsible(t *testing.T) {
 	root0.Roster = roster
 	root0.Hash = root0.CalculateHash()
 	root0.BackLinkIDs = []SkipBlockID{root0.Hash}
-	db.Store(root0)
+	db.Store(root0, nil)
 	root1 := root0.Copy()
 	root1.Index++
-	db.Store(root1)
+	db.Store(root1, nil)
 	inter0 := NewSkipBlock()
 	inter0.ParentBlockID = root1.Hash
 	inter0.Roster = roster
 	inter0.Hash = inter0.CalculateHash()
-	db.Store(inter0)
+	db.Store(inter0, nil)
 	inter1 := inter0.Copy()
 	inter1.Index++
 	inter1.BackLinkIDs = []SkipBlockID{inter0.Hash}
@@ -71,16 +71,16 @@ func TestSkipBlock_VerifySignatures(t *testing.T) {
 	root.Roster = roster2
 	root.BackLinkIDs = append(root.BackLinkIDs, SkipBlockID{1, 2, 3, 4})
 	root.Hash = root.CalculateHash()
-	db.Store(root)
-	log.ErrFatal(root.VerifyForwardSignatures())
-	log.ErrFatal(db.VerifyLinks(root))
+	db.Store(root, nil)
+	log.ErrFatal(root.VerifyForwardSignatures(nil))
+	log.ErrFatal(db.VerifyLinks(root, nil))
 
 	block1 := root.Copy()
 	block1.BackLinkIDs = append(block1.BackLinkIDs, root.Hash)
 	block1.Index++
-	db.Store(block1)
-	require.Nil(t, block1.VerifyForwardSignatures())
-	require.NotNil(t, db.VerifyLinks(block1))
+	db.Store(block1, nil)
+	require.Nil(t, block1.VerifyForwardSignatures(nil))
+	require.NotNil(t, db.VerifyLinks(block1, nil))
 }
 
 func TestSkipBlock_Hash1(t *testing.T) {


### PR DESCRIPTION
This PR changes the enableViewChange flag to be set per skipchain and to be in the scope of the service instead of a global variable.

The service must be pass through specific functions of the different structs so it doesn't seem very clean but that's the only way I found to avoid the global declaration and keep the verification functions at the struct level.

Let me know if I can improve this

Fixes #1474 