### PR TITLE
KyberJS: fix G1 generator

### DIFF
--- a/external/js/kyber/spec/pairing/point.spec.ts
+++ b/external/js/kyber/spec/pairing/point.spec.ts
@@ -56,6 +56,19 @@ describe('BN256 Point Tests', () => {
         expect(prop).toHold();
     });
 
+    // Test written because of the edge case found by the property-based
+    // test
+    it('should marshal and unmarshal g1 point generated with k=1', () => {
+        const p1 = new BN256G1Point([1]);
+
+        const buf = p1.marshalBinary();
+        const p2 = new BN256G1Point();
+        p2.unmarshalBinary(buf);
+
+        expect(p1.equal(p2)).toBeTruthy();
+        expect(p2.marshalSize()).toBe(buf.length);
+    });
+
     it('should get random g1', () => {
         for (let i = 0; i < 100; i++) {
             const a = new BN256G1Point().pick();

--- a/external/js/kyber/src/pairing/curve-point.ts
+++ b/external/js/kyber/src/pairing/curve-point.ts
@@ -10,7 +10,7 @@ const curveB = new GfP(3);
  * Point class used by G1
  */
 export default class CurvePoint {
-    static generator = new CurvePoint(1, -2, 1, 0);
+    static generator = new CurvePoint(1, -2, 1, 1);
     
     private x: GfP;
     private y: GfP;
@@ -18,10 +18,13 @@ export default class CurvePoint {
     private t: GfP;
 
     constructor(x?: BNType, y?: BNType, z?: BNType, t?: BNType) {
-        this.x = new GfP(x || 0);
-        this.y = new GfP(y || 1);
-        this.z = new GfP(z || 0);
-        this.t = new GfP(t || 0);
+        // the coefficient are modulo p to insure we have same
+        // values when it comes to comparison
+        // Other arithmetic operations are already modulo.
+        this.x = new GfP(x || 0).mod(p);
+        this.y = new GfP(y || 1).mod(p);
+        this.z = new GfP(z || 0).mod(p);
+        this.t = new GfP(t || 0).mod(p);
     }
 
     /**


### PR DESCRIPTION
This fixes the generator by setting the t value to 1 which
is the correct value. It also add a modulo operation to the
constructor to insure any instantiated point will lie in
the same range as others