### PR TITLE
Correctly keeping track of poller and viewChangeMonitor

### DIFF
--- a/byzcoin/heartbeat.go
+++ b/byzcoin/heartbeat.go
@@ -84,6 +84,17 @@ func (r *heartbeats) updateTimeout(key string, timeout time.Duration) {
 	}
 }
 
+func (r *heartbeats) stop(key string) {
+	r.Lock()
+	defer r.Unlock()
+	hb, ok := r.heartbeatMap[key]
+	if !ok {
+		return
+	}
+	hb.closeChan <- true
+	delete(r.heartbeatMap, key)
+}
+
 func (r *heartbeats) start(key string, timeout time.Duration, timeoutChan chan string) error {
 	r.Lock()
 	defer r.Unlock()

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -1117,7 +1117,7 @@ func (s *Service) bftForwardLinkLevel0Ack(msg []byte, data []byte) bool {
 	if ok {
 		s.verifyNewBlockBuffer.Delete(arr)
 	} else {
-		log.Error(s.ServerIdentity().Address, "ack failed for msg", msg)
+		log.Errorf("%s got asked to acknowledge for unknown block %x", s.ServerIdentity(), msg)
 	}
 	return ok
 }


### PR DESCRIPTION
Previously, the block-poller and the viewChangeMonitor have not been correctly
started/stopped when a node joined or left a roster of a ByzCoin. Now
they are correctly started/stopped, so that a full change in the roster
is possible.

Closes #1608 