### PR TITLE
Publish cothorityjs pre5

### DIFF
--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@dedis/cothority",
-  "version": "3.0.0-pre3",
+  "version": "3.0.0-pre4",
   "description": "A typescript implementation of the cothority",
   "main": "index.js",
   "browser": "bundle.min.js",

--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@dedis/cothority",
-  "version": "3.0.0-pre4",
+  "version": "3.0.0-pre5",
   "description": "A typescript implementation of the cothority",
   "main": "index.js",
   "browser": "bundle.min.js",

--- a/external/js/cothority/spec/skipchain/skipchain-rpc.spec.ts
+++ b/external/js/cothority/spec/skipchain/skipchain-rpc.spec.ts
@@ -38,6 +38,20 @@ describe("SkipchainRPC Tests", () => {
         expect(chainIDs).toContain(genesis.hash);
     });
 
+    it("should create a chain with different roster", async () => {
+        const rpc = new SkipchainRPC(roster);
+        const rpc2 = new SkipchainRPC(roster.slice(0, 2));
+        const { latest: genesis } = await rpc.createSkipchain();
+
+        for (let i = 0; i < 3; i++) {
+            await rpc.addBlock(genesis.hash, Buffer.from("abc"));
+            await rpc2.addBlock(genesis.hash, Buffer.from("def"));
+        }
+
+        const chain = await rpc.getUpdateChain(genesis.hash);
+        expect(chain.length).toBe(7);
+    });
+
     it("should fail to get the block", async () => {
         const rpc = new SkipchainRPC(roster);
 

--- a/external/js/cothority/src/skipchain/skipchain-rpc.ts
+++ b/external/js/cothority/src/skipchain/skipchain-rpc.ts
@@ -204,7 +204,7 @@ export default class SkipchainRPC {
                 return new Error("no forward link associated with the next block");
             }
 
-            const err = link.verify(curr.roster.getServicePublics(SkipchainRPC.serviceName));
+            const err = link.verify(prev.roster.getServicePublics(SkipchainRPC.serviceName));
             if (err) {
                 return new Error(`invalid link: ${err.message}`);
             }


### PR DESCRIPTION
This PR updates the version to publish pre5 with a fix when verifying a chain of blocks with different roster.