### PR TITLE
Updating invoke:view_change rule

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -1847,14 +1847,10 @@ func (s *Service) monitorLeaderFailure() {
 		return
 	}
 	s.working.Add(1)
-	s.closedMutex.Unlock()
 	defer s.working.Done()
+	s.closedMutex.Unlock()
 
 	go func() {
-		select {
-		case <-s.closeLeaderMonitorChan:
-		default:
-		}
 		for {
 			select {
 			case key := <-s.heartbeatsTimeout:
@@ -1903,6 +1899,8 @@ func (s *Service) registerContract(contractID string, c ContractFn) error {
 // it finds a valid config-file and synchronises skipblocks if it can contact
 // other nodes.
 func (s *Service) startAllChains() error {
+	s.closedMutex.Lock()
+	defer s.closedMutex.Unlock()
 	if !s.closed {
 		return errors.New("Can only call startAllChains if the service has been closed before")
 	}
@@ -1982,16 +1980,13 @@ func (s *Service) startAllChains() error {
 		// TODO fault threshold might change
 	}
 
-	s.monitorLeaderFailure()
-
 	// Running trySyncAll in background so it doesn't stop the other
 	// services from starting.
 	// TODO: do this on a per-needed basis, or only a couple of seconds
 	// after startup.
 	go func() {
-		s.working.Add(1)
+		s.monitorLeaderFailure()
 		s.trySyncAll()
-		s.working.Done()
 	}()
 
 	return nil

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -585,7 +585,7 @@ func (s *Service) CheckStateChangeValidity(req *CheckStateChangeValidity) (*Chec
 
 	scs := make(StateChanges, len(sces))
 	for i, e := range sces {
-		scs[i] = e.StateChange
+		scs[i] = e.StateChange.Copy()
 	}
 
 	return &CheckStateChangeValidityResponse{

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -1798,7 +1798,7 @@ func TestService_StateChangeStorage(t *testing.T) {
 			})
 			require.Nil(t, err)
 
-			sb, err := service.skService().GetSingleBlock(&skipchain.GetSingleBlock{res.BlockID})
+			sb, err := service.skService().GetSingleBlock(&skipchain.GetSingleBlock{ID: res.BlockID})
 			require.Nil(t, err)
 			var header DataHeader
 			err = protobuf.DecodeWithConstructors(sb.Data, &header, network.DefaultConstructors(cothority.Suite))
@@ -1876,7 +1876,7 @@ func TestService_StateChangeCatchUp(t *testing.T) {
 		// add transactions that must be recreated
 		createTx(instr.Hash(), uint64(i+1), 0)
 	}
-	createTx(instr.Hash(), uint64(n), 1)
+	createTx(instr.Hash(), uint64(n), 2)
 
 	// Remove some entries to check it will recreate them
 	err := s.service().stateChangeStorage.db.Update(func(tx *bolt.Tx) error {

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -1641,6 +1641,7 @@ func TestService_DarcToSc(t *testing.T) {
 	}
 
 	// remove the mapping and then load it again
+	log.Lvl1("Reloading all services")
 	for _, service := range s.services {
 		service.darcToSc = make(map[string]skipchain.SkipBlockID)
 		service.TestClose()
@@ -1648,6 +1649,7 @@ func TestService_DarcToSc(t *testing.T) {
 	}
 
 	// check that the mapping is still correct
+	log.Lvl1("Verifying mapping is still correct")
 	for _, service := range s.services {
 		require.True(t, service.darcToSc[string(darcID)].Equal(scID))
 	}

--- a/byzcoin/struct.go
+++ b/byzcoin/struct.go
@@ -49,6 +49,18 @@ func (sces StateChangeEntries) Swap(i, j int) {
 	sces[i], sces[j] = sces[j], sces[i]
 }
 
+func (sc StateChange) Copy() StateChange {
+	c := StateChange{
+		StateAction: sc.StateAction,
+		Version:     sc.Version,
+	}
+	c.InstanceID = append([]byte{}, sc.InstanceID...)
+	c.ContractID = append([]byte{}, sc.ContractID...)
+	c.Value = append([]byte{}, sc.Value...)
+	c.DarcID = append([]byte{}, sc.DarcID...)
+	return c
+}
+
 // keyTime stores information to keep track of the age of the
 // oldest version of an instance for cleaning purposes.
 type keyTime struct {

--- a/byzcoin/struct.go
+++ b/byzcoin/struct.go
@@ -49,6 +49,8 @@ func (sces StateChangeEntries) Swap(i, j int) {
 	sces[i], sces[j] = sces[j], sces[i]
 }
 
+// Copy creates a deep copy of the statechange, so that tests
+// can correctly work on those copies.
 func (sc StateChange) Copy() StateChange {
 	c := StateChange{
 		StateAction: sc.StateAction,


### PR DESCRIPTION
Whenever the `ChainConfig` gets a new roster, the `invoke:view_change` rule needs to be updated with the list of public keys that are now allowed to create a view change.

An alternative would be to not do this using the darcs, but allow `invoke:view_change` directly based
on the roster. But that seemed to adventurous...

Also fixes a bug in `TestService_StateChangeStorage`.

Closes #1607 