### PR TITLE
Fix one lint problem and add lint as a direction on Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,5 @@ docker:
 test_java: docker
 	cd external/java; mvn test
 
+lint:
+	golint ./...

--- a/messaging/propagate_test.go
+++ b/messaging/propagate_test.go
@@ -49,10 +49,9 @@ func propagate(t *testing.T, nbrNodes, nbrFailures []int) {
 						recvCount++
 						iMut.Unlock()
 						return nil
-					} else {
-						t.Error("Didn't receive correct data")
-						return errors.New("Didn't receive correct data")
 					}
+					t.Error("Didn't receive correct data")
+					return errors.New("Didn't receive correct data")
 				}, nbrFailures[i])
 			log.ErrFatal(err)
 		}


### PR DESCRIPTION
I don't know if this is of your interest; but, just in case, I added a direction to the Makefile as well.

Additionally, there are still some golint problems:

```
calypso/protocol/ocs_struct.go:45:2: struct field Ui should be UI
calypso/protocol/onchain_test.go:52:2: var Ui should be UI
pop/service/service_test.go:447:3: don't use underscores in Go names; var hash_fr should be hashFr
pop/service/service_test.go:561:2: don't use underscores in Go names; var copy_descs should be copyDescs
```

Idk if this is something you might want to check :)

