### PR TITLE
Uses URL from ServerIdentity struct (JS only) issue #1791

### DIFF
--- a/external/js/cothority/README.md
+++ b/external/js/cothority/README.md
@@ -94,22 +94,9 @@ As this is a [polyfill](https://remysharp.com/2010/10/08/what-is-a-polyfill), pl
 check that what you need is implemented or you will need to use a different approach. Of
 course for NodeJS, you will always get a [Buffer](https://nodejs.org/api/buffer.html).
 
-### Use a developpment version from an external app
+## Use a developpment version from an external app
 
-**Note**: Using the official command `yarn link` doesn't seem to work. We leave
-the steps at the end for informational purpose, but we found out that using symlink
-is simpler, clearer, and actually works.
-
-Build and Link the local `@dedis/cothority` module to a local app:
-
-```bash
-(cothority/external/js/cothority) $ npm run build
-$ ln -s /<cothority root path>/cothority/external/js/cothority/dist /<local app root path>/node_modules/@dedis/cothority
-```
-
-**For information purpose**: The "clean" way to symlink a local package is
-with the `yarn link` command. However it happens to link the root folder
-instead of the `root/dist` one. Hence this is not likely to work:
+Steps to use `js/cothority` as a local module for a local external app:
 
 1) Build a version
 
@@ -120,18 +107,18 @@ instead of the `root/dist` one. Hence this is not likely to work:
 2) Create a link
 
 ```bash
-(cothority/external/js/cothority/dist) $ yarn link
+(cothority/external/js/cothority) $ npm run link
 ```
 
 3) From the root folder of the external app, link the new package
 
 ```bash
-(external_app) $ yarn link "@dedis/cothority"
+(external_app) $ npm link @dedis/cothority
 ```
 
-4) If needed, install the new linked pachage
+4) To unlink
 
 ```bash
-(external_app) $ npm install --save @dedis/cothority
+(external_app) $ npm unlink @dedis/cothority
+(cothority/external/js/cothority) $ npm unlink
 ```
-

--- a/external/js/cothority/README.md
+++ b/external/js/cothority/README.md
@@ -31,6 +31,8 @@ You should be able to run the tests with
 npm run test
 ```
 
+To run the tests, be sure to have docker installed and `make docker` executed from the root of this repo.
+
 ## Protobuf generation
 
 To add a new protobuf file to the library, simply place your `*.proto` file
@@ -91,3 +93,45 @@ will be provided thanks to the [buffer package](https://www.npmjs.com/package/bu
 As this is a [polyfill](https://remysharp.com/2010/10/08/what-is-a-polyfill), please
 check that what you need is implemented or you will need to use a different approach. Of
 course for NodeJS, you will always get a [Buffer](https://nodejs.org/api/buffer.html).
+
+### Use a developpment version from an external app
+
+**Note**: Using the official command `yarn link` doesn't seem to work. We leave
+the steps at the end for informational purpose, but we found out that using symlink
+is simpler, clearer, and actually works.
+
+Build and Link the local `@dedis/cothority` module to a local app:
+
+```bash
+(cothority/external/js/cothority) $ npm run build
+$ ln -s /<cothority root path>/cothority/external/js/cothority/dist /<local app root path>/node_modules/@dedis/cothority
+```
+
+**For information purpose**: The "clean" way to symlink a local package is
+with the `yarn link` command. However it happens to link the root folder
+instead of the `root/dist` one. Hence this is not likely to work:
+
+1) Build a version
+
+```bash
+(cothority/external/js/cothority) $ npm run build
+```
+
+2) Create a link
+
+```bash
+(cothority/external/js/cothority/dist) $ yarn link
+```
+
+3) From the root folder of the external app, link the new package
+
+```bash
+(external_app) $ yarn link "@dedis/cothority"
+```
+
+4) If needed, install the new linked pachage
+
+```bash
+(external_app) $ npm install --save @dedis/cothority
+```
+

--- a/external/js/cothority/README.md
+++ b/external/js/cothority/README.md
@@ -94,7 +94,7 @@ As this is a [polyfill](https://remysharp.com/2010/10/08/what-is-a-polyfill), pl
 check that what you need is implemented or you will need to use a different approach. Of
 course for NodeJS, you will always get a [Buffer](https://nodejs.org/api/buffer.html).
 
-## Use a developpment version from an external app
+## Use a development version from an external app
 
 Steps to use `js/cothority` as a local module for a local external app:
 

--- a/external/js/cothority/spec/index.spec.ts
+++ b/external/js/cothority/spec/index.spec.ts
@@ -1,7 +1,15 @@
+import Docker from "dockerode";
 import { byzcoin } from "../src";
 
 describe("Module import Tests", () => {
     it("should import the module", () => {
         expect(byzcoin.ByzCoinRPC).toBeDefined();
+    });
+});
+
+describe("Docker should be available", () => {
+    it("should not yield an error when getting docker infos", async () => {
+        const docker = new Docker();
+        await expectAsync(docker.info()).toBeResolved();
     });
 });

--- a/external/js/cothority/spec/network/proto.spec.ts
+++ b/external/js/cothority/spec/network/proto.spec.ts
@@ -18,6 +18,7 @@ describe("Network Proto Tests", () => {
             Public = "e5e23e58539a09d3211d8fa0fb3475d48655e0c06d83e93c8e6e7d16aa87c106"
             Description = "conode2"
             Suite = "Ed25519"
+            Url = "ws:127.0.0.1:7010"
         `;
         const roster = Roster.fromTOML(str);
 
@@ -44,6 +45,45 @@ describe("Network Proto Tests", () => {
         const srvid = new ServerIdentity({ address: "tls://127.0.0.1:5000", id: Buffer.from([]) });
 
         expect(srvid.getWebSocketAddress()).toBe("ws://127.0.0.1:5001");
+
+        const str = `
+        [[servers]]
+        Address = "tls://127.0.0.1:7770"
+        Suite = "Ed25519"
+        Public = "741b3af1fa069b2b964102bae6bc707315f61f5564fae426c261f5b6ceda3590"
+        Description = "Conode_1"
+        [servers.Services]
+          [servers.Services.ByzCoin]
+            Public = "3a2fde872cde581442bd9d522f5d9c0d71a52acc739b3e826e1fef9112cc34d172613965c692465d0f11bf89dbea407c1c34ee6fe9767baaa0314501433e520a7504651c8b321a811ee0b3de86cd03a8b187a6f7b4a1d6f89316b4bfd22bae44738f890bbd608c9145e2e8fc10f11e8f42ba4800171c8d7555418919900d7d9d"
+            Suite = "bn256.adapter"
+          [servers.Services.Skipchain]
+            Public = "55eb6fdb543561dbb806e8357e013e17988ba60e210552d05b178c831c0caaa4241bf16bc3f8bafebf3b81bca839bd1696a45dfc3990f992ac165e132474894003bf57c3761eed667cb2af0f7056daec53619a833a26b446fe0c8762b63ed0f145a8b49f3a92704c21715aef5f3e1b2e5769a069123965df3f20b4310cb73fc0"
+            Suite = "bn256.adapter"
+        `;
+        const roster = Roster.fromTOML(str);
+
+        expect(roster.list[0].getWebSocketAddress()).toBe("ws://127.0.0.1:7771");
+    });
+
+    it("should get the specified url address if given", () => {
+        const str = `
+        [[servers]]
+        Address = "tls://127.0.0.1:7770"
+        Suite = "Ed25519"
+        Public = "741b3af1fa069b2b964102bae6bc707315f61f5564fae426c261f5b6ceda3590"
+        Description = "Conode_1"
+        Url = "any::127.0.0.1:7010"
+        [servers.Services]
+          [servers.Services.ByzCoin]
+            Public = "3a2fde872cde581442bd9d522f5d9c0d71a52acc739b3e826e1fef9112cc34d172613965c692465d0f11bf89dbea407c1c34ee6fe9767baaa0314501433e520a7504651c8b321a811ee0b3de86cd03a8b187a6f7b4a1d6f89316b4bfd22bae44738f890bbd608c9145e2e8fc10f11e8f42ba4800171c8d7555418919900d7d9d"
+            Suite = "bn256.adapter"
+          [servers.Services.Skipchain]
+            Public = "55eb6fdb543561dbb806e8357e013e17988ba60e210552d05b178c831c0caaa4241bf16bc3f8bafebf3b81bca839bd1696a45dfc3990f992ac165e132474894003bf57c3761eed667cb2af0f7056daec53619a833a26b446fe0c8762b63ed0f145a8b49f3a92704c21715aef5f3e1b2e5769a069123965df3f20b4310cb73fc0"
+            Suite = "bn256.adapter"
+        `;
+        const roster = Roster.fromTOML(str);
+
+        expect(roster.list[0].getWebSocketAddress()).toBe("any::127.0.0.1:7010");
     });
 
     it("should valid and invalid addresses", () => {

--- a/external/js/cothority/spec/support/conondes.ts
+++ b/external/js/cothority/spec/support/conondes.ts
@@ -21,7 +21,7 @@ export async function startConodes(): Promise<void> {
     const container = containers[0];
 
     if (container) {
-        if (container.State === "running" || container.State === "exited") {
+        if (container.State === "running") {
             // already running
             return;
         } else {

--- a/external/js/cothority/src/network/proto.ts
+++ b/external/js/cothority/src/network/proto.ts
@@ -214,7 +214,7 @@ export class ServerIdentity extends Message<ServerIdentity> {
     }
 
     /**
-     * Returns this.url if wset, otherwise converts the server
+     * Returns this.url if set, otherwise converts the server
      * address to match the websocket format
      * @returns the websocket address
      */

--- a/external/js/cothority/src/network/proto.ts
+++ b/external/js/cothority/src/network/proto.ts
@@ -37,13 +37,13 @@ export class Roster extends Message<Roster> {
      *        Public = "e5e23e58539a09d3211d8fa0fb3475d48655e0c06d83e93c8e6e7d16aa87c106"
      *        Description = "conode2"
      *
-     * @param toml of the above format
+     * @param data toml with the above format
      * @returns the parsed roster
      */
     static fromTOML(data: string): Roster {
         const roster = toml.parse(data);
         const list = roster.servers.map((server: any) => {
-            const { Public, Suite, Address, Description, Services } = server;
+            const { Public, Suite, Address, Description, Services, Url } = server;
             const p = PointFactory.fromToml(Suite, Public);
 
             return new ServerIdentity({
@@ -56,6 +56,7 @@ export class Roster extends Message<Roster> {
 
                     return new ServiceIdentity({ name: key, public: point.toProto(), suite });
                 }),
+                url: Url,
             });
         });
 
@@ -213,11 +214,16 @@ export class ServerIdentity extends Message<ServerIdentity> {
     }
 
     /**
-     * Convert the address of the server to match the websocket format
+     * Returns this.url if wset, otherwise converts the server
+     * address to match the websocket format
      * @returns the websocket address
      */
     getWebSocketAddress(): string {
-        return ServerIdentity.addressToWebsocket(this.address);
+        if (this.url) {
+            return this.url;
+        } else {
+            return ServerIdentity.addressToWebsocket(this.address);
+        }
     }
 }
 


### PR DESCRIPTION
Solves issue #1791. 
If an `Url` param is found in the toml file, `getWebSocketAddress()` will use it instead of simply transforming the current server address with a port increment of one.

This PR also adds a test case to check if a docker service is available and changes a strange condition in `spec/support/conondes.ts` that was failing the tests. It also documents how to use `js/cothority` as a local module, which was used in order to check the service against `dedis/student_18_explorer`.