### PR TITLE
Java mask

### DIFF
--- a/external/java/src/main/java/ch/epfl/dedis/lib/crypto/BlsSig.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/crypto/BlsSig.java
@@ -54,6 +54,14 @@ public class BlsSig {
         return new BlsSig(xHM.toBytes());
     }
 
+    /**
+     * Getter for the signature in byte representation.
+     */
+    public byte[] getSig() {
+        return sig;
+    }
+
+
     private static Bn256G1Point hashToPoint(byte[] msg) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");

--- a/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Bn256G1Point.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Bn256G1Point.java
@@ -177,6 +177,16 @@ public class Bn256G1Point implements Point {
     }
 
     /**
+     * Get the infinity (zero) point.
+     */
+    @Override
+    public Point getZero() {
+        BN.G1 p = new BN.G1();
+        p.setInfinity();
+        return new Bn256G1Point(p);
+    }
+
+    /**
      * Perform the pairing operation on this point and G2.
      *
      * @param g2 is a point on G2.

--- a/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Bn256G2Point.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Bn256G2Point.java
@@ -177,6 +177,16 @@ public class Bn256G2Point implements Point {
     }
 
     /**
+     * Get the infinity (zero) point.
+     */
+    @Override
+    public Point getZero() {
+        BN.G2 p = new BN.G2();
+        p.setInfinity();
+        return new Bn256G2Point(p);
+    }
+
+    /**
      * Perform the pairing operation on this point and G1.
      *
      * @param g1 is a point on G1.

--- a/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Bn256Scalar.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Bn256Scalar.java
@@ -79,7 +79,6 @@ public class Bn256Scalar implements Scalar {
         return this.x.equals(BigInteger.ZERO);
     }
 
-
     public Scalar mul(Scalar s) {
         return new Bn256Scalar(this.x.multiply(convert(s).x));
     }

--- a/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Ed25519Point.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Ed25519Point.java
@@ -26,7 +26,6 @@ public class Ed25519Point implements Point {
         if (Arrays.equals(marshalID, Arrays.copyOfRange(b, 0, 8))) {
             b = Arrays.copyOfRange(b, 8, b.length);
         }
-
         element = new GroupElement(Ed25519.curve, b);
     }
 
@@ -75,7 +74,11 @@ public class Ed25519Point implements Point {
     }
 
     public boolean isZero() {
-        return !element.toP2().getY().isNonZero();
+        return this.element.equals(Ed25519.curve.getZero(GroupElement.Representation.P3));
+    }
+
+    public Point getZero() {
+        return new Ed25519Point(Ed25519.curve.getZero(GroupElement.Representation.P3));
     }
 
     public String toString() {
@@ -100,7 +103,6 @@ public class Ed25519Point implements Point {
         }
         return Arrays.copyOfRange(bytes, 1, len + 1);
     }
-
 
     public static Point embed(byte[] data) throws CothorityCryptoException {
         if (data.length > Ed25519.pubLen) {

--- a/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Mask.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Mask.java
@@ -1,0 +1,91 @@
+package ch.epfl.dedis.lib.crypto;
+
+import ch.epfl.dedis.lib.Hex;
+import ch.epfl.dedis.lib.exception.CothorityCryptoException;
+
+public class Mask {
+    private final byte[] mask;
+    private final Point[] publics;
+    private Point aggregate = null;
+
+    Mask(Point[] publics, byte[] mask) throws CothorityCryptoException {
+        if (publics.length == 0) {
+            throw new CothorityCryptoException("no public keys");
+        }
+        this.publics = publics;
+        this.mask = new byte[(this.publics.length + 7) >> 3];
+        this.aggregate = publics[0].getZero();
+        for (int i = 0; i < publics.length; i++) {
+            byte byt = (byte)(i >> 3);
+            byte msk = (byte)(1 << (i&7));
+            if (((this.mask[byt] & msk) == 0) && ((mask[byt] & msk) != 0)) {
+                this.mask[byt] ^= msk; // flip bit in mask from 0 to 1
+                this.aggregate = this.aggregate.add(this.publics[i]);
+            }
+            if (((this.mask[byt] & msk) != 0) && ((mask[byt] & msk) == 0)) {
+                this.mask[byt] ^= msk; // flip bit in mask from 1 to 0
+                this.aggregate = this.aggregate.add(this.publics[i].negate());
+            }
+        }
+    }
+
+    public int len() {
+        return (this.publics.length + 7) >> 3;
+    }
+
+    public Point getAggregate() {
+        return this.aggregate;
+    }
+
+    public boolean indexEnabled(int i) throws IndexOutOfBoundsException {
+        if (i >= this.publics.length) {
+            throw new IndexOutOfBoundsException();
+        }
+        byte byt = (byte)(i >> 3);
+        byte msk = (byte)(1 << (i&7));
+        return ((this.mask[byt] & msk) != 0);
+    }
+
+    public boolean keyEnabled(Point p) throws CothorityCryptoException {
+        for (int i = 0; i < this.publics.length; i++) {
+            if (this.publics[i].equals(p)) {
+                return this.indexEnabled(i);
+            }
+        }
+        throw new CothorityCryptoException("key not found");
+    }
+
+    public int countEnabled() {
+        // hw is hamming weight
+        int hw = 0;
+        for (int i = 0; i < this.publics.length; i++) {
+            byte byt = (byte)(i >> 3);
+            byte msk = (byte)(1 << (i&7));
+            if ((this.mask[byt] & msk) != 0) {
+                hw++;
+            }
+        }
+        return hw;
+    }
+
+    public int countTotal() {
+        return this.publics.length;
+    }
+
+    @Override
+    public String toString() {
+        String out = "";
+        out += "mask: " + Hex.printHexBinary(this.mask);
+        out += "\npublic keys:";
+        for (Point p : this.publics) {
+            out += "\n" + p.toString();
+        }
+        out += "\naggregate: ";
+        if (this.aggregate == null) {
+            out += "null";
+        } else {
+            out += this.aggregate.toString();
+        }
+        return out;
+    }
+}

--- a/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Mask.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Mask.java
@@ -3,11 +3,21 @@ package ch.epfl.dedis.lib.crypto;
 import ch.epfl.dedis.lib.Hex;
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 
+/**
+ * Mask is a bitmask for a set of points.
+ */
 public class Mask {
     private final byte[] mask;
     private final Point[] publics;
-    private Point aggregate = null;
+    private Point aggregate;
 
+    /**
+     * Create a read-only mask from a set of public keys and the given bitmask.
+     *
+     * @param publics is the set of public keys.
+     * @param mask is the bit mask, the number of bits must be greater or equals to the number of public keys.
+     * @throws CothorityCryptoException is thrown when the list of public keys is empty.
+     */
     Mask(Point[] publics, byte[] mask) throws CothorityCryptoException {
         if (publics.length == 0) {
             throw new CothorityCryptoException("no public keys");
@@ -29,14 +39,26 @@ public class Mask {
         }
     }
 
+    /**
+     * Gets the length of the mask in bytes.
+     */
     public int len() {
         return (this.publics.length + 7) >> 3;
     }
 
+    /**
+     * Gets the aggregate public key according to the mask.
+     */
     public Point getAggregate() {
         return this.aggregate;
     }
 
+    /**
+     * Checks whether the given index is enabled in the mask or not.
+     *
+     * @param i is the index.
+     * @throws IndexOutOfBoundsException when i >= the number of public keys.
+     */
     public boolean indexEnabled(int i) throws IndexOutOfBoundsException {
         if (i >= this.publics.length) {
             throw new IndexOutOfBoundsException();
@@ -46,6 +68,12 @@ public class Mask {
         return ((this.mask[byt] & msk) != 0);
     }
 
+    /**
+     * Checks whether the index, corresponding to the given key, is enabled in the mask or not.
+     *
+     * @param p is the public key.
+     * @throws CothorityCryptoException if the key is not found.
+     */
     public boolean keyEnabled(Point p) throws CothorityCryptoException {
         for (int i = 0; i < this.publics.length; i++) {
             if (this.publics[i].equals(p)) {
@@ -55,6 +83,9 @@ public class Mask {
         throw new CothorityCryptoException("key not found");
     }
 
+    /**
+     * Count the number of enabled public keys in the participation mask.
+     */
     public int countEnabled() {
         // hw is hamming weight
         int hw = 0;
@@ -68,6 +99,9 @@ public class Mask {
         return hw;
     }
 
+    /**
+     * Count the total number of public keys in this mask.
+     */
     public int countTotal() {
         return this.publics.length;
     }

--- a/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Mask.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Mask.java
@@ -15,7 +15,7 @@ public class Mask {
      * Create a read-only mask from a set of public keys and the given bitmask.
      *
      * @param publics is the set of public keys.
-     * @param mask is the bit mask, the number of bits must be greater or equals to the number of public keys.
+     * @param mask is the bit mask, the number of bits must be greater than or equal to the number of public keys.
      * @throws CothorityCryptoException is thrown when the list of public keys is empty.
      */
     Mask(Point[] publics, byte[] mask) throws CothorityCryptoException {

--- a/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Point.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Point.java
@@ -12,6 +12,7 @@ public interface Point {
     Point copy();
     ByteString toProto();
     byte[] toBytes();
+    Point getZero();
 
     @Override
     String toString();

--- a/external/java/src/main/java/ch/epfl/dedis/lib/crypto/bn256/BN.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/crypto/bn256/BN.java
@@ -157,6 +157,14 @@ public class BN {
         }
 
         /**
+         * Set the point to the infinity (zero) point.
+         */
+        public G1 setInfinity() {
+            this.p.setInfinity();
+            return this;
+        }
+
+        /**
          * Checks whether the point is an infinity (zero) point.
          *
          * @return true if the point is at infinity.
@@ -324,6 +332,14 @@ public class BN {
          */
         public G2 neg(G2 a) {
             this.p.negative(a.p);
+            return this;
+        }
+
+        /**
+         * Set the point to the infinity (zero) point.
+         */
+        public G2 setInfinity() {
+            this.p.setInfinity();
             return this;
         }
 

--- a/external/java/src/test/java/ch/epfl/dedis/lib/crypto/Ed25519Test.java
+++ b/external/java/src/test/java/ch/epfl/dedis/lib/crypto/Ed25519Test.java
@@ -167,6 +167,13 @@ class Ed25519Test {
     }
 
     @Test
+    void getZero() {
+        Ed25519KeyPair kp1 = new Ed25519KeyPair();
+        assertFalse(kp1.point.isZero());
+        assertTrue(kp1.point.getZero().isZero());
+    }
+
+    @Test
     void testEncryption() throws Exception {
         byte[] orig = "My cool file".getBytes();
         byte[] symmetricKey = new byte[16];

--- a/external/java/src/test/java/ch/epfl/dedis/lib/crypto/MaskTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/lib/crypto/MaskTest.java
@@ -1,0 +1,99 @@
+package ch.epfl.dedis.lib.crypto;
+
+import ch.epfl.dedis.lib.crypto.bn256.BN;
+import org.junit.jupiter.api.Test;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MaskTest {
+
+    private Point[] publics;
+    private Random rnd = new SecureRandom();
+    private int n = 9;
+
+    MaskTest() {
+        List<Point> ps = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            ps.add(new Bn256G2Point(BN.G2.rand(rnd).getPoint()));
+        }
+        publics = ps.toArray(new Point[0]);
+    }
+
+    @Test
+    void len() throws Exception {
+        Mask mask = new Mask(publics, new byte[]{0,0});
+        assertEquals(2, mask.len(), "invalid size");
+    }
+
+    @Test
+    void getAggregate() throws Exception {
+        Mask mask = new Mask(publics, new byte[]{0,0});
+        assertTrue(mask.getAggregate().isZero(),"aggregate should be zero when the mask is not set");
+
+        mask = new Mask(publics, new byte[]{1, 0});
+        assertFalse(mask.getAggregate().isZero(),"aggregate should not be zero");
+        assertEquals(publics[0], mask.getAggregate());
+
+        mask = new Mask(publics, new byte[]{(byte)255, (byte)255});
+        assertFalse(mask.getAggregate().isZero(),"aggregate should not be zero");
+    }
+
+    @Test
+    void indexEnabled() throws Exception {
+        Mask mask = new Mask(publics, new byte[]{(byte)255, (byte)255});
+        for (int i = 0; i < this.publics.length; i++) {
+            assertTrue(mask.indexEnabled(i), "not enabled: " + i);
+        }
+        mask = new Mask(publics, new byte[]{0,0});
+        for (int i = 0; i < this.publics.length; i++) {
+            assertFalse(mask.indexEnabled(i), "should be enabled: " + i);
+        }
+    }
+
+    @Test
+    void keyEnabled() throws Exception {
+        Mask mask = new Mask(publics, new byte[]{(byte)255, (byte)255});
+        for (Point p : this.publics) {
+            assertTrue(mask.keyEnabled(p), "should be enabled");
+        }
+
+        mask = new Mask(publics, new byte[]{0, 0});
+        for (Point p : this.publics) {
+            assertFalse(mask.keyEnabled(p), "should not be enabled");
+        }
+    }
+
+    @Test
+    void countEnabled() throws Exception {
+        // enable all
+        Mask mask = new Mask(publics, new byte[]{(byte)255, (byte)255});
+        assertEquals(n, mask.countEnabled());
+
+        // disable one
+        mask = new Mask(publics, new byte[]{(byte)254, (byte)255});
+        assertEquals(n-1, mask.countEnabled());
+
+        // disable another one
+        mask = new Mask(publics, new byte[]{(byte)255, (byte)0});
+        assertEquals(n-1, mask.countEnabled());
+
+        // disable all
+        mask = new Mask(publics, new byte[]{0,0});
+        assertEquals(0, mask.countEnabled());
+    }
+
+    @Test
+    void countTotal() throws Exception {
+        Mask mask = new Mask(publics, new byte[]{0,0});
+        assertEquals(mask.countTotal(), n);
+
+        mask = new Mask(Arrays.copyOf(publics, n-1), new byte[]{0});
+        assertEquals(mask.countTotal(), n-1);
+    }
+}

--- a/external/java/src/test/java/ch/epfl/dedis/lib/crypto/bn256/BNTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/lib/crypto/bn256/BNTest.java
@@ -288,4 +288,19 @@ class BNTest {
         BN.GT e12 = new BN.GT();
         assertNotEquals(e12, e1);
     }
+
+    @Test
+    void setZero() {
+        Random rnd = new SecureRandom();
+
+        BN.G1 g1 = new BN.G1(BN.randPosBigInt(rnd, Constants.p));
+        assertFalse(g1.isInfinity());
+        g1.setInfinity();
+        assertTrue(g1.isInfinity());
+
+        BN.G2 g2 = new BN.G2(BN.randPosBigInt(rnd, Constants.p));
+        assertFalse(g2.isInfinity());
+        g2.setInfinity();
+        assertTrue(g2.isInfinity());
+    }
 }


### PR DESCRIPTION
The consequence of implementing the mask is that we need to add a
getZero method to the Point interface. Because we need to start from the
zero point when doing the aggregate.

The isZero function of ed25519 is updated to match what is in Kyber, not
completely sure what the consequences are but the tests are passing.

Waiting for https://github.com/dedis/cothority/pull/1640