### PR TITLE
Run conode with log level 1 for java test

### DIFF
--- a/external/docker/Dockerfile
+++ b/external/docker/Dockerfile
@@ -15,4 +15,4 @@ COPY co7/*.toml co7/
 # 2 - debug-level: 0 - none .. 5 - a lot
 # -wait - don't return from script when all nodes are started
 RUN cp ./conode /usr/local/bin/
-CMD ["env", "GODEBUG=gctrace=0", "DEBUG_TIME=true", "COTHORITY_ALLOW_INSECURE_ADMIN=1", "./run_nodes.sh", "4", "2" ]
+CMD ["env", "GODEBUG=gctrace=0", "DEBUG_TIME=true", "COTHORITY_ALLOW_INSECURE_ADMIN=1", "./run_nodes.sh", "4", "1" ]

--- a/external/java/src/test/java/ch/epfl/dedis/integration/DockerTestServerController.java
+++ b/external/java/src/test/java/ch/epfl/dedis/integration/DockerTestServerController.java
@@ -67,7 +67,7 @@ public class DockerTestServerController extends TestServerController {
             throw new InterruptedException("Node numbering starts at 1!");
         }
         logger.info("Starting container co{}/private.toml", nodeNumber);
-        runCmdInBackground(blockchainContainer, "env", "COTHORITY_ALLOW_INSECURE_ADMIN=1", "conode", "-d", "2", "-c", "co" + nodeNumber + "/private.toml", "server");
+        runCmdInBackground(blockchainContainer, "env", "COTHORITY_ALLOW_INSECURE_ADMIN=1", "conode", "-d", "1", "-c", "co" + nodeNumber + "/private.toml", "server");
         // Wait a bit for the server to actually start.
         Thread.sleep(1000);
     }


### PR DESCRIPTION
Because Travis often fails with the message:
"The job exceeded the maximum log length, and has been terminated."