### PR TITLE
conode: added call to rand.Seed in main()

### DIFF
--- a/conode/conode.go
+++ b/conode/conode.go
@@ -18,11 +18,13 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/rand"
 	"net"
 	"os"
 	"path"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/ftcosi/check"
@@ -48,6 +50,10 @@ const (
 )
 
 var gitTag = ""
+
+// Seed the random number generator, because onet uses it to choose
+// permutations of rosters, etc.
+func init() { rand.Seed(time.Now().UTC().UnixNano()) }
 
 func main() {
 	cliApp := cli.NewApp()

--- a/skipchain/api.go
+++ b/skipchain/api.go
@@ -214,7 +214,6 @@ func (c *Client) GetUpdateChainLevel(roster *onet.Roster, latest SkipBlockID,
 
 		// Try up to retries random servers from the given roster.
 		i := 0
-		// TODO: not random until the seed is set up
 		perm := rand.Perm(len(roster.List))
 		for ; i < retries; i++ {
 			// To handle the case where len(perm) < retries.


### PR DESCRIPTION
We noticed that we are using rand.Perm in onet.Roster, but we never call
rand.Seed. In testing code this is perhaps helpful, but in production it's
not ideal. So we put the call to Seed in main(). Libtest.sh also uses
conode.go, so the integration tests are seeded too.

Fixes #1587.