### PR TITLE
Treat Invalid ClientTransaction

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -1582,6 +1582,7 @@ clientTransactions:
 		// (via cdbTemp = cdbI.c), otherwise dump it.
 		sstTempC := sstTemp.Clone()
 		h := tx.ClientTransaction.Instructions.Hash()
+		var statesTemp StateChanges
 		for _, instr := range tx.ClientTransaction.Instructions {
 			scs, cout, err := s.executeInstruction(sstTempC, cin, instr, h)
 			if err != nil {
@@ -1641,8 +1642,8 @@ clientTransactions:
 				txOut = append(txOut, tx)
 				continue clientTransactions
 			}
-			states = append(states, scs...)
-			states = append(states, counterScs...)
+			statesTemp = append(statesTemp, scs...)
+			statesTemp = append(statesTemp, counterScs...)
 			cin = cout
 		}
 
@@ -1678,6 +1679,7 @@ clientTransactions:
 		tx.Accepted = true
 		txOut = append(txOut, tx)
 		blocksz += txsz
+		states = append(states, statesTemp...)
 	}
 
 	// Store the result in the cache before returning.

--- a/byzcoin/transaction_test.go
+++ b/byzcoin/transaction_test.go
@@ -81,7 +81,7 @@ func createOneClientTx(dID darc.ID, kind string, value []byte, signer darc.Signe
 }
 
 func createOneClientTxWithCounter(dID darc.ID, kind string, value []byte, signer darc.Signer, counter uint64) (ClientTransaction, error) {
-	instr := createInstr(dID, kind, "data", value)
+	instr := createSpawnInstr(dID, kind, "data", value)
 	instr.SignerCounter = []uint64{counter}
 	t := ClientTransaction{
 		Instructions: []Instruction{instr},
@@ -96,9 +96,9 @@ func createOneClientTxWithCounter(dID darc.ID, kind string, value []byte, signer
 }
 
 func createClientTxWithTwoInstrWithCounter(dID darc.ID, kind string, value []byte, signer darc.Signer, counter uint64) (ClientTransaction, error) {
-	instr1 := createInstr(dID, kind, "", value)
+	instr1 := createSpawnInstr(dID, kind, "", value)
 	instr1.SignerCounter = []uint64{counter}
-	instr2 := createInstr(dID, kind, "", value)
+	instr2 := createSpawnInstr(dID, kind, "", value)
 	instr2.SignerCounter = []uint64{counter + 1}
 	t := ClientTransaction{
 		Instructions: []Instruction{instr1, instr2},
@@ -112,7 +112,7 @@ func createClientTxWithTwoInstrWithCounter(dID darc.ID, kind string, value []byt
 	return t, nil
 }
 
-func createInstr(dID darc.ID, contractID string, argName string, value []byte) Instruction {
+func createSpawnInstr(dID darc.ID, contractID string, argName string, value []byte) Instruction {
 	return Instruction{
 		InstanceID: NewInstanceID(dID),
 		Spawn: &Spawn{
@@ -120,6 +120,16 @@ func createInstr(dID darc.ID, contractID string, argName string, value []byte) I
 			Args:       Arguments{{Name: argName, Value: value}},
 		},
 		SignerCounter: []uint64{1},
+	}
+}
+
+func createInvokeInstr(dID InstanceID, cmd, argName string, value []byte) Instruction {
+	return Instruction{
+		InstanceID: dID,
+		Invoke: &Invoke{
+			Command: cmd,
+			Args:    Arguments{{Name: argName, Value: value}},
+		},
 	}
 }
 


### PR DESCRIPTION
Now: If a ClientTransaction with a valid and an invalid instruction comes in, the valid instruction is still applied to the global state, but only on the leader, which breaks the root hash...
Solution: Correctly refuse clienttransaction with one valid and one invalid instruction.