### PR TITLE
Increase block interval for failure tests

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -581,9 +581,10 @@ func (s *Service) updateTrieCallback(sbID skipchain.SkipBlockID) error {
 			panic("This is a new genesis block, but we're already running " +
 				"the heartbeat monitor, it should never happen.")
 		}
-		log.Lvlf2("%s started heartbeat monitor for %x", s.ServerIdentity(), sb.SkipChainID())
+		log.Lvlf2("%s started heartbeat monitor for %x with window %v", s.ServerIdentity(), sb.SkipChainID(), interval*rotationWindow)
 		s.heartbeats.start(string(sb.SkipChainID()), interval*rotationWindow, s.heartbeatsTimeout)
 	} else {
+		log.Lvlf2("%s updating heartbeat monitor for %x with window %v", s.ServerIdentity(), sb.SkipChainID(), interval*rotationWindow)
 		s.heartbeats.updateTimeout(string(sb.SkipChainID()), interval*rotationWindow)
 	}
 

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -120,7 +120,7 @@ func testAddTransaction(t *testing.T, sendToIdx int, failure bool) {
 	log.SetShowTime(true)
 	var s *ser
 	if failure {
-		s = newSerN(t, 1, 200*time.Millisecond, 4, false)
+		s = newSerN(t, 1, time.Second, 4, false)
 		for _, service := range s.services {
 			service.SetPropagationTimeout(4 * time.Second)
 		}

--- a/calypso/service_test.go
+++ b/calypso/service_test.go
@@ -234,6 +234,7 @@ func (s *ts) waitInstID(t *testing.T, instID byzcoin.InstanceID) *byzcoin.Proof 
 			require.Nil(t, pr.Verify(s.gbReply.Skipblock.Hash))
 			break
 		}
+		time.Sleep(100 * time.Millisecond)
 	}
 	if err != nil {
 		require.Fail(t, "didn't find proof")


### PR DESCRIPTION
Doing TestClose and then startAllChains may take longer than the block
interval, which will cause an unintentional view-change in tests that do
not expect it. So increasing the block interval for those tests.

In addition, we add some more delay for the calypso benchmark to make
Jenkins happy.