### PR TITLE
Java trie verification

### DIFF
--- a/byzcoin/trie/proof.go
+++ b/byzcoin/trie/proof.go
@@ -34,7 +34,7 @@ func (p *Proof) Exists(key []byte) (bool, error) {
 
 	var i int
 	for i = range p.Interiors {
-		if !bytes.Equal(p.Interiors[i].hash(), expectedHash) {
+		if !bytes.Equal(expectedHash, p.Interiors[i].hash()) {
 			return false, errors.New("invalid hash chain")
 		}
 		if bits[i] {

--- a/external/java/src/main/java/ch/epfl/dedis/byzcoin/ByzCoinRPC.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzcoin/ByzCoinRPC.java
@@ -564,12 +564,18 @@ public class ByzCoinRPC {
         if (!proof.isContract("config", skipchainId)) {
             throw new CothorityNotFoundException("couldn't verify proof for genesisConfiguration");
         }
+        if (!proof.exists(InstanceId.zero().getId())) {
+            throw new CothorityNotFoundException("config instance does not exist");
+        }
         ByzCoinRPC bc = new ByzCoinRPC();
         bc.config = new Config(proof.getValue());
 
         Proof proof2 = ByzCoinRPC.getProof(roster, skipchainId, new InstanceId(proof.getDarcID().getId()));
         if (!proof2.isContract(DarcInstance.ContractId, skipchainId)) {
             throw new CothorityNotFoundException("couldn't verify proof for genesisConfiguration");
+        }
+        if (!proof2.exists(proof.getDarcID().getId())) {
+            throw new CothorityNotFoundException("darc instance does not exist");
         }
         try {
             bc.genesisDarc = new Darc(proof2.getValue());

--- a/external/java/src/main/java/ch/epfl/dedis/byzcoin/ByzCoinRPC.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzcoin/ByzCoinRPC.java
@@ -611,12 +611,13 @@ public class ByzCoinRPC {
 
     /**
      * Static method to request a proof from ByzCoin. This is used in the instantiation method.
+     * The returned proof is not verified. Please call Proof.verify.
      *
      * @param roster      where to contact the cothority
      * @param skipchainId the id of the underlying skipchain
      * @param key         which key we're interested in
      * @return a proof pointing to the instance. The proof can also be a proof that the instance does not exist.
-     * @throws CothorityCommunicationException
+     * @throws CothorityCommunicationException if there is an error in getting the proof
      */
     private static Proof getProof(Roster roster, SkipblockId skipchainId, InstanceId key) throws CothorityCommunicationException {
         ByzCoinProto.GetProof.Builder configBuilder = ByzCoinProto.GetProof.newBuilder();

--- a/external/java/src/main/java/ch/epfl/dedis/byzcoin/Instance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzcoin/Instance.java
@@ -3,7 +3,6 @@ package ch.epfl.dedis.byzcoin;
 import ch.epfl.dedis.lib.darc.DarcId;
 import ch.epfl.dedis.lib.exception.CothorityCommunicationException;
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
-import ch.epfl.dedis.lib.exception.CothorityException;
 import ch.epfl.dedis.lib.exception.CothorityNotFoundException;
 
 import java.util.List;
@@ -20,12 +19,13 @@ public class Instance {
 
     /**
      * Creates a new instance from its basic parameters.
-     * @param id the id of the instance
-     * @param cid the contractId, a string
-     * @param did the darcId responsible for this instance
+     *
+     * @param id   the id of the instance
+     * @param cid  the contractId, a string
+     * @param did  the darcId responsible for this instance
      * @param data the data stored in this instance
      */
-    private Instance(InstanceId id, String cid, DarcId did, byte[] data){
+    private Instance(InstanceId id, String cid, DarcId did, byte[] data) {
         this.id = id;
         contractId = cid;
         darcId = did;
@@ -36,11 +36,11 @@ public class Instance {
      * Creates an instance from a proof received from ByzCoin.
      *
      * @param p the proof for the instance
-     * @throws CothorityNotFoundException if the proof is not found
      * @return a new Instance
+     * @throws CothorityNotFoundException if the proof is not found
      */
     public static Instance fromProof(Proof p) throws CothorityNotFoundException {
-        if (!p.matches()){
+        if (!p.matches()) {
             throw new CothorityNotFoundException("this is a proof of absence");
         }
         StateChangeBody body = p.getValues();
@@ -54,10 +54,15 @@ public class Instance {
      * @param id a valid instance id
      * @return a new Instance
      * @throws CothorityCommunicationException if something goes wrong
-     * @throws CothorityNotFoundException if the requested instance cannot be found
+     * @throws CothorityNotFoundException      if the requested instance cannot be found
+     * @throws CothorityCryptoException        if something is wrong with the proof
      */
-    public static Instance fromByzcoin(ByzCoinRPC bc, InstanceId id) throws CothorityCommunicationException, CothorityNotFoundException{
-        return fromProof(bc.getProof(id));
+    public static Instance fromByzcoin(ByzCoinRPC bc, InstanceId id) throws CothorityCommunicationException, CothorityNotFoundException, CothorityCryptoException {
+        Proof p = bc.getProof(id);
+        if (!p.exists(id.getId())) {
+            throw new CothorityCryptoException("instance is not in proof");
+        }
+        return fromProof(p);
     }
 
     /**
@@ -77,7 +82,9 @@ public class Instance {
     /**
      * @return the darcid of this instance
      */
-    public DarcId getDarcId() { return darcId; }
+    public DarcId getDarcId() {
+        return darcId;
+    }
 
     /**
      * @return the data of this instance.

--- a/external/java/src/main/java/ch/epfl/dedis/byzcoin/Proof.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzcoin/Proof.java
@@ -114,16 +114,16 @@ public class Proof {
                 publics = getPoints(this.links.get(i).getNewRoster().getListList());
                 continue;
             }
-            ForwardLink fl = new ForwardLink(this.links.get(i));
-            if (!fl.verify(publics)) {
+            ForwardLink l = new ForwardLink(this.links.get(i));
+            if (!l.verify(publics)) {
                 throw new CothorityCryptoException("stored skipblock is not properly evolved from genesis block");
             }
-            if (!Arrays.equals(fl.getFrom().getId(), sbID.getId())) {
+            if (!Arrays.equals(l.getFrom().getId(), sbID.getId())) {
                 throw new CothorityCryptoException("stored skipblock is not properly evolved from genesis block");
             }
-            sbID = fl.getTo();
+            sbID = l.getTo();
             try {
-                if (fl.getNewRoster() != null) {
+                if (l.getNewRoster() != null) {
                     publics = getPoints(this.links.get(i).getNewRoster().getListList());
                 }
             } catch (URISyntaxException e) {
@@ -175,20 +175,6 @@ public class Proof {
      */
     public DarcId getDarcID() {
         return getValues().getDarcId();
-    }
-
-    private static List<Point> getPoints(List<NetworkProto.ServerIdentity> protos) throws CothorityCryptoException {
-        List<ServerIdentity> sids = new ArrayList<>();
-        for (NetworkProto.ServerIdentity sid : protos) {
-            try {
-                sids.add(new ServerIdentity(sid));
-            } catch (URISyntaxException e) {
-                throw new CothorityCryptoException(e.getMessage());
-            }
-        }
-        return sids.stream()
-                .map(sid -> (Bn256G2Point) sid.getServicePublic("Skipchain"))
-                .collect(Collectors.toList());
     }
 
     /**
@@ -337,5 +323,19 @@ public class Proof {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static List<Point> getPoints(List<NetworkProto.ServerIdentity> protos) throws CothorityCryptoException {
+        List<ServerIdentity> sids = new ArrayList<>();
+        for (NetworkProto.ServerIdentity sid : protos) {
+            try {
+                sids.add(new ServerIdentity(sid));
+            } catch (URISyntaxException e) {
+                throw new CothorityCryptoException(e.getMessage());
+            }
+        }
+        return sids.stream()
+                .map(sid -> (Bn256G2Point) sid.getServicePublic("Skipchain"))
+                .collect(Collectors.toList());
     }
 }

--- a/external/java/src/main/java/ch/epfl/dedis/byzcoin/Proof.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzcoin/Proof.java
@@ -230,7 +230,7 @@ public class Proof {
         int i;
         for (i = 0; i < this.proof.getInteriorsCount(); i++) {
             if (!Arrays.equals(expectedHash, hashInterior(this.proof.getInteriors(i)))) {
-                return false;
+                throw new CothorityCryptoException("invalid interior node");
             }
             if (bits[i]) {
                 expectedHash = this.proof.getInteriors(i).getLeft().toByteArray();
@@ -250,7 +250,7 @@ public class Proof {
             }
             return false;
         }
-        return false;
+        throw new CothorityCryptoException("no corresponding leaf/empty node with respect to the interior nodes");
     }
 
     private static Boolean[] binSlice(byte[] buf) {

--- a/external/java/src/main/java/ch/epfl/dedis/byzcoin/Proof.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzcoin/Proof.java
@@ -2,16 +2,29 @@ package ch.epfl.dedis.byzcoin;
 
 import ch.epfl.dedis.lib.SkipBlock;
 import ch.epfl.dedis.lib.SkipblockId;
+import ch.epfl.dedis.lib.crypto.Bn256G2Point;
+import ch.epfl.dedis.lib.crypto.Point;
 import ch.epfl.dedis.lib.darc.DarcId;
 import ch.epfl.dedis.lib.exception.CothorityCryptoException;
 import ch.epfl.dedis.lib.exception.CothorityException;
 import ch.epfl.dedis.lib.exception.CothorityNotFoundException;
+import ch.epfl.dedis.lib.network.ServerIdentity;
+import ch.epfl.dedis.lib.proto.NetworkProto;
 import ch.epfl.dedis.lib.proto.TrieProto;
 import ch.epfl.dedis.lib.proto.ByzCoinProto;
 import ch.epfl.dedis.lib.proto.SkipchainProto;
+import ch.epfl.dedis.skipchain.ForwardLink;
 import com.google.protobuf.InvalidProtocolBufferException;
 
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Proof represents a key/value entry in the trie and the path to the
@@ -42,12 +55,13 @@ public class Proof {
      * @return the instance stored in this proof - it will not verify if the proof is valid!
      * @throws CothorityNotFoundException if the requested instance cannot be found
      */
-    public Instance getInstance() throws CothorityNotFoundException{
+    public Instance getInstance() throws CothorityNotFoundException {
         return Instance.fromProof(this);
     }
 
     /**
      * Get the protobuf representation of the proof.
+     *
      * @return the protobuf representation of the proof
      */
     public ByzCoinProto.Proof toProto() {
@@ -62,6 +76,7 @@ public class Proof {
 
     /**
      * accessor for the skipblock assocaited with this proof.
+     *
      * @return SkipBlock
      */
     public SkipBlock getLatest() {
@@ -74,16 +89,53 @@ public class Proof {
      * leaf. At the end it will verify against the root hash to make sure
      * that the inclusion proof is correct.
      *
-     * @param id the skipblock to verify
+     * @param scID the skipblock to verify
      * @return true if all checks verify, false if there is a mismatch in the hashes
      * @throws CothorityException if something goes wrong
      */
-    public boolean verify(SkipblockId id) throws CothorityException {
-        if (!isByzCoinProof()){
-            return false;
+    public void verify(SkipblockId scID) throws CothorityException {
+        ByzCoinProto.DataHeader header;
+        try {
+            header = ByzCoinProto.DataHeader.parseFrom(this.latest.getData());
+        } catch (InvalidProtocolBufferException e) {
+            throw new CothorityCryptoException(e.getMessage());
         }
-        // TODO: more verifications
-        return true;
+        if (!Arrays.equals(this.getRoot(), header.getTrieroot().toByteArray())) {
+            throw new CothorityCryptoException("root of trie is not in skipblock");
+        }
+
+        SkipblockId sbID = null;
+        List<Point> publics = null;
+
+        for (int i = 0; i < this.links.size(); i++) {
+            if (i == 0) {
+                sbID = scID;
+                publics = getPoints(this.links.get(i).getNewRoster().getListList());
+                continue;
+            }
+            ForwardLink fl = new ForwardLink(this.links.get(i));
+            if (!fl.verify(publics)) {
+                throw new CothorityCryptoException("stored skipblock is not properly evolved from genesis block");
+            }
+            if (!Arrays.equals(fl.getFrom().getId(), sbID.getId())) {
+                throw new CothorityCryptoException("stored skipblock is not properly evolved from genesis block");
+            }
+            sbID = fl.getTo();
+            try {
+                if (fl.getNewRoster() != null) {
+                    publics = getPoints(this.links.get(i).getNewRoster().getListList());
+                }
+            } catch (URISyntaxException e) {
+                throw new CothorityCryptoException(e.getMessage());
+            }
+        }
+    }
+
+    public byte[] getRoot() {
+        if (this.proof.getInteriorsCount() == 0) {
+            return null;
+        }
+        return hashInterior(this.proof.getInteriors(0));
     }
 
     /**
@@ -91,8 +143,125 @@ public class Proof {
      * is a proof of absence.
      */
     public boolean matches() {
-        // TODO make more verification
-        return proof.getLeaf().hasKey() && !proof.getLeaf().getKey().isEmpty();
+        if (proof.getLeaf().getKey().isEmpty()) {
+            return false;
+        }
+        try {
+            return this.exists(proof.getLeaf().getKey().toByteArray());
+        } catch (CothorityCryptoException e) {
+            return false;
+        }
+    }
+
+    public boolean exists(byte[] key) throws CothorityCryptoException {
+        if (key == null) {
+            throw new CothorityCryptoException("key is nil");
+        }
+
+        if (this.proof.getInteriorsCount() == 0) {
+            throw new CothorityCryptoException("no interior nodes");
+        }
+
+        Boolean[] bits = binSlice(key);
+        byte[] expectedHash = hashInterior(this.proof.getInteriors(0));
+
+        int i;
+        for (i = 0; i < this.proof.getInteriorsCount(); i++) {
+            if (!Arrays.equals(expectedHash, hashInterior(this.proof.getInteriors(i)))) {
+                return false;
+            }
+            if (bits[i]) {
+                expectedHash = this.proof.getInteriors(i).getLeft().toByteArray();
+            } else {
+                expectedHash = this.proof.getInteriors(i).getRight().toByteArray();
+            }
+        }
+        // we use i below instead of i+1 (like the go code) because the final i is one more than the i used in the final iteration
+        if (Arrays.equals(expectedHash, hashLeaf(this.proof.getLeaf(), this.proof.getNonce().toByteArray()))) {
+            if (!Arrays.equals(Arrays.copyOf(bits, i), this.proof.getLeaf().getPrefixList().toArray(new Boolean[0]))) {
+                throw new CothorityCryptoException("invalid prefix in leaf node");
+            }
+            return Arrays.equals(this.proof.getLeaf().getKey().toByteArray(), key);
+        } else if (Arrays.equals(expectedHash, hashEmpty(this.proof.getEmpty(), this.proof.getNonce().toByteArray()))) {
+            if (!Arrays.equals(Arrays.copyOf(bits, i), this.proof.getEmpty().getPrefixList().toArray(new Boolean[0]))) {
+                throw new CothorityCryptoException("invalid prefix in empty node");
+            }
+            return false;
+        }
+        return false;
+    }
+
+    private static Boolean[] binSlice(byte[] buf) {
+        byte[] hashKey;
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(buf);
+            hashKey = digest.digest();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+
+        Boolean[] bits = new Boolean[hashKey.length * 8];
+        for (int i = 0; i < bits.length; i++) {
+            bits[i] = ((hashKey[i / 8] << (i % 8)) & (1 << 7)) > 0;
+        }
+        return bits;
+    }
+
+    private static byte[] toByteSlice(List<Boolean> bits) {
+        byte[] buf = new byte[(bits.size() + 7) / 8];
+        for (int i = 0; i < bits.size(); i++) {
+            if (bits.get(i)) {
+                buf[i / 8] |= (1 << 7) >> (i % 8);
+            }
+        }
+        return buf;
+    }
+
+    private static byte[] hashInterior(TrieProto.InteriorNode interior) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(interior.getLeft().toByteArray());
+            digest.update(interior.getRight().toByteArray());
+            return digest.digest();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static byte[] hashLeaf(TrieProto.LeafNode leaf, byte[] nonce) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(new byte[]{3}); // typeLeaf
+            digest.update(nonce);
+            digest.update(toByteSlice(leaf.getPrefixList()));
+
+            byte[] lBuf = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(leaf.getPrefixCount()).array();
+            digest.update(lBuf);
+
+            digest.update(leaf.getKey().toByteArray());
+            digest.update(leaf.getValue().toByteArray());
+
+            return digest.digest();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static byte[] hashEmpty(TrieProto.EmptyNode empty, byte[] nonce) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(new byte[]{2}); // typeEmpty
+            digest.update(nonce);
+            digest.update(toByteSlice(empty.getPrefixList()));
+
+            byte[] lBuf = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(empty.getPrefixCount()).array();
+            digest.update(lBuf);
+
+            return digest.digest();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
@@ -112,14 +281,14 @@ public class Proof {
     /**
      * @return the value of the proof.
      */
-    public byte[] getValue(){
+    public byte[] getValue() {
         return getValues().getValue();
     }
 
     /**
      * @return the string of the contractID.
      */
-    public String getContractID(){
+    public String getContractID() {
         return new String(getValues().getContractID());
     }
 
@@ -127,49 +296,34 @@ public class Proof {
      * @return the darcID defining the access rules to the instance.
      * @throws CothorityCryptoException if there's a problem with the cryptography
      */
-    public DarcId getDarcID() throws CothorityCryptoException{
+    public DarcId getDarcID() throws CothorityCryptoException {
         return getValues().getDarcId();
     }
 
-    /**
-     * @return true if this looks like a matching proof for byzcoin.
-     */
-    public boolean isByzCoinProof(){
-        if (!matches()) {
-            return false;
+    private static List<Point> getPoints(List<NetworkProto.ServerIdentity> protos) throws CothorityCryptoException {
+        List<ServerIdentity> sids = new ArrayList<>();
+        for (NetworkProto.ServerIdentity sid : protos) {
+            try {
+                sids.add(new ServerIdentity(sid));
+            } catch (URISyntaxException e) {
+                throw new CothorityCryptoException(e.getMessage());
+            }
         }
-        return true;
-    }
-
-    /**
-     * @param expected the string of the expected contract.
-     * @return true if this is a matching byzcoin proof for a contract of the given contract.
-     */
-    public boolean isContract(String expected){
-        if (!isByzCoinProof()){
-            return false;
-        }
-        if (!getContractID().equals(expected)) {
-            return false;
-        }
-        return true;
+        return sids.stream()
+                .map(sid -> (Bn256G2Point) sid.getServicePublic("Skipchain"))
+                .collect(Collectors.toList());
     }
 
     /**
      * Checks if the proof is valid and of type expected.
      *
      * @param expected the expected contractId
-     * @param id the Byzcoin id to verify the proof against
+     * @param id       the Byzcoin id to verify the proof against
      * @return true if the proof is correct with regard to that Byzcoin id and the contract is of the expected type.
      * @throws CothorityException if something goes wrong
      */
-    public boolean isContract(String expected, SkipblockId id) throws CothorityException{
-        if (!verify(id)){
-            return false;
-        }
-        if (!isContract(expected)){
-            return false;
-        }
-        return true;
+    public boolean isContract(String expected, SkipblockId id) throws CothorityException {
+        verify(id);
+        return getContractID().equals(expected);
     }
 }

--- a/external/java/src/main/java/ch/epfl/dedis/byzcoin/contracts/ChainConfigInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzcoin/contracts/ChainConfigInstance.java
@@ -52,8 +52,9 @@ public class ChainConfigInstance {
      *
      * @throws CothorityNotFoundException      if the chainConfiguration couldn't be found in ByzCoin
      * @throws CothorityCommunicationException if there was an communication error
+     * @throws CothorityCryptoException        if there is something wrong with the proof
      */
-    public void update() throws CothorityCommunicationException, CothorityNotFoundException {
+    public void update() throws CothorityCommunicationException, CothorityNotFoundException, CothorityCryptoException {
         instance = Instance.fromByzcoin(bc, instance.getId());
         chainConfig = new ChainConfigData(instance);
     }
@@ -136,8 +137,9 @@ public class ChainConfigInstance {
      * @return the new ValueInstance
      * @throws CothorityNotFoundException      if the configuration is not where it is supposed to be
      * @throws CothorityCommunicationException if the communication throws an error
+     * @throws CothorityCryptoException        if there is something wrong with the proof
      */
-    public static ChainConfigInstance fromByzcoin(ByzCoinRPC bc) throws CothorityNotFoundException, CothorityCommunicationException {
+    public static ChainConfigInstance fromByzcoin(ByzCoinRPC bc) throws CothorityNotFoundException, CothorityCommunicationException, CothorityCryptoException {
         return new ChainConfigInstance(bc, Instance.fromByzcoin(bc, new InstanceId(new byte[32])));
     }
 
@@ -147,10 +149,9 @@ public class ChainConfigInstance {
      * @param bc a running ByzCoin service
      * @param p  the proof for the valueInstance
      * @return the new ValueInstance
-     * @throws CothorityNotFoundException      if the configuration is not where it is supposed to be
-     * @throws CothorityCommunicationException if the communication throws an error
+     * @throws CothorityNotFoundException if the configuration is not where it is supposed to be
      */
-    public static ChainConfigInstance fromByzcoin(ByzCoinRPC bc, Proof p) throws CothorityNotFoundException, CothorityCommunicationException {
+    public static ChainConfigInstance fromByzcoin(ByzCoinRPC bc, Proof p) throws CothorityNotFoundException {
         return new ChainConfigInstance(bc, Instance.fromProof(p));
     }
 }

--- a/external/java/src/main/java/ch/epfl/dedis/byzcoin/contracts/DarcInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzcoin/contracts/DarcInstance.java
@@ -212,7 +212,11 @@ public class DarcInstance {
                 throw new CothorityCommunicationException("this is not a correct darc-spawn");
             }
         }
-        return bc.getProof(iid);
+        Proof p = bc.getProof(iid);
+        if (!p.exists(iid.getId())) {
+            throw new CothorityCryptoException("instance is not in proof");
+        }
+        return p;
     }
 
     /**

--- a/external/java/src/main/java/ch/epfl/dedis/calypso/CalypsoRPC.java
+++ b/external/java/src/main/java/ch/epfl/dedis/calypso/CalypsoRPC.java
@@ -42,8 +42,7 @@ public class CalypsoRPC extends ByzCoinRPC {
         LTSInstance inst = new LTSInstance(this, darcId, ltsRoster, signers, signerCtrs);
         Proof proof = inst.getProof();
         // Start the LTS/DKG protocol.
-        CreateLTSReply lts = createLTS(proof);
-        this.lts = lts;
+        this.lts = createLTS(proof);
     }
 
     /**

--- a/external/java/src/main/java/ch/epfl/dedis/calypso/CalypsoRPC.java
+++ b/external/java/src/main/java/ch/epfl/dedis/calypso/CalypsoRPC.java
@@ -40,7 +40,10 @@ public class CalypsoRPC extends ByzCoinRPC {
         super(byzcoin);
         // Send a transaction to store the LTS roster in ByzCoin
         LTSInstance inst = new LTSInstance(this, darcId, ltsRoster, signers, signerCtrs);
-        Proof proof = inst.getProof();
+        Proof proof = inst.getProofAndVerify();
+        if (!proof.exists(inst.getInstance().getId().getId())) {
+            throw new CothorityCryptoException("instance is not in the proof");
+        }
         // Start the LTS/DKG protocol.
         this.lts = createLTS(proof);
     }

--- a/external/java/src/main/java/ch/epfl/dedis/calypso/ReadInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/calypso/ReadInstance.java
@@ -107,6 +107,11 @@ public class ReadInstance {
     public byte[] decryptKeyMaterial(Scalar reader) throws CothorityException {
         Proof readProof = calypso.getProof(getInstance().getId());
         Proof writeProof = calypso.getProof(getRead().getWriteId());
+
+        if (!readProof.exists(getInstance().getId().getId()) || !writeProof.exists(getRead().getWriteId().getId())) {
+            throw new CothorityCryptoException("proofs are invalid");
+        }
+
         DecryptKeyReply dk = calypso.tryDecrypt(writeProof, readProof);
         return dk.getKeyMaterial(reader);
     }
@@ -168,7 +173,11 @@ public class ReadInstance {
      * @throws CothorityException if something goes wrong
      */
     private static Instance getInstance(CalypsoRPC calypso, InstanceId id) throws CothorityException {
-        Instance inst = calypso.getProof(id).getInstance();
+        Proof p = calypso.getProof(id);
+        if (!p.exists(id.getId())) {
+            throw new CothorityNotFoundException("instance is not in the proof");
+        }
+        Instance inst = p.getInstance();
         if (!inst.getContractId().equals(ContractId)) {
             logger.error("wrong contractId: {}", inst.getContractId());
             throw new CothorityNotFoundException("this is not an " + ContractId + " instance");

--- a/external/java/src/main/java/ch/epfl/dedis/calypso/WriteData.java
+++ b/external/java/src/main/java/ch/epfl/dedis/calypso/WriteData.java
@@ -73,10 +73,11 @@ public class WriteData {
      * @param bc a running Byzcoin service
      * @param id an instanceId of a WriteInstance
      * @throws CothorityNotFoundException if the requested instance cannot be found
-     * @throws CothorityCommunicationException if something went wrong
+     * @throws CothorityCommunicationException if something went wrong with the communication
+     * @throws CothorityCryptoException if there is something wrong with the proof
      * @return the new WriteData
      */
-    public static WriteData fromByzcoin(ByzCoinRPC bc, InstanceId id) throws CothorityNotFoundException, CothorityCommunicationException {
+    public static WriteData fromByzcoin(ByzCoinRPC bc, InstanceId id) throws CothorityNotFoundException, CothorityCommunicationException, CothorityCryptoException {
         return WriteData.fromInstance(Instance.fromByzcoin(bc, id));
     }
 

--- a/external/java/src/main/java/ch/epfl/dedis/calypso/WriteInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/calypso/WriteInstance.java
@@ -2,6 +2,7 @@ package ch.epfl.dedis.calypso;
 
 import ch.epfl.dedis.byzcoin.Instance;
 import ch.epfl.dedis.byzcoin.InstanceId;
+import ch.epfl.dedis.byzcoin.Proof;
 import ch.epfl.dedis.byzcoin.transaction.Argument;
 import ch.epfl.dedis.byzcoin.transaction.ClientTransaction;
 import ch.epfl.dedis.byzcoin.transaction.Instruction;
@@ -130,7 +131,11 @@ public class WriteInstance {
 
     // TODO same as what's in EventLogInstance, make a super class?
     private Instance getInstance(InstanceId id) throws CothorityException {
-        Instance inst = calypso.getProof(id).getInstance();
+        Proof p = calypso.getProof(id);
+        if (!p.exists(id.getId())) {
+            throw new CothorityNotFoundException("instance is not in the proof");
+        }
+        Instance inst = p.getInstance();
         if (!inst.getContractId().equals(ContractId)) {
             logger.error("wrong contractId: {}", inst.getContractId());
             throw new CothorityNotFoundException("this is not an " + ContractId + " instance");

--- a/external/java/src/main/java/ch/epfl/dedis/eventlog/EventLogInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/eventlog/EventLogInstance.java
@@ -127,11 +127,8 @@ public class EventLogInstance {
      */
     public Event get(InstanceId key) throws CothorityException {
         Proof p = bc.getProof(key);
-        if (!p.matches()) {
-            throw new CothorityCryptoException("key does not exist");
-        }
-        if (!Arrays.equals(p.getKey(), key.getId())) {
-            throw new CothorityCryptoException("wrong key");
+        if (!p.exists(key.getId())) {
+            throw new CothorityCryptoException("event does not exist");
         }
         StateChangeBody body = p.getValues();
         try {

--- a/external/java/src/main/java/ch/epfl/dedis/lib/SkipBlock.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/SkipBlock.java
@@ -7,7 +7,6 @@ import ch.epfl.dedis.lib.network.Roster;
 import ch.epfl.dedis.skipchain.ForwardLink;
 import ch.epfl.dedis.lib.proto.SkipchainProto;
 import ch.epfl.dedis.skipchain.SkipchainRPC;
-import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import java.net.URISyntaxException;

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/ByzCoinRPCTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/ByzCoinRPCTest.java
@@ -67,10 +67,9 @@ class ByzCoinRPCTest {
 
         // Then make a transaction, and we should see a new block, here it's just a darc evolution
         SignerCounters counters = bc.getSignerCounters(Collections.singletonList(admin.getIdentity().toString()));
-        bc.getGenesisDarcInstance().evolveDarcAndWait(bc.getGenesisDarc(), admin, counters.head()+1, 0);
+        bc.getGenesisDarcInstance().evolveDarcAndWait(bc.getGenesisDarc(), admin, counters.head()+1, 10);
 
         // Update again should give us a different block
-        Thread.sleep(2 * bc.getConfig().getBlockInterval().toMillis());
         assertNotEquals(bc.getLatestBlock().getId(), this.bc.getGenesisBlock().getId());
 
         // Getting the block should work

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/ByzCoinRPCTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/ByzCoinRPCTest.java
@@ -82,6 +82,18 @@ class ByzCoinRPCTest {
         assertTrue(newGenesis.getForwardLinks().size() > 0);
     }
 
+    @Test
+    void getProof() throws Exception {
+        // Then make a transaction so we can do something with the proof.
+        SignerCounters counters = bc.getSignerCounters(Collections.singletonList(admin.getIdentity().toString()));
+        bc.getGenesisDarcInstance().evolveDarcAndWait(bc.getGenesisDarc(), admin, counters.head()+1, 0);
+
+        // Get one Proof.
+        InstanceId inst = bc.getGenesisDarcInstance().getInstance().getId();
+        Proof p = bc.getProof(inst);
+        assertTrue(p.exists(inst.getId()));
+    }
+
     /**
      * We only give the client the roster and the genesis ID. It should be able to find the configuration, latest block
      * and the genesis darc.

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/ProofTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/ProofTest.java
@@ -1,0 +1,115 @@
+package ch.epfl.dedis.byzcoin;
+
+import ch.epfl.dedis.byzcoin.contracts.DarcInstance;
+import ch.epfl.dedis.integration.TestServerController;
+import ch.epfl.dedis.integration.TestServerInit;
+import ch.epfl.dedis.lib.SkipblockId;
+import ch.epfl.dedis.lib.darc.Darc;
+import ch.epfl.dedis.lib.darc.DarcId;
+import ch.epfl.dedis.lib.darc.Signer;
+import ch.epfl.dedis.lib.darc.SignerEd25519;
+import ch.epfl.dedis.lib.exception.CothorityCommunicationException;
+import ch.epfl.dedis.lib.exception.CothorityCryptoException;
+import ch.epfl.dedis.lib.proto.ByzCoinProto;
+import ch.epfl.dedis.lib.proto.TrieProto;
+import com.google.protobuf.ByteString;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProofTest {
+    private ByzCoinRPC bc;
+    private Signer admin;
+
+    @BeforeEach
+    void initAll() throws Exception {
+        TestServerController testInstanceController = TestServerInit.getInstance();
+        admin = new SignerEd25519();
+        Darc genesisDarc = ByzCoinRPC.makeGenesisDarc(admin, testInstanceController.getRoster());
+
+        bc = new ByzCoinRPC(testInstanceController.getRoster(), genesisDarc, Duration.of(1000, MILLIS));
+        if (!bc.checkLiveness()) {
+            throw new CothorityCommunicationException("liveness check failed");
+        }
+    }
+
+    @Test
+    void test() throws Exception {
+        // create a bunch of blocks
+        SignerCounters counters = bc.getSignerCounters(Collections.singletonList(admin.getIdentity().toString()));
+        DarcInstance gi = bc.getGenesisDarcInstance();
+        List<DarcId> ids = new ArrayList<>();
+        int n = 4;
+        for (int i = 0; i < n; i++) {
+            Signer newSigner = new SignerEd25519();
+            Darc newDarc = new Darc(Collections.singletonList(newSigner.getIdentity()),
+                    Collections.singletonList(newSigner.getIdentity()),
+                    ("new darc" + i).getBytes());
+            // we wait so that there are more blocks
+            gi.spawnDarcAndWait(newDarc, admin, counters.head()+1+i, 10);
+            ids.add(newDarc.getBaseId());
+        }
+
+        // get the proof for all the darcs, it should pass
+        for (DarcId id : ids) {
+            Proof p = bc.getProof(new InstanceId(id.getId()));
+            assertTrue(p.exists(id.getId()));
+        }
+
+        // get proof for something that doesn't exist, it should return false but should not throw
+        InstanceId badId = new InstanceId("aaaaaaaabbbbbbbbccccccccdddddddd".getBytes());
+        assertFalse(bc.getProof(badId).exists(badId.getId()));
+
+        // if the skipchain ID is wrong, it should fail
+        Proof p = bc.getProof(new InstanceId(ids.get(0).getId()));
+        assertThrows(CothorityCryptoException.class, () ->
+                new Proof(p.toProto(), new SkipblockId(new byte[32])));
+
+        // useful variables for constructing a bad proof
+        TrieProto.Proof inclusionProof = p.toProto().getInclusionproof();
+        TrieProto.LeafNode leaf = inclusionProof.getLeaf();
+        TrieProto.InteriorNode interior1 = inclusionProof.getInteriors(1);
+        List<Boolean> prefixList = leaf.getPrefixList();
+        assertTrue(prefixList.size() > 0);
+
+        // take one proof and modify the leaf, existence check throw
+        ByzCoinProto.Proof badProtoProof = p.toProto().toBuilder()
+                .setInclusionproof(inclusionProof.toBuilder()
+                        .setLeaf(leaf.toBuilder()
+                                .setKey(ByteString.copyFrom("abcdefg".getBytes()))))
+                .build();
+        assertThrows(CothorityCryptoException.class, () -> new Proof(badProtoProof, bc.getGenesisBlock().getId()).exists(ids.get(0).getId()));
+
+        // no interior nodes
+        ByzCoinProto.Proof badProtoProof2 = p.toProto().toBuilder()
+                .setInclusionproof(inclusionProof.toBuilder()
+                        .clearInteriors())
+                .build();
+        assertThrows(CothorityCryptoException.class, () -> new Proof(badProtoProof2, bc.getGenesisBlock().getId()));
+
+        // take one proof and modify an intermediate, it should fail
+        ByzCoinProto.Proof badProtoProof3 = p.toProto().toBuilder()
+                .setInclusionproof(inclusionProof.toBuilder()
+                        .setInteriors(1, interior1.toBuilder()
+                                .setLeft(ByteString.copyFrom("gauche".getBytes()))))
+                .build();
+        assertThrows(CothorityCryptoException.class, () -> new Proof(badProtoProof3, bc.getGenesisBlock().getId()).exists(ids.get(0).getId()));
+
+        // wrong prefix (we invert the prefix)
+        ByzCoinProto.Proof badProtoProof4 = p.toProto().toBuilder()
+                .setInclusionproof(inclusionProof.toBuilder()
+                        .setLeaf(leaf.toBuilder()
+                                .clearPrefix()
+                                .addAllPrefix(prefixList.stream().map(x -> !x).collect(Collectors.toList()))))
+                .build();
+        assertThrows(CothorityCryptoException.class, () -> new Proof(badProtoProof4, bc.getGenesisBlock().getId()).exists(ids.get(0).getId()));
+    }
+}

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/EventlogTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/EventlogTest.java
@@ -111,6 +111,9 @@ class EventlogTest {
         // check that we can't get an event that doesn't exist
         InstanceId badKey = new InstanceId(Hex.parseHexBinary("CDC4FB0BDD74CD86410DC80C818E7A0DB3C6452C9161CF7C6FC16D00C5CF0DA7"));
         assertThrows(CothorityCryptoException.class, () -> el.get(badKey));
+
+        // Try to reconnect after doing a lot of transactions.
+        ByzCoinRPC.fromByzCoin(bc.getRoster(), bc.getGenesisBlock().getId());
     }
 
     @Test

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/EventlogTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/EventlogTest.java
@@ -5,6 +5,7 @@ import ch.epfl.dedis.integration.TestServerController;
 import ch.epfl.dedis.integration.TestServerInit;
 import ch.epfl.dedis.byzcoin.ByzCoinRPC;
 import ch.epfl.dedis.byzcoin.InstanceId;
+import ch.epfl.dedis.lib.Hex;
 import ch.epfl.dedis.lib.darc.Darc;
 import ch.epfl.dedis.lib.darc.Rules;
 import ch.epfl.dedis.lib.darc.Signer;
@@ -27,6 +28,7 @@ import java.util.List;
 
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EventlogTest {
@@ -91,6 +93,7 @@ class EventlogTest {
             for (InstanceId key : keys) {
                 try {
                     logger.info("ok");
+                    // this checks the trie proofs.
                     Event event2 = el.get(key);
                     assertEquals(event, event2);
                 } catch (CothorityCryptoException e){
@@ -104,6 +107,10 @@ class EventlogTest {
             }
         }
         assertTrue(allOK, "one of the events failed");
+
+        // check that we can't get an event that doesn't exist
+        InstanceId badKey = new InstanceId(Hex.parseHexBinary("CDC4FB0BDD74CD86410DC80C818E7A0DB3C6452C9161CF7C6FC16D00C5CF0DA7"));
+        assertThrows(CothorityCryptoException.class, () -> el.get(badKey));
     }
 
     @Test

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/ValueTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/ValueTest.java
@@ -151,6 +151,4 @@ class ValueTest {
         ClientTransactionId ref = txr.get(0).getClientTransaction().getId();
         assertTrue(txr.get(0).getClientTransaction().getId().equals(txid));
     }
-
-
 }

--- a/external/java/src/test/java/ch/epfl/dedis/calypso/CalypsoTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/calypso/CalypsoTest.java
@@ -438,7 +438,7 @@ class CalypsoTest {
         LTSInstance ltsInst = LTSInstance.fromByzCoin(calypso, calypso.getLTS().getInstanceId());
         ltsInst.reshareLTS(calypso.getRoster(), Collections.singletonList(admin), adminCtrs.getCounters());
         // start the resharing
-        Proof proof = ltsInst.getProof();
+        Proof proof = ltsInst.getProofAndVerify();
         logger.info("starting resharing");
         calypso.reshareLTS(proof);
         // try to write something to make sure it works
@@ -464,7 +464,7 @@ class CalypsoTest {
             ltsInst.reshareLTS(newRoster, Collections.singletonList(admin), adminCtrs.getCounters());
 
             // start the resharing
-            Proof proof = ltsInst.getProof();
+            Proof proof = ltsInst.getProofAndVerify();
             logger.info("starting resharing");
             calypso.reshareLTS(proof);
 

--- a/external/java/src/test/java/ch/epfl/dedis/skipchain/SkipchainRPCTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/skipchain/SkipchainRPCTest.java
@@ -36,6 +36,7 @@ class SkipchainRPCTest {
     void initAll() throws Exception {
         TestServerController testInstanceController = TestServerInit.getInstance();
         Signer admin = new SignerEd25519();
+        // TODO this is not true anymore
         // use a smaller roster because we're going to evolve it later
         Roster roster = new Roster(testInstanceController.getRoster().getNodes().subList(0, 2));
         Darc genesisDarc = ByzCoinRPC.makeGenesisDarc(admin, roster);

--- a/external/java/src/test/java/ch/epfl/dedis/skipchain/SkipchainRPCTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/skipchain/SkipchainRPCTest.java
@@ -36,11 +36,7 @@ class SkipchainRPCTest {
     void initAll() throws Exception {
         TestServerController testInstanceController = TestServerInit.getInstance();
         Signer admin = new SignerEd25519();
-        // TODO this is not true anymore
-        // use a smaller roster because we're going to evolve it later
-        Roster roster = new Roster(testInstanceController.getRoster().getNodes().subList(0, 2));
-        Darc genesisDarc = ByzCoinRPC.makeGenesisDarc(admin, roster);
-
+        Darc genesisDarc = ByzCoinRPC.makeGenesisDarc(admin, testInstanceController.getRoster());
         ByzCoinRPC bc = new ByzCoinRPC(testInstanceController.getRoster(), genesisDarc, Duration.of(1000, MILLIS));
         if (!bc.checkLiveness()) {
             throw new CothorityCommunicationException("liveness check failed");


### PR DESCRIPTION
Port the proof verification code from go to java. There are no tests that are specific for proofs because we don't have the code to construct those proofs. The proof verification is performed implicitly in EventLog.get and ByzCoinRPC.fromByzCoin.

Fixes https://github.com/dedis/cothority/issues/1440