### PR TITLE
Remove view change flag

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -1503,7 +1503,6 @@ func newService(c *onet.Context) (onet.Service, error) {
 		return nil, err
 	}
 	s.skService().RegisterStoreSkipblockCallback(s.updateCollectionCallback)
-	s.skService().EnableViewChange()
 
 	// Register the view-change cosi protocols.
 	var err error

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -41,18 +41,6 @@ const bftFollowBlock = "SkipchainBFTFollow"
 var storageKey = []byte("skipchainconfig")
 var dbVersion = 1
 
-// If this flag is set, then we relax our forward-link signature verification
-// to accept the aggregate signature by the public keys of the rotated roster.
-// View-change should only be enabled if there are no security implications
-// when the forward-links are signed by the rotated roster instead of the
-// roster in the skipblock that points to it. The security implication depends
-// on the services that use skipchain, so it is disabled by default. The option
-// can be changed from outside of the package by calling EnableViewChange. This
-// flag should ideally be the service configuration, but other structs depend
-// on it too, e.g., SkipBlock, so we keep it in a global.
-var enableViewChange bool
-var enableViewChangeOnce sync.Once
-
 var sid onet.ServiceID
 
 func init() {
@@ -861,13 +849,6 @@ func (s *Service) SetPropTimeout(t time.Duration) {
 	s.propTimeout = t
 }
 
-// EnableViewChange enables view-change, it cannot be turned off afterwards.
-func (s *Service) EnableViewChange() {
-	enableViewChangeOnce.Do(func() {
-		enableViewChange = true
-	})
-}
-
 // TestClose is called by Server.Close in case we're in testing. It
 // makes sure that skipchain is not processing requests and will avoid
 // further requests that might be queued up.
@@ -924,13 +905,11 @@ func (s *Service) forwardLinkLevel0(src, dst *SkipBlock) error {
 	// create the message we want to sign for this round
 	roster := src.Roster
 
-	if enableViewChange {
-		// If the server identities in the two rosters are the same,
-		// then it might be a view-change, so we use the second roster
-		// with the new leader.
-		if src.Roster.IsRotation(dst.Roster) {
-			roster = dst.Roster
-		}
+	// If the server identities in the two rosters are the same,
+	// then it might be a view-change, so we use the second roster
+	// with the new leader.
+	if src.Roster.Contains(dst.Roster.Publics()) {
+		roster = dst.Roster
 	}
 
 	log.Lvlf2("%s is adding forward-link level 0 to: %d->%d with roster %s", s.ServerIdentity(),

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -359,12 +359,15 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, er
 			// Requesting creation of secondary forward link.
 			log.Lvlf2("%s: sending request for height %d to %s", s.ServerIdentity(),
 				i+1, back.Roster.List[0])
-			s.SendRaw(back.Roster.List[0], &ForwardSignature{
+			err := s.SendRaw(back.Roster.List[0], &ForwardSignature{
 				TargetHeight: i + 1,
 				Previous:     back.Hash,
 				Newest:       prop.Copy(),
 			})
-			// time.Sleep(time.Second)
+
+			if err != nil {
+				log.Lvlf2("%v", err)
+			}
 		}
 	}
 	reply := &StoreSkipBlockReply{
@@ -904,13 +907,6 @@ func (s *Service) forwardLinkLevel0(src, dst *SkipBlock) error {
 
 	// create the message we want to sign for this round
 	roster := src.Roster
-
-	// If the server identities in the two rosters are the same,
-	// then it might be a view-change, so we use the second roster
-	// with the new leader.
-	if src.Roster.Contains(dst.Roster.Publics()) {
-		roster = dst.Roster
-	}
 
 	log.Lvlf2("%s is adding forward-link level 0 to: %d->%d with roster %s", s.ServerIdentity(),
 		src.Index, dst.Index, roster.List)

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -366,7 +366,7 @@ func (s *Service) StoreSkipBlock(psbd *StoreSkipBlock) (*StoreSkipBlockReply, er
 			})
 
 			if err != nil {
-				log.Lvlf2("%v", err)
+				log.Warn(err)
 			}
 		}
 	}

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -551,8 +551,8 @@ func (fl *ForwardLink) Copy() *ForwardLink {
 	}
 }
 
-// Verify checks the signature against a list of public keys. When the list
-// corresponds to the new roster but in a different order, the new roster is used.
+// Verify checks the signature against a list of public keys. The list must
+// correspond to the block roster to match the signature.
 // It returns nil if the signature is correct, or an error if not.
 func (fl *ForwardLink) Verify(suite cosi.Suite, pubs []kyber.Point) error {
 	if bytes.Compare(fl.Signature.Msg, fl.Hash()) != 0 {

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -559,10 +559,6 @@ func (fl *ForwardLink) Verify(suite cosi.Suite, pubs []kyber.Point) error {
 		return errors.New("wrong hash of forward link")
 	}
 
-	if fl.NewRoster != nil && fl.NewRoster.Contains(pubs) {
-		pubs = fl.NewRoster.Publics()
-	}
-
 	// This calculation must match the one in byzcoinx.
 	return cosi.Verify(suite, pubs, fl.Signature.Msg, fl.Signature.Sig,
 		cosi.NewThresholdPolicy(byzcoinx.Threshold(len(pubs))))


### PR DESCRIPTION
This PR removes the view change flag because we use the roster of the source block which means that we cannot allow a different roster to sign the forward link even if it's a rotation. No fix to the mask during the verification is necessary as the failing nodes are already ignored in the signature mask, in the correct order.

Fixes #1538 