### PR TITLE
renaming Byzcoin.Block.getClientTransactions to getAcceptedClientTransactions

### DIFF
--- a/external/java/src/main/java/ch/epfl/dedis/byzcoin/Block.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzcoin/Block.java
@@ -84,12 +84,17 @@ public class Block {
     }
 
     /**
-     * @return a list of ClientTransactions stored in this block.
+     * Returns only accepted ClientTransactions stored in the block. If you also need rejected
+     * transactions, then use getTxResults.
+     *
+     * @return a list of accepted ClientTransactions stored in this block.
      */
-    public List<ClientTransaction> getClientTransactions(){
+    public List<ClientTransaction> getAcceptedClientTransactions(){
         List<ClientTransaction> result = new ArrayList<>();
         dataBody.getTxResults().forEach(txr ->{
-            result.add(txr.getClientTransaction());
+            if (txr.isAccepted()) {
+                result.add(txr.getClientTransaction());
+            }
         });
         return result;
     }

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/ByzCoinRPCTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/ByzCoinRPCTest.java
@@ -178,7 +178,7 @@ public class ByzCoinRPCTest {
             logger.info("got SkipBlock {}", block);
             try {
                 Block b = new Block(block);
-                allCtxs.addAll(b.getClientTransactions());
+                allCtxs.addAll(b.getAcceptedClientTransactions());
             } catch (CothorityCryptoException e) {
                 throw new RuntimeException(e);
             }

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/ValueTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/ValueTest.java
@@ -72,7 +72,7 @@ class ValueTest {
         // this part is a regression test for
         // https://github.com/dedis/cothority/issues/1527
         Block ob = new Block(p);
-        ob.getClientTransactions()
+        ob.getAcceptedClientTransactions()
                 .forEach(clientTransaction -> clientTransaction.getInstructions().
                         forEach(instr -> processInstr(instr)));
     }


### PR DESCRIPTION
Proposition from ByzGen to rename this method and make it clear that there is a `getTxResults` method, too.