### PR TITLE
Fix kyberjs test for g2 points

### DIFF
--- a/external/js/kyber/spec/pairing/point.spec.ts
+++ b/external/js/kyber/spec/pairing/point.spec.ts
@@ -86,6 +86,18 @@ describe('BN256 Point Tests', () => {
         expect(prop).toHold();
     });
 
+    it('should add and subtract 0 and 1', () => {
+        const p1 = new BN256G2Point([]);
+        const p2 = new BN256G2Point([1]);
+
+        expect(p1.getElement().isInfinity());
+
+        const aa = new BN256G2Point().add(p1, p2);
+        const bb = new BN256G2Point().sub(p1, p2.clone().neg(p2));
+
+        expect(aa.equal(bb)).toBeTruthy();
+    });
+
     it('should add and multiply g2 points', () => {
         const prop = jsc.forall(jsc.array(jsc.uint8), (a) => {
             const p1 = new BN256G2Point(a);

--- a/external/js/kyber/src/pairing/curve-point.ts
+++ b/external/js/kyber/src/pairing/curve-point.ts
@@ -218,7 +218,6 @@ export default class CurvePoint {
         this.x = a.x;
         this.y = a.y.negate();
         this.z = a.z;
-        this.t = new GfP(0);
     }
 
     /**

--- a/external/js/kyber/src/pairing/twist-point.ts
+++ b/external/js/kyber/src/pairing/twist-point.ts
@@ -242,7 +242,6 @@ export default class TwistPoint {
         this.x = a.x;
         this.y = a.y.negative();
         this.z = a.z;
-        this.t = GfP2.zero();
     }
 
     /**


### PR DESCRIPTION
This fixes the test by changing the negative function of
the point to not set t. The _t_ is actually never used so I'm not really sure why it is there at the first place but the issue was caused because it was set to 0 for the negative operation.

Fixes #1681