### PR TITLE
Route logs from exec commands to java logger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ node_js:
   - "lts/*"
 
 env:
-#   - TEST_DIR=cothority
   - TEST_DIR=kyber
 
 install:
@@ -17,8 +16,6 @@ install:
   # GOPATH. So make a copy of it over where it is supposed to be.
   - git clone . `go env GOPATH`/src/github.com/dedis/cothority
   - (cd `go env GOPATH`/src/github.com/dedis/cothority && go get -t ./... )
-
-script: cd external/js/$TEST_DIR && npm install && npm run test && npm run build
 
 cache:
   directories:
@@ -54,3 +51,14 @@ matrix:
 
       script:
         - make test_java
+
+    - language: node_js
+      name: "kyber-js Tests"
+  
+      script:
+        - cd $TRAVIS_BUILD_DIR/external/js/kyber
+        - npm install
+        - npm run test
+        - npm run build
+
+

--- a/external/java/src/test/java/ch/epfl/dedis/integration/DockerTestServerController.java
+++ b/external/java/src/test/java/ch/epfl/dedis/integration/DockerTestServerController.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.FrameConsumerResultCallback;
+import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.ImageFromDockerfile;
@@ -106,7 +107,12 @@ public class DockerTestServerController extends TestServerController {
                 .withCmd(cmd)
                 .exec();
 
+        FrameConsumerResultCallback fc = new FrameConsumerResultCallback();
+        Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(logger);
+        fc.addConsumer(OutputFrame.OutputType.STDOUT, logConsumer);
+        fc.addConsumer(OutputFrame.OutputType.STDERR, logConsumer);
+
         dockerClient.execStartCmd(execCreateCmdResponse.getId())
-                .exec(new FrameConsumerResultCallback()).awaitStarted();
+                .exec(fc).awaitStarted();
     }
 }


### PR DESCRIPTION
The logs from the container as a whole are routed to
the logger via withLogConsumer. But for a conode
restarted via exec, the logs need to be fetched by a
callback.

Fixes #1426.