### PR TITLE
Rogue public key attack

### DIFF
--- a/conode/README.md
+++ b/conode/README.md
@@ -54,3 +54,13 @@ For creating a new docker image, there are two commands:
 on your machine.
 * `make docker BUILD_TAG=v3.0.0-pre1` - creates a docker image from source at tag
 BUILD_TAG.
+
+# Version 3
+
+## BLS security for version <= 3.0.2
+
+Prior to version 3.0.3, the BLS signature scheme was open to rogue public-key
+attacks. A verification has been added using Proof of Possession but conodes
+lacking the update won't be able to provide it. In order to migrate a cothority
+incrementally, the environment variable `ACCEPT_UNVERIFIED_PK` can be set and
+then missing proofs will be ignored.

--- a/pki/README.md
+++ b/pki/README.md
@@ -1,0 +1,52 @@
+Navigation: [DEDIS](https://github.com/dedis/doc/tree/master/README.md) ::
+[Cothority](../README.md) :: PKI
+
+# Public Key Infrastructure
+
+This service has the sole purpose of providing an API to get proofs that public
+keys hold by the conodes have a known pair secret key. In the context of the
+BLS CoSi scheme, a rogue public-key could be use to forge a correct signature
+using a single malicious node registered with a very specific public key.
+
+Even if the usage is very specific, it has been implemented as a service open
+to external requests so that it is possible for a client to ask for the Proofs
+of Possession of a given conode. It's not harmful because the API will only
+sign the public key appended to a nonce, thus avoiding to open an oracle.
+
+Note that the main key pair is authentified during the TLS handshake and is then
+not part of the proofs but only the services registered with a given suite
+because those generate a key pair. A request will then contain multiple proofs
+for a single conode.
+
+## Storage
+
+Because the only purpose of a Proof of Possession is to show that the private
+is known, it can be stored and reused indefinitely. The service then stores the
+requests so that it can provide future ones more efficiently.
+
+The database is used for that goal. One bucket contains the key/value pairs
+where the key is the public key marshalled into bytes and the value is the proof
+itself (Public key, Nonce, Signature).
+
+## Suites
+
+Each suite has its own sign and verify algorithms. Two suites are supported:
+- Ed25519
+- BN256
+
+If it happens that a service needs a different suite, it should be added in that
+service so that the new kind of key pair will be verified.
+
+## Attacks on Proof of Possession
+
+This section describes some known attacks that need to be known so that we don't
+open an API that could allow an attacker to forge a Proof of Possession.
+
+### BLS
+
+[This paper](https://link.springer.com/content/pdf/10.1007%2F978-3-540-72540-4.pdf)
+(page 251; 4.3) contains the description of an attack on the Proof of Possession.
+Basically if an attacker happens to be forge a signature of its public key
+(with the nonce) using the private key of the targeted honest peer, it could
+make a Proof of Possession of its public key. Fortunately we don't have any
+oracle open.

--- a/pki/README.md
+++ b/pki/README.md
@@ -18,6 +18,24 @@ not part of the proofs but only the services registered with a given suite
 because those generate a key pair. A request will then contain multiple proofs
 for a single conode.
 
+## Context
+
+This service has been implemented in the context of the issue #1675 where a
+modification of the BLS protocol to make it robust to rogue public-key attack
+was impossible to maintain backwards compatibility.
+
+In the context of that particular attack, it is very important to not let a
+forged public-key entered a roster because it could then forge any kind of
+signature for the aggregate public key. That's why the security has been
+implemented so that a change of the roster will be verified before accepting
+a new block. **That also means the BLS protocol is still insecure as is**. If
+one wants to use it, it would be adviced to implement the robust BLS scheme as
+described in [this paper](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html).
+
+In conclusion, as far as a roster has been accepted in a block, it is secure
+to use it and in any other case, this service should be used to verify its
+honesty.
+
 ## Storage
 
 Because the only purpose of a Proof of Possession is to show that the private
@@ -39,14 +57,14 @@ service so that the new kind of key pair will be verified.
 
 ## Attacks on Proof of Possession
 
-This section describes some known attacks that need to be known so that we don't
+This section describes some attacks that need to be known so that we don't
 open an API that could allow an attacker to forge a Proof of Possession.
 
 ### BLS
 
 [This paper](https://link.springer.com/content/pdf/10.1007%2F978-3-540-72540-4.pdf)
 (page 251; 4.3) contains the description of an attack on the Proof of Possession.
-Basically if an attacker happens to be forge a signature of its public key
+Basically if an attacker happens to have forged a signature of its public key
 (with the nonce) using the private key of the targeted honest peer, it could
 make a Proof of Possession of its public key. Fortunately we don't have any
 oracle open.

--- a/pki/api.go
+++ b/pki/api.go
@@ -1,0 +1,45 @@
+package pki
+
+import (
+	"bytes"
+	"errors"
+
+	"go.dedis.ch/cothority/v3"
+	"go.dedis.ch/onet/v3"
+	"go.dedis.ch/onet/v3/network"
+)
+
+// Client is the client to make requests to the PKI service
+type Client struct {
+	*onet.Client
+}
+
+// NewClient makes a new client
+func NewClient() *Client {
+	return &Client{Client: onet.NewClient(cothority.Suite, ServiceName)}
+}
+
+// GetProof returns the proofs of possession for the BLS key pairs
+func (c *Client) GetProof(srvid *network.ServerIdentity) ([]PkProof, error) {
+	nonce, err := makeNonce()
+	if err != nil {
+		return nil, err
+	}
+
+	req := &RequestPkProof{Nonce: nonce}
+	rep := &ResponsePkProof{}
+
+	err = c.SendProtobuf(srvid, req, rep)
+	if err != nil {
+		return nil, err
+	}
+
+	// make sure correct nonce has been used
+	for _, proof := range rep.Proofs {
+		if !bytes.Equal(proof.Nonce[:nonceLength], nonce) {
+			return nil, errors.New("nonce does not match with the request")
+		}
+	}
+
+	return rep.Proofs, nil
+}

--- a/pki/api_test.go
+++ b/pki/api_test.go
@@ -1,0 +1,75 @@
+package pki
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/cothority/v3"
+	"go.dedis.ch/onet/v3"
+)
+
+func init() {
+	onet.RegisterNewService(corruptedServiceName, newCorruptedService)
+}
+
+func TestAPI_GetProof(t *testing.T) {
+	local := onet.NewLocalTest(cothority.Suite)
+	defer local.CloseAll()
+
+	server := local.GenServers(1)[0]
+
+	client := NewClient()
+	proofs, err := client.GetProof(server.ServerIdentity)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(proofs))
+}
+
+func TestAPI_CorruptedGetProof(t *testing.T) {
+	local := onet.NewLocalTest(cothority.Suite)
+	defer local.CloseAll()
+
+	server := local.GenServers(1)[0]
+	service := server.Service(corruptedServiceName).(*corruptedService)
+
+	client := newCorruptedClient()
+
+	service.response = &ResponsePkProof{Proofs: PkProofs{}}
+	_, err := client.GetProof(server.ServerIdentity)
+	require.Error(t, err)
+	require.Equal(t, "got a wrong proof for service testServiceA", err.Error())
+
+	service.err = errors.New("test")
+	_, err = client.GetProof(server.ServerIdentity)
+	require.Error(t, err)
+	require.Equal(t, "request failed with: websocket: close 4000: test", err.Error())
+}
+
+func newCorruptedClient() *Client {
+	return &Client{
+		Client: onet.NewClient(cothority.Suite, corruptedServiceName),
+	}
+}
+
+const corruptedServiceName = "pki-service-corrupted"
+
+type corruptedService struct {
+	*onet.ServiceProcessor
+
+	err      error
+	response *ResponsePkProof
+}
+
+func newCorruptedService(c *onet.Context) (onet.Service, error) {
+	service := &corruptedService{
+		ServiceProcessor: onet.NewServiceProcessor(c),
+	}
+
+	err := service.RegisterHandlers(service.RequestProof)
+
+	return service, err
+}
+
+func (cs *corruptedService) RequestProof(req *RequestPkProof) (*ResponsePkProof, error) {
+	return cs.response, cs.err
+}

--- a/pki/api_test.go
+++ b/pki/api_test.go
@@ -37,7 +37,7 @@ func TestAPI_CorruptedGetProof(t *testing.T) {
 	service.response = &ResponsePkProof{Proofs: PkProofs{}}
 	_, err := client.GetProof(server.ServerIdentity)
 	require.Error(t, err)
-	require.Equal(t, "got a wrong proof for service testServiceA", err.Error())
+	require.Equal(t, "got a wrong proof for service testServiceA: couldn't find a proof", err.Error())
 
 	service.err = errors.New("test")
 	_, err = client.GetProof(server.ServerIdentity)

--- a/pki/service.go
+++ b/pki/service.go
@@ -5,6 +5,7 @@ package pki
 import (
 	"crypto/rand"
 	"errors"
+	"fmt"
 
 	"go.dedis.ch/cothority/v3"
 	"go.dedis.ch/kyber/v3"
@@ -77,9 +78,22 @@ func (s *Service) GetProof(srvid *network.ServerIdentity) ([]PkProof, error) {
 	}
 
 	// store the proofs as we can reuse them later on
+	// Note that proofs have been verified by the client already
 	err = s.storeProofs(proofs)
 
 	return proofs, err
+}
+
+// VerifyRoster takes a roster and make sure any server identity inside is honest
+func (s *Service) VerifyRoster(roster *onet.Roster) error {
+	for _, si := range roster.List {
+		_, err := s.GetProof(si)
+		if err != nil {
+			return fmt.Errorf("couldn't verify %v: %v", si, err)
+		}
+	}
+
+	return nil
 }
 
 // RequestProof returns the list of public-key proofs for the given server identity

--- a/pki/service.go
+++ b/pki/service.go
@@ -1,0 +1,105 @@
+// Package pki provides a Public Key Infrastructure that has the purpose of storing and
+// getting proof of possession of the public keys a conode is holding for certain services
+package pki
+
+import (
+	"crypto/rand"
+	"fmt"
+
+	"go.dedis.ch/kyber/v3/pairing"
+	"go.dedis.ch/kyber/v3/sign/bls"
+	"go.dedis.ch/onet/v3"
+	"go.dedis.ch/onet/v3/network"
+	bbolt "go.etcd.io/bbolt"
+)
+
+var pairingSuite = pairing.NewSuiteBn256()
+
+// ServiceName is the name used to register the service
+const ServiceName = "PKI"
+
+const nonceLength = 64
+
+func init() {
+	onet.RegisterNewService(ServiceName, newPKIService)
+}
+
+// Service is the data structure of the service
+type Service struct {
+	*onet.ServiceProcessor
+
+	db     *bbolt.DB
+	bucket []byte
+}
+
+// GetProof returns the proofs of possession of a distant conode using either a local proof
+// or by requesting it to the conode
+func (s *Service) GetProof(srvid *network.ServerIdentity) ([]PkProof, error) {
+	client := NewClient()
+	proofs, err := client.GetProof(srvid)
+
+	// TODO: database storage
+
+	return proofs, err
+}
+
+// RequestProof returns the list of public-key proofs for the given server identity
+func (s *Service) RequestProof(req *RequestPkProof) (*ResponsePkProof, error) {
+	if len(req.Nonce) != 64 {
+		return nil, fmt.Errorf("nonce needs to be of length %d", nonceLength)
+	}
+
+	proofs := make([]PkProof, len(s.ServerIdentity().ServiceIdentities))
+
+	for i, k := range s.ServerIdentity().ServiceIdentities {
+		if k.Suite == "bn256.adapter" {
+			pub, err := k.Public.MarshalBinary()
+			if err != nil {
+				return nil, err
+			}
+
+			// need a nonce with enough entropy to prevent a brute force attack
+			nonce, err := makeNonce()
+			if err != nil {
+				return nil, err
+			}
+
+			// combination of two nonces so that neither of the participants
+			// can produce a forged proof of possession
+			nonce = append(req.Nonce, nonce...)
+
+			sig, err := bls.Sign(pairingSuite, k.GetPrivate(), append(pub, nonce...))
+			if err != nil {
+				return nil, err
+			}
+
+			proofs[i].Public = pub
+			proofs[i].Nonce = nonce
+			proofs[i].Signature = sig
+		}
+	}
+
+	return &ResponsePkProof{Proofs: proofs}, nil
+}
+
+func newPKIService(c *onet.Context) (onet.Service, error) {
+	db, bucket := c.GetAdditionalBucket([]byte("pki-service"))
+
+	service := &Service{
+		ServiceProcessor: onet.NewServiceProcessor(c),
+		db:               db,
+		bucket:           bucket,
+	}
+
+	err := service.RegisterHandlers(service.RequestProof)
+
+	return service, err
+}
+
+func makeNonce() ([]byte, error) {
+	// need a nonce with enough entropy to prevent a brute force attack
+	nonce := make([]byte, nonceLength)
+	_, err := rand.Read(nonce)
+
+	return nonce, err
+}

--- a/pki/service.go
+++ b/pki/service.go
@@ -1,27 +1,54 @@
 // Package pki provides a Public Key Infrastructure that has the purpose of storing and
-// getting proof of possession of the public keys a conode is holding for certain services
+// getting proof of possession of the public keys that a conode is holding for certain services
 package pki
 
 import (
 	"crypto/rand"
-	"fmt"
+	"errors"
 
+	"go.dedis.ch/cothority/v3"
+	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/kyber/v3/pairing"
 	"go.dedis.ch/kyber/v3/sign/bls"
+	"go.dedis.ch/kyber/v3/sign/schnorr"
+	"go.dedis.ch/kyber/v3/suites"
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/network"
+	"go.dedis.ch/protobuf"
 	bbolt "go.etcd.io/bbolt"
 )
-
-var pairingSuite = pairing.NewSuiteBn256()
 
 // ServiceName is the name used to register the service
 const ServiceName = "PKI"
 
-const nonceLength = 64
+const nonceLength = 8
+
+var bn256Suite = pairing.NewSuiteBn256()
+var ed25519Suite = suites.MustFind("Ed25519")
+
+var signRegister map[string]SignFunc
+var verifyRegister map[string]VerifyFunc
 
 func init() {
 	onet.RegisterNewService(ServiceName, newPKIService)
+
+	// register for the signing functions
+	signRegister = make(map[string]SignFunc)
+	signRegister[bn256Suite.String()] = func(secret kyber.Scalar, msg []byte) ([]byte, error) {
+		return bls.Sign(bn256Suite, secret, msg)
+	}
+	signRegister[cothority.Suite.String()] = func(secret kyber.Scalar, msg []byte) ([]byte, error) {
+		return schnorr.Sign(cothority.Suite, secret, msg)
+	}
+
+	// register for the verification functions
+	verifyRegister = make(map[string]VerifyFunc)
+	verifyRegister[bn256Suite.String()] = func(pub kyber.Point, msg []byte, sig []byte) error {
+		return bls.Verify(bn256Suite, pub, msg, sig)
+	}
+	verifyRegister[ed25519Suite.String()] = func(pub kyber.Point, msg []byte, sig []byte) error {
+		return schnorr.Verify(ed25519Suite, pub, msg, sig)
+	}
 }
 
 // Service is the data structure of the service
@@ -30,56 +57,125 @@ type Service struct {
 
 	db     *bbolt.DB
 	bucket []byte
+	client *Client
 }
 
 // GetProof returns the proofs of possession of a distant conode using either a local proof
 // or by requesting it to the conode
 func (s *Service) GetProof(srvid *network.ServerIdentity) ([]PkProof, error) {
-	client := NewClient()
-	proofs, err := client.GetProof(srvid)
+	proofs, ok, err := s.readProofs(srvid)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return proofs, nil
+	}
 
-	// TODO: database storage
+	proofs, err = s.client.GetProof(srvid)
+	if err != nil {
+		return nil, err
+	}
+
+	// store the proofs as we can reuse them later on
+	err = s.storeProofs(proofs)
 
 	return proofs, err
 }
 
 // RequestProof returns the list of public-key proofs for the given server identity
 func (s *Service) RequestProof(req *RequestPkProof) (*ResponsePkProof, error) {
-	if len(req.Nonce) != 64 {
-		return nil, fmt.Errorf("nonce needs to be of length %d", nonceLength)
-	}
-
 	proofs := make([]PkProof, len(s.ServerIdentity().ServiceIdentities))
 
 	for i, k := range s.ServerIdentity().ServiceIdentities {
-		if k.Suite == "bn256.adapter" {
-			pub, err := k.Public.MarshalBinary()
-			if err != nil {
-				return nil, err
-			}
-
-			// need a nonce with enough entropy to prevent a brute force attack
-			nonce, err := makeNonce()
-			if err != nil {
-				return nil, err
-			}
-
-			// combination of two nonces so that neither of the participants
-			// can produce a forged proof of possession
-			nonce = append(req.Nonce, nonce...)
-
-			sig, err := bls.Sign(pairingSuite, k.GetPrivate(), append(pub, nonce...))
-			if err != nil {
-				return nil, err
-			}
-
-			proofs[i].Public = pub
-			proofs[i].Nonce = nonce
-			proofs[i].Signature = sig
+		f := signRegister[k.Suite]
+		if f == nil {
+			return nil, errors.New("unknown suite for the service key pair")
 		}
+
+		pub, err := k.Public.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+
+		// need a nonce to avoid a signature of the raw public key
+		// that could be used elsewhere
+		nonce, err := makeNonce()
+		if err != nil {
+			return nil, err
+		}
+
+		// Here it is important to use the public key because an attacker could forge
+		// a proof of possession if the message signed doesn't have enough entropy using
+		// H(m)^s / H(m)^t = H(m)^(s-t) where s is the attacker secret and t the honest
+		// peer secret. Using the public key prevents the attacker to forge m.
+		// Note: this applies mainly to the BLS scheme
+		sig, err := f(k.GetPrivate(), append(pub, nonce...))
+		if err != nil {
+			return nil, err
+		}
+
+		proofs[i].Public = pub
+		proofs[i].Nonce = nonce
+		proofs[i].Signature = sig
 	}
 
 	return &ResponsePkProof{Proofs: proofs}, nil
+}
+
+// readProofs tries to get the proofs from the cache and return false if at least
+// one is missing meaning a request will be necessary
+func (s *Service) readProofs(si *network.ServerIdentity) ([]PkProof, bool, error) {
+	proofs := []PkProof{}
+	ok := true
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(s.bucket)
+
+		for _, srvid := range si.ServiceIdentities {
+			pub, err := srvid.Public.MarshalBinary()
+			if err != nil {
+				return err
+			}
+
+			buf := b.Get(pub)
+			if buf == nil {
+				ok = false
+				return nil
+			}
+
+			var pr PkProof
+			err = protobuf.Decode(buf, &pr)
+			if err != nil {
+				return err
+			}
+
+			proofs = append(proofs, pr)
+		}
+
+		return nil
+	})
+
+	return proofs, ok, err
+}
+
+// storeProofs stores the given proofs in the db
+func (s *Service) storeProofs(proofs []PkProof) error {
+	return s.db.Update(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(s.bucket)
+
+		for _, pr := range proofs {
+			buf, err := protobuf.Encode(&pr)
+			if err != nil {
+				return err
+			}
+
+			err = b.Put(pr.Public, buf)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
 }
 
 func newPKIService(c *onet.Context) (onet.Service, error) {
@@ -89,6 +185,7 @@ func newPKIService(c *onet.Context) (onet.Service, error) {
 		ServiceProcessor: onet.NewServiceProcessor(c),
 		db:               db,
 		bucket:           bucket,
+		client:           NewClient(),
 	}
 
 	err := service.RegisterHandlers(service.RequestProof)
@@ -97,7 +194,6 @@ func newPKIService(c *onet.Context) (onet.Service, error) {
 }
 
 func makeNonce() ([]byte, error) {
-	// need a nonce with enough entropy to prevent a brute force attack
 	nonce := make([]byte, nonceLength)
 	_, err := rand.Read(nonce)
 

--- a/pki/service_test.go
+++ b/pki/service_test.go
@@ -1,0 +1,46 @@
+package pki
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/cothority/v3"
+	"go.dedis.ch/onet/v3"
+)
+
+func init() {
+	onet.RegisterNewServiceWithSuite("testServiceA", bn256Suite, newPKIService)
+	onet.RegisterNewServiceWithSuite("testServiceB", cothority.Suite, newPKIService)
+}
+
+func TestService_GetProof(t *testing.T) {
+	local := onet.NewLocalTest(cothority.Suite)
+	defer local.CloseAll()
+
+	servers := local.GenServers(2)
+
+	service := servers[0].Service(ServiceName).(*Service)
+	proofs, err := service.GetProof(servers[1].ServerIdentity)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(proofs))
+
+	servers[1].Pause()
+	proofs, err = service.GetProof(servers[1].ServerIdentity)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(proofs))
+}
+
+func TestService_RequestProof(t *testing.T) {
+	local := onet.NewLocalTest(cothority.Suite)
+	defer local.CloseAll()
+
+	server := local.GenServers(1)[0]
+	service := server.Service(ServiceName).(*Service)
+
+	rep, err := service.RequestProof(&RequestPkProof{})
+	require.NoError(t, err)
+	require.Equal(t, 2, len(rep.Proofs))
+
+	require.Nil(t, rep.Proofs.Verify(&server.ServerIdentity.ServiceIdentities[0]))
+	require.Nil(t, rep.Proofs.Verify(&server.ServerIdentity.ServiceIdentities[1]))
+}

--- a/pki/service_test.go
+++ b/pki/service_test.go
@@ -39,6 +39,11 @@ func TestService_VerifyRoster(t *testing.T) {
 
 	err := service.VerifyRoster(ro)
 	require.NoError(t, err)
+
+	ro.List[1].ServiceIdentities[0].Public = bn256Suite.Point().Base()
+	err = service.VerifyRoster(ro)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "couldn't verify ")
 }
 
 func TestService_RequestProof(t *testing.T) {
@@ -54,4 +59,9 @@ func TestService_RequestProof(t *testing.T) {
 
 	require.Nil(t, rep.Proofs.Verify(&server.ServerIdentity.ServiceIdentities[0]))
 	require.Nil(t, rep.Proofs.Verify(&server.ServerIdentity.ServiceIdentities[1]))
+
+	server.ServerIdentity.ServiceIdentities[0].Suite = "unknown"
+	_, err = service.RequestProof(&RequestPkProof{})
+	require.Error(t, err)
+	require.Equal(t, "unknown suite for the service key pair", err.Error())
 }

--- a/pki/service_test.go
+++ b/pki/service_test.go
@@ -30,6 +30,17 @@ func TestService_GetProof(t *testing.T) {
 	require.Equal(t, 2, len(proofs))
 }
 
+func TestService_VerifyRoster(t *testing.T) {
+	local := onet.NewLocalTest(cothority.Suite)
+	defer local.CloseAll()
+
+	servers, ro, _ := local.GenTree(4, false)
+	service := servers[0].Service(ServiceName).(*Service)
+
+	err := service.VerifyRoster(ro)
+	require.NoError(t, err)
+}
+
 func TestService_RequestProof(t *testing.T) {
 	local := onet.NewLocalTest(cothority.Suite)
 	defer local.CloseAll()

--- a/pki/struct.go
+++ b/pki/struct.go
@@ -1,0 +1,49 @@
+package pki
+
+import (
+	"bytes"
+
+	"go.dedis.ch/kyber/v3/sign/bls"
+	"go.dedis.ch/onet/v3/network"
+)
+
+// PkProof is the proof of possession of a key
+type PkProof struct {
+	Public    []byte
+	Nonce     []byte
+	Signature []byte
+}
+
+// PkProofs is a list of PkProof
+type PkProofs []PkProof
+
+// Verify returns true if the service identity can be verified
+func (pp PkProofs) Verify(srvid *network.ServiceIdentity) bool {
+	pub, err := srvid.Public.MarshalBinary()
+	if err != nil {
+		return false
+	}
+
+	for _, p := range pp {
+		if bytes.Equal(p.Public, pub) {
+			msg := append(p.Public, p.Nonce...)
+			if bls.Verify(pairingSuite, srvid.Public, msg, p.Signature) == nil {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// RequestPkProof is the message for asking a proof
+type RequestPkProof struct {
+	// We use a nonce from the requester and the receiver to prevent
+	// forged proof of possession
+	Nonce []byte
+}
+
+// ResponsePkProof contains the response of a request
+type ResponsePkProof struct {
+	Proofs PkProofs
+}

--- a/pki/struct.go
+++ b/pki/struct.go
@@ -9,6 +9,14 @@ import (
 	"go.dedis.ch/onet/v3/network"
 )
 
+func init() {
+	network.RegisterMessages(
+		&PkProof{},
+		&RequestPkProof{},
+		&ResponsePkProof{},
+	)
+}
+
 // SignFunc generates the signature of a message given the secret key
 type SignFunc func(secret kyber.Scalar, msg []byte) ([]byte, error)
 

--- a/pki/struct.go
+++ b/pki/struct.go
@@ -48,10 +48,12 @@ func (pp PkProofs) Verify(srvid *network.ServiceIdentity) error {
 			if err != nil {
 				return fmt.Errorf("signature verification failed: %v", err)
 			}
+
+			return nil
 		}
 	}
 
-	return nil
+	return errors.New("couldn't find a proof")
 }
 
 // RequestPkProof is the message for asking a proof

--- a/pki/struct_test.go
+++ b/pki/struct_test.go
@@ -1,0 +1,46 @@
+package pki
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/cothority/v3"
+	"go.dedis.ch/onet/v3"
+)
+
+func TestStruct_PkProofs(t *testing.T) {
+	local := onet.NewLocalTest(cothority.Suite)
+	defer local.CloseAll()
+
+	serv := local.GenServers(1)[0]
+	srvid := &serv.ServerIdentity.ServiceIdentities[0]
+
+	pub, err := srvid.Public.MarshalBinary()
+	require.NoError(t, err)
+
+	pp := PkProofs{PkProof{
+		Public:    pub,
+		Nonce:     []byte{},
+		Signature: []byte{},
+	}}
+
+	err = pp.Verify(srvid)
+	require.Error(t, err)
+	require.Equal(t, "nonce length does not match", err.Error())
+
+	pp[0].Nonce = make([]byte, nonceLength)
+	srvid.Suite = "unknown"
+	err = pp.Verify(srvid)
+	require.Error(t, err)
+	require.Equal(t, "unknown suite used for the service", err.Error())
+
+	srvid.Suite = cothority.Suite.String()
+	err = pp.Verify(srvid)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "signature verification failed:")
+
+	pp[0].Public = []byte{}
+	err = pp.Verify(srvid)
+	require.Error(t, err)
+	require.Equal(t, "couldn't find a proof", err.Error())
+}

--- a/skipchain/msgs.go
+++ b/skipchain/msgs.go
@@ -1,6 +1,7 @@
 package skipchain
 
 import (
+	"go.dedis.ch/cothority/v3/pki"
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/network"
@@ -162,6 +163,9 @@ type ForwardSignature struct {
 	// Links holds the forwardlinks to prove that 'Newest' is valid. For
 	// the level-0 forwardlink, this is empty.
 	Links []*ForwardLink
+	// PkProofs holds the list of proofs of possession for the new conodes
+	// that the block is trying to insert in the Cothority
+	PkProofs pki.PkProofs
 }
 
 // GetSingleBlock asks for a single block.

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -36,7 +36,7 @@ import (
 	"go.dedis.ch/onet/v3/network"
 )
 
-const envAcceptUnverified = "BLS_ACCEPT_UNVERIFIED_PK"
+const envAcceptUnverified = "ACCEPT_UNVERIFIED_PK"
 
 // ServiceName can be used to refer to the name of this service
 const ServiceName = "Skipchain"
@@ -958,7 +958,7 @@ func (s *Service) forwardLinkLevel0(src, dst *SkipBlock) error {
 			if err != nil && !acceptUnverified {
 				// new conodes appended to the cothority need to be online to send
 				// their proof
-				return fmt.Errorf("Couldn't get the proof of possession for %v", si)
+				return fmt.Errorf("Couldn't get the proof of possession for %v: %v", si, err)
 			}
 
 			proofs = append(proofs, pr...)
@@ -1116,8 +1116,8 @@ func (s *Service) bftForwardLinkLevel0(msg, data []byte) bool {
 					// For backwards compatibility, we allow admins to run their conodes
 					// with an environment variable to accept unverified public keys if
 					// the PKI service is not available
-					if !fs.PkProofs.Verify(&srvid) {
-						log.Error("a service key pair cannot be verified")
+					if err := fs.PkProofs.Verify(&srvid); err != nil {
+						log.Errorf("a service key pair cannot be verified: %v", err)
 						return false
 					}
 				}

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -947,23 +947,21 @@ func (s *Service) forwardLinkLevel0(src, dst *SkipBlock) error {
 	proofs := []pki.PkProof{}
 	_, acceptUnverified := os.LookupEnv(envAcceptUnverified)
 
-	if !acceptUnverified {
-		// don't make the request if we accept unverified public key because
-		// it doesn't protect anyway
-		for _, si := range dst.Roster.List {
-			if i, _ := src.Roster.Search(si.ID); i < 0 {
-				newRoster = append(newRoster, si)
+	// don't make the request if we accept unverified public key because
+	// it doesn't protect anyway
+	for _, si := range dst.Roster.List {
+		if i, _ := src.Roster.Search(si.ID); i < 0 {
+			newRoster = append(newRoster, si)
 
-				// Get the proofs of possession of the public keys
-				pr, err := pkiService.GetProof(si)
-				if err != nil {
-					// new conodes appended to the cothority need to be online to send
-					// their proof
-					return fmt.Errorf("Couldn't get the proof of possession for %v", si)
-				}
-
-				proofs = append(proofs, pr...)
+			// Get the proofs of possession of the public keys
+			pr, err := pkiService.GetProof(si)
+			if err != nil && !acceptUnverified {
+				// new conodes appended to the cothority need to be online to send
+				// their proof
+				return fmt.Errorf("Couldn't get the proof of possession for %v", si)
 			}
+
+			proofs = append(proofs, pr...)
 		}
 	}
 
@@ -1017,7 +1015,7 @@ func (s *Service) forwardLinkLevel0(src, dst *SkipBlock) error {
 		return nil
 	}
 
-	log.Lvlf3("%v is propagating %d blocks to %v", s.ServerIdentity(), len(proof), newRoster)
+	log.Lvlf2("%v is propagating %d blocks to %v", s.ServerIdentity(), len(proof), newRoster)
 
 	// current conode needs to be in the propagation roster
 	newRoster = append(newRoster, s.ServerIdentity())
@@ -1515,7 +1513,7 @@ func (s *Service) propagateProofHandler(msg network.Message) error {
 		return err
 	}
 
-	log.Lvlf3("Proof has been propagated to %v", s.ServerIdentity())
+	log.Lvlf2("Proof has been propagated to %v", s.ServerIdentity())
 	return nil
 }
 

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -197,9 +197,6 @@ func TestService_StoreCorruptedSkipBlock(t *testing.T) {
 }
 
 func TestService_RoguePublicKey(t *testing.T) {
-	log.OutputToBuf()
-	defer log.OutputToOs()
-
 	local := onet.NewLocalTest(cothority.Suite)
 	defer waitPropagationFinished(t, local)
 	defer local.CloseAll()
@@ -220,10 +217,10 @@ func TestService_RoguePublicKey(t *testing.T) {
 
 	_, err = service.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: genesis.Hash, NewBlock: newBlock})
 	require.Error(t, err)
-	require.Contains(t, log.GetStdErr(), "a service key pair cannot be verified")
+	require.Contains(t, err.Error(), "got a wrong proof for service")
 
 	// backwards compatibility check
-	os.Setenv(envAcceptUnverified, "true")
+	os.Setenv(envAcceptUnverified, "")
 	defer os.Unsetenv(envAcceptUnverified)
 	_, err = service.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: genesis.Hash, NewBlock: newBlock})
 	require.NoError(t, err)

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -224,6 +224,7 @@ func TestService_RoguePublicKey(t *testing.T) {
 
 	// backwards compatibility check
 	os.Setenv(envAcceptUnverified, "true")
+	defer os.Unsetenv(envAcceptUnverified)
 	_, err = service.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: genesis.Hash, NewBlock: newBlock})
 	require.NoError(t, err)
 }


### PR DESCRIPTION
This PR first adds a service that will act a very simple PKI so that we can ask for proofs to conodes and the service will store them to avoid further requests (see the README).

Then it fixes the rogue public-key attack by making sure the roster of a block is honest. It *doesn't* fix the protocol by itself. There is no way to be backwards compatible and make it secured. This requires a breaking change that should be planned for v4. The robust scheme could also be implemented now so that new services could use it.

Concerning the backwards compatibility, an admin can use the environment variable `ACCEPT_UNVERIFIED_PK` to migrate a cothority step by step. When all of the conode have a version higher enough, it can be turned off to make the protection efficient.

Fixes #1675 