### PR TITLE
Fix eventlog integration test

### DIFF
--- a/eventlog/api.go
+++ b/eventlog/api.go
@@ -4,13 +4,12 @@ import (
 	"bytes"
 	"errors"
 
+	"github.com/dedis/cothority"
 	"github.com/dedis/cothority/byzcoin"
 	"github.com/dedis/cothority/darc"
+	"github.com/dedis/onet"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/protobuf"
-
-	"github.com/dedis/cothority"
-	"github.com/dedis/onet"
 )
 
 // Client is a structure to communicate with the eventlog service
@@ -104,6 +103,12 @@ type LogID []byte
 
 // Log asks the service to log events.
 func (c *Client) Log(ev ...Event) ([]LogID, error) {
+	return c.LogAndWait(0, ev...)
+}
+
+// LogAndWait sends a request to log the events and waits for N block intervals
+// that the events are added to the ledger
+func (c *Client) LogAndWait(numInterval int, ev ...Event) ([]LogID, error) {
 	if c.signerCtrs == nil {
 		c.RefreshSignerCounters()
 	}
@@ -112,7 +117,7 @@ func (c *Client) Log(ev ...Event) ([]LogID, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, err := c.ByzCoin.AddTransaction(*tx); err != nil {
+	if _, err := c.ByzCoin.AddTransactionAndWait(*tx, numInterval); err != nil {
 		return nil, err
 	}
 	return keys, nil

--- a/eventlog/el/main.go
+++ b/eventlog/el/main.go
@@ -135,7 +135,7 @@ var cmds = cli.Commands{
 			},
 			cli.IntFlag{
 				Name:  "wait, w",
-				Usage: "wait for block inclusion",
+				Usage: "wait for block inclusion (default: do not wait)",
 				Value: 0,
 			},
 		},

--- a/eventlog/el/main.go
+++ b/eventlog/el/main.go
@@ -133,6 +133,11 @@ var cmds = cli.Commands{
 				Name:  "content, c",
 				Usage: "the text of the log",
 			},
+			cli.IntFlag{
+				Name:  "wait, w",
+				Usage: "wait for block inclusion",
+				Value: 0,
+			},
 		},
 		Action: doLog,
 	},
@@ -331,17 +336,18 @@ func doLog(c *cli.Context) error {
 
 	t := c.String("topic")
 	content := c.String("content")
+	w := c.Int("wait")
 
 	// Content is set, so one shot log.
 	if content != "" {
-		_, err := cl.Log(eventlog.NewEvent(t, content))
+		_, err := cl.LogAndWait(w, eventlog.NewEvent(t, content))
 		return err
 	}
 
 	// Content is empty, so read from stdin.
 	s := bufio.NewScanner(os.Stdin)
 	for s.Scan() {
-		_, err := cl.Log(eventlog.NewEvent(t, s.Text()))
+		_, err := cl.LogAndWait(w, eventlog.NewEvent(t, s.Text()))
 		if err != nil {
 			return err
 		}

--- a/eventlog/el/test.sh
+++ b/eventlog/el/test.sh
@@ -25,27 +25,12 @@ main(){
 	stopTest
 }
 
-# This is necessary becaues el does not remember the current signer counter from invocation
-# to invocation, it always gets it from the server. And so if you call el twice
-# in one block, the second one will use the same counter as the first one did.
-waitBlock(){
-	sleep .5
-}
-
 testLogging(){
 	runCoBG 1 2 3
-	testOK $el log -t test -c 'abc'
-	waitBlock
-	testOK $el log -c 'def'
-	waitBlock
-	waitBlock
-	echo ghi | testOK $el log
-	waitBlock
-	seq 100 | testOK $el log -t seq100
-
-	# Wait two block intervals to be sure they are all committed
-	waitBlock
-	waitBlock
+	testOK $el log -t test -c 'abc' -w 10
+	testOK $el log -c 'def' -w 10
+	echo ghi | testOK $el log -w 10
+	seq 100 | testOK $el log -t seq100 -w 10
 
 	testGrep "abc" $el search -t test
 	testCountLines 103 $el search


### PR DESCRIPTION
This fixes the eventlog integration test by adding
an option to wait for block inclusion.

The wait block routine doesn't seem to work well on Jenkins and you should anyway be able to know when the event has been sent through because of the signer counter.