### PR TITLE
Fix catch up 1777

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -996,7 +996,7 @@ func (s *Service) downloadDB(sb *skipchain.SkipBlock) error {
 				sb = search.SkipBlock
 			}
 			var header DataHeader
-			err = protobuf.DecodeWithConstructors(sb.Data, &header, network.DefaultConstructors(cothority.Suite))
+			err = protobuf.Decode(sb.Data, &header)
 			if err != nil {
 				return errors.New("couldn't unmarshal header: " + err.Error())
 			}
@@ -1100,6 +1100,10 @@ func (s *Service) catchUp(sb *skipchain.SkipBlock) {
 		if err != nil {
 			log.Error("Error while downloading trie:", err)
 		}
+
+		// Note: in that case we don't get the previous blocks and therefore we can't
+		// recreate the state changes. The storage will then be filled with new
+		// incoming blocks
 		return
 	}
 
@@ -1370,7 +1374,7 @@ func isViewChangeTx(txs TxResults) *viewchange.View {
 		return nil
 	}
 	var req viewchange.NewViewReq
-	if err := protobuf.DecodeWithConstructors(invoke.Args.Search("newview"), &req, network.DefaultConstructors(cothority.Suite)); err != nil {
+	if err := protobuf.Decode(invoke.Args.Search("newview"), &req); err != nil {
 		log.Error("failed to decode new-view req")
 		return nil
 	}
@@ -1642,7 +1646,7 @@ func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool
 	}()
 
 	var header DataHeader
-	err := protobuf.DecodeWithConstructors(newSB.Data, &header, network.DefaultConstructors(cothority.Suite))
+	err := protobuf.Decode(newSB.Data, &header)
 	if err != nil {
 		log.Error(s.ServerIdentity(), "verifySkipblock: couldn't unmarshal header")
 		return false
@@ -1669,7 +1673,7 @@ func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool
 	}
 
 	var body DataBody
-	err = protobuf.DecodeWithConstructors(newSB.Payload, &body, network.DefaultConstructors(cothority.Suite))
+	err = protobuf.Decode(newSB.Payload, &body)
 	if err != nil {
 		log.Error("verifySkipblock: couldn't unmarshal body")
 		return false
@@ -2349,7 +2353,7 @@ func (s *Service) getBlockTx(sid skipchain.SkipBlockID) (TxResults, *skipchain.S
 	}
 
 	var body DataBody
-	err = protobuf.DecodeWithConstructors(sb.Payload, &body, network.DefaultConstructors(cothority.Suite))
+	err = protobuf.Decode(sb.Payload, &body)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -1042,18 +1042,6 @@ func (s *Service) catchupAll() error {
 			return err
 		}
 		s.catchUp(sb)
-
-		// the MT root is not checked so we don't need the correct nonce
-		sst, err := s.stateChangeStorage.getStateTrie(sb.SkipChainID())
-		if err != nil {
-			log.Error(s.ServerIdentity(), err)
-			continue
-		}
-
-		_, err = s.buildStateChanges(sb.Hash, sst, []Coin{})
-		if err != nil {
-			log.Error(s.ServerIdentity(), err)
-		}
 	}
 	return nil
 }
@@ -1190,7 +1178,7 @@ func (s *Service) updateTrieCallback(sbID skipchain.SkipBlockID) error {
 	// create state trie here.
 	if sb.Index == 0 && !s.hasStateTrie(sb.SkipChainID()) {
 		var body DataBody
-		err := protobuf.DecodeWithConstructors(sb.Payload, &body, network.DefaultConstructors(cothority.Suite))
+		err := protobuf.Decode(sb.Payload, &body)
 		if err != nil {
 			log.Error(s.ServerIdentity(), "could not unmarshal body for genesis block", err)
 			return errors.New("couldn't unmarshal body for genesis block")
@@ -1234,14 +1222,14 @@ func (s *Service) updateTrieCallback(sbID skipchain.SkipBlockID) error {
 
 	// Get the DataHeader and the DataBody of the block.
 	var header DataHeader
-	err = protobuf.DecodeWithConstructors(sb.Data, &header, network.DefaultConstructors(cothority.Suite))
+	err = protobuf.Decode(sb.Data, &header)
 	if err != nil {
 		log.Error(s.ServerIdentity(), "could not unmarshal header", err)
 		return errors.New("couldn't unmarshal header")
 	}
 
 	var body DataBody
-	err = protobuf.DecodeWithConstructors(sb.Payload, &body, network.DefaultConstructors(cothority.Suite))
+	err = protobuf.Decode(sb.Payload, &body)
 	if err != nil {
 		log.Error(s.ServerIdentity(), "could not unmarshal body", err)
 		return errors.New("couldn't unmarshal body")

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -2241,6 +2241,12 @@ func (s *Service) startAllChains() error {
 			continue
 		}
 
+		// recreate state changes for this chain
+		// Note: this should optimized but for the moment we need to start from the genesis
+		// to populate the statistics used to clean the storage to prevent overflow
+		// TODO: use loadFromDB to recreate the storage state
+		s.buildStateChanges(gen)
+
 		interval, _, err := s.LoadBlockInfo(gen)
 		if err != nil {
 			log.Errorf("%s Ignoring chain %x because we can't load blockInterval: %s", s.ServerIdentity(), gen, err)
@@ -2354,10 +2360,15 @@ func (s *Service) getBlockTx(sid skipchain.SkipBlockID) (TxResults, *skipchain.S
 // buildStateChanges recursively gets the TXs of a skipchain's blocks and populates
 // the state changes storage by restoring them from the TXs. We don't need to worry
 // about overriding thanks to the key generation.
-func (s *Service) buildStateChanges(sid skipchain.SkipBlockID, sst *stagingStateTrie, cin []Coin) ([]Coin, error) {
+func (s *Service) buildStateChanges(sid skipchain.SkipBlockID) error {
 	txs, sb, err := s.getBlockTx(sid)
 	if err != nil {
-		return nil, err
+		return err
+	}
+
+	sst, err := newMemStagingStateTrie([]byte{})
+	if err != nil {
+		return err
 	}
 
 	// when an error occured, we stop where we are because those state changes
@@ -2367,25 +2378,15 @@ func (s *Service) buildStateChanges(sid skipchain.SkipBlockID, sst *stagingState
 		if tx.Accepted {
 			// Only accepted transactions must be used
 			// to create the state changes
-			h := tx.ClientTransaction.Instructions.Hash()
-			for _, instr := range tx.ClientTransaction.Instructions {
-				scs, cout, err := s.executeInstruction(sst, cin, instr, h)
-				cin = cout
-				if err != nil {
-					return nil, err
-				}
-				counterScs, err := incrementSignerCounters(sst, instr.SignerIdentities)
-				if err != nil {
-					return nil, err
-				}
+			var scs StateChanges
+			scs, sst, err = s.processOneTx(sst, tx.ClientTransaction)
+			if err != nil {
+				return err
+			}
 
-				scs = append(scs, counterScs...)
-				err = sst.StoreAll(scs)
-				if err != nil {
-					return nil, err
-				}
-
-				s.stateChangeStorage.append(scs, sb)
+			err = s.stateChangeStorage.append(scs, sb)
+			if err != nil {
+				return err
 			}
 		}
 	}
@@ -2395,13 +2396,13 @@ func (s *Service) buildStateChanges(sid skipchain.SkipBlockID, sst *stagingState
 		// link that points to an existing block.
 		for _, link := range sb.ForwardLink {
 			if block := s.db().GetByID(link.To); block != nil {
-				return s.buildStateChanges(block.Hash, sst, cin)
+				return s.buildStateChanges(block.Hash)
 			}
 		}
-		return nil, errors.New("last block has forwardlinks that are not available")
+		return errors.New("last block has forwardlinks that are not available")
 	}
 
-	return nil, nil
+	return nil
 }
 
 var existingDB = regexp.MustCompile(`^ByzCoin_[0-9a-f]+$`)


### PR DESCRIPTION
This PR moves the restoration of the state change storage to start on boot to recreate the state of the storage (used to clean). It was previously executed after the blocks catch up with the given state trie which is bad. The blocks catch up procedure takes care of creating the state changes for new blocks so we don't need to redo it again after it.

Note: it also cleans the `DecodeWithConstructor` usage to be only `Decode`