### PR TITLE
fix: PopParty instance not calculated correctly

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -1257,7 +1257,7 @@ func (s *Service) executeInstruction(st ReadOnlyStateTrie, cin []Coin, instr Ins
 	// If the leader does not have a verifier for this contract, it drops the
 	// transaction.
 	if !exists {
-		err = errors.New("Leader is dropping instruction of unknown contract: " + contractID)
+		err = fmt.Errorf("Leader is dropping instruction of unknown contract \"%s\" on instance \"%x\"", contractID, instr.InstanceID.Slice())
 		return
 	}
 	// Now we call the contract function with the data of the key.

--- a/byzcoin/transaction.go
+++ b/byzcoin/transaction.go
@@ -186,6 +186,7 @@ func (instr Instruction) String() string {
 	out += fmt.Sprintf("instr: %x\n", instr.Hash())
 	out += fmt.Sprintf("\tinstID: %v\n", instr.InstanceID)
 	out += fmt.Sprintf("\taction: %s\n", instr.Action())
+	out += fmt.Sprintf("\tcounters: %v\n", instr.SignerCounter)
 	out += fmt.Sprintf("\tsignatures: %d\n", len(instr.Signatures))
 	return out
 }

--- a/pop/app.go
+++ b/pop/app.go
@@ -805,7 +805,7 @@ func bcStore(c *cli.Context) error {
 	}
 
 	log.Info("Storing InstanceID in pop-service")
-	iid := inst.DeriveID("")
+	iid := ct.Instructions[0].DeriveID("")
 	for _, c := range cfg.Roster.List {
 		err = service.NewClient().StoreInstanceID(c.Address, finalID, iid, orgDarc.GetBaseID())
 		if err != nil {


### PR DESCRIPTION
We used DeriveID on the instruction to calculate the instance ID, but
that is not correct because the instruction later gets modified to
include a signature. This issue should be fixed by this PR.

Fixes Jenkins failure too.