### PR TITLE
Implement commit for byzcoin staging trie

### DIFF
--- a/byzcoin/statetrie.go
+++ b/byzcoin/statetrie.go
@@ -74,8 +74,7 @@ func (t *stagingStateTrie) GetValues(key []byte) (value []byte, version uint64, 
 
 // Commit commits the staged data to the source trie.
 func (t *stagingStateTrie) Commit() error {
-	// TODO if this is implemented, we can replace the stateChangeCache.
-	return errors.New("not implemented")
+	return t.StagingTrie.Commit()
 }
 
 // GetIndex returns the index of the current trie.

--- a/byzcoin/statetrie_test.go
+++ b/byzcoin/statetrie_test.go
@@ -1,6 +1,7 @@
 package byzcoin
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -51,4 +52,20 @@ func TestStateTrie(t *testing.T) {
 	require.Equal(t, version, ver)
 	require.Equal(t, cid, string(contractID))
 	require.True(t, did.Equal(darcID))
+
+	// test the staging state trie, most of the tests are done in the trie package
+	key2 := []byte("key2")
+	val2 := []byte("val2")
+	sst := st.MakeStagingStateTrie()
+	oldRoot := sst.GetRoot()
+	require.NoError(t, sst.Set(key2, val2))
+	newRoot := sst.GetRoot()
+	require.False(t, bytes.Equal(oldRoot, newRoot))
+	candidateVal2, err := sst.Get(key2)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(val2, candidateVal2))
+
+	// test the commit of staging state trie, root should be computed differently now, but it should be the same
+	require.NoError(t, sst.Commit())
+	require.True(t, bytes.Equal(sst.GetRoot(), newRoot))
 }


### PR DESCRIPTION
The the commit feature was never used before because the staging trie is always thrown away after we propose the block. We need it for the pipeline feature because it can be used as a checkpoint. That is, everything that's not committed could be "rolled back" when an error happens in the pipeline.