### PR TITLE
Don't return interface

### DIFF
--- a/byzcoin/proof_test.go
+++ b/byzcoin/proof_test.go
@@ -55,7 +55,7 @@ func TestVerify(t *testing.T) {
 }
 
 type sc struct {
-	c            *stateTrie             // a usable collectionDB to store key/value pairs
+	c            *StateTrie             // a usable collectionDB to store key/value pairs
 	s            *skipchain.SkipBlockDB // a usable skipchain DB to store blocks
 	genesis      *skipchain.SkipBlock   // the first genesis block, doesn't hold any data
 	genesisPrivs []kyber.Scalar         // private keys of genesis roster

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -72,7 +72,7 @@ type Service struct {
 	*onet.ServiceProcessor
 	// stateTries contains a reference to all the tries that the service is
 	// responsible for, one for each skipchain.
-	stateTries map[string]*stateTrie
+	stateTries map[string]*StateTrie
 	// notifications is used for client transaction and block notification
 	notifications bcNotifications
 
@@ -396,7 +396,7 @@ func (s *Service) SetPropagationTimeout(p time.Duration) {
 func (s *Service) createNewBlock(scID skipchain.SkipBlockID, r *onet.Roster, tx []TxResult) (*skipchain.SkipBlock, error) {
 	var sb *skipchain.SkipBlock
 	var mr []byte
-	var sst *stagingStateTrie
+	var sst *StagingStateTrie
 
 	if scID.IsNull() {
 		// For a genesis block, we create a throwaway staging trie.
@@ -683,11 +683,11 @@ func isViewChangeTx(txs TxResults) *viewchange.View {
 
 // GetReadOnlyStateTrie returns a read-only accessor to the trie for the given
 // skipchain.
-func (s *Service) GetReadOnlyStateTrie(scID skipchain.SkipBlockID) ReadOnlyStateTrie {
+func (s *Service) GetReadOnlyStateTrie(scID skipchain.SkipBlockID) *StateTrie {
 	return s.getStateTrie(scID)
 }
 
-func (s *Service) getStateTrie(id skipchain.SkipBlockID) *stateTrie {
+func (s *Service) getStateTrie(id skipchain.SkipBlockID) *StateTrie {
 	if len(id) == 0 {
 		return nil
 	}
@@ -708,7 +708,7 @@ func (s *Service) getStateTrie(id skipchain.SkipBlockID) *stateTrie {
 	return col
 }
 
-func (s *Service) createStateTrie(id skipchain.SkipBlockID, nonce []byte) *stateTrie {
+func (s *Service) createStateTrie(id skipchain.SkipBlockID, nonce []byte) *StateTrie {
 	if len(id) == 0 {
 		return nil
 	}
@@ -951,7 +951,7 @@ func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool
 
 	// Load/create a staging trie to add the state changes to it and
 	// compute the Merkle root.
-	var sst *stagingStateTrie
+	var sst *StagingStateTrie
 	if newSB.Index == 0 {
 		nonce, err := s.loadNonceFromTxs(body.TxResults)
 		if err != nil {
@@ -1066,7 +1066,7 @@ func txSize(txr ...TxResult) (out int) {
 // State caching is implemented here, which is critical to performance, because
 // on the leader it reduces the number of contract executions by 1/3 and on
 // followers by 1/2.
-func (s *Service) createStateChanges(sst *stagingStateTrie, scID skipchain.SkipBlockID, txIn TxResults, timeout time.Duration) (merkleRoot []byte, txOut TxResults, states StateChanges) {
+func (s *Service) createStateChanges(sst *StagingStateTrie, scID skipchain.SkipBlockID, txIn TxResults, timeout time.Duration) (merkleRoot []byte, txOut TxResults, states StateChanges) {
 	// If what we want is in the cache, then take it from there. Otherwise
 	// ignore the error and compute the state changes.
 	var err error
@@ -1368,7 +1368,7 @@ func (s *Service) startAllChains() error {
 			return errors.New("Data of wrong type")
 		}
 	}
-	s.stateTries = make(map[string]*stateTrie)
+	s.stateTries = make(map[string]*StateTrie)
 	s.notifications = bcNotifications{
 		waitChannels: make(map[string]chan bool),
 	}

--- a/byzcoin/statetrie.go
+++ b/byzcoin/statetrie.go
@@ -18,22 +18,22 @@ type ReadOnlyStateTrie interface {
 	GetProof(key []byte) (*trie.Proof, error)
 }
 
-// stagingStateTrie is a wrapper around trie.StagingTrie that allows for use in
+// StagingStateTrie is a wrapper around trie.StagingTrie that allows for use in
 // byzcoin.
-type stagingStateTrie struct {
+type StagingStateTrie struct {
 	trie.StagingTrie
 }
 
 // Clone makes a copy of the staged data of the structure, the source Trie is
 // not copied.
-func (t *stagingStateTrie) Clone() *stagingStateTrie {
-	return &stagingStateTrie{
+func (t *StagingStateTrie) Clone() *StagingStateTrie {
+	return &StagingStateTrie{
 		StagingTrie: *t.StagingTrie.Clone(),
 	}
 }
 
 // StoreAll puts all the state changes and the index in the staging area.
-func (t *stagingStateTrie) StoreAll(scs StateChanges) error {
+func (t *StagingStateTrie) StoreAll(scs StateChanges) error {
 	pairs := make([]trie.KVPair, len(scs))
 	for i := range pairs {
 		pairs[i] = &scs[i]
@@ -46,7 +46,7 @@ func (t *stagingStateTrie) StoreAll(scs StateChanges) error {
 
 // GetValues returns the associated value, contract ID and darcID. An error is
 // returned if the key does not exist or another issue occurs.
-func (t *stagingStateTrie) GetValues(key []byte) (value []byte, contractID string, darcID darc.ID, err error) {
+func (t *StagingStateTrie) GetValues(key []byte) (value []byte, contractID string, darcID darc.ID, err error) {
 	var buf []byte
 	buf, err = t.Get(key)
 	if err != nil {
@@ -70,45 +70,45 @@ func (t *stagingStateTrie) GetValues(key []byte) (value []byte, contractID strin
 }
 
 // Commit commits the staged data to the source trie.
-func (t *stagingStateTrie) Commit() error {
+func (t *StagingStateTrie) Commit() error {
 	// TODO if this is implemented, we can replace the stateChangeCache.
 	return errors.New("not implemented")
 }
 
 const trieIndexKey = "trieIndexKey"
 
-// stateTrie is a wrapper around trie.Trie that support the storage of an
+// StateTrie is a wrapper around trie.Trie that support the storage of an
 // index.
-type stateTrie struct {
+type StateTrie struct {
 	trie.Trie
 }
 
 // loadStateTrie loads an existing StateTrie, an error is returned if no trie
 // exists in db
-func loadStateTrie(db *bolt.DB, bucket []byte) (*stateTrie, error) {
+func loadStateTrie(db *bolt.DB, bucket []byte) (*StateTrie, error) {
 	t, err := trie.LoadTrie(trie.NewDiskDB(db, bucket))
 	if err != nil {
 		return nil, err
 	}
-	return &stateTrie{
+	return &StateTrie{
 		Trie: *t,
 	}, nil
 }
 
 // newStateTrie creates a new, disk-based trie.Trie, an error is returned if
 // the db already contains a trie.
-func newStateTrie(db *bolt.DB, bucket, nonce []byte) (*stateTrie, error) {
+func newStateTrie(db *bolt.DB, bucket, nonce []byte) (*StateTrie, error) {
 	t, err := trie.NewTrie(trie.NewDiskDB(db, bucket), nonce)
 	if err != nil {
 		return nil, err
 	}
-	return &stateTrie{
+	return &StateTrie{
 		Trie: *t,
 	}, nil
 }
 
 // StoreAll stores the state changes in the Trie.
-func (t *stateTrie) StoreAll(scs StateChanges, index int) error {
+func (t *StateTrie) StoreAll(scs StateChanges, index int) error {
 	pairs := make([]trie.KVPair, len(scs))
 	for i := range pairs {
 		pairs[i] = &scs[i]
@@ -125,7 +125,7 @@ func (t *stateTrie) StoreAll(scs StateChanges, index int) error {
 
 // GetValues returns the associated value, contractID and darcID. An error is
 // returned if the key does not exist.
-func (t *stateTrie) GetValues(key []byte) (value []byte, contractID string, darcID darc.ID, err error) {
+func (t *StateTrie) GetValues(key []byte) (value []byte, contractID string, darcID darc.ID, err error) {
 	var buf []byte
 	buf, err = t.Get(key)
 	if err != nil {
@@ -149,7 +149,7 @@ func (t *stateTrie) GetValues(key []byte) (value []byte, contractID string, darc
 }
 
 // GetIndex gets the latest index.
-func (t *stateTrie) GetIndex() int {
+func (t *StateTrie) GetIndex() int {
 	indexBuf := t.GetMetadata([]byte(trieIndexKey))
 	if indexBuf == nil {
 		return -1
@@ -158,19 +158,19 @@ func (t *stateTrie) GetIndex() int {
 }
 
 // MakeStagingStateTrie creates a StagingStateTrie from the StateTrie.
-func (t *stateTrie) MakeStagingStateTrie() *stagingStateTrie {
-	return &stagingStateTrie{
+func (t *StateTrie) MakeStagingStateTrie() *StagingStateTrie {
+	return &StagingStateTrie{
 		StagingTrie: *t.MakeStagingTrie(),
 	}
 }
 
 // newMemStagingStateTrie creates an in-memory StagingStateTrie.
-func newMemStagingStateTrie(nonce []byte) (*stagingStateTrie, error) {
+func newMemStagingStateTrie(nonce []byte) (*StagingStateTrie, error) {
 	memTrie, err := trie.NewTrie(trie.NewMemDB(), nonce)
 	if err != nil {
 		return nil, err
 	}
-	et := stagingStateTrie{
+	et := StagingStateTrie{
 		StagingTrie: *memTrie.MakeStagingTrie(),
 	}
 	return &et, nil


### PR DESCRIPTION
In general, it's better to return the structure than to return an interface.
Here in special, because the return value can be nil. As such, we will return
a nil interface, which is not equal to nil...