### PR TITLE
Skipchain propagation optimization

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -899,6 +899,18 @@ func (s *Service) updateTrieCallback(sbID skipchain.SkipBlockID) error {
 			"programmer error if you see this message.")
 	}
 
+	// Checks if the block has forward links, which means that it is not a
+	// new block but either a forward link update or a skipchain propagation
+	// meaning the last block will be called later.
+	// We still need the update for state change storage so we only
+	// skip the catch up.
+	// In the case of a genesis block, we need to let it pass so we
+	// learn about it because the callback won't be called after the
+	// catch up
+	if len(sb.ForwardLink) > 0 && !s.catchingUp && sb.Index != 0 {
+		return nil
+	}
+
 	// Create the trie for the genesis block if it has not been
 	// created yet.
 	// We don't need to wrap the check and use another

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -902,8 +902,6 @@ func (s *Service) updateTrieCallback(sbID skipchain.SkipBlockID) error {
 	// Checks if the block has forward links, which means that it is not a
 	// new block but either a forward link update or a skipchain propagation
 	// meaning the last block will be called later.
-	// We still need the update for state change storage so we only
-	// skip the catch up.
 	// In the case of a genesis block, we need to let it pass so we
 	// learn about it because the callback won't be called after the
 	// catch up

--- a/skipchain/api_test.go
+++ b/skipchain/api_test.go
@@ -104,7 +104,7 @@ func TestClient_GetUpdateChain(t *testing.T) {
 		newSB.Roster = onet.NewRoster(roster.List[i : i+2])
 		service := local.Services[servers[i].ServerIdentity.ID][skipchainSID].(*Service)
 		log.Lvl2("Doing skipblock", i, servers[i].ServerIdentity, newSB.Roster.List)
-		reply, err := service.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: sbs[i-1].Hash, NewBlock: newSB})
+		reply, err := service.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: sbs[0].Hash, NewBlock: newSB})
 		require.Nil(t, err)
 		require.NotNil(t, reply.Latest)
 		sbs[i] = reply.Latest

--- a/skipchain/api_test.go
+++ b/skipchain/api_test.go
@@ -1,15 +1,11 @@
 package skipchain
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
-	"testing"
-
-	"github.com/stretchr/testify/require"
-
-	"bytes"
-
 	"sync"
+	"testing"
 
 	"github.com/dedis/cothority"
 	"github.com/dedis/kyber"
@@ -17,6 +13,7 @@ import (
 	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {

--- a/skipchain/api_test.go
+++ b/skipchain/api_test.go
@@ -104,7 +104,7 @@ func TestClient_GetUpdateChain(t *testing.T) {
 		newSB.Roster = onet.NewRoster(roster.List[i : i+2])
 		service := local.Services[servers[i].ServerIdentity.ID][skipchainSID].(*Service)
 		log.Lvl2("Doing skipblock", i, servers[i].ServerIdentity, newSB.Roster.List)
-		reply, err := service.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: sbs[0].Hash, NewBlock: newSB})
+		reply, err := service.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: sbs[i-1].Hash, NewBlock: newSB})
 		require.Nil(t, err)
 		require.NotNil(t, reply.Latest)
 		sbs[i] = reply.Latest

--- a/skipchain/msgs.go
+++ b/skipchain/msgs.go
@@ -46,6 +46,7 @@ func init() {
 		// Propagation
 		&PropagateGenesis{},
 		&PropagateForwardLink{},
+		&PropagateProof{},
 		// Request forward-signature
 		&ForwardSignature{},
 		// - Data structures
@@ -136,9 +137,13 @@ type PropagateGenesis struct {
 // of the Cothority
 type PropagateForwardLink struct {
 	ForwardLink *ForwardLink
-	Newest      *SkipBlock
-	Roster      *onet.Roster
 	Height      int
+}
+
+// PropagateProof sends the smallest path from the genesis to the latest
+// block to a conode recently added to the cothority
+type PropagateProof struct {
+	Proof Proof
 }
 
 // ForwardSignature is called once a new skipblock has been accepted by

--- a/skipchain/msgs.go
+++ b/skipchain/msgs.go
@@ -44,7 +44,8 @@ func init() {
 		&ListFollowReply{},
 		// - Internal calls
 		// Propagation
-		&PropagateSkipBlocks{},
+		&PropagateGenesis{},
+		&PropagateForwardLink{},
 		// Request forward-signature
 		&ForwardSignature{},
 		// - Data structures
@@ -125,10 +126,19 @@ type GetAllSkipChainIDsReply struct {
 
 // Internal calls
 
-// PropagateSkipBlocks sends a newly signed SkipBlock to all members of
+// PropagateGenesis sends a newly created SkipChain to all members of
 // the Cothority
-type PropagateSkipBlocks struct {
-	SkipBlocks []*SkipBlock
+type PropagateGenesis struct {
+	Genesis *SkipBlock
+}
+
+// PropagateForwardLink sends a newly signed forward-link to all members
+// of the Cothority
+type PropagateForwardLink struct {
+	ForwardLink *ForwardLink
+	Newest      *SkipBlock
+	Roster      *onet.Roster
+	Height      int
 }
 
 // ForwardSignature is called once a new skipblock has been accepted by

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -1378,7 +1378,7 @@ func (s *Service) propagateGenesisHandler(msg network.Message) {
 	}
 
 	if !s.blockIsFriendly(pg.Genesis) {
-		log.Error("Block is not friendly")
+		log.Error("Conode doesn't want to follow that skipchain")
 		return
 	}
 
@@ -1433,12 +1433,7 @@ func (s *Service) propagateForwardLinkHandler(msg network.Message) {
 	}
 
 	// Add the block if available
-	if sb, ok := s.blockBuffer.get(sb.SkipChainID(), pfl.ForwardLink.To); ok {
-		if !s.blockIsFriendly(sb) {
-			log.Error("Trying to add a block that is not friendly")
-			return
-		}
-
+	if sb := s.blockBuffer.get(sb.SkipChainID(), pfl.ForwardLink.To); sb != nil {
 		id := s.db.Store(sb)
 		if id == nil {
 			// error already logged

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -979,6 +979,11 @@ func (s *Service) forwardLinkLevel0(src, dst *SkipBlock) error {
 			newRoster = append(newRoster, si)
 		}
 	}
+
+	if len(newRoster) == 0 {
+		return nil
+	}
+
 	log.Lvlf3("%v is propagating %d blocks to %v", s.ServerIdentity(), len(proof), newRoster)
 
 	// current conode needs to be in the propagation roster

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -593,7 +593,7 @@ func TestService_ParallelGenesis(t *testing.T) {
 }
 
 func TestService_Propagation(t *testing.T) {
-	nbrNodes := 60
+	nbrNodes := 10
 	if testing.Short() {
 		nbrNodes = 20
 	}

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -593,7 +593,7 @@ func TestService_ParallelGenesis(t *testing.T) {
 }
 
 func TestService_Propagation(t *testing.T) {
-	nbrNodes := 10
+	nbrNodes := 60
 	if testing.Short() {
 		nbrNodes = 20
 	}

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -1119,13 +1119,13 @@ func (db *SkipBlockDB) getAllSkipchains() (map[string]*SkipBlock, error) {
 // Blocks are stored per skipchain to prevent the cache to grow and it
 // is cleared after a new block is added (again per skipchain)
 type skipBlockBuffer struct {
-	buffer map[[32]byte]*SkipBlock
+	buffer map[string]*SkipBlock
 	sync.Mutex
 }
 
 func newSkipBlockBuffer() *skipBlockBuffer {
 	return &skipBlockBuffer{
-		buffer: make(map[[32]byte]*SkipBlock),
+		buffer: make(map[string]*SkipBlock),
 	}
 }
 
@@ -1134,9 +1134,7 @@ func (sbb *skipBlockBuffer) add(block *SkipBlock) {
 	sbb.Lock()
 	defer sbb.Unlock()
 
-	key := [32]byte{}
-	copy(key[:], block.SkipChainID())
-	sbb.buffer[key] = block
+	sbb.buffer[string(block.SkipChainID())] = block
 }
 
 // get returns the block if the skipchain ID hits with the
@@ -1145,10 +1143,7 @@ func (sbb *skipBlockBuffer) get(sid SkipBlockID, id SkipBlockID) *SkipBlock {
 	sbb.Lock()
 	defer sbb.Unlock()
 
-	key := [32]byte{}
-	copy(key[:], sid)
-
-	block, ok := sbb.buffer[key]
+	block, ok := sbb.buffer[string(sid)]
 	if !ok || !block.Hash.Equal(id) {
 		return nil
 	}
@@ -1161,8 +1156,5 @@ func (sbb *skipBlockBuffer) clear(sid SkipBlockID) {
 	sbb.Lock()
 	defer sbb.Unlock()
 
-	key := [32]byte{}
-	copy(key[:], sid)
-
-	delete(sbb.buffer, key)
+	delete(sbb.buffer, string(sid))
 }

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -1000,6 +1000,10 @@ func (db *SkipBlockDB) GetProof(sid SkipBlockID) (sbs []*SkipBlock, err error) {
 				return err
 			}
 
+			if sb == nil {
+				return errors.New("Couldn't find one of the blocks")
+			}
+
 			sbs = append(sbs, sb)
 		}
 

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -1141,7 +1141,7 @@ func (sbb *skipBlockBuffer) add(block *SkipBlock) {
 
 // get returns the block if the skipchain ID hits with the
 // correct block ID
-func (sbb *skipBlockBuffer) get(sid SkipBlockID, id SkipBlockID) (*SkipBlock, bool) {
+func (sbb *skipBlockBuffer) get(sid SkipBlockID, id SkipBlockID) *SkipBlock {
 	sbb.Lock()
 	defer sbb.Unlock()
 
@@ -1149,11 +1149,11 @@ func (sbb *skipBlockBuffer) get(sid SkipBlockID, id SkipBlockID) (*SkipBlock, bo
 	copy(key[:], sid)
 
 	block, ok := sbb.buffer[key]
-	if ok && !block.Hash.Equal(id) {
-		return nil, false
+	if !ok || !block.Hash.Equal(id) {
+		return nil
 	}
 
-	return block, ok
+	return block
 }
 
 // clear deletes the current block of the given skipchain

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -514,7 +514,7 @@ func (sbs Proof) Verify() error {
 			}
 
 			if !hit {
-				return fmt.Errorf("Wrong backlink %v %v", sb.BackLinkIDs, sbs[i-1].Hash)
+				return errors.New("Missing backlink")
 			}
 		}
 		if i < len(sbs)-1 {

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -224,3 +224,35 @@ func setupSkipBlockDB(t *testing.T) (*SkipBlockDB, string) {
 
 	return NewSkipBlockDB(db, []byte("skipblock-test")), fname
 }
+
+// Checks if the buffer api works as expected
+func TestBlockBuffer(t *testing.T) {
+	bb := newSkipBlockBuffer()
+	sid := []byte{1}
+	bid := []byte{2}
+
+	sb := NewSkipBlock()
+	sb.Index = 1
+	sb.GenesisID = sid
+	sb.Hash = bid
+	bb.add(sb)
+
+	sb, ok := bb.get(sid, bid)
+	require.True(t, ok)
+	require.NotNil(t, sb)
+
+	// wrong key
+	sb, ok = bb.get(bid, bid)
+	require.False(t, ok)
+	require.Nil(t, sb)
+
+	// wrong block id
+	sb, ok = bb.get(sid, sid)
+	require.False(t, ok)
+	require.Nil(t, sb)
+
+	bb.clear(sid)
+	sb, ok = bb.get(sid, bid)
+	require.False(t, ok)
+	require.Nil(t, sb)
+}

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -271,22 +271,18 @@ func TestBlockBuffer(t *testing.T) {
 	sb.Hash = bid
 	bb.add(sb)
 
-	sb, ok := bb.get(sid, bid)
-	require.True(t, ok)
+	sb = bb.get(sid, bid)
 	require.NotNil(t, sb)
 
 	// wrong key
-	sb, ok = bb.get(bid, bid)
-	require.False(t, ok)
+	sb = bb.get(bid, bid)
 	require.Nil(t, sb)
 
 	// wrong block id
-	sb, ok = bb.get(sid, sid)
-	require.False(t, ok)
+	sb = bb.get(sid, sid)
 	require.Nil(t, sb)
 
 	bb.clear(sid)
-	sb, ok = bb.get(sid, bid)
-	require.False(t, ok)
+	sb = bb.get(sid, bid)
 	require.Nil(t, sb)
 }


### PR DESCRIPTION
This changes the way the skipchain is propagating new block and
forward links so that it sends minimal information and let conodes
ask for missing data.

Fixes #1395 #1213 #1201