### PR TITLE
Add java test for calypso resharing

### DIFF
--- a/calypso/service.go
+++ b/calypso/service.go
@@ -203,7 +203,7 @@ func (s *Service) CreateLTS(req *CreateLTS) (reply *CreateLTSReply, err error) {
 }
 
 // ReshareLTS starts a request to reshare the LTS. The new roster which holds
-// the new secret shares must exist in the InstanceID specified by the request.
+// the new secret shares must exist in the proof specified by the request.
 // All hosts must be online in this step.
 func (s *Service) ReshareLTS(req *ReshareLTS) (*ReshareLTSReply, error) {
 	// Verify the request

--- a/calypso/service_test.go
+++ b/calypso/service_test.go
@@ -158,7 +158,7 @@ func TestService_ReshareLTS_OneMore(t *testing.T) {
 			require.NotNil(t, s.ltsReply.X)
 			sec1 := s.reconstructKey(t)
 
-			// Create a new roster that has one more node that
+			// Create a new roster that has one more node than
 			// before
 			s.ltsRoster = onet.NewRoster(s.allRoster.List[:nodes+1])
 			ltsInstInfoBuf, err := protobuf.Encode(&LtsInstanceInfo{*s.ltsRoster})

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/ByzCoinRPCTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/ByzCoinRPCTest.java
@@ -32,7 +32,6 @@ import java.util.stream.Stream;
 
 import static ch.epfl.dedis.integration.TestServerController.*;
 import static java.time.temporal.ChronoUnit.MILLIS;
-import static java.time.temporal.ChronoUnit.NANOS;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ByzCoinRPCTest {


### PR DESCRIPTION
We add two tests that tries to do reshare LTS secrets. One for resharing
in the same roster and the other for resharing in a larger roster. This
is very similar to the tests in Go.

Closes #1536