### PR TITLE
Make verify will now make sure there is no replace in go.mod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
         - go get github.com/dedis/Coding || true
 
       script:
-        - env GO111MODULE=on go mod verify
+        - make -C conode verify
         - env GO111MODULE=on make test
         - make -C conode bindist
 

--- a/conode/Makefile
+++ b/conode/Makefile
@@ -56,6 +56,8 @@ clean:
 
 verify:
 	GO111MODULE=on go mod verify
+	@echo "Checking for replace in go.mod..."
+	@if GO111MODULE=on go list -m all | grep --quiet '=>'; then exit 1; fi
 
 # The suffix on conode exe is the result from: echo `uname -s`.`uname -m`
 # so that we can find the right one in the wrapper script.


### PR DESCRIPTION
This adds a step to the command that will look for replace in the
go.mod file and exit if any is found.

Fixes #1752