### PR TITLE
Generate gBar from LTSID

### DIFF
--- a/calypso/struct.go
+++ b/calypso/struct.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dedis/cothority/darc"
 	"github.com/dedis/kyber"
 	"github.com/dedis/kyber/suites"
+	"github.com/dedis/kyber/xof/keccak"
 	"github.com/dedis/onet/log"
 	"github.com/dedis/onet/network"
 )
@@ -53,7 +54,7 @@ func NewWrite(suite suites.Suite, ltsid byzcoin.InstanceID, writeDarc darc.ID, X
 	kp := suite.Point().Embed(key, suite.RandomStream())
 	wr.C = suite.Point().Add(C, kp)
 
-	gBar := suite.Point().Mul(suite.Scalar().SetBytes(ltsid.Slice()), nil)
+	gBar := suite.Point().Embed(ltsid.Slice(), keccak.New(ltsid.Slice()))
 	wr.Ubar = suite.Point().Mul(r, gBar)
 	s := suite.Scalar().Pick(suite.RandomStream())
 	w := suite.Point().Mul(s, nil)
@@ -84,7 +85,7 @@ func (wr *Write) CheckProof(suite suite, writeID darc.ID) error {
 	ue := suite.Point().Mul(suite.Scalar().Neg(wr.E), wr.U)
 	w := suite.Point().Add(gf, ue)
 
-	gBar := suite.Point().Mul(suite.Scalar().SetBytes(wr.LTSID.Slice()), nil)
+	gBar := suite.Point().Embed(wr.LTSID.Slice(), keccak.New(wr.LTSID.Slice()))
 	gfBar := suite.Point().Mul(wr.F, gBar)
 	ueBar := suite.Point().Mul(suite.Scalar().Neg(wr.E), wr.Ubar)
 	wBar := suite.Point().Add(gfBar, ueBar)

--- a/external/java/pom.xml
+++ b/external/java/pom.xml
@@ -139,6 +139,11 @@
             <artifactId>toml4j</artifactId>
             <version>0.7.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.60</version>
+        </dependency>
 
         <!-- dependencies used for test purpose -->
         <dependency>

--- a/external/java/src/test/java/ch/epfl/dedis/KeyAndSignOperationsTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/KeyAndSignOperationsTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.security.*;
 import java.security.spec.ECGenParameterSpec;
 
-import static ch.epfl.dedis.lib.crypto.TestSignerX509EC.readPrivateKey;
-import static ch.epfl.dedis.lib.crypto.TestSignerX509EC.readPublicKey;
+import static ch.epfl.dedis.lib.crypto.SignerX509ECTest.readPrivateKey;
+import static ch.epfl.dedis.lib.crypto.SignerX509ECTest.readPublicKey;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/DarcTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/DarcTest.java
@@ -9,7 +9,7 @@ import ch.epfl.dedis.byzcoin.Proof;
 import ch.epfl.dedis.byzcoin.transaction.Argument;
 import ch.epfl.dedis.byzcoin.transaction.ClientTransaction;
 import ch.epfl.dedis.byzcoin.transaction.Instruction;
-import ch.epfl.dedis.lib.crypto.TestSignerX509EC;
+import ch.epfl.dedis.lib.crypto.SignerX509ECTest;
 import ch.epfl.dedis.lib.darc.*;
 import ch.epfl.dedis.lib.exception.CothorityCommunicationException;
 import ch.epfl.dedis.lib.exception.CothorityException;
@@ -76,8 +76,8 @@ class DarcTest {
         SignerCounters counters = bc.getSignerCounters(Collections.singletonList(admin.getIdentity().toString()));
 
         // Evolve to give kcsigner the evolve permission
-        SignerX509EC kcsigner = new TestSignerX509EC();
-        SignerX509EC kcsigner2 = new TestSignerX509EC();
+        SignerX509EC kcsigner = new SignerX509ECTest();
+        SignerX509EC kcsigner2 = new SignerX509ECTest();
         Darc adminDarc2 = genesisDarc.copyRulesAndVersion();
         adminDarc2.setRule(Darc.RuleEvolve, kcsigner.getIdentity().toString().getBytes());
         DarcInstance di = DarcInstance.fromByzCoin(bc, genesisDarc);

--- a/external/java/src/test/java/ch/epfl/dedis/byzgen/GrantAccessTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzgen/GrantAccessTest.java
@@ -7,7 +7,7 @@ import ch.epfl.dedis.lib.Hex;
 import ch.epfl.dedis.lib.SkipblockId;
 import ch.epfl.dedis.byzcoin.contracts.DarcInstance;
 import ch.epfl.dedis.calypso.*;
-import ch.epfl.dedis.lib.crypto.TestSignerX509EC;
+import ch.epfl.dedis.lib.crypto.SignerX509ECTest;
 import ch.epfl.dedis.lib.darc.*;
 import ch.epfl.dedis.lib.exception.CothorityException;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,9 +19,9 @@ import java.util.Collections;
 public class GrantAccessTest {
     static final String SUPERADMIN_SCALAR = "AEE42B6A924BDFBB6DAEF8B252258D2FDF70AFD31852368AF55549E1DF8FC80D";
     private static final SignerEd25519 superadmin = new SignerEd25519(Hex.parseHexBinary(SUPERADMIN_SCALAR));
-    private final SignerX509EC consumerSigner = new TestSignerX509EC();
-    private final SignerX509EC publisherSigner = new TestSignerX509EC();
-    private final SignerX509EC consumerPublicPart = new TestLimitedSignerX509EC(consumerSigner);
+    private final SignerX509EC consumerSigner = new SignerX509ECTest();
+    private final SignerX509EC publisherSigner = new SignerX509ECTest();
+    private final SignerX509EC consumerPublicPart = new LimitedSignerX509ECTest(consumerSigner);
     private TestServerController testServerController;
     private CalypsoRPC calypso;
 
@@ -166,8 +166,8 @@ public class GrantAccessTest {
         di.evolveDarcAndWait(newGenesis, superadmin, counters.head()+1, 10);
     }
 
-    private class TestLimitedSignerX509EC extends TestSignerX509EC {
-        public TestLimitedSignerX509EC(SignerX509EC consumerKeys) {
+    private class LimitedSignerX509ECTest extends SignerX509ECTest {
+        public LimitedSignerX509ECTest(SignerX509EC consumerKeys) {
             super(consumerKeys.getPublicKey(), null);
         }
 

--- a/external/java/src/test/java/ch/epfl/dedis/lib/crypto/SignerX509ECTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/lib/crypto/SignerX509ECTest.java
@@ -12,14 +12,14 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 
-public class TestSignerX509EC extends SignerX509EC {
+public class SignerX509ECTest extends SignerX509EC {
     private final PublicKey publicKey;
     private final PrivateKey privateKey;
 
     /**
      * this constructor create internally random key
      */
-    public TestSignerX509EC() {
+    public SignerX509ECTest() {
         this("secp256r1");
     }
 
@@ -28,15 +28,15 @@ public class TestSignerX509EC extends SignerX509EC {
      *
      * @param keyType type of curve can be one of "secp256r1", "secp384r1", "secp521r1"
      */
-    public TestSignerX509EC(String keyType) {
+    public SignerX509ECTest(String keyType) {
         this(createKeyPair(keyType));
     }
 
-    public TestSignerX509EC(java.security.KeyPair keyPair) {
+    public SignerX509ECTest(java.security.KeyPair keyPair) {
         this(keyPair.getPublic(), keyPair.getPrivate());
     }
 
-    public TestSignerX509EC(PublicKey publicKey, PrivateKey privateKey) {
+    public SignerX509ECTest(PublicKey publicKey, PrivateKey privateKey) {
         this.publicKey = publicKey;
         this.privateKey = privateKey;
     }
@@ -69,7 +69,7 @@ public class TestSignerX509EC extends SignerX509EC {
      * @param publicKeyResourceName resource name of a public key x509 der format
      * @throws IOException when key pair can not be read
      */
-    public TestSignerX509EC(String privateKeyResourceName, String publicKeyResourceName) throws IOException {
+    public SignerX509ECTest(String privateKeyResourceName, String publicKeyResourceName) throws IOException {
         try {
             publicKey = readPublicKey(getClass().getClassLoader().getResourceAsStream(publicKeyResourceName));
             privateKey = readPrivateKey(getClass().getClassLoader().getResourceAsStream(privateKeyResourceName));

--- a/external/java/src/test/java/ch/epfl/dedis/lib/crypto/XofTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/lib/crypto/XofTest.java
@@ -1,0 +1,25 @@
+package ch.epfl.dedis.lib.crypto;
+
+import ch.epfl.dedis.lib.Hex;
+import org.bouncycastle.crypto.digests.SHAKEDigest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class XofTest {
+    @Test
+    void compatibility() {
+        SHAKEDigest d = new SHAKEDigest(256);
+
+        byte[] seed = "helloworld".getBytes();
+        d.update(seed, 0, seed.length);
+
+        byte[] out1 = new byte[64];
+        d.doOutput(out1, 0, 64);
+        assertArrayEquals(Hex.parseHexBinary("0599df850188c1933b38dc74b7e6972bc054234f01cd7f9e8e2e8cc40acb149d894d9b3d8149cafe7ff89526576c7d8626424a83c82522d4b8120fceca7f7319"), out1);
+
+        byte[] out2 = new byte[64];
+        d.doOutput(out2, 0, 64);
+        assertArrayEquals(Hex.parseHexBinary("c33eae5774174971b4b3470b3372014d6d3fd019385ffad099ac444860dfeb3c2ce6d2629ef0570a132a7db23326c825e981735fa7d61fca2bbcbc69dae37fcd"), out2);
+    }
+}

--- a/external/java/src/test/java/ch/epfl/dedis/lib/darc/SignerTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/lib/darc/SignerTest.java
@@ -3,8 +3,7 @@ package ch.epfl.dedis.lib.darc;
 import ch.epfl.dedis.lib.crypto.Ed25519Point;
 import ch.epfl.dedis.lib.crypto.Point;
 import ch.epfl.dedis.lib.crypto.Scalar;
-import ch.epfl.dedis.lib.crypto.TestSignerX509EC;
-import ch.epfl.dedis.lib.exception.CothorityCryptoException;
+import ch.epfl.dedis.lib.crypto.SignerX509ECTest;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -44,8 +43,8 @@ public class SignerTest {
 
     @Test
     void keycard() throws Exception {
-        SignerX509EC signer = new TestSignerX509EC("secp256k1-pkcs8.der", "secp256k1-pub.der");
-        SignerX509EC signer2 = new TestSignerX509EC("secp256k1-pkcs8.der", "secp256k1-pub.der");
+        SignerX509EC signer = new SignerX509ECTest("secp256k1-pkcs8.der", "secp256k1-pub.der");
+        SignerX509EC signer2 = new SignerX509ECTest("secp256k1-pkcs8.der", "secp256k1-pub.der");
 
         assertThrows(RuntimeException.class, () -> signer.getPrivate());
         assertThrows(IllegalStateException.class, () -> signer.serialize());


### PR DESCRIPTION
Knowing the secret scalar used to generate `gBar` is a security risk. Instead, we use a deterministic way to embed LTSID to create `gBar`. 

Regarding the use of Bouncy Castle, according to https://keccak.team/software.html it is the only Java keccak/SHAKE implementation that's on maven. There are various implementations on GitHub but it's rather time consuming to access the quality of each one, and none of the ones I looked are on maven.

Fixes #1492 
