### PR TITLE
add a --host argument to status

### DIFF
--- a/status/test.sh
+++ b/status/test.sh
@@ -18,6 +18,8 @@ testNetwork(){
     testOut "Running network"
     testGrep "Available_Services" runCl -g public.toml
     testGrep "Available_Services" runCl -g public.toml
+    testGrep "Available_Services" runCl --host localhost:2002
+    testGrep "Available_Services" runCl --host tls://localhost:2002
 }
 
 testBuild(){


### PR DESCRIPTION
currently `status` only allows to report the status from a group.toml file. This adds the possibility to directly request the status from a host using `--host`.