### PR TITLE
Improve standard verification of new blocks

### DIFF
--- a/skipchain/verification.go
+++ b/skipchain/verification.go
@@ -16,6 +16,25 @@ func (s *Service) verifyFuncBase(newID []byte, newSB *SkipBlock) bool {
 		log.Lvl2("verifyBlock failed")
 		return false
 	}
+
+	prev := s.db.GetByID(newSB.BackLinkIDs[0])
+	if prev == nil {
+		return false
+	}
+
+	if !prev.SkipChainID().Equal(newSB.SkipChainID()) {
+		return false
+	}
+	if prev.MaximumHeight != newSB.MaximumHeight {
+		return false
+	}
+	if prev.BaseHeight != newSB.BaseHeight {
+		return false
+	}
+	if prev.Index+1 != newSB.Index {
+		return false
+	}
+
 	log.Lvl4("No verification - accepted")
 	return true
 }


### PR DESCRIPTION
This makes sure that a new block will follow the previous static
configuration like the maximum height, the base height, the
genesis ID, etc ...

Fixes #1761