### PR TITLE
Use randomness in Java embed

### DIFF
--- a/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Ed25519.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/crypto/Ed25519.java
@@ -25,6 +25,7 @@ public class Ed25519 {
     public static Field field = curve.getField();
     public static Point base = new Ed25519Point(Ed25519.ed25519.getB());
     public static Scalar prime_order = new Ed25519Scalar("EDD3F55C1A631258D69CF7A2DEF9DE1400000000000000000000000000000010", false);
+    public static Scalar cofactor = new Ed25519Scalar("0800000000000000000000000000000000000000000000000000000000000000", false);
 
     public static byte[] uuid4() {
         ByteBuffer bb = ByteBuffer.wrap(new byte[16]);


### PR DESCRIPTION
This PR addresses the first issue in #1493. It does not address the
timing attack the same way as what is described in the issue. Instead,
it uses the randomness technique similar to the Go implementation. If
only one byte decides whether the point is valid (which appears to be
the case in the initial Java implementation). Then the probability of
using SPRNG to find the valid point does not change depending on the
number of bytes that we need to fill. In other words, the expected value
(the timing) is constant, just like the Go one.

Fixes #1493