### PR TITLE
Fix StateChangeStorage

### DIFF
--- a/byzcoin/struct.go
+++ b/byzcoin/struct.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"math/big"
 	"sort"
 	"sync"
 	"time"
@@ -13,6 +12,7 @@ import (
 	bolt "github.com/coreos/bbolt"
 	"github.com/dedis/cothority/skipchain"
 	"github.com/dedis/onet"
+	"github.com/dedis/onet/log"
 	"github.com/dedis/protobuf"
 )
 
@@ -105,6 +105,7 @@ type stateChangeStorage struct {
 	maxNbrBlock    int
 	sortedKeys     keyTimeArray
 	sortedKeysLock sync.Mutex
+	accessLock     sync.Mutex
 }
 
 // Create a storage with a default maximum size
@@ -346,6 +347,8 @@ func (s *stateChangeStorage) key(iid []byte, ver uint64, idx int64) ([]byte, err
 // this will clean the oldest state changes until there is enough
 // space left and append the new ones
 func (s *stateChangeStorage) append(scs StateChanges, sb *skipchain.SkipBlock) error {
+	s.accessLock.Lock()
+	defer s.accessLock.Unlock()
 	// Run a cleaning procedure first to insure we're not above the limit
 	err := s.cleanBySize()
 	if err != nil {
@@ -422,6 +425,8 @@ func (s *stateChangeStorage) append(scs StateChanges, sb *skipchain.SkipBlock) e
 
 // This will return the list of state changes for the given instance
 func (s *stateChangeStorage) getAll(iid []byte, sid skipchain.SkipBlockID) (entries []StateChangeEntry, err error) {
+	s.accessLock.Lock()
+	defer s.accessLock.Unlock()
 	if len(iid) != prefixLength {
 		return nil, errLengthInstanceID
 	}
@@ -454,6 +459,8 @@ func (s *stateChangeStorage) getAll(iid []byte, sid skipchain.SkipBlockID) (entr
 // Use the bool returned value to check if the version exists
 func (s *stateChangeStorage) getByVersion(iid []byte,
 	ver uint64, sid skipchain.SkipBlockID) (sce StateChangeEntry, ok bool, err error) {
+	s.accessLock.Lock()
+	defer s.accessLock.Unlock()
 	if len(iid) != prefixLength {
 		err = errLengthInstanceID
 		return
@@ -490,6 +497,8 @@ func (s *stateChangeStorage) getByVersion(iid []byte,
 // getByBlock looks for the state changes associated with a given
 // skipblock
 func (s *stateChangeStorage) getByBlock(sid skipchain.SkipBlockID, idx int) (entries StateChangeEntries, err error) {
+	s.accessLock.Lock()
+	defer s.accessLock.Unlock()
 	err = s.db.View(func(tx *bolt.Tx) error {
 		b := s.getBucket(tx, sid)
 
@@ -520,6 +529,8 @@ func (s *stateChangeStorage) getByBlock(sid skipchain.SkipBlockID, idx int) (ent
 // getLast looks for the last version of a given instance and return the entry. Use
 // the bool value to know if there is a hit or not.
 func (s *stateChangeStorage) getLast(iid []byte, sid skipchain.SkipBlockID) (sce StateChangeEntry, ok bool, err error) {
+	s.accessLock.Lock()
+	defer s.accessLock.Unlock()
 	if len(iid) != prefixLength {
 		err = errLengthInstanceID
 		return
@@ -530,12 +541,11 @@ func (s *stateChangeStorage) getLast(iid []byte, sid skipchain.SkipBlockID) (sce
 		c := b.Cursor()
 
 		// Seek the next instance ID and take a step back
-		// to reach the newest version
-		key := new(big.Int)
-		key.SetBytes(iid)
-		key.Add(key, new(big.Int).SetInt64(1))
-
-		c.Seek(key.Bytes())
+		// to reach the newest version.
+		// By appending 2^64-1 to the key, we get the last
+		// possible key.
+		key := append(iid, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}...)
+		c.Seek(key)
 		k, v := c.Prev()
 
 		if bytes.HasPrefix(k, iid) {
@@ -546,7 +556,23 @@ func (s *stateChangeStorage) getLast(iid []byte, sid skipchain.SkipBlockID) (sce
 
 			ok = true
 		}
+		return nil
+	})
 
+	return
+}
+
+func (s *stateChangeStorage) dumpAll(sid skipchain.SkipBlockID) (sce StateChangeEntry, ok bool, err error) {
+	s.accessLock.Lock()
+	defer s.accessLock.Unlock()
+	err = s.db.View(func(tx *bolt.Tx) error {
+		b := s.getBucket(tx, sid)
+		c := b.Cursor()
+		k, _ := c.First()
+		for k != nil {
+			log.Lvlf1("%x", k)
+			k, _ = c.Next()
+		}
 		return nil
 	})
 
@@ -554,6 +580,8 @@ func (s *stateChangeStorage) getLast(iid []byte, sid skipchain.SkipBlockID) (sce
 }
 
 func (s *stateChangeStorage) getStateTrie(scid skipchain.SkipBlockID) (*stagingStateTrie, error) {
+	s.accessLock.Lock()
+	defer s.accessLock.Unlock()
 	nonce := GenNonce()
 	sst, err := newMemStagingStateTrie(nonce[:])
 	if err != nil {

--- a/byzcoin/transaction.go
+++ b/byzcoin/transaction.go
@@ -340,8 +340,8 @@ func (txr TxResults) Hash() []byte {
 func NewStateChange(sa StateAction, iID InstanceID, contractID string, value []byte, darcID darc.ID) StateChange {
 	return StateChange{
 		StateAction: sa,
-		InstanceID:  iID.Slice(),
-		ContractID:  []byte(contractID),
+		InstanceID:  append([]byte{}, iID[:]...),
+		ContractID:  append([]byte{}, []byte(contractID)...),
 		Value:       value,
 		DarcID:      darcID,
 	}


### PR DESCRIPTION
- don't use big.Int to get next key, else IDs starting with 0x00 get truncated
- beautify structures: most global parameters go first
- wait in StateChangeStorage-test for all nodes to be updated