### PR TITLE
Clarify why we use 4 conodes in java test

### DIFF
--- a/external/java/src/test/java/ch/epfl/dedis/integration/DockerTestServerController.java
+++ b/external/java/src/test/java/ch/epfl/dedis/integration/DockerTestServerController.java
@@ -93,6 +93,10 @@ public class DockerTestServerController extends TestServerController {
         }
     }
 
+    /**
+     * We only get 4 conodes because the run_conode.sh file (from the Dockerfile) only starts 4 conodes.
+     * The other conodes (5 to 7) are used for testing roster changes.
+     */
     @Override
     public List<CalypsoFactory.ConodeAddress> getConodes() {
         return Arrays.asList(


### PR DESCRIPTION
It was confusing why we have configurations for 7 conodes but only start
4. So add a comment to explain why.

Fixes #1618