### PR TITLE
Improve documentation for Darc.copy

### DIFF
--- a/external/java/src/main/java/ch/epfl/dedis/byzcoin/contracts/DarcInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzcoin/contracts/DarcInstance.java
@@ -263,7 +263,7 @@ public class DarcInstance {
      * @throws CothorityCryptoException if there's a problem with the cryptography
      */
     public Darc getDarc() throws CothorityCryptoException {
-        return darc.copy();
+        return darc.copyRulesAndVersion();
     }
 
     /**

--- a/external/java/src/main/java/ch/epfl/dedis/lib/darc/Darc.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/darc/Darc.java
@@ -283,11 +283,11 @@ public class Darc {
     }
 
     /**
-     * @return a copy of the darc with the same version number.
-     * // TODO this part should be in a copy constructor
+     * @return a copy of the darc with the same version number, rules and description.
+     * The prevID and baseID are initiated to null, which must be set afterwards if the darc is to be used.
      * @throws CothorityCryptoException if there's a problem with the cryptography
      */
-    public Darc copy() throws CothorityCryptoException {
+    public Darc copyRulesAndVersion() {
         Rules rs = new Rules(this.rules);
         Darc c = new Darc(rs, description.clone());
         c.version = version;

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/AuthorizationTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/AuthorizationTest.java
@@ -179,7 +179,7 @@ public class AuthorizationTest {
     private static void grantSystemWriteAccess(CalypsoRPC ocs, Darc userDarc) throws Exception {
         SignerEd25519 admin = new SignerEd25519(Hex.parseHexBinary(SUPERADMIN_SCALAR));
 
-        Darc newGenesis = ocs.getGenesisDarc().copy();
+        Darc newGenesis = ocs.getGenesisDarc().copyRulesAndVersion();
         newGenesis.addIdentity(Darc.RuleSignature, IdentityFactory.New(userDarc), Rules.OR);
         newGenesis.addIdentity(Darc.RuleEvolve, IdentityFactory.New(userDarc), Rules.OR);
 

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/DarcTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/DarcTest.java
@@ -51,7 +51,7 @@ class DarcTest {
         DarcInstance dc = DarcInstance.fromByzCoin(bc, genesisDarc);
         logger.info("DC is: {}", dc.getId());
         logger.info("genesisDarc is: {}", genesisDarc.getId());
-        Darc newDarc = genesisDarc.copy();
+        Darc newDarc = genesisDarc.copyRulesAndVersion();
         newDarc.setRule("spawn:darc", "all".getBytes());
         Instruction instr = dc.evolveDarcInstruction(newDarc, admin, 0, 1);
         logger.info("DC is: {}", dc.getId());
@@ -66,14 +66,14 @@ class DarcTest {
     void keycardSignature() throws Exception {
         SignerX509EC kcsigner = new TestSignerX509EC();
         SignerX509EC kcsigner2 = new TestSignerX509EC();
-        Darc adminDarc2 = genesisDarc.copy();
+        Darc adminDarc2 = genesisDarc.copyRulesAndVersion();
         adminDarc2.setRule(Darc.RuleEvolve, kcsigner.getIdentity().toString().getBytes());
         DarcInstance di = DarcInstance.fromByzCoin(bc, genesisDarc);
         di.evolveDarcAndWait(adminDarc2, admin, 10);
         di.update();
         assertEquals(1, di.getDarc().getVersion());
 
-        final Darc adminDarc3 = adminDarc2.copy();
+        final Darc adminDarc3 = adminDarc2.copyRulesAndVersion();
         assertThrows(Exception.class, () -> {
                     logger.info("Trying to evolve darc with wrong signer");
                     adminDarc3.setRule(Darc.RuleEvolve, kcsigner2.getIdentity().toString().getBytes());
@@ -83,7 +83,7 @@ class DarcTest {
         di.update();
         assertEquals(1, di.getDarc().getVersion());
 
-        final Darc adminDarc3bis = adminDarc2.copy();
+        final Darc adminDarc3bis = adminDarc2.copyRulesAndVersion();
         adminDarc3bis.setRule(Darc.RuleEvolve, kcsigner2.getIdentity().toString().getBytes());
         logger.info("Updating darc with new signer");
         di.evolveDarcAndWait(adminDarc3bis, kcsigner, 10);
@@ -94,7 +94,7 @@ class DarcTest {
     @Test
     void spawnDarc() throws Exception {
         DarcInstance dc = DarcInstance.fromByzCoin(bc, genesisDarc);
-        Darc darc2 = genesisDarc.copy();
+        Darc darc2 = genesisDarc.copyRulesAndVersion();
         darc2.setRule("spawn:darc", admin.getIdentity().toString().getBytes());
         dc.evolveDarcAndWait(darc2, admin, 10);
 

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/ValueTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/ValueTest.java
@@ -54,7 +54,7 @@ class ValueTest {
     @Test
     void spawnValue() throws Exception {
         DarcInstance dc = DarcInstance.fromByzCoin(bc, genesisDarc);
-        Darc darc2 = genesisDarc.copy();
+        Darc darc2 = genesisDarc.copyRulesAndVersion();
         darc2.setRule("spawn:value", admin.getIdentity().toString().getBytes());
         darc2.setRule("invoke:update", admin.getIdentity().toString().getBytes());
         dc.evolveDarcAndWait(darc2, admin, 10);
@@ -93,7 +93,7 @@ class ValueTest {
         // going to succeed in order to sync the test to the creation of the new
         // block.
         DarcInstance dc = DarcInstance.fromByzCoin(bc, genesisDarc);
-        Darc darc2 = genesisDarc.copy();
+        Darc darc2 = genesisDarc.copyRulesAndVersion();
         darc2.setRule("spawn:value", admin.getIdentity().toString().getBytes());
         darc2.setRule("invoke:update", admin.getIdentity().toString().getBytes());
         dc.evolveDarcAndWait(darc2, admin, 10);

--- a/external/java/src/test/java/ch/epfl/dedis/byzgen/GrantAccessTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzgen/GrantAccessTest.java
@@ -8,8 +8,6 @@ import ch.epfl.dedis.byzcoin.contracts.DarcInstance;
 import ch.epfl.dedis.calypso.*;
 import ch.epfl.dedis.lib.crypto.TestSignerX509EC;
 import ch.epfl.dedis.lib.darc.*;
-import ch.epfl.dedis.lib.exception.CothorityCommunicationException;
-import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 import ch.epfl.dedis.lib.exception.CothorityException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -74,7 +72,7 @@ public class GrantAccessTest {
 
         //when
         Identity identityX509EC = new IdentityX509EC(consumerPublicPart);
-        Darc newDarc = documentDarc.copy();
+        Darc newDarc = documentDarc.copyRulesAndVersion();
         newDarc.addIdentity("spawn:calypsoRead", identityX509EC, Rules.OR);
         documentDarcInstance.evolveDarcAndWait(newDarc, publisherSigner, 10);
 
@@ -103,7 +101,7 @@ public class GrantAccessTest {
                 doc.getWriteData(calypso.getLTS()));
 
         //when
-        Darc newDarc = documentDarc.copy();
+        Darc newDarc = documentDarc.copyRulesAndVersion();
         newDarc.addIdentity("spawn:calypsoRead", new IdentityDarc(consumerId), Rules.OR);
         documentDarcInstance.evolveDarcAndWait(newDarc, publisherSigner, 10);
 
@@ -145,7 +143,7 @@ public class GrantAccessTest {
     }
 
     private static void grantSystemWriteAccess(CalypsoRPC ocs, Darc userDarc) throws Exception {
-        Darc newGenesis = ocs.getGenesisDarc().copy();
+        Darc newGenesis = ocs.getGenesisDarc().copyRulesAndVersion();
         newGenesis.addIdentity(Darc.RuleSignature, IdentityFactory.New(userDarc), Rules.OR);
         newGenesis.addIdentity(Darc.RuleEvolve, IdentityFactory.New(userDarc), Rules.OR);
 


### PR DESCRIPTION
The Darc.copy method does not make a full copy, so update the
documentation and function name to reflect it.