### PR TITLE
Fix skipblock ID string representation

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -2028,7 +2028,7 @@ func (s *Service) trySyncAll() {
 			log.Error(s.ServerIdentity(), err)
 		}
 
-		index, ok := indices[sb.SkipChainID().String()]
+		index, ok := indices[fmt.Sprintf("%x", sb.SkipChainID())]
 		if !ok {
 			// from the beginning
 			index = 0

--- a/byzcoin/struct.go
+++ b/byzcoin/struct.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"math/big"
 	"sort"
 	"sync"
@@ -140,7 +141,7 @@ func (s *stateChangeStorage) loadFromDB() (map[string]int, error) {
 				return nil
 			})
 
-			indices[skipchain.SkipBlockID(scid).String()] = int(lastIndex + 1)
+			indices[fmt.Sprintf("%x", scid)] = int(lastIndex + 1)
 			return err
 		})
 	})

--- a/byzcoin/struct.go
+++ b/byzcoin/struct.go
@@ -184,13 +184,14 @@ func (s *stateChangeStorage) setMaxNbrBlock(nbr int) {
 // is above the maximum. It will remove elements until cleanThreshold of
 // the space is available.
 func (s *stateChangeStorage) cleanBySize() error {
+	// size and sortedKeys need to be concurrent safe
+	s.sortedKeysLock.Lock()
+	defer s.sortedKeysLock.Unlock()
+
 	if s.size < s.maxSize || s.maxSize == 0 {
 		// nothing to clean
 		return nil
 	}
-
-	s.sortedKeysLock.Lock()
-	defer s.sortedKeysLock.Unlock()
 
 	sortedKeys := make(keyTimeArray, len(s.sortedKeys))
 	copy(sortedKeys, s.sortedKeys)

--- a/byzcoin/struct_test.go
+++ b/byzcoin/struct_test.go
@@ -1,6 +1,7 @@
 package byzcoin
 
 import (
+	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -56,7 +57,7 @@ func TestStateChangeStorage_Init(t *testing.T) {
 
 	indices, err := scs.loadFromDB()
 	require.Nil(t, err)
-	require.Equal(t, k, indices[sbs[0].Hash.String()])
+	require.Equal(t, k, indices[fmt.Sprintf("%x", sbs[0].Hash)])
 	require.Equal(t, size, scs.size)
 }
 

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -47,11 +47,6 @@ func (sbid SkipBlockID) Equal(sb SkipBlockID) bool {
 	return bytes.Equal([]byte(sbid), []byte(sb))
 }
 
-// String returns the hex string of the byte array
-func (sbid SkipBlockID) String() string {
-	return fmt.Sprintf("%x", []byte(sbid[:]))
-}
-
 // VerifierID represents one of the verifications used to accept or
 // deny a SkipBlock.
 type VerifierID uuid.UUID

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -2,7 +2,6 @@ package skipchain
 
 import (
 	"bytes"
-	"encoding/hex"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -90,7 +89,6 @@ func TestSkipBlock_Hash1(t *testing.T) {
 	sbd1.Height = 4
 	h1 := sbd1.updateHash()
 	assert.Equal(t, h1, sbd1.Hash)
-	assert.Equal(t, hex.EncodeToString(h1), h1.String())
 
 	sbd2 := NewSkipBlock()
 	sbd2.Data = []byte("2")


### PR DESCRIPTION
This removes the String function that was causing bad
formatting when using "%x".

It also fixes a data race in the state change storage.

Fixes #1575