### PR TITLE
Fix out of bound leader index in view change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ matrix:
       # defaults to Go 1.8 and does not respect the go version
       # specifier.
       install:
-        - gimme 1.11
-        - . $HOME/.gimme/envs/go1.11.env
+        - gimme 1.11.6
+        - . $HOME/.gimme/envs/go1.11.6.env
         - env GO111MODULE=off go get github.com/dedis/Coding || true
 
       script:
@@ -65,8 +65,8 @@ matrix:
 
       before_install: dpkg --compare-versions `npm -v` ge 6.7 || npm i -g npm@^6.7.0
       install:
-        - gimme 1.11
-        - . $HOME/.gimme/envs/go1.11.env
+        - gimme 1.11.6
+        - . $HOME/.gimme/envs/go1.11.6.env
         - env GO111MODULE=off go get github.com/dedis/Coding || true
 
       script:

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -1451,12 +1451,16 @@ func (s *Service) skService() *skipchain.Service {
 }
 
 func (s *Service) isLeader(view viewchange.View) bool {
-	sb := s.db().GetByID(view.ID)
-	if view.LeaderIndex < len(sb.Roster.List) {
-		sid := sb.Roster.List[view.LeaderIndex]
-		return sid.ID.Equal(s.ServerIdentity().ID)
+	if view.LeaderIndex < 0 {
+		// no guaranties on the leader index value
+		return false
 	}
-	return false
+
+	sb := s.db().GetByID(view.ID)
+
+	idx := view.LeaderIndex % len(sb.Roster.List)
+	sid := sb.Roster.List[idx]
+	return sid.ID.Equal(s.ServerIdentity().ID)
 }
 
 // gives us access to the skipchain's database, so we can get blocks by ID


### PR DESCRIPTION
This fixes the potential crash due to a panic when a view change request is sent with an invalid leader index. It changes the protocol so that negative indices are refused and bigger are reduced modulo the roster length.