### PR TITLE
Use AES-GCM to encrypt data on Calypso

### DIFF
--- a/external/java/src/main/java/ch/epfl/dedis/calypso/Document.java
+++ b/external/java/src/main/java/ch/epfl/dedis/calypso/Document.java
@@ -34,9 +34,8 @@ public class Document {
      *                    This will be encrypted before the transmission to the skipchain.
      * @param extraData   any public data that will be stored unencrypted on the skipchain.
      * @param publisherId the publisher darc with the rules to create a WriteInstance and a ReadInstance.
-     * @throws CothorityCryptoException if there's a problem with the cryptography
      */
-    public Document(byte[] data, byte[] keyMaterial, byte[] extraData, DarcId publisherId) throws CothorityCryptoException {
+    public Document(byte[] data, byte[] keyMaterial, byte[] extraData, DarcId publisherId) {
         this.data = data;
         this.keyMaterial = keyMaterial;
         this.publisherId = publisherId;
@@ -50,14 +49,12 @@ public class Document {
      * @param data        any data that will be stored encrypted on the skipchain.
      *                    There is a 10MB-limit on how much data can be stored. If you
      *                    need more, this must be a pointer to an off-chain storage.
-     * @param keylen      how long the symmetric symmetricKey should be, in bytes. 16 bytes
-     *                    should be a safe guess for the moment.
      * @param extraData   any public data that will not be encrypted
      * @param publisherId the publisher darc with the rules to create a WriteInstance and a ReadInstance.
      * @throws CothorityCryptoException if there's a problem with the cryptography
      */
-    public Document(byte[] data, int keylen, byte[] extraData, DarcId publisherId) throws CothorityCryptoException {
-        this(data, new Encryption.keyIv(keylen).getKeyMaterial(), extraData, publisherId);
+    public Document(byte[] data, byte[] extraData, DarcId publisherId) throws CothorityCryptoException {
+        this(data, new Encryption.KeyIv().getKeyMaterial(), extraData, publisherId);
     }
 
     /**

--- a/external/java/src/main/java/ch/epfl/dedis/calypso/Document.java
+++ b/external/java/src/main/java/ch/epfl/dedis/calypso/Document.java
@@ -44,16 +44,15 @@ public class Document {
 
     /**
      * Creates a new document from data, creates a new Darc, a symmetric
-     * symmetricKey and encrypts the data using CBC-RSA.
+     * symmetricKey and encrypts the data using AES-GCM.
      *
      * @param data        any data that will be stored encrypted on the skipchain.
      *                    There is a 10MB-limit on how much data can be stored. If you
      *                    need more, this must be a pointer to an off-chain storage.
      * @param extraData   any public data that will not be encrypted
      * @param publisherId the publisher darc with the rules to create a WriteInstance and a ReadInstance.
-     * @throws CothorityCryptoException if there's a problem with the cryptography
      */
-    public Document(byte[] data, byte[] extraData, DarcId publisherId) throws CothorityCryptoException {
+    public Document(byte[] data, byte[] extraData, DarcId publisherId) {
         this(data, new Encryption.KeyIv().getKeyMaterial(), extraData, publisherId);
     }
 
@@ -127,9 +126,8 @@ public class Document {
 
     /**
      * @return the decrypted data stored in this document.
-     * @throws CothorityCryptoException if there's a problem with the cryptography
      */
-    public byte[] getData() throws CothorityCryptoException {
+    public byte[] getData() {
         return data;
     }
 

--- a/external/java/src/main/java/ch/epfl/dedis/calypso/Encryption.java
+++ b/external/java/src/main/java/ch/epfl/dedis/calypso/Encryption.java
@@ -27,9 +27,12 @@ public class Encryption {
         final SecretKeySpec keySpec;
 
         /**
-         * Construct KeyIV from some keyMaterial.
+         * Construct KeyIV from some keyMaterial, which is the concatenation of IV and Key. The IV must not repeat.
+         * If there is no need to use a specific IV and Key, please use the default constructor, and then use
+         * getKeyMaterial to get the keyMaterial.
          *
-         * @param keyMaterial must be 28 bytes, the first 12 bytes is used as the IV, the second 16 bytes is the actual key.
+         * @param keyMaterial must be 28 bytes, the first 12 bytes is used as the IV, the second 16 bytes is the actual
+         *                    key.
          * @throws CothorityCryptoException is something goes wrong.
          */
         public KeyIv(byte[] keyMaterial) throws CothorityCryptoException {
@@ -44,7 +47,7 @@ public class Encryption {
         }
 
         /**
-         * Construct KeyIV with a random key and IV.
+         * Default construct KeyIV with a random key and IV. Use getKeyMaterial to get the keyMaterial back.
          */
         public KeyIv() {
             symmetricKey = new byte[KEY_LENGTH];

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/AuthorizationTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/AuthorizationTest.java
@@ -131,7 +131,7 @@ public class AuthorizationTest {
         documentDarc.addIdentity("spawn:calypsoRead", consumerIdentity, Rules.OR);
         calypso.getGenesisDarcInstance().spawnDarcAndWait(documentDarc, admin, adminCtrs.head()+1, 10);
 
-        Document doc = new Document("ala ma kota".getBytes(), 16, "extra data".getBytes(), documentDarc.getBaseId());
+        Document doc = new Document("ala ma kota".getBytes(), "extra data".getBytes(), documentDarc.getBaseId());
         return doc.spawnWrite(calypso, documentDarc.getBaseId(), publisherSigner, publisherSignerCtr);
     }
 

--- a/external/java/src/test/java/ch/epfl/dedis/byzgen/GrantAccessTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzgen/GrantAccessTest.java
@@ -47,7 +47,7 @@ public class GrantAccessTest {
         SignerCounters counters = calypso.getSignerCounters(Collections.singletonList(superadmin.getIdentity().toString()));
         calypso.getGenesisDarcInstance().spawnDarcAndWait(documentDarc, superadmin, counters.head()+1, 10);
 
-        Document doc = new Document("ala ma kota".getBytes(), 16, "extra data".getBytes(), documentDarc.getBaseId());
+        Document doc = new Document("ala ma kota".getBytes(), "extra data".getBytes(), documentDarc.getBaseId());
         WriteInstance writeInstance = new WriteInstance(calypso, documentDarc.getBaseId(),
                 Arrays.asList(publisherSigner), Collections.singletonList(1L),
                 doc.getWriteData(calypso.getLTS()));
@@ -74,7 +74,7 @@ public class GrantAccessTest {
         DarcInstance documentDarcInstance = calypso.getGenesisDarcInstance().spawnDarcAndWait(documentDarc,
                 superadmin, counters.head()+1, 10);
 
-        Document doc = new Document("ala ma kota".getBytes(), 16, "extra data".getBytes(), documentDarc.getBaseId());
+        Document doc = new Document("ala ma kota".getBytes(), "extra data".getBytes(), documentDarc.getBaseId());
         WriteInstance writeInstance = new WriteInstance(calypso, documentDarc.getBaseId(),
                 Arrays.asList(publisherSigner), Collections.singletonList(1L),
                 doc.getWriteData(calypso.getLTS()));
@@ -108,7 +108,7 @@ public class GrantAccessTest {
         DarcInstance documentDarcInstance = calypso.getGenesisDarcInstance().spawnDarcAndWait(documentDarc,
                 superadmin, counters.head()+1, 10);
 
-        Document doc = new Document("ala ma kota".getBytes(), 16, "extra data".getBytes(), documentDarc.getBaseId());
+        Document doc = new Document("ala ma kota".getBytes(), "extra data".getBytes(), documentDarc.getBaseId());
         WriteInstance writeInstance = new WriteInstance(calypso, documentDarc.getBaseId(),
                 Arrays.asList(publisherSigner), Collections.singletonList(1L),
                 doc.getWriteData(calypso.getLTS()));

--- a/external/java/src/test/java/ch/epfl/dedis/calypso/CalypsoTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/calypso/CalypsoTest.java
@@ -88,7 +88,7 @@ class CalypsoTest {
 
         docData = "https://dedis.ch/secret_document.osd";
         extraData = "created on Monday";
-        doc = new Document(docData.getBytes(), 16, extraData.getBytes(), publisherDarc.getBaseId());
+        doc = new Document(docData.getBytes(), extraData.getBytes(), publisherDarc.getBaseId());
     }
 
     @AfterEach
@@ -104,7 +104,7 @@ class CalypsoTest {
     @Test
     void fullCycleDocument() throws CothorityException{
         // The document is stored in 'doc' and not encrypted yet.
-        Document doc = new Document(docData.getBytes(), 16, extraData.getBytes(), publisherDarc.getBaseId());
+        Document doc = new Document(docData.getBytes(), extraData.getBytes(), publisherDarc.getBaseId());
 
         // First, create an encrypted version of the document. Alternatively one could create
         // an own WriteData from scratch and hand it an already encrypted document.
@@ -183,7 +183,7 @@ class CalypsoTest {
 
     @Test
     void decryptKey() throws Exception {
-        Document doc1 = new Document("this is secret 1".getBytes(), 16, null, publisherDarc.getBaseId());
+        Document doc1 = new Document("this is secret 1".getBytes(), null, publisherDarc.getBaseId());
         WriteInstance w1 = new WriteInstance(calypso, publisherDarc.getBaseId(),
                 Arrays.asList(publisher), Collections.singletonList(1L),
                 doc1.getWriteData(calypso.getLTS()));
@@ -192,7 +192,7 @@ class CalypsoTest {
         Proof pw1 = calypso.getProof(w1.getInstance().getId());
         Proof pr1 = calypso.getProof(r1.getInstance().getId());
 
-        Document doc2 = new Document("this is secret 2".getBytes(), 16, null, publisherDarc.getBaseId());
+        Document doc2 = new Document("this is secret 2".getBytes(), null, publisherDarc.getBaseId());
         WriteInstance w2 = new WriteInstance(calypso, publisherDarc.getBaseId(),
                 Arrays.asList(publisher), Collections.singletonList(3L),
                 doc2.getWriteData(calypso.getLTS()));

--- a/external/java/src/test/java/ch/epfl/dedis/calypso/EncryptionTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/calypso/EncryptionTest.java
@@ -1,0 +1,30 @@
+package ch.epfl.dedis.calypso;
+
+import ch.epfl.dedis.lib.exception.CothorityCryptoException;
+import org.junit.jupiter.api.Test;
+
+import java.security.SecureRandom;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EncryptionTest {
+
+    @Test
+    void test() throws Exception {
+        Random rand = new SecureRandom();
+        byte[] data = "abcdefg".getBytes();
+
+        byte[] shortKeyMaterial = new byte[27];
+        rand.nextBytes(shortKeyMaterial);
+        assertThrows(CothorityCryptoException.class, () -> Encryption.encryptData(data, shortKeyMaterial));
+
+        byte[] keyMaterial = new byte[28];
+        rand.nextBytes(keyMaterial);
+        assertArrayEquals(data, Encryption.decryptData(Encryption.encryptData(data, keyMaterial), keyMaterial));
+
+        byte[] longKeyMaterial = new byte[29];
+        rand.nextBytes(longKeyMaterial);
+        assertThrows(CothorityCryptoException.class, () -> Encryption.encryptData(data, longKeyMaterial));
+    }
+}

--- a/external/java/src/test/java/ch/epfl/dedis/calypso/ReadInstanceTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/calypso/ReadInstanceTest.java
@@ -58,7 +58,7 @@ class ReadInstanceTest {
         }
 
         String secret = "this is a secret";
-        Document doc = new Document(secret.getBytes(), 16, null, genesisDarc.getBaseId());
+        Document doc = new Document(secret.getBytes(), null, genesisDarc.getBaseId());
         w = new WriteInstance(calypso, genesisDarc.getId(),
                 Arrays.asList(admin), Collections.singletonList(2L),
                 doc.getWriteData(calypso.getLTS()));

--- a/external/java/src/test/java/ch/epfl/dedis/calypso/WriteInstanceTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/calypso/WriteInstanceTest.java
@@ -55,7 +55,7 @@ class WriteInstanceTest {
         }
 
         String secret = "this is a secret";
-        Document doc = new Document(secret.getBytes(), 16, null, genesisDarc.getBaseId());
+        Document doc = new Document(secret.getBytes(), null, genesisDarc.getBaseId());
         w = new WriteInstance(calypso, genesisDarc.getId(),
                 Collections.singletonList(admin), Collections.singletonList(2L),
                 doc.getWriteData(calypso.getLTS()));

--- a/external/java/src/test/java/ch/epfl/dedis/lib/crypto/Ed25519Test.java
+++ b/external/java/src/test/java/ch/epfl/dedis/lib/crypto/Ed25519Test.java
@@ -8,7 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.crypto.Cipher;
-import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.SecureRandom;
 
@@ -176,19 +176,19 @@ class Ed25519Test {
     @Test
     void testEncryption() throws Exception {
         byte[] orig = "My cool file".getBytes();
-        byte[] symmetricKey = new byte[16];
-        int ivSize = 16;
+        byte[] symmetricKey = new byte[Encryption.KEY_LENGTH];
+        int ivSize = 12;
         byte[] iv = new byte[ivSize];
         SecureRandom random = new SecureRandom();
         random.nextBytes(iv);
-        IvParameterSpec ivParameterSpec = new IvParameterSpec(iv);
+        GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(Encryption.GCM_TLEN, iv);
         random.nextBytes(symmetricKey);
-        Cipher cipher = Cipher.getInstance(Encryption.algo);
-        SecretKeySpec key = new SecretKeySpec(symmetricKey, Encryption.algoKey);
-        cipher.init(Cipher.ENCRYPT_MODE, key, ivParameterSpec);
+        Cipher cipher = Cipher.getInstance(Encryption.ALGO);
+        SecretKeySpec key = new SecretKeySpec(symmetricKey, Encryption.ALGO_KEY);
+        cipher.init(Cipher.ENCRYPT_MODE, key, gcmParameterSpec);
         byte[] data_enc = cipher.doFinal(orig);
 
-        cipher.init(Cipher.DECRYPT_MODE, key, ivParameterSpec);
+        cipher.init(Cipher.DECRYPT_MODE, key, gcmParameterSpec);
         byte[] data = cipher.doFinal(data_enc);
         assertArrayEquals(orig, data);
     }
@@ -196,7 +196,7 @@ class Ed25519Test {
     @Test
     void testDocumentEncryption()throws Exception{
         byte[] orig = "foo beats bar".getBytes();
-        byte[] keyMaterial = new byte[Encryption.ivLength + 16];
+        byte[] keyMaterial = new byte[Encryption.IV_LENGTH + Encryption.KEY_LENGTH];
         new SecureRandom().nextBytes(keyMaterial);
 
         byte[] dataEnc = Encryption.encryptData(orig, keyMaterial);


### PR DESCRIPTION
Previously the encryption was done using AES-CBC, which is not
authenticated so that's bad. This PR changes is to use AES-GCM.

Fixes #1488