### PR TITLE
Check the length of interior nodes before access

### DIFF
--- a/byzcoin/trie/proof.go
+++ b/byzcoin/trie/proof.go
@@ -25,12 +25,12 @@ func (p *Proof) Exists(key []byte) (bool, error) {
 		return false, errors.New("key is nil")
 	}
 
-	bits := p.binSlice(key)
-	expectedHash := p.Interiors[0].hash() // first one is the root hash
-
 	if len(p.Interiors) == 0 {
 		return false, errors.New("no interior nodes")
 	}
+
+	bits := p.binSlice(key)
+	expectedHash := p.Interiors[0].hash() // first one is the root hash
 
 	var i int
 	for i = range p.Interiors {


### PR DESCRIPTION
Move the length check before trying to indexing the interior nodes to
avoid panic. This issue was noticed when porting this code to Java.