### PR TITLE
Fix jenkins long tests

### DIFF
--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -1214,8 +1214,10 @@ func TestService_SetConfigRosterNewNodes(t *testing.T) {
 
 	// Make sure the latest node is correctly activated.
 	ctx, _ = createConfigTxWithCounter(t, testInterval, *rosterR, defaultMaxBlockSize, s, counter)
-	counter++
-	s.sendTxAndWait(t, ctx, 10)
+	for i := range s.services {
+		counter++
+		s.sendTxToAndWait(t, ctx, i, 10)
+	}
 
 	for _, node := range rosterR.List {
 		log.Lvl2("Checking node", node, "has testDarc stored")
@@ -1238,7 +1240,6 @@ func TestService_SetConfigRosterNewNodes(t *testing.T) {
 			time.Sleep(testInterval)
 		}
 	}
-	time.Sleep(1 * time.Second)
 }
 
 func TestService_SetConfigRosterSwitchNodes(t *testing.T) {

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -546,7 +546,7 @@ func TestService_FloodLedger(t *testing.T) {
 	s := newSer(t, 2, testInterval)
 	defer s.local.CloseAll()
 
-	// Store the latest block
+	// Fetch the latest block
 	reply, err := skipchain.NewClient().GetUpdateChain(s.genesis.Roster, s.genesis.SkipChainID())
 	require.Nil(t, err)
 	before := reply.Update[len(reply.Update)-1]

--- a/skipchain/api.go
+++ b/skipchain/api.go
@@ -213,6 +213,7 @@ func (c *Client) GetUpdateChainLevel(roster *onet.Roster, latest SkipBlockID,
 
 		// Try up to retries random servers from the given roster.
 		i := 0
+		// TODO: not random until the seed is set up
 		perm := rand.Perm(len(roster.List))
 		for ; i < retries; i++ {
 			// To handle the case where len(perm) < retries.

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -393,7 +393,7 @@ func (s *Service) GetUpdateChain(guc *GetUpdateChain) (*GetUpdateChainReply, err
 	blocks := []*SkipBlock{block.Copy()}
 	log.Lvlf3("Starting to search chain at %s", s.Context.ServerIdentity())
 	maxHeight := guc.MaxHeight
-	if maxHeight == 0 {
+	if maxHeight <= 0 {
 		maxHeight = block.MaximumHeight
 	}
 	maxBlocks := guc.MaxBlocks
@@ -401,7 +401,7 @@ func (s *Service) GetUpdateChain(guc *GetUpdateChain) (*GetUpdateChainReply, err
 	// more than maxBlocks blocks - except if it is 0, then add as many blocks as
 	// we have.
 	for block.GetForwardLen() > 0 &&
-		(maxBlocks == 0 || len(blocks) < maxBlocks) {
+		(maxBlocks <= 0 || len(blocks) < maxBlocks) {
 		var link *ForwardLink
 		if block.GetForwardLen() < maxHeight {
 			link = block.ForwardLink[block.GetForwardLen()-1]


### PR DESCRIPTION
This PR fixes two tests randomly failing on Jenkins during the long tests.

TestService_SetConfigRosterNewNodes was failing because some conodes were still catching up after joining the cothority. A round of tx has been added to each new conode.

TestService_FloodLedger was failing because the GetUpdateChain was buggy with negative parameters.

Hopefully Jenkins will be stable after this PR, at least it's working fine on a different job.

Fixes #1584 