### PR TITLE
Fix BCAdmin to work for non-admins

### DIFF
--- a/byzcoin/bcadmin/lib/config.go
+++ b/byzcoin/bcadmin/lib/config.go
@@ -21,12 +21,12 @@ import (
 var ConfigPath = "."
 
 // Config is the structure used by ol to save its configuration. It holds everything
-// necessary to talk to a ByzCoin instance. The GenesisDarc and AdminIdentity
+// necessary to talk to a ByzCoin instance. The AdminDarc and AdminIdentity
 // can change over the lifetime of a ledger.
 type Config struct {
 	Roster        onet.Roster
 	ByzCoinID     skipchain.SkipBlockID
-	GenesisDarc   darc.Darc
+	AdminDarc     darc.Darc
 	AdminIdentity darc.Identity
 }
 

--- a/byzcoin/bcadmin/test.sh
+++ b/byzcoin/bcadmin/test.sh
@@ -13,6 +13,7 @@ main(){
     startTest
     buildConode go.dedis.ch/cothority/v3/byzcoin go.dedis.ch/cothority/v3/byzcoin/contracts
 	[ ! -x ./bcadmin ] && exit 1
+    run testLink
     run testCoin
     run testRoster
     run testCreateStoreRead
@@ -23,6 +24,22 @@ main(){
     run testExpression
     run testQR
     stopTest
+}
+
+testLink(){
+  rm -f config/*
+  runCoBG 1 2 3
+  testOK runBA create public.toml --interval .5s
+  bc=config/bc*cfg
+  key=config/key*cfg
+  rm -rf linkDir
+  bcID=$( echo $bc | sed -e "s/.*bc-\(.*\).cfg/\1/" )
+  testGrep $bcID runBA -c linkDri link public.toml
+  bcIDWrong=$( printf "%032d" 1234 )
+  testNGrep $bcIDWrong runBA -c linkDri link public.toml
+  testFail runBA -c linkDir link public.toml $bcIDWrong
+  testOK runBA -c linkDir link public.toml $bcID
+  testFile linkDir/bc*
 }
 
 testCoin(){

--- a/byzcoin/wallet/main.go
+++ b/byzcoin/wallet/main.go
@@ -374,18 +374,18 @@ func loadConfig() (cfg config, cl *byzcoin.Client, err error) {
 	}
 
 	dj := cfgJSON.ByzcoinConfig.GenesisDarc
-	cfg.BCConfig.GenesisDarc.Version = dj.Version
-	cfg.BCConfig.GenesisDarc.Description = []byte(dj.Description)
-	cfg.BCConfig.GenesisDarc.BaseID, err = hex.DecodeString(dj.BaseID)
+	cfg.BCConfig.AdminDarc.Version = dj.Version
+	cfg.BCConfig.AdminDarc.Description = []byte(dj.Description)
+	cfg.BCConfig.AdminDarc.BaseID, err = hex.DecodeString(dj.BaseID)
 	if err != nil {
 		return
 	}
-	cfg.BCConfig.GenesisDarc.PrevID, err = hex.DecodeString(dj.PrevID)
+	cfg.BCConfig.AdminDarc.PrevID, err = hex.DecodeString(dj.PrevID)
 	if err != nil {
 		return
 	}
 	for _, rul := range dj.Rules {
-		cfg.BCConfig.GenesisDarc.Rules.List = append(cfg.BCConfig.GenesisDarc.Rules.List,
+		cfg.BCConfig.AdminDarc.Rules.List = append(cfg.BCConfig.AdminDarc.Rules.List,
 			darc.Rule{Action: darc.Action(rul.Action), Expr: expression.Expr(rul.Expression)})
 	}
 
@@ -418,7 +418,7 @@ func (cfg config) save() error {
 			Description: si.Description,
 		})
 	}
-	d := cfg.BCConfig.GenesisDarc
+	d := cfg.BCConfig.AdminDarc
 	jd := darcJSON{
 		Version:     d.Version,
 		Description: string(d.Description),

--- a/personhood/phapp/main.go
+++ b/personhood/phapp/main.go
@@ -220,7 +220,7 @@ func spawner(c *cli.Context) error {
 		})
 	}
 	ctx, err := combineInstrsAndSign(cl, *signer, byzcoin.Instruction{
-		InstanceID: byzcoin.NewInstanceID(cfg.GenesisDarc.GetBaseID()),
+		InstanceID: byzcoin.NewInstanceID(cfg.AdminDarc.GetBaseID()),
 		Spawn: &byzcoin.Spawn{
 			ContractID: personhood.ContractSpawnerID,
 			Args:       args,
@@ -338,7 +338,7 @@ func register(c *cli.Context) error {
 		}
 	}
 
-	gdID := byzcoin.NewInstanceID(cfg.GenesisDarc.GetBaseID())
+	gdID := byzcoin.NewInstanceID(cfg.AdminDarc.GetBaseID())
 	id := darc.NewIdentityEd25519(pub)
 	rules := darc.InitRulesWith([]darc.Identity{id}, []darc.Identity{id}, "invoke:"+byzcoin.ContractDarcID+".evolve")
 	expr := id.String()
@@ -515,7 +515,7 @@ func combineInstrsAndSign(cl *byzcoin.Client, signer darc.Signer, instrs ...byzc
 }
 
 func verifyGenesisDarc(cl *byzcoin.Client, cfg lib.Config, signer darc.Signer) error {
-	gdID := cfg.GenesisDarc.GetBaseID()
+	gdID := cfg.AdminDarc.GetBaseID()
 	p, err := cl.GetProof(gdID)
 	if err != nil {
 		return err


### PR DESCRIPTION
The previous version of bcadmin supposed that only the genesis-admin(s)
work on darcs. This PR makes it possible for non-genesis-admins
to create new darcs and to mint their money!