### PR TITLE
Adding calypso_v4 API

### DIFF
--- a/calypso/api_v4.go
+++ b/calypso/api_v4.go
@@ -1,0 +1,64 @@
+package calypso
+
+import (
+	"go.dedis.ch/cothority/v3"
+	"go.dedis.ch/kyber/v3"
+	"go.dedis.ch/onet/v3"
+)
+
+// TODO: add LTSID of type kyber.Point
+// TODO: think about authentication
+// TODO: add CreateAndAuthorise
+// TODO: add REST interface
+
+type LTSID kyber.Point
+
+// ClientV4 is a class to communicate to the calypso service.
+type ClientV4 struct {
+	*onet.Client
+}
+
+// NewClientV4 creates a new client to interact with the Calypso Service.
+func NewClientV4() *ClientV4 {
+	return &ClientV4{Client: onet.NewClient(cothority.Suite, ServiceName)}
+}
+
+// CreateLTS starts a new Distributed Key Generation with the nodes in the roster and
+// returns the collective public key X. This X is also used later to identify the
+// LTS instance, as there can be more than one LTS group on a node.
+//
+// It also sets up an authorisation option for the nodes.
+//
+// This can only be called from localhost, except if the environment variable
+// COTHORITY_ALLOW_INSECURE_ADMIN is set to 'true'.
+//
+// In case of error, X is nil, and the error indicates what is wrong.
+// The `sig` returned is a collective signature on the following hash:
+//   sha256( X | protobuf.Encode(auth) )
+// It can be verified using the aggregate service key from the roster:
+//   msg := sha256.New()
+//   Xbuf, err := X.MarshalBinary()
+//   // Check for errors
+//   msg.Write(Xbuf)
+//   authBuf, err := protobuf.Encode(auth)
+//   // Check for errors
+//   err = schnorr.Verify(cothority.Suite, roster.ServiceAggregate(calypso.ServiceName),
+//       msg.Sum(nil), sig)
+//   // If err == nil, the signature is correct
+func (c *ClientV4) CreateLTS(ltsRoster *onet.Roster, auth Auth) (X LTSID, sig []byte, err error) {
+	return
+}
+
+// Reencrypt requests the re-encryption of the secret stored in the grant.
+// The grant must also contain the ephemeral key to which the secret will be
+// reencrypted to.
+// Finally the grant must contain information about how to verify that the
+// reencryption request is valid.
+//
+// This can be called from anywhere.
+//
+// If the grant is valid, the reencrypted XHat is returned and err is nil. In case
+// of error, XHat is nil, and the error will be returned.
+func (c *ClientV4) Reencrypt(X kyber.Point, grant Grant) (XHat kyber.Point, err error) {
+	return
+}

--- a/calypso/proto.go
+++ b/calypso/proto.go
@@ -1,6 +1,8 @@
 package calypso
 
 import (
+	"time"
+
 	"go.dedis.ch/cothority/v3/byzcoin"
 	"go.dedis.ch/cothority/v3/skipchain"
 	"go.dedis.ch/kyber/v3"
@@ -9,6 +11,7 @@ import (
 
 // PROTOSTART
 // type :skipchain.SkipBlockID:bytes
+// type :time.Time:uint64
 // package calypso;
 // import "byzcoin.proto";
 // import "onet.proto";
@@ -125,4 +128,65 @@ type GetLTSReply struct {
 // LtsInstanceInfo is the information stored in an LTS instance.
 type LtsInstanceInfo struct {
 	Roster onet.Roster
+}
+
+//
+// V4 proposed extensions
+//
+
+// Auth holds all possible authentication structures. When using it to call
+// Authorise, only one of the fields must be non-nil.
+type Auth struct {
+	ByzCoin      *AuthByzCoin
+	AuthX509Cert *AuthX509Cert
+}
+
+// AuthByzCoin holds the information necessary to authenticate a byzcoin request.
+// In the ByzCoin model, all requests are valid as long as they are stored in the
+// blockchain with the given ID.
+// The TTL is to avoid that too old requests are re-used. If it is 0, it is disabled.
+type AuthByzCoin struct {
+	ByzCoinID skipchain.SkipBlockID
+	TTL       time.Time
+}
+
+// AuthX509Cert holds the information necessary to authenticate a HyperLedger/Fabric
+// request. In its simplest form, it is simply the CA that will have to sign the
+// certificates of the requesters.
+// The Threshold indicates how many clients must have signed the request before it
+// is accepted.
+type AuthX509Cert struct {
+	// Slice of ASN.1 encoded X509 certificates.
+	CA        [][]byte
+	Threshold int
+}
+
+// Grant holds one of the possible grant proofs for a reencryption request. Each
+// grant proof must hold the secret to be reencrypted, the ephemeral key, as well
+// as the proof itself that the request is valid. For each of the authentication
+// schemes, this proof will be different.
+type Grant struct {
+	ByzCoin  *GrantByzCoin
+	X509Cert *GrantX509Cert
+}
+
+// GrantByzCoin holds the proof of the write instance, holding the secret itself.
+// The proof of the read instance holds the ephemeral key. Both proofs can be
+// verified using one of the stored ByzCoinIDs.
+type GrantByzCoin struct {
+	// Write is the proof containing the write request.
+	Write byzcoin.Proof
+	// Read is the proof that he has been accepted to read the secret.
+	Read byzcoin.Proof
+}
+
+// GrantX509Cert holds the proof that at least a threshold number of clients
+// accepted the reencryption.
+// For each client, there must exist a certificate that can be verified by the
+// CA certificate from AuthX509Cert. Additionally, each client must sign the
+// following message:
+//   sha256( Secret | Ephemeral | Time )
+type GrantX509Cert struct {
+	Secret       kyber.Point
+	Certificates [][]byte
 }

--- a/calypso/verify.go
+++ b/calypso/verify.go
@@ -1,0 +1,64 @@
+package calypso
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+
+	"golang.org/x/crypto/ed25519"
+)
+
+var (
+	// selection of OID numbers is not random See documents
+	// https://tools.ietf.org/html/rfc5280#page-49
+	// https://tools.ietf.org/html/rfc7229
+	WriteIdOID      = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 13, 1}
+	EphemeralKeyOID = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 13, 2}
+)
+
+func Verify(rootCert *x509.Certificate, toVerify *x509.Certificate) (writeId []byte, key ed25519.PublicKey, err error) {
+	roots := x509.NewCertPool()
+	roots.AddCert(rootCert)
+
+	cert, err := x509.ParseCertificate(toVerify.Raw)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	opts := x509.VerifyOptions{
+		Roots: roots,
+	}
+
+	writeIdExt := getExtension(cert, WriteIdOID)
+	ephemeralKeyExt := getExtension(cert, EphemeralKeyOID)
+
+	unmarkUnhandledCriticalExtension(cert, WriteIdOID)
+	unmarkUnhandledCriticalExtension(cert, EphemeralKeyOID)
+
+	if _, err := cert.Verify(opts); err != nil {
+		return nil, nil, err
+	}
+
+	return writeIdExt.Value, ephemeralKeyExt.Value, nil
+}
+
+func unmarkUnhandledCriticalExtension(cert *x509.Certificate, id asn1.ObjectIdentifier) {
+	for i, extension := range cert.UnhandledCriticalExtensions {
+		if id.Equal(extension) {
+			cert.UnhandledCriticalExtensions = append(cert.UnhandledCriticalExtensions[0:i],
+				cert.UnhandledCriticalExtensions[i+1:]...)
+			return
+		}
+	}
+}
+
+func getExtension(certificate *x509.Certificate, id asn1.ObjectIdentifier) *pkix.Extension {
+
+	for _, ext := range certificate.Extensions {
+		if ext.Id.Equal(id) {
+			return &ext
+		}
+	}
+
+	return nil
+}

--- a/calypso/verify_test.go
+++ b/calypso/verify_test.go
@@ -1,0 +1,60 @@
+package calypso
+
+import (
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"testing"
+)
+
+const (
+	rootCert1 = `-----BEGIN CERTIFICATE-----
+MIIB1jCCATigAwIBAgIBATAKBggqhkjOPQQDBDAdMRswGQYDVQQDExJCeXpHZW4g
+c2lnbmVyIG9yZzEwHhcNMTkwMzI4MjEwNzUxWhcNNDQwMzIxMjEwNzUxWjAdMRsw
+GQYDVQQDExJCeXpHZW4gc2lnbmVyIG9yZzEwgZswEAYHKoZIzj0CAQYFK4EEACMD
+gYYABABqdo+aDVte5Fz/xG5Z2GYmIbcVJdXxrMJrTBYgHQafSw0BBKrAyeMcZ534
+/V6eNfkiZa3kuflo6Y2E/NtVxyl7dgFBYTdqvLtPdg7+K7pdj8eKFrAQ0DDi5S0x
+aM96oR3S0bU4MIbfMqW1fAsLPw3476Gvju73bfJhEJ3ukx6W2olq+KMmMCQwDgYD
+VR0PAQH/BAQDAgIEMBIGA1UdEwEB/wQIMAYBAf8CAQEwCgYIKoZIzj0EAwQDgYsA
+MIGHAkEcvPgm0qnXMgpJiOD52VUL3qTwU6uzRYhwIWa3sWCP471/muzsq6PctAEu
+CHkpnAlH3DuS2MBBql8ifwwK2PdOGQJCAQcE3+qdiyrABJ315INCTu6HAjpGv0cR
+VQWcCmSs80tS9gzvQJ8+peWRuzGvy1Uoyj0qHTSJOHx6z86oOIVbXAIj
+-----END CERTIFICATE-----`
+
+	validPem = `-----BEGIN CERTIFICATE-----
+MIICKTCCAYqgAwIBAgIQYNsgS2KrQ1ptA7E+cRfiUjAKBggqhkjOPQQDBDAdMRsw
+GQYDVQQDExJCeXpHZW4gc2lnbmVyIG9yZzEwHhcNMTkwMzI4MjEwNzUxWhcNMTkw
+NDExMjEwNzUxWjAoMSYwJAYDVQQDDB1FcGhlbWVyYWwgcmVhZCBvcGVyYXRpb24g
+JiBDbzB2MBAGByqGSM49AgEGBSuBBAAiA2IABPEbevkxsAu3BqZjMBzl+ppSLX1F
+4oqnAUxmXx+Yw9mgyunTWzHKPAgHoYmaVDL2a+MDVngmbJI+BiXaZBE00gW854pz
+ROa1Z7KxjYGgbRINavXX5nSTbs+xH3w76d3ppKOBgzCBgDAOBgNVHQ8BAf8EBAMC
+BSAwDAYDVR0TAQH/BAIwADAvBggrBgEFBQcNAQEB/wQg7PBd8YGomyUmjZpqOy9h
+gdAdKEfArphKLRkkozsRRvIwLwYIKwYBBQUHDQIBAf8EIBuJzdwW5DfOVymjPvBM
+YXsz+apB9URZnhN1jZy2wrixMAoGCCqGSM49BAMEA4GMADCBiAJCAYwxRrOwCydO
+r5KoAndH8/U9nIaM4BWcx1pwYFMM44P0BzXDQgDSYwIAhAQ5hvOpaMPB4IMKI37C
+G1lsOKivZEboAkIA90UbyVD7ahZdbpCDKUYAoVejKgA5JAsm8kUGPWt+siw2hsT9
+V/NTETY3evBjoX8kkWs/E5pWpwEGKPQaS25gw1s=
+-----END CERTIFICATE-----`
+)
+
+func Test_VerifyCertificateHappyDayScenario(t *testing.T) {
+	caCert, _ := certFromPem([]byte(rootCert1))
+	cert, _ := certFromPem([]byte(validPem))
+
+	writeId, key, _ := Verify(caCert, cert)
+	t.Log("writeId", hex.EncodeToString(writeId))
+	t.Log("key", hex.EncodeToString(key))
+}
+
+func certFromPem(pemCerts []byte) (cert *x509.Certificate, err error) {
+	var block *pem.Block
+
+	block, pemCerts = pem.Decode(pemCerts)
+
+	if block.Type != "CERTIFICATE" {
+		return nil, errors.New("expected a certificate")
+	}
+
+	return x509.ParseCertificate(block.Bytes)
+}

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/AuthProxProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/AuthProxProto.java
@@ -146,7 +146,7 @@ public final class AuthProxProto {
               break;
             }
             case 26: {
-              if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+              if (!((mutable_bitField0_ & 0x00000004) != 0)) {
                 participants_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
                 mutable_bitField0_ |= 0x00000004;
               }
@@ -155,7 +155,7 @@ public final class AuthProxProto {
             }
             case 34: {
               ch.epfl.dedis.lib.proto.AuthProxProto.PriShare.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+              if (((bitField0_ & 0x00000004) != 0)) {
                 subBuilder = longpri_.toBuilder();
               }
               longpri_ = input.readMessage(ch.epfl.dedis.lib.proto.AuthProxProto.PriShare.parser(), extensionRegistry);
@@ -167,7 +167,7 @@ public final class AuthProxProto {
               break;
             }
             case 42: {
-              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+              if (!((mutable_bitField0_ & 0x00000010) != 0)) {
                 longpubs_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
                 mutable_bitField0_ |= 0x00000010;
               }
@@ -189,11 +189,11 @@ public final class AuthProxProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
-          participants_ = java.util.Collections.unmodifiableList(participants_);
+        if (((mutable_bitField0_ & 0x00000004) != 0)) {
+          participants_ = java.util.Collections.unmodifiableList(participants_); // C
         }
-        if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-          longpubs_ = java.util.Collections.unmodifiableList(longpubs_);
+        if (((mutable_bitField0_ & 0x00000010) != 0)) {
+          longpubs_ = java.util.Collections.unmodifiableList(longpubs_); // C
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -219,7 +219,7 @@ public final class AuthProxProto {
      * <code>required string type = 1;</code>
      */
     public boolean hasType() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required string type = 1;</code>
@@ -261,7 +261,7 @@ public final class AuthProxProto {
      * <code>required string issuer = 2;</code>
      */
     public boolean hasIssuer() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required string issuer = 2;</code>
@@ -325,7 +325,7 @@ public final class AuthProxProto {
      * <code>required .authprox.PriShare longpri = 4;</code>
      */
     public boolean hasLongpri() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required .authprox.PriShare longpri = 4;</code>
@@ -388,16 +388,16 @@ public final class AuthProxProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, type_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, issuer_);
       }
       for (int i = 0; i < participants_.size(); i++) {
         output.writeBytes(3, participants_.get(i));
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeMessage(4, getLongpri());
       }
       for (int i = 0; i < longpubs_.size(); i++) {
@@ -412,10 +412,10 @@ public final class AuthProxProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, type_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, issuer_);
       }
       {
@@ -427,7 +427,7 @@ public final class AuthProxProto {
         size += dataSize;
         size += 1 * getParticipantsList().size();
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(4, getLongpri());
       }
@@ -455,28 +455,27 @@ public final class AuthProxProto {
       }
       ch.epfl.dedis.lib.proto.AuthProxProto.EnrollRequest other = (ch.epfl.dedis.lib.proto.AuthProxProto.EnrollRequest) obj;
 
-      boolean result = true;
-      result = result && (hasType() == other.hasType());
+      if (hasType() != other.hasType()) return false;
       if (hasType()) {
-        result = result && getType()
-            .equals(other.getType());
+        if (!getType()
+            .equals(other.getType())) return false;
       }
-      result = result && (hasIssuer() == other.hasIssuer());
+      if (hasIssuer() != other.hasIssuer()) return false;
       if (hasIssuer()) {
-        result = result && getIssuer()
-            .equals(other.getIssuer());
+        if (!getIssuer()
+            .equals(other.getIssuer())) return false;
       }
-      result = result && getParticipantsList()
-          .equals(other.getParticipantsList());
-      result = result && (hasLongpri() == other.hasLongpri());
+      if (!getParticipantsList()
+          .equals(other.getParticipantsList())) return false;
+      if (hasLongpri() != other.hasLongpri()) return false;
       if (hasLongpri()) {
-        result = result && getLongpri()
-            .equals(other.getLongpri());
+        if (!getLongpri()
+            .equals(other.getLongpri())) return false;
       }
-      result = result && getLongpubsList()
-          .equals(other.getLongpubsList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getLongpubsList()
+          .equals(other.getLongpubsList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -687,28 +686,28 @@ public final class AuthProxProto {
         ch.epfl.dedis.lib.proto.AuthProxProto.EnrollRequest result = new ch.epfl.dedis.lib.proto.AuthProxProto.EnrollRequest(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.type_ = type_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.issuer_ = issuer_;
-        if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((bitField0_ & 0x00000004) != 0)) {
           participants_ = java.util.Collections.unmodifiableList(participants_);
           bitField0_ = (bitField0_ & ~0x00000004);
         }
         result.participants_ = participants_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          if (longpriBuilder_ == null) {
+            result.longpri_ = longpri_;
+          } else {
+            result.longpri_ = longpriBuilder_.build();
+          }
           to_bitField0_ |= 0x00000004;
         }
-        if (longpriBuilder_ == null) {
-          result.longpri_ = longpri_;
-        } else {
-          result.longpri_ = longpriBuilder_.build();
-        }
-        if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((bitField0_ & 0x00000010) != 0)) {
           longpubs_ = java.util.Collections.unmodifiableList(longpubs_);
           bitField0_ = (bitField0_ & ~0x00000010);
         }
@@ -720,35 +719,35 @@ public final class AuthProxProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -839,7 +838,7 @@ public final class AuthProxProto {
        * <code>required string type = 1;</code>
        */
       public boolean hasType() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required string type = 1;</code>
@@ -915,7 +914,7 @@ public final class AuthProxProto {
        * <code>required string issuer = 2;</code>
        */
       public boolean hasIssuer() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required string issuer = 2;</code>
@@ -988,7 +987,7 @@ public final class AuthProxProto {
 
       private java.util.List<com.google.protobuf.ByteString> participants_ = java.util.Collections.emptyList();
       private void ensureParticipantsIsMutable() {
-        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
+        if (!((bitField0_ & 0x00000004) != 0)) {
           participants_ = new java.util.ArrayList<com.google.protobuf.ByteString>(participants_);
           bitField0_ |= 0x00000004;
          }
@@ -998,7 +997,8 @@ public final class AuthProxProto {
        */
       public java.util.List<com.google.protobuf.ByteString>
           getParticipantsList() {
-        return java.util.Collections.unmodifiableList(participants_);
+        return ((bitField0_ & 0x00000004) != 0) ?
+                 java.util.Collections.unmodifiableList(participants_) : participants_;
       }
       /**
        * <code>repeated bytes participants = 3;</code>
@@ -1058,14 +1058,14 @@ public final class AuthProxProto {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.AuthProxProto.PriShare longpri_ = null;
+      private ch.epfl.dedis.lib.proto.AuthProxProto.PriShare longpri_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.AuthProxProto.PriShare, ch.epfl.dedis.lib.proto.AuthProxProto.PriShare.Builder, ch.epfl.dedis.lib.proto.AuthProxProto.PriShareOrBuilder> longpriBuilder_;
       /**
        * <code>required .authprox.PriShare longpri = 4;</code>
        */
       public boolean hasLongpri() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <code>required .authprox.PriShare longpri = 4;</code>
@@ -1112,7 +1112,7 @@ public final class AuthProxProto {
        */
       public Builder mergeLongpri(ch.epfl.dedis.lib.proto.AuthProxProto.PriShare value) {
         if (longpriBuilder_ == null) {
-          if (((bitField0_ & 0x00000008) == 0x00000008) &&
+          if (((bitField0_ & 0x00000008) != 0) &&
               longpri_ != null &&
               longpri_ != ch.epfl.dedis.lib.proto.AuthProxProto.PriShare.getDefaultInstance()) {
             longpri_ =
@@ -1178,7 +1178,7 @@ public final class AuthProxProto {
 
       private java.util.List<com.google.protobuf.ByteString> longpubs_ = java.util.Collections.emptyList();
       private void ensureLongpubsIsMutable() {
-        if (!((bitField0_ & 0x00000010) == 0x00000010)) {
+        if (!((bitField0_ & 0x00000010) != 0)) {
           longpubs_ = new java.util.ArrayList<com.google.protobuf.ByteString>(longpubs_);
           bitField0_ |= 0x00000010;
          }
@@ -1188,7 +1188,8 @@ public final class AuthProxProto {
        */
       public java.util.List<com.google.protobuf.ByteString>
           getLongpubsList() {
-        return java.util.Collections.unmodifiableList(longpubs_);
+        return ((bitField0_ & 0x00000010) != 0) ?
+                 java.util.Collections.unmodifiableList(longpubs_) : longpubs_;
       }
       /**
        * <code>repeated bytes longpubs = 5;</code>
@@ -1416,9 +1417,8 @@ public final class AuthProxProto {
       }
       ch.epfl.dedis.lib.proto.AuthProxProto.EnrollResponse other = (ch.epfl.dedis.lib.proto.AuthProxProto.EnrollResponse) obj;
 
-      boolean result = true;
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -1597,35 +1597,35 @@ public final class AuthProxProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -1866,7 +1866,7 @@ public final class AuthProxProto {
             }
             case 34: {
               ch.epfl.dedis.lib.proto.AuthProxProto.PriShare.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000008) == 0x00000008)) {
+              if (((bitField0_ & 0x00000008) != 0)) {
                 subBuilder = randpri_.toBuilder();
               }
               randpri_ = input.readMessage(ch.epfl.dedis.lib.proto.AuthProxProto.PriShare.parser(), extensionRegistry);
@@ -1878,7 +1878,7 @@ public final class AuthProxProto {
               break;
             }
             case 42: {
-              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+              if (!((mutable_bitField0_ & 0x00000010) != 0)) {
                 randpubs_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
                 mutable_bitField0_ |= 0x00000010;
               }
@@ -1905,8 +1905,8 @@ public final class AuthProxProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-          randpubs_ = java.util.Collections.unmodifiableList(randpubs_);
+        if (((mutable_bitField0_ & 0x00000010) != 0)) {
+          randpubs_ = java.util.Collections.unmodifiableList(randpubs_); // C
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -1932,7 +1932,7 @@ public final class AuthProxProto {
      * <code>required string type = 1;</code>
      */
     public boolean hasType() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required string type = 1;</code>
@@ -1974,7 +1974,7 @@ public final class AuthProxProto {
      * <code>required string issuer = 2;</code>
      */
     public boolean hasIssuer() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required string issuer = 2;</code>
@@ -2016,7 +2016,7 @@ public final class AuthProxProto {
      * <code>required bytes authinfo = 3;</code>
      */
     public boolean hasAuthinfo() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required bytes authinfo = 3;</code>
@@ -2031,7 +2031,7 @@ public final class AuthProxProto {
      * <code>required .authprox.PriShare randpri = 4;</code>
      */
     public boolean hasRandpri() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <code>required .authprox.PriShare randpri = 4;</code>
@@ -2074,7 +2074,7 @@ public final class AuthProxProto {
      * <code>required bytes message = 6;</code>
      */
     public boolean hasMessage() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000010) != 0);
     }
     /**
      * <code>required bytes message = 6;</code>
@@ -2117,22 +2117,22 @@ public final class AuthProxProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, type_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, issuer_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(3, authinfo_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeMessage(4, getRandpri());
       }
       for (int i = 0; i < randpubs_.size(); i++) {
         output.writeBytes(5, randpubs_.get(i));
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         output.writeBytes(6, message_);
       }
       unknownFields.writeTo(output);
@@ -2144,17 +2144,17 @@ public final class AuthProxProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, type_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, issuer_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, authinfo_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(4, getRandpri());
       }
@@ -2167,7 +2167,7 @@ public final class AuthProxProto {
         size += dataSize;
         size += 1 * getRandpubsList().size();
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(6, message_);
       }
@@ -2186,36 +2186,35 @@ public final class AuthProxProto {
       }
       ch.epfl.dedis.lib.proto.AuthProxProto.SignatureRequest other = (ch.epfl.dedis.lib.proto.AuthProxProto.SignatureRequest) obj;
 
-      boolean result = true;
-      result = result && (hasType() == other.hasType());
+      if (hasType() != other.hasType()) return false;
       if (hasType()) {
-        result = result && getType()
-            .equals(other.getType());
+        if (!getType()
+            .equals(other.getType())) return false;
       }
-      result = result && (hasIssuer() == other.hasIssuer());
+      if (hasIssuer() != other.hasIssuer()) return false;
       if (hasIssuer()) {
-        result = result && getIssuer()
-            .equals(other.getIssuer());
+        if (!getIssuer()
+            .equals(other.getIssuer())) return false;
       }
-      result = result && (hasAuthinfo() == other.hasAuthinfo());
+      if (hasAuthinfo() != other.hasAuthinfo()) return false;
       if (hasAuthinfo()) {
-        result = result && getAuthinfo()
-            .equals(other.getAuthinfo());
+        if (!getAuthinfo()
+            .equals(other.getAuthinfo())) return false;
       }
-      result = result && (hasRandpri() == other.hasRandpri());
+      if (hasRandpri() != other.hasRandpri()) return false;
       if (hasRandpri()) {
-        result = result && getRandpri()
-            .equals(other.getRandpri());
+        if (!getRandpri()
+            .equals(other.getRandpri())) return false;
       }
-      result = result && getRandpubsList()
-          .equals(other.getRandpubsList());
-      result = result && (hasMessage() == other.hasMessage());
+      if (!getRandpubsList()
+          .equals(other.getRandpubsList())) return false;
+      if (hasMessage() != other.hasMessage()) return false;
       if (hasMessage()) {
-        result = result && getMessage()
-            .equals(other.getMessage());
+        if (!getMessage()
+            .equals(other.getMessage())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -2434,32 +2433,32 @@ public final class AuthProxProto {
         ch.epfl.dedis.lib.proto.AuthProxProto.SignatureRequest result = new ch.epfl.dedis.lib.proto.AuthProxProto.SignatureRequest(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.type_ = type_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.issuer_ = issuer_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.authinfo_ = authinfo_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          if (randpriBuilder_ == null) {
+            result.randpri_ = randpri_;
+          } else {
+            result.randpri_ = randpriBuilder_.build();
+          }
           to_bitField0_ |= 0x00000008;
         }
-        if (randpriBuilder_ == null) {
-          result.randpri_ = randpri_;
-        } else {
-          result.randpri_ = randpriBuilder_.build();
-        }
-        if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((bitField0_ & 0x00000010) != 0)) {
           randpubs_ = java.util.Collections.unmodifiableList(randpubs_);
           bitField0_ = (bitField0_ & ~0x00000010);
         }
         result.randpubs_ = randpubs_;
-        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+        if (((from_bitField0_ & 0x00000020) != 0)) {
           to_bitField0_ |= 0x00000010;
         }
         result.message_ = message_;
@@ -2470,35 +2469,35 @@ public final class AuthProxProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -2591,7 +2590,7 @@ public final class AuthProxProto {
        * <code>required string type = 1;</code>
        */
       public boolean hasType() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required string type = 1;</code>
@@ -2667,7 +2666,7 @@ public final class AuthProxProto {
        * <code>required string issuer = 2;</code>
        */
       public boolean hasIssuer() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required string issuer = 2;</code>
@@ -2743,7 +2742,7 @@ public final class AuthProxProto {
        * <code>required bytes authinfo = 3;</code>
        */
       public boolean hasAuthinfo() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required bytes authinfo = 3;</code>
@@ -2773,14 +2772,14 @@ public final class AuthProxProto {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.AuthProxProto.PriShare randpri_ = null;
+      private ch.epfl.dedis.lib.proto.AuthProxProto.PriShare randpri_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.AuthProxProto.PriShare, ch.epfl.dedis.lib.proto.AuthProxProto.PriShare.Builder, ch.epfl.dedis.lib.proto.AuthProxProto.PriShareOrBuilder> randpriBuilder_;
       /**
        * <code>required .authprox.PriShare randpri = 4;</code>
        */
       public boolean hasRandpri() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <code>required .authprox.PriShare randpri = 4;</code>
@@ -2827,7 +2826,7 @@ public final class AuthProxProto {
        */
       public Builder mergeRandpri(ch.epfl.dedis.lib.proto.AuthProxProto.PriShare value) {
         if (randpriBuilder_ == null) {
-          if (((bitField0_ & 0x00000008) == 0x00000008) &&
+          if (((bitField0_ & 0x00000008) != 0) &&
               randpri_ != null &&
               randpri_ != ch.epfl.dedis.lib.proto.AuthProxProto.PriShare.getDefaultInstance()) {
             randpri_ =
@@ -2893,7 +2892,7 @@ public final class AuthProxProto {
 
       private java.util.List<com.google.protobuf.ByteString> randpubs_ = java.util.Collections.emptyList();
       private void ensureRandpubsIsMutable() {
-        if (!((bitField0_ & 0x00000010) == 0x00000010)) {
+        if (!((bitField0_ & 0x00000010) != 0)) {
           randpubs_ = new java.util.ArrayList<com.google.protobuf.ByteString>(randpubs_);
           bitField0_ |= 0x00000010;
          }
@@ -2903,7 +2902,8 @@ public final class AuthProxProto {
        */
       public java.util.List<com.google.protobuf.ByteString>
           getRandpubsList() {
-        return java.util.Collections.unmodifiableList(randpubs_);
+        return ((bitField0_ & 0x00000010) != 0) ?
+                 java.util.Collections.unmodifiableList(randpubs_) : randpubs_;
       }
       /**
        * <code>repeated bytes randpubs = 5;</code>
@@ -2968,7 +2968,7 @@ public final class AuthProxProto {
        * <code>required bytes message = 6;</code>
        */
       public boolean hasMessage() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
+        return ((bitField0_ & 0x00000020) != 0);
       }
       /**
        * <code>required bytes message = 6;</code>
@@ -3167,9 +3167,8 @@ public final class AuthProxProto {
       }
       ch.epfl.dedis.lib.proto.AuthProxProto.PriShare other = (ch.epfl.dedis.lib.proto.AuthProxProto.PriShare) obj;
 
-      boolean result = true;
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -3349,35 +3348,35 @@ public final class AuthProxProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -3555,7 +3554,7 @@ public final class AuthProxProto {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.AuthProxProto.PriShare.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = partial_.toBuilder();
               }
               partial_ = input.readMessage(ch.epfl.dedis.lib.proto.AuthProxProto.PriShare.parser(), extensionRegistry);
@@ -3615,7 +3614,7 @@ public final class AuthProxProto {
      * <code>required .authprox.PriShare partial = 1;</code>
      */
     public boolean hasPartial() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required .authprox.PriShare partial = 1;</code>
@@ -3636,7 +3635,7 @@ public final class AuthProxProto {
      * <code>required bytes sessionid = 2;</code>
      */
     public boolean hasSessionid() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes sessionid = 2;</code>
@@ -3651,7 +3650,7 @@ public final class AuthProxProto {
      * <code>required bytes signature = 3;</code>
      */
     public boolean hasSignature() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required bytes signature = 3;</code>
@@ -3686,13 +3685,13 @@ public final class AuthProxProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getPartial());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, sessionid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(3, signature_);
       }
       unknownFields.writeTo(output);
@@ -3704,15 +3703,15 @@ public final class AuthProxProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getPartial());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, sessionid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, signature_);
       }
@@ -3731,24 +3730,23 @@ public final class AuthProxProto {
       }
       ch.epfl.dedis.lib.proto.AuthProxProto.PartialSig other = (ch.epfl.dedis.lib.proto.AuthProxProto.PartialSig) obj;
 
-      boolean result = true;
-      result = result && (hasPartial() == other.hasPartial());
+      if (hasPartial() != other.hasPartial()) return false;
       if (hasPartial()) {
-        result = result && getPartial()
-            .equals(other.getPartial());
+        if (!getPartial()
+            .equals(other.getPartial())) return false;
       }
-      result = result && (hasSessionid() == other.hasSessionid());
+      if (hasSessionid() != other.hasSessionid()) return false;
       if (hasSessionid()) {
-        result = result && getSessionid()
-            .equals(other.getSessionid());
+        if (!getSessionid()
+            .equals(other.getSessionid())) return false;
       }
-      result = result && (hasSignature() == other.hasSignature());
+      if (hasSignature() != other.hasSignature()) return false;
       if (hasSignature()) {
-        result = result && getSignature()
-            .equals(other.getSignature());
+        if (!getSignature()
+            .equals(other.getSignature())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -3947,19 +3945,19 @@ public final class AuthProxProto {
         ch.epfl.dedis.lib.proto.AuthProxProto.PartialSig result = new ch.epfl.dedis.lib.proto.AuthProxProto.PartialSig(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (partialBuilder_ == null) {
+            result.partial_ = partial_;
+          } else {
+            result.partial_ = partialBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
         }
-        if (partialBuilder_ == null) {
-          result.partial_ = partial_;
-        } else {
-          result.partial_ = partialBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.sessionid_ = sessionid_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.signature_ = signature_;
@@ -3970,35 +3968,35 @@ public final class AuthProxProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -4060,14 +4058,14 @@ public final class AuthProxProto {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.AuthProxProto.PriShare partial_ = null;
+      private ch.epfl.dedis.lib.proto.AuthProxProto.PriShare partial_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.AuthProxProto.PriShare, ch.epfl.dedis.lib.proto.AuthProxProto.PriShare.Builder, ch.epfl.dedis.lib.proto.AuthProxProto.PriShareOrBuilder> partialBuilder_;
       /**
        * <code>required .authprox.PriShare partial = 1;</code>
        */
       public boolean hasPartial() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required .authprox.PriShare partial = 1;</code>
@@ -4114,7 +4112,7 @@ public final class AuthProxProto {
        */
       public Builder mergePartial(ch.epfl.dedis.lib.proto.AuthProxProto.PriShare value) {
         if (partialBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               partial_ != null &&
               partial_ != ch.epfl.dedis.lib.proto.AuthProxProto.PriShare.getDefaultInstance()) {
             partial_ =
@@ -4183,7 +4181,7 @@ public final class AuthProxProto {
        * <code>required bytes sessionid = 2;</code>
        */
       public boolean hasSessionid() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes sessionid = 2;</code>
@@ -4218,7 +4216,7 @@ public final class AuthProxProto {
        * <code>required bytes signature = 3;</code>
        */
       public boolean hasSignature() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required bytes signature = 3;</code>
@@ -4362,7 +4360,7 @@ public final class AuthProxProto {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.AuthProxProto.PartialSig.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = partialsignature_.toBuilder();
               }
               partialsignature_ = input.readMessage(ch.epfl.dedis.lib.proto.AuthProxProto.PartialSig.parser(), extensionRegistry);
@@ -4412,7 +4410,7 @@ public final class AuthProxProto {
      * <code>required .authprox.PartialSig partialsignature = 1;</code>
      */
     public boolean hasPartialsignature() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required .authprox.PartialSig partialsignature = 1;</code>
@@ -4449,7 +4447,7 @@ public final class AuthProxProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getPartialsignature());
       }
       unknownFields.writeTo(output);
@@ -4461,7 +4459,7 @@ public final class AuthProxProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getPartialsignature());
       }
@@ -4480,14 +4478,13 @@ public final class AuthProxProto {
       }
       ch.epfl.dedis.lib.proto.AuthProxProto.SignatureResponse other = (ch.epfl.dedis.lib.proto.AuthProxProto.SignatureResponse) obj;
 
-      boolean result = true;
-      result = result && (hasPartialsignature() == other.hasPartialsignature());
+      if (hasPartialsignature() != other.hasPartialsignature()) return false;
       if (hasPartialsignature()) {
-        result = result && getPartialsignature()
-            .equals(other.getPartialsignature());
+        if (!getPartialsignature()
+            .equals(other.getPartialsignature())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -4673,13 +4670,13 @@ public final class AuthProxProto {
         ch.epfl.dedis.lib.proto.AuthProxProto.SignatureResponse result = new ch.epfl.dedis.lib.proto.AuthProxProto.SignatureResponse(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (partialsignatureBuilder_ == null) {
+            result.partialsignature_ = partialsignature_;
+          } else {
+            result.partialsignature_ = partialsignatureBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
-        }
-        if (partialsignatureBuilder_ == null) {
-          result.partialsignature_ = partialsignature_;
-        } else {
-          result.partialsignature_ = partialsignatureBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -4688,35 +4685,35 @@ public final class AuthProxProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -4769,14 +4766,14 @@ public final class AuthProxProto {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.AuthProxProto.PartialSig partialsignature_ = null;
+      private ch.epfl.dedis.lib.proto.AuthProxProto.PartialSig partialsignature_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.AuthProxProto.PartialSig, ch.epfl.dedis.lib.proto.AuthProxProto.PartialSig.Builder, ch.epfl.dedis.lib.proto.AuthProxProto.PartialSigOrBuilder> partialsignatureBuilder_;
       /**
        * <code>required .authprox.PartialSig partialsignature = 1;</code>
        */
       public boolean hasPartialsignature() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required .authprox.PartialSig partialsignature = 1;</code>
@@ -4823,7 +4820,7 @@ public final class AuthProxProto {
        */
       public Builder mergePartialsignature(ch.epfl.dedis.lib.proto.AuthProxProto.PartialSig value) {
         if (partialsignatureBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               partialsignature_ != null &&
               partialsignature_ != ch.epfl.dedis.lib.proto.AuthProxProto.PartialSig.getDefaultInstance()) {
             partialsignature_ =
@@ -5031,7 +5028,7 @@ public final class AuthProxProto {
               break;
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 types_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -5040,7 +5037,7 @@ public final class AuthProxProto {
             }
             case 18: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
                 issuers_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000002;
               }
@@ -5062,10 +5059,10 @@ public final class AuthProxProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           types_ = types_.getUnmodifiableView();
         }
-        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((mutable_bitField0_ & 0x00000002) != 0)) {
           issuers_ = issuers_.getUnmodifiableView();
         }
         this.unknownFields = unknownFields.build();
@@ -5203,13 +5200,12 @@ public final class AuthProxProto {
       }
       ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentsRequest other = (ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentsRequest) obj;
 
-      boolean result = true;
-      result = result && getTypesList()
-          .equals(other.getTypesList());
-      result = result && getIssuersList()
-          .equals(other.getIssuersList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getTypesList()
+          .equals(other.getTypesList())) return false;
+      if (!getIssuersList()
+          .equals(other.getIssuersList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -5398,12 +5394,12 @@ public final class AuthProxProto {
       public ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentsRequest buildPartial() {
         ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentsRequest result = new ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentsRequest(this);
         int from_bitField0_ = bitField0_;
-        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((bitField0_ & 0x00000001) != 0)) {
           types_ = types_.getUnmodifiableView();
           bitField0_ = (bitField0_ & ~0x00000001);
         }
         result.types_ = types_;
-        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((bitField0_ & 0x00000002) != 0)) {
           issuers_ = issuers_.getUnmodifiableView();
           bitField0_ = (bitField0_ & ~0x00000002);
         }
@@ -5414,35 +5410,35 @@ public final class AuthProxProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -5508,7 +5504,7 @@ public final class AuthProxProto {
 
       private com.google.protobuf.LazyStringList types_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureTypesIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           types_ = new com.google.protobuf.LazyStringArrayList(types_);
           bitField0_ |= 0x00000001;
          }
@@ -5601,7 +5597,7 @@ public final class AuthProxProto {
 
       private com.google.protobuf.LazyStringList issuers_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureIssuersIsMutable() {
-        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+        if (!((bitField0_ & 0x00000002) != 0)) {
           issuers_ = new com.google.protobuf.LazyStringArrayList(issuers_);
           bitField0_ |= 0x00000002;
          }
@@ -5817,7 +5813,7 @@ public final class AuthProxProto {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 enrollments_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentInfo>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -5840,7 +5836,7 @@ public final class AuthProxProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           enrollments_ = java.util.Collections.unmodifiableList(enrollments_);
         }
         this.unknownFields = unknownFields.build();
@@ -5946,11 +5942,10 @@ public final class AuthProxProto {
       }
       ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentsResponse other = (ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentsResponse) obj;
 
-      boolean result = true;
-      result = result && getEnrollmentsList()
-          .equals(other.getEnrollmentsList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getEnrollmentsList()
+          .equals(other.getEnrollmentsList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -6136,7 +6131,7 @@ public final class AuthProxProto {
         ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentsResponse result = new ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentsResponse(this);
         int from_bitField0_ = bitField0_;
         if (enrollmentsBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             enrollments_ = java.util.Collections.unmodifiableList(enrollments_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -6150,35 +6145,35 @@ public final class AuthProxProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -6256,7 +6251,7 @@ public final class AuthProxProto {
       private java.util.List<ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentInfo> enrollments_ =
         java.util.Collections.emptyList();
       private void ensureEnrollmentsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           enrollments_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentInfo>(enrollments_);
           bitField0_ |= 0x00000001;
          }
@@ -6485,7 +6480,7 @@ public final class AuthProxProto {
           enrollmentsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentInfo, ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentInfo.Builder, ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentInfoOrBuilder>(
                   enrollments_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           enrollments_ = null;
@@ -6688,7 +6683,7 @@ public final class AuthProxProto {
      * <code>required string type = 1;</code>
      */
     public boolean hasType() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required string type = 1;</code>
@@ -6730,7 +6725,7 @@ public final class AuthProxProto {
      * <code>required string issuer = 2;</code>
      */
     public boolean hasIssuer() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required string issuer = 2;</code>
@@ -6772,7 +6767,7 @@ public final class AuthProxProto {
      * <code>required bytes public = 3;</code>
      */
     public boolean hasPublic() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required bytes public = 3;</code>
@@ -6807,13 +6802,13 @@ public final class AuthProxProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, type_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, issuer_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(3, public_);
       }
       unknownFields.writeTo(output);
@@ -6825,13 +6820,13 @@ public final class AuthProxProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, type_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, issuer_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, public_);
       }
@@ -6850,24 +6845,23 @@ public final class AuthProxProto {
       }
       ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentInfo other = (ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentInfo) obj;
 
-      boolean result = true;
-      result = result && (hasType() == other.hasType());
+      if (hasType() != other.hasType()) return false;
       if (hasType()) {
-        result = result && getType()
-            .equals(other.getType());
+        if (!getType()
+            .equals(other.getType())) return false;
       }
-      result = result && (hasIssuer() == other.hasIssuer());
+      if (hasIssuer() != other.hasIssuer()) return false;
       if (hasIssuer()) {
-        result = result && getIssuer()
-            .equals(other.getIssuer());
+        if (!getIssuer()
+            .equals(other.getIssuer())) return false;
       }
-      result = result && (hasPublic() == other.hasPublic());
+      if (hasPublic() != other.hasPublic()) return false;
       if (hasPublic()) {
-        result = result && getPublic()
-            .equals(other.getPublic());
+        if (!getPublic()
+            .equals(other.getPublic())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -7060,15 +7054,15 @@ public final class AuthProxProto {
         ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentInfo result = new ch.epfl.dedis.lib.proto.AuthProxProto.EnrollmentInfo(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.type_ = type_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.issuer_ = issuer_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.public_ = public_;
@@ -7079,35 +7073,35 @@ public final class AuthProxProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -7178,7 +7172,7 @@ public final class AuthProxProto {
        * <code>required string type = 1;</code>
        */
       public boolean hasType() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required string type = 1;</code>
@@ -7254,7 +7248,7 @@ public final class AuthProxProto {
        * <code>required string issuer = 2;</code>
        */
       public boolean hasIssuer() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required string issuer = 2;</code>
@@ -7330,7 +7324,7 @@ public final class AuthProxProto {
        * <code>required bytes public = 3;</code>
        */
       public boolean hasPublic() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required bytes public = 3;</code>

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/ByzCoinProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/ByzCoinProto.java
@@ -110,7 +110,6 @@ public final class ByzCoinProto {
       trieroot_ = com.google.protobuf.ByteString.EMPTY;
       clienttransactionhash_ = com.google.protobuf.ByteString.EMPTY;
       statechangeshash_ = com.google.protobuf.ByteString.EMPTY;
-      timestamp_ = 0L;
     }
 
     @java.lang.Override
@@ -201,7 +200,7 @@ public final class ByzCoinProto {
      * <code>required bytes trieroot = 1;</code>
      */
     public boolean hasTrieroot() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -225,7 +224,7 @@ public final class ByzCoinProto {
      * <code>required bytes clienttransactionhash = 2;</code>
      */
     public boolean hasClienttransactionhash() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -249,7 +248,7 @@ public final class ByzCoinProto {
      * <code>required bytes statechangeshash = 3;</code>
      */
     public boolean hasStatechangeshash() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <pre>
@@ -273,7 +272,7 @@ public final class ByzCoinProto {
      * <code>required sint64 timestamp = 4;</code>
      */
     public boolean hasTimestamp() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <pre>
@@ -316,16 +315,16 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, trieroot_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, clienttransactionhash_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(3, statechangeshash_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeSInt64(4, timestamp_);
       }
       unknownFields.writeTo(output);
@@ -337,19 +336,19 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, trieroot_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, clienttransactionhash_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, statechangeshash_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt64Size(4, timestamp_);
       }
@@ -368,29 +367,28 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.DataHeader other = (ch.epfl.dedis.lib.proto.ByzCoinProto.DataHeader) obj;
 
-      boolean result = true;
-      result = result && (hasTrieroot() == other.hasTrieroot());
+      if (hasTrieroot() != other.hasTrieroot()) return false;
       if (hasTrieroot()) {
-        result = result && getTrieroot()
-            .equals(other.getTrieroot());
+        if (!getTrieroot()
+            .equals(other.getTrieroot())) return false;
       }
-      result = result && (hasClienttransactionhash() == other.hasClienttransactionhash());
+      if (hasClienttransactionhash() != other.hasClienttransactionhash()) return false;
       if (hasClienttransactionhash()) {
-        result = result && getClienttransactionhash()
-            .equals(other.getClienttransactionhash());
+        if (!getClienttransactionhash()
+            .equals(other.getClienttransactionhash())) return false;
       }
-      result = result && (hasStatechangeshash() == other.hasStatechangeshash());
+      if (hasStatechangeshash() != other.hasStatechangeshash()) return false;
       if (hasStatechangeshash()) {
-        result = result && getStatechangeshash()
-            .equals(other.getStatechangeshash());
+        if (!getStatechangeshash()
+            .equals(other.getStatechangeshash())) return false;
       }
-      result = result && (hasTimestamp() == other.hasTimestamp());
+      if (hasTimestamp() != other.hasTimestamp()) return false;
       if (hasTimestamp()) {
-        result = result && (getTimestamp()
-            == other.getTimestamp());
+        if (getTimestamp()
+            != other.getTimestamp()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -590,22 +588,22 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.DataHeader result = new ch.epfl.dedis.lib.proto.ByzCoinProto.DataHeader(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.trieroot_ = trieroot_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.clienttransactionhash_ = clienttransactionhash_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.statechangeshash_ = statechangeshash_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          result.timestamp_ = timestamp_;
           to_bitField0_ |= 0x00000008;
         }
-        result.timestamp_ = timestamp_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -613,35 +611,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -719,7 +717,7 @@ public final class ByzCoinProto {
        * <code>required bytes trieroot = 1;</code>
        */
       public boolean hasTrieroot() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -773,7 +771,7 @@ public final class ByzCoinProto {
        * <code>required bytes clienttransactionhash = 2;</code>
        */
       public boolean hasClienttransactionhash() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -825,7 +823,7 @@ public final class ByzCoinProto {
        * <code>required bytes statechangeshash = 3;</code>
        */
       public boolean hasStatechangeshash() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <pre>
@@ -879,7 +877,7 @@ public final class ByzCoinProto {
        * <code>required sint64 timestamp = 4;</code>
        */
       public boolean hasTimestamp() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <pre>
@@ -1044,7 +1042,7 @@ public final class ByzCoinProto {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 txresults_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.TxResult>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -1067,7 +1065,7 @@ public final class ByzCoinProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           txresults_ = java.util.Collections.unmodifiableList(txresults_);
         }
         this.unknownFields = unknownFields.build();
@@ -1173,11 +1171,10 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.DataBody other = (ch.epfl.dedis.lib.proto.ByzCoinProto.DataBody) obj;
 
-      boolean result = true;
-      result = result && getTxresultsList()
-          .equals(other.getTxresultsList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getTxresultsList()
+          .equals(other.getTxresultsList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -1364,7 +1361,7 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.DataBody result = new ch.epfl.dedis.lib.proto.ByzCoinProto.DataBody(this);
         int from_bitField0_ = bitField0_;
         if (txresultsBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             txresults_ = java.util.Collections.unmodifiableList(txresults_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -1378,35 +1375,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -1484,7 +1481,7 @@ public final class ByzCoinProto {
       private java.util.List<ch.epfl.dedis.lib.proto.ByzCoinProto.TxResult> txresults_ =
         java.util.Collections.emptyList();
       private void ensureTxresultsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           txresults_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.TxResult>(txresults_);
           bitField0_ |= 0x00000001;
          }
@@ -1713,7 +1710,7 @@ public final class ByzCoinProto {
           txresultsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.ByzCoinProto.TxResult, ch.epfl.dedis.lib.proto.ByzCoinProto.TxResult.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.TxResultOrBuilder>(
                   txresults_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           txresults_ = null;
@@ -1934,9 +1931,6 @@ public final class ByzCoinProto {
       super(builder);
     }
     private CreateGenesisBlock() {
-      version_ = 0;
-      blockinterval_ = 0L;
-      maxblocksize_ = 0;
       darccontractids_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     }
 
@@ -1971,7 +1965,7 @@ public final class ByzCoinProto {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.OnetProto.Roster.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = roster_.toBuilder();
               }
               roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.parser(), extensionRegistry);
@@ -1984,7 +1978,7 @@ public final class ByzCoinProto {
             }
             case 26: {
               ch.epfl.dedis.lib.proto.DarcProto.Darc.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+              if (((bitField0_ & 0x00000004) != 0)) {
                 subBuilder = genesisdarc_.toBuilder();
               }
               genesisdarc_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Darc.parser(), extensionRegistry);
@@ -2007,7 +2001,7 @@ public final class ByzCoinProto {
             }
             case 50: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+              if (!((mutable_bitField0_ & 0x00000020) != 0)) {
                 darccontractids_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000020;
               }
@@ -2029,7 +2023,7 @@ public final class ByzCoinProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+        if (((mutable_bitField0_ & 0x00000020) != 0)) {
           darccontractids_ = darccontractids_.getUnmodifiableView();
         }
         this.unknownFields = unknownFields.build();
@@ -2060,7 +2054,7 @@ public final class ByzCoinProto {
      * <code>required sint32 version = 1;</code>
      */
     public boolean hasVersion() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -2083,7 +2077,7 @@ public final class ByzCoinProto {
      * <code>required .onet.Roster roster = 2;</code>
      */
     public boolean hasRoster() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -2116,7 +2110,7 @@ public final class ByzCoinProto {
      * <code>required .darc.Darc genesisdarc = 3;</code>
      */
     public boolean hasGenesisdarc() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <pre>
@@ -2149,7 +2143,7 @@ public final class ByzCoinProto {
      * <code>required sint64 blockinterval = 4;</code>
      */
     public boolean hasBlockinterval() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <pre>
@@ -2172,7 +2166,7 @@ public final class ByzCoinProto {
      * <code>optional sint32 maxblocksize = 5;</code>
      */
     public boolean hasMaxblocksize() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000010) != 0);
     }
     /**
      * <pre>
@@ -2272,19 +2266,19 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeSInt32(1, version_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getRoster());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeMessage(3, getGenesisdarc());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeSInt64(4, blockinterval_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         output.writeSInt32(5, maxblocksize_);
       }
       for (int i = 0; i < darccontractids_.size(); i++) {
@@ -2299,23 +2293,23 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(1, version_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getRoster());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, getGenesisdarc());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt64Size(4, blockinterval_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(5, maxblocksize_);
       }
@@ -2342,36 +2336,35 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.CreateGenesisBlock other = (ch.epfl.dedis.lib.proto.ByzCoinProto.CreateGenesisBlock) obj;
 
-      boolean result = true;
-      result = result && (hasVersion() == other.hasVersion());
+      if (hasVersion() != other.hasVersion()) return false;
       if (hasVersion()) {
-        result = result && (getVersion()
-            == other.getVersion());
+        if (getVersion()
+            != other.getVersion()) return false;
       }
-      result = result && (hasRoster() == other.hasRoster());
+      if (hasRoster() != other.hasRoster()) return false;
       if (hasRoster()) {
-        result = result && getRoster()
-            .equals(other.getRoster());
+        if (!getRoster()
+            .equals(other.getRoster())) return false;
       }
-      result = result && (hasGenesisdarc() == other.hasGenesisdarc());
+      if (hasGenesisdarc() != other.hasGenesisdarc()) return false;
       if (hasGenesisdarc()) {
-        result = result && getGenesisdarc()
-            .equals(other.getGenesisdarc());
+        if (!getGenesisdarc()
+            .equals(other.getGenesisdarc())) return false;
       }
-      result = result && (hasBlockinterval() == other.hasBlockinterval());
+      if (hasBlockinterval() != other.hasBlockinterval()) return false;
       if (hasBlockinterval()) {
-        result = result && (getBlockinterval()
-            == other.getBlockinterval());
+        if (getBlockinterval()
+            != other.getBlockinterval()) return false;
       }
-      result = result && (hasMaxblocksize() == other.hasMaxblocksize());
+      if (hasMaxblocksize() != other.hasMaxblocksize()) return false;
       if (hasMaxblocksize()) {
-        result = result && (getMaxblocksize()
-            == other.getMaxblocksize());
+        if (getMaxblocksize()
+            != other.getMaxblocksize()) return false;
       }
-      result = result && getDarccontractidsList()
-          .equals(other.getDarccontractidsList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getDarccontractidsList()
+          .equals(other.getDarccontractidsList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -2593,35 +2586,35 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.CreateGenesisBlock result = new ch.epfl.dedis.lib.proto.ByzCoinProto.CreateGenesisBlock(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.version_ = version_;
           to_bitField0_ |= 0x00000001;
         }
-        result.version_ = version_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (rosterBuilder_ == null) {
+            result.roster_ = roster_;
+          } else {
+            result.roster_ = rosterBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
         }
-        if (rosterBuilder_ == null) {
-          result.roster_ = roster_;
-        } else {
-          result.roster_ = rosterBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          if (genesisdarcBuilder_ == null) {
+            result.genesisdarc_ = genesisdarc_;
+          } else {
+            result.genesisdarc_ = genesisdarcBuilder_.build();
+          }
           to_bitField0_ |= 0x00000004;
         }
-        if (genesisdarcBuilder_ == null) {
-          result.genesisdarc_ = genesisdarc_;
-        } else {
-          result.genesisdarc_ = genesisdarcBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          result.blockinterval_ = blockinterval_;
           to_bitField0_ |= 0x00000008;
         }
-        result.blockinterval_ = blockinterval_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((from_bitField0_ & 0x00000010) != 0)) {
+          result.maxblocksize_ = maxblocksize_;
           to_bitField0_ |= 0x00000010;
         }
-        result.maxblocksize_ = maxblocksize_;
-        if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        if (((bitField0_ & 0x00000020) != 0)) {
           darccontractids_ = darccontractids_.getUnmodifiableView();
           bitField0_ = (bitField0_ & ~0x00000020);
         }
@@ -2633,35 +2626,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -2757,7 +2750,7 @@ public final class ByzCoinProto {
        * <code>required sint32 version = 1;</code>
        */
       public boolean hasVersion() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -2796,7 +2789,7 @@ public final class ByzCoinProto {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.OnetProto.Roster roster_ = null;
+      private ch.epfl.dedis.lib.proto.OnetProto.Roster roster_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.OnetProto.Roster, ch.epfl.dedis.lib.proto.OnetProto.Roster.Builder, ch.epfl.dedis.lib.proto.OnetProto.RosterOrBuilder> rosterBuilder_;
       /**
@@ -2807,7 +2800,7 @@ public final class ByzCoinProto {
        * <code>required .onet.Roster roster = 2;</code>
        */
       public boolean hasRoster() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -2870,7 +2863,7 @@ public final class ByzCoinProto {
        */
       public Builder mergeRoster(ch.epfl.dedis.lib.proto.OnetProto.Roster value) {
         if (rosterBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               roster_ != null &&
               roster_ != ch.epfl.dedis.lib.proto.OnetProto.Roster.getDefaultInstance()) {
             roster_ =
@@ -2950,7 +2943,7 @@ public final class ByzCoinProto {
         return rosterBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.DarcProto.Darc genesisdarc_ = null;
+      private ch.epfl.dedis.lib.proto.DarcProto.Darc genesisdarc_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.DarcProto.Darc, ch.epfl.dedis.lib.proto.DarcProto.Darc.Builder, ch.epfl.dedis.lib.proto.DarcProto.DarcOrBuilder> genesisdarcBuilder_;
       /**
@@ -2961,7 +2954,7 @@ public final class ByzCoinProto {
        * <code>required .darc.Darc genesisdarc = 3;</code>
        */
       public boolean hasGenesisdarc() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <pre>
@@ -3024,7 +3017,7 @@ public final class ByzCoinProto {
        */
       public Builder mergeGenesisdarc(ch.epfl.dedis.lib.proto.DarcProto.Darc value) {
         if (genesisdarcBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004) &&
+          if (((bitField0_ & 0x00000004) != 0) &&
               genesisdarc_ != null &&
               genesisdarc_ != ch.epfl.dedis.lib.proto.DarcProto.Darc.getDefaultInstance()) {
             genesisdarc_ =
@@ -3113,7 +3106,7 @@ public final class ByzCoinProto {
        * <code>required sint64 blockinterval = 4;</code>
        */
       public boolean hasBlockinterval() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <pre>
@@ -3161,7 +3154,7 @@ public final class ByzCoinProto {
        * <code>optional sint32 maxblocksize = 5;</code>
        */
       public boolean hasMaxblocksize() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return ((bitField0_ & 0x00000010) != 0);
       }
       /**
        * <pre>
@@ -3202,7 +3195,7 @@ public final class ByzCoinProto {
 
       private com.google.protobuf.LazyStringList darccontractids_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureDarccontractidsIsMutable() {
-        if (!((bitField0_ & 0x00000020) == 0x00000020)) {
+        if (!((bitField0_ & 0x00000020) != 0)) {
           darccontractids_ = new com.google.protobuf.LazyStringArrayList(darccontractids_);
           bitField0_ |= 0x00000020;
          }
@@ -3453,7 +3446,6 @@ public final class ByzCoinProto {
       super(builder);
     }
     private CreateGenesisBlockResponse() {
-      version_ = 0;
     }
 
     @java.lang.Override
@@ -3487,7 +3479,7 @@ public final class ByzCoinProto {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = skipblock_.toBuilder();
               }
               skipblock_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.parser(), extensionRegistry);
@@ -3541,7 +3533,7 @@ public final class ByzCoinProto {
      * <code>required sint32 version = 1;</code>
      */
     public boolean hasVersion() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -3564,7 +3556,7 @@ public final class ByzCoinProto {
      * <code>optional .skipchain.SkipBlock skipblock = 2;</code>
      */
     public boolean hasSkipblock() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -3611,10 +3603,10 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeSInt32(1, version_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getSkipblock());
       }
       unknownFields.writeTo(output);
@@ -3626,11 +3618,11 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(1, version_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getSkipblock());
       }
@@ -3649,19 +3641,18 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.CreateGenesisBlockResponse other = (ch.epfl.dedis.lib.proto.ByzCoinProto.CreateGenesisBlockResponse) obj;
 
-      boolean result = true;
-      result = result && (hasVersion() == other.hasVersion());
+      if (hasVersion() != other.hasVersion()) return false;
       if (hasVersion()) {
-        result = result && (getVersion()
-            == other.getVersion());
+        if (getVersion()
+            != other.getVersion()) return false;
       }
-      result = result && (hasSkipblock() == other.hasSkipblock());
+      if (hasSkipblock() != other.hasSkipblock()) return false;
       if (hasSkipblock()) {
-        result = result && getSkipblock()
-            .equals(other.getSkipblock());
+        if (!getSkipblock()
+            .equals(other.getSkipblock())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -3853,17 +3844,17 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.CreateGenesisBlockResponse result = new ch.epfl.dedis.lib.proto.ByzCoinProto.CreateGenesisBlockResponse(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.version_ = version_;
           to_bitField0_ |= 0x00000001;
         }
-        result.version_ = version_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (skipblockBuilder_ == null) {
+            result.skipblock_ = skipblock_;
+          } else {
+            result.skipblock_ = skipblockBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
-        }
-        if (skipblockBuilder_ == null) {
-          result.skipblock_ = skipblock_;
-        } else {
-          result.skipblock_ = skipblockBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -3872,35 +3863,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -3967,7 +3958,7 @@ public final class ByzCoinProto {
        * <code>required sint32 version = 1;</code>
        */
       public boolean hasVersion() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -4006,7 +3997,7 @@ public final class ByzCoinProto {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock skipblock_ = null;
+      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock skipblock_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlockOrBuilder> skipblockBuilder_;
       /**
@@ -4017,7 +4008,7 @@ public final class ByzCoinProto {
        * <code>optional .skipchain.SkipBlock skipblock = 2;</code>
        */
       public boolean hasSkipblock() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -4080,7 +4071,7 @@ public final class ByzCoinProto {
        */
       public Builder mergeSkipblock(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock value) {
         if (skipblockBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               skipblock_ != null &&
               skipblock_ != ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.getDefaultInstance()) {
             skipblock_ =
@@ -4311,9 +4302,7 @@ public final class ByzCoinProto {
       super(builder);
     }
     private AddTxRequest() {
-      version_ = 0;
       skipchainid_ = com.google.protobuf.ByteString.EMPTY;
-      inclusionwait_ = 0;
     }
 
     @java.lang.Override
@@ -4352,7 +4341,7 @@ public final class ByzCoinProto {
             }
             case 26: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+              if (((bitField0_ & 0x00000004) != 0)) {
                 subBuilder = transaction_.toBuilder();
               }
               transaction_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction.parser(), extensionRegistry);
@@ -4411,7 +4400,7 @@ public final class ByzCoinProto {
      * <code>required sint32 version = 1;</code>
      */
     public boolean hasVersion() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -4434,7 +4423,7 @@ public final class ByzCoinProto {
      * <code>required bytes skipchainid = 2;</code>
      */
     public boolean hasSkipchainid() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -4457,7 +4446,7 @@ public final class ByzCoinProto {
      * <code>required .byzcoin.ClientTransaction transaction = 3;</code>
      */
     public boolean hasTransaction() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <pre>
@@ -4491,7 +4480,7 @@ public final class ByzCoinProto {
      * <code>optional sint32 inclusionwait = 4;</code>
      */
     public boolean hasInclusionwait() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <pre>
@@ -4535,16 +4524,16 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeSInt32(1, version_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, skipchainid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeMessage(3, getTransaction());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeSInt32(4, inclusionwait_);
       }
       unknownFields.writeTo(output);
@@ -4556,19 +4545,19 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(1, version_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, skipchainid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, getTransaction());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(4, inclusionwait_);
       }
@@ -4587,29 +4576,28 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.AddTxRequest other = (ch.epfl.dedis.lib.proto.ByzCoinProto.AddTxRequest) obj;
 
-      boolean result = true;
-      result = result && (hasVersion() == other.hasVersion());
+      if (hasVersion() != other.hasVersion()) return false;
       if (hasVersion()) {
-        result = result && (getVersion()
-            == other.getVersion());
+        if (getVersion()
+            != other.getVersion()) return false;
       }
-      result = result && (hasSkipchainid() == other.hasSkipchainid());
+      if (hasSkipchainid() != other.hasSkipchainid()) return false;
       if (hasSkipchainid()) {
-        result = result && getSkipchainid()
-            .equals(other.getSkipchainid());
+        if (!getSkipchainid()
+            .equals(other.getSkipchainid())) return false;
       }
-      result = result && (hasTransaction() == other.hasTransaction());
+      if (hasTransaction() != other.hasTransaction()) return false;
       if (hasTransaction()) {
-        result = result && getTransaction()
-            .equals(other.getTransaction());
+        if (!getTransaction()
+            .equals(other.getTransaction())) return false;
       }
-      result = result && (hasInclusionwait() == other.hasInclusionwait());
+      if (hasInclusionwait() != other.hasInclusionwait()) return false;
       if (hasInclusionwait()) {
-        result = result && (getInclusionwait()
-            == other.getInclusionwait());
+        if (getInclusionwait()
+            != other.getInclusionwait()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -4813,26 +4801,26 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.AddTxRequest result = new ch.epfl.dedis.lib.proto.ByzCoinProto.AddTxRequest(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.version_ = version_;
           to_bitField0_ |= 0x00000001;
         }
-        result.version_ = version_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.skipchainid_ = skipchainid_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          if (transactionBuilder_ == null) {
+            result.transaction_ = transaction_;
+          } else {
+            result.transaction_ = transactionBuilder_.build();
+          }
           to_bitField0_ |= 0x00000004;
         }
-        if (transactionBuilder_ == null) {
-          result.transaction_ = transaction_;
-        } else {
-          result.transaction_ = transactionBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          result.inclusionwait_ = inclusionwait_;
           to_bitField0_ |= 0x00000008;
         }
-        result.inclusionwait_ = inclusionwait_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -4840,35 +4828,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -4945,7 +4933,7 @@ public final class ByzCoinProto {
        * <code>required sint32 version = 1;</code>
        */
       public boolean hasVersion() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -4993,7 +4981,7 @@ public final class ByzCoinProto {
        * <code>required bytes skipchainid = 2;</code>
        */
       public boolean hasSkipchainid() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -5035,7 +5023,7 @@ public final class ByzCoinProto {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction transaction_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction transaction_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction, ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransactionOrBuilder> transactionBuilder_;
       /**
@@ -5046,7 +5034,7 @@ public final class ByzCoinProto {
        * <code>required .byzcoin.ClientTransaction transaction = 3;</code>
        */
       public boolean hasTransaction() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <pre>
@@ -5109,7 +5097,7 @@ public final class ByzCoinProto {
        */
       public Builder mergeTransaction(ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction value) {
         if (transactionBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004) &&
+          if (((bitField0_ & 0x00000004) != 0) &&
               transaction_ != null &&
               transaction_ != ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction.getDefaultInstance()) {
             transaction_ =
@@ -5199,7 +5187,7 @@ public final class ByzCoinProto {
        * <code>optional sint32 inclusionwait = 4;</code>
        */
       public boolean hasInclusionwait() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <pre>
@@ -5331,7 +5319,6 @@ public final class ByzCoinProto {
       super(builder);
     }
     private AddTxResponse() {
-      version_ = 0;
     }
 
     @java.lang.Override
@@ -5406,7 +5393,7 @@ public final class ByzCoinProto {
      * <code>required sint32 version = 1;</code>
      */
     public boolean hasVersion() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -5437,7 +5424,7 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeSInt32(1, version_);
       }
       unknownFields.writeTo(output);
@@ -5449,7 +5436,7 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(1, version_);
       }
@@ -5468,14 +5455,13 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.AddTxResponse other = (ch.epfl.dedis.lib.proto.ByzCoinProto.AddTxResponse) obj;
 
-      boolean result = true;
-      result = result && (hasVersion() == other.hasVersion());
+      if (hasVersion() != other.hasVersion()) return false;
       if (hasVersion()) {
-        result = result && (getVersion()
-            == other.getVersion());
+        if (getVersion()
+            != other.getVersion()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -5656,10 +5642,10 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.AddTxResponse result = new ch.epfl.dedis.lib.proto.ByzCoinProto.AddTxResponse(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.version_ = version_;
           to_bitField0_ |= 0x00000001;
         }
-        result.version_ = version_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -5667,35 +5653,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -5754,7 +5740,7 @@ public final class ByzCoinProto {
        * <code>required sint32 version = 1;</code>
        */
       public boolean hasVersion() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -5919,7 +5905,6 @@ public final class ByzCoinProto {
       super(builder);
     }
     private GetProof() {
-      version_ = 0;
       key_ = com.google.protobuf.ByteString.EMPTY;
       id_ = com.google.protobuf.ByteString.EMPTY;
     }
@@ -6006,7 +5991,7 @@ public final class ByzCoinProto {
      * <code>required sint32 version = 1;</code>
      */
     public boolean hasVersion() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -6029,7 +6014,7 @@ public final class ByzCoinProto {
      * <code>required bytes key = 2;</code>
      */
     public boolean hasKey() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -6053,7 +6038,7 @@ public final class ByzCoinProto {
      * <code>required bytes id = 3;</code>
      */
     public boolean hasId() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <pre>
@@ -6093,13 +6078,13 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeSInt32(1, version_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, key_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(3, id_);
       }
       unknownFields.writeTo(output);
@@ -6111,15 +6096,15 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(1, version_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, key_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, id_);
       }
@@ -6138,24 +6123,23 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.GetProof other = (ch.epfl.dedis.lib.proto.ByzCoinProto.GetProof) obj;
 
-      boolean result = true;
-      result = result && (hasVersion() == other.hasVersion());
+      if (hasVersion() != other.hasVersion()) return false;
       if (hasVersion()) {
-        result = result && (getVersion()
-            == other.getVersion());
+        if (getVersion()
+            != other.getVersion()) return false;
       }
-      result = result && (hasKey() == other.hasKey());
+      if (hasKey() != other.hasKey()) return false;
       if (hasKey()) {
-        result = result && getKey()
-            .equals(other.getKey());
+        if (!getKey()
+            .equals(other.getKey())) return false;
       }
-      result = result && (hasId() == other.hasId());
+      if (hasId() != other.hasId()) return false;
       if (hasId()) {
-        result = result && getId()
-            .equals(other.getId());
+        if (!getId()
+            .equals(other.getId())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -6348,15 +6332,15 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.GetProof result = new ch.epfl.dedis.lib.proto.ByzCoinProto.GetProof(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.version_ = version_;
           to_bitField0_ |= 0x00000001;
         }
-        result.version_ = version_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.key_ = key_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.id_ = id_;
@@ -6367,35 +6351,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -6466,7 +6450,7 @@ public final class ByzCoinProto {
        * <code>required sint32 version = 1;</code>
        */
       public boolean hasVersion() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -6514,7 +6498,7 @@ public final class ByzCoinProto {
        * <code>required bytes key = 2;</code>
        */
       public boolean hasKey() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -6566,7 +6550,7 @@ public final class ByzCoinProto {
        * <code>required bytes id = 3;</code>
        */
       public boolean hasId() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <pre>
@@ -6730,7 +6714,6 @@ public final class ByzCoinProto {
       super(builder);
     }
     private GetProofResponse() {
-      version_ = 0;
     }
 
     @java.lang.Override
@@ -6764,7 +6747,7 @@ public final class ByzCoinProto {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = proof_.toBuilder();
               }
               proof_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.parser(), extensionRegistry);
@@ -6818,7 +6801,7 @@ public final class ByzCoinProto {
      * <code>required sint32 version = 1;</code>
      */
     public boolean hasVersion() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -6842,7 +6825,7 @@ public final class ByzCoinProto {
      * <code>required .byzcoin.Proof proof = 2;</code>
      */
     public boolean hasProof() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -6893,10 +6876,10 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeSInt32(1, version_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getProof());
       }
       unknownFields.writeTo(output);
@@ -6908,11 +6891,11 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(1, version_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getProof());
       }
@@ -6931,19 +6914,18 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.GetProofResponse other = (ch.epfl.dedis.lib.proto.ByzCoinProto.GetProofResponse) obj;
 
-      boolean result = true;
-      result = result && (hasVersion() == other.hasVersion());
+      if (hasVersion() != other.hasVersion()) return false;
       if (hasVersion()) {
-        result = result && (getVersion()
-            == other.getVersion());
+        if (getVersion()
+            != other.getVersion()) return false;
       }
-      result = result && (hasProof() == other.hasProof());
+      if (hasProof() != other.hasProof()) return false;
       if (hasProof()) {
-        result = result && getProof()
-            .equals(other.getProof());
+        if (!getProof()
+            .equals(other.getProof())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -7136,17 +7118,17 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.GetProofResponse result = new ch.epfl.dedis.lib.proto.ByzCoinProto.GetProofResponse(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.version_ = version_;
           to_bitField0_ |= 0x00000001;
         }
-        result.version_ = version_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (proofBuilder_ == null) {
+            result.proof_ = proof_;
+          } else {
+            result.proof_ = proofBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
-        }
-        if (proofBuilder_ == null) {
-          result.proof_ = proof_;
-        } else {
-          result.proof_ = proofBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -7155,35 +7137,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -7251,7 +7233,7 @@ public final class ByzCoinProto {
        * <code>required sint32 version = 1;</code>
        */
       public boolean hasVersion() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -7290,7 +7272,7 @@ public final class ByzCoinProto {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.Proof proof_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.Proof proof_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.Proof, ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.ProofOrBuilder> proofBuilder_;
       /**
@@ -7302,7 +7284,7 @@ public final class ByzCoinProto {
        * <code>required .byzcoin.Proof proof = 2;</code>
        */
       public boolean hasProof() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -7369,7 +7351,7 @@ public final class ByzCoinProto {
        */
       public Builder mergeProof(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof value) {
         if (proofBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               proof_ != null &&
               proof_ != ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.getDefaultInstance()) {
             proof_ =
@@ -7622,7 +7604,6 @@ public final class ByzCoinProto {
       super(builder);
     }
     private CheckAuthorization() {
-      version_ = 0;
       byzcoinid_ = com.google.protobuf.ByteString.EMPTY;
       darcid_ = com.google.protobuf.ByteString.EMPTY;
       identities_ = java.util.Collections.emptyList();
@@ -7668,7 +7649,7 @@ public final class ByzCoinProto {
               break;
             }
             case 34: {
-              if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+              if (!((mutable_bitField0_ & 0x00000008) != 0)) {
                 identities_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.DarcProto.Identity>();
                 mutable_bitField0_ |= 0x00000008;
               }
@@ -7691,7 +7672,7 @@ public final class ByzCoinProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((mutable_bitField0_ & 0x00000008) != 0)) {
           identities_ = java.util.Collections.unmodifiableList(identities_);
         }
         this.unknownFields = unknownFields.build();
@@ -7722,7 +7703,7 @@ public final class ByzCoinProto {
      * <code>required sint32 version = 1;</code>
      */
     public boolean hasVersion() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -7745,7 +7726,7 @@ public final class ByzCoinProto {
      * <code>required bytes byzcoinid = 2;</code>
      */
     public boolean hasByzcoinid() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -7768,7 +7749,7 @@ public final class ByzCoinProto {
      * <code>required bytes darcid = 3;</code>
      */
     public boolean hasDarcid() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <pre>
@@ -7868,13 +7849,13 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeSInt32(1, version_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, byzcoinid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(3, darcid_);
       }
       for (int i = 0; i < identities_.size(); i++) {
@@ -7889,15 +7870,15 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(1, version_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, byzcoinid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, darcid_);
       }
@@ -7920,26 +7901,25 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.CheckAuthorization other = (ch.epfl.dedis.lib.proto.ByzCoinProto.CheckAuthorization) obj;
 
-      boolean result = true;
-      result = result && (hasVersion() == other.hasVersion());
+      if (hasVersion() != other.hasVersion()) return false;
       if (hasVersion()) {
-        result = result && (getVersion()
-            == other.getVersion());
+        if (getVersion()
+            != other.getVersion()) return false;
       }
-      result = result && (hasByzcoinid() == other.hasByzcoinid());
+      if (hasByzcoinid() != other.hasByzcoinid()) return false;
       if (hasByzcoinid()) {
-        result = result && getByzcoinid()
-            .equals(other.getByzcoinid());
+        if (!getByzcoinid()
+            .equals(other.getByzcoinid())) return false;
       }
-      result = result && (hasDarcid() == other.hasDarcid());
+      if (hasDarcid() != other.hasDarcid()) return false;
       if (hasDarcid()) {
-        result = result && getDarcid()
-            .equals(other.getDarcid());
+        if (!getDarcid()
+            .equals(other.getDarcid())) return false;
       }
-      result = result && getIdentitiesList()
-          .equals(other.getIdentitiesList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getIdentitiesList()
+          .equals(other.getIdentitiesList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -8144,20 +8124,20 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.CheckAuthorization result = new ch.epfl.dedis.lib.proto.ByzCoinProto.CheckAuthorization(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.version_ = version_;
           to_bitField0_ |= 0x00000001;
         }
-        result.version_ = version_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.byzcoinid_ = byzcoinid_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.darcid_ = darcid_;
         if (identitiesBuilder_ == null) {
-          if (((bitField0_ & 0x00000008) == 0x00000008)) {
+          if (((bitField0_ & 0x00000008) != 0)) {
             identities_ = java.util.Collections.unmodifiableList(identities_);
             bitField0_ = (bitField0_ & ~0x00000008);
           }
@@ -8172,35 +8152,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -8302,7 +8282,7 @@ public final class ByzCoinProto {
        * <code>required sint32 version = 1;</code>
        */
       public boolean hasVersion() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -8350,7 +8330,7 @@ public final class ByzCoinProto {
        * <code>required bytes byzcoinid = 2;</code>
        */
       public boolean hasByzcoinid() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -8401,7 +8381,7 @@ public final class ByzCoinProto {
        * <code>required bytes darcid = 3;</code>
        */
       public boolean hasDarcid() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <pre>
@@ -8446,7 +8426,7 @@ public final class ByzCoinProto {
       private java.util.List<ch.epfl.dedis.lib.proto.DarcProto.Identity> identities_ =
         java.util.Collections.emptyList();
       private void ensureIdentitiesIsMutable() {
-        if (!((bitField0_ & 0x00000008) == 0x00000008)) {
+        if (!((bitField0_ & 0x00000008) != 0)) {
           identities_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.DarcProto.Identity>(identities_);
           bitField0_ |= 0x00000008;
          }
@@ -8747,7 +8727,7 @@ public final class ByzCoinProto {
           identitiesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.DarcProto.Identity, ch.epfl.dedis.lib.proto.DarcProto.Identity.Builder, ch.epfl.dedis.lib.proto.DarcProto.IdentityOrBuilder>(
                   identities_,
-                  ((bitField0_ & 0x00000008) == 0x00000008),
+                  ((bitField0_ & 0x00000008) != 0),
                   getParentForChildren(),
                   isClean());
           identities_ = null;
@@ -8878,7 +8858,7 @@ public final class ByzCoinProto {
               break;
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 actions_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -8900,7 +8880,7 @@ public final class ByzCoinProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           actions_ = actions_.getUnmodifiableView();
         }
         this.unknownFields = unknownFields.build();
@@ -8998,11 +8978,10 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.CheckAuthorizationResponse other = (ch.epfl.dedis.lib.proto.ByzCoinProto.CheckAuthorizationResponse) obj;
 
-      boolean result = true;
-      result = result && getActionsList()
-          .equals(other.getActionsList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getActionsList()
+          .equals(other.getActionsList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -9184,7 +9163,7 @@ public final class ByzCoinProto {
       public ch.epfl.dedis.lib.proto.ByzCoinProto.CheckAuthorizationResponse buildPartial() {
         ch.epfl.dedis.lib.proto.ByzCoinProto.CheckAuthorizationResponse result = new ch.epfl.dedis.lib.proto.ByzCoinProto.CheckAuthorizationResponse(this);
         int from_bitField0_ = bitField0_;
-        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((bitField0_ & 0x00000001) != 0)) {
           actions_ = actions_.getUnmodifiableView();
           bitField0_ = (bitField0_ & ~0x00000001);
         }
@@ -9195,35 +9174,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -9279,7 +9258,7 @@ public final class ByzCoinProto {
 
       private com.google.protobuf.LazyStringList actions_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureActionsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           actions_ = new com.google.protobuf.LazyStringArrayList(actions_);
           bitField0_ |= 0x00000001;
          }
@@ -9494,8 +9473,6 @@ public final class ByzCoinProto {
       super(builder);
     }
     private ChainConfig() {
-      blockinterval_ = 0L;
-      maxblocksize_ = 0;
       darccontractids_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     }
 
@@ -9530,7 +9507,7 @@ public final class ByzCoinProto {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.OnetProto.Roster.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = roster_.toBuilder();
               }
               roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.parser(), extensionRegistry);
@@ -9548,7 +9525,7 @@ public final class ByzCoinProto {
             }
             case 34: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+              if (!((mutable_bitField0_ & 0x00000008) != 0)) {
                 darccontractids_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000008;
               }
@@ -9570,7 +9547,7 @@ public final class ByzCoinProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((mutable_bitField0_ & 0x00000008) != 0)) {
           darccontractids_ = darccontractids_.getUnmodifiableView();
         }
         this.unknownFields = unknownFields.build();
@@ -9597,7 +9574,7 @@ public final class ByzCoinProto {
      * <code>required sint64 blockinterval = 1;</code>
      */
     public boolean hasBlockinterval() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required sint64 blockinterval = 1;</code>
@@ -9612,7 +9589,7 @@ public final class ByzCoinProto {
      * <code>required .onet.Roster roster = 2;</code>
      */
     public boolean hasRoster() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required .onet.Roster roster = 2;</code>
@@ -9633,7 +9610,7 @@ public final class ByzCoinProto {
      * <code>required sint32 maxblocksize = 3;</code>
      */
     public boolean hasMaxblocksize() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required sint32 maxblocksize = 3;</code>
@@ -9701,13 +9678,13 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeSInt64(1, blockinterval_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getRoster());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeSInt32(3, maxblocksize_);
       }
       for (int i = 0; i < darccontractids_.size(); i++) {
@@ -9722,15 +9699,15 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt64Size(1, blockinterval_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getRoster());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(3, maxblocksize_);
       }
@@ -9757,26 +9734,25 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.ChainConfig other = (ch.epfl.dedis.lib.proto.ByzCoinProto.ChainConfig) obj;
 
-      boolean result = true;
-      result = result && (hasBlockinterval() == other.hasBlockinterval());
+      if (hasBlockinterval() != other.hasBlockinterval()) return false;
       if (hasBlockinterval()) {
-        result = result && (getBlockinterval()
-            == other.getBlockinterval());
+        if (getBlockinterval()
+            != other.getBlockinterval()) return false;
       }
-      result = result && (hasRoster() == other.hasRoster());
+      if (hasRoster() != other.hasRoster()) return false;
       if (hasRoster()) {
-        result = result && getRoster()
-            .equals(other.getRoster());
+        if (!getRoster()
+            .equals(other.getRoster())) return false;
       }
-      result = result && (hasMaxblocksize() == other.hasMaxblocksize());
+      if (hasMaxblocksize() != other.hasMaxblocksize()) return false;
       if (hasMaxblocksize()) {
-        result = result && (getMaxblocksize()
-            == other.getMaxblocksize());
+        if (getMaxblocksize()
+            != other.getMaxblocksize()) return false;
       }
-      result = result && getDarccontractidsList()
-          .equals(other.getDarccontractidsList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getDarccontractidsList()
+          .equals(other.getDarccontractidsList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -9982,23 +9958,23 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.ChainConfig result = new ch.epfl.dedis.lib.proto.ByzCoinProto.ChainConfig(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.blockinterval_ = blockinterval_;
           to_bitField0_ |= 0x00000001;
         }
-        result.blockinterval_ = blockinterval_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (rosterBuilder_ == null) {
+            result.roster_ = roster_;
+          } else {
+            result.roster_ = rosterBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
         }
-        if (rosterBuilder_ == null) {
-          result.roster_ = roster_;
-        } else {
-          result.roster_ = rosterBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.maxblocksize_ = maxblocksize_;
           to_bitField0_ |= 0x00000004;
         }
-        result.maxblocksize_ = maxblocksize_;
-        if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((bitField0_ & 0x00000008) != 0)) {
           darccontractids_ = darccontractids_.getUnmodifiableView();
           bitField0_ = (bitField0_ & ~0x00000008);
         }
@@ -10010,35 +9986,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -10118,7 +10094,7 @@ public final class ByzCoinProto {
        * <code>required sint64 blockinterval = 1;</code>
        */
       public boolean hasBlockinterval() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required sint64 blockinterval = 1;</code>
@@ -10145,14 +10121,14 @@ public final class ByzCoinProto {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.OnetProto.Roster roster_ = null;
+      private ch.epfl.dedis.lib.proto.OnetProto.Roster roster_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.OnetProto.Roster, ch.epfl.dedis.lib.proto.OnetProto.Roster.Builder, ch.epfl.dedis.lib.proto.OnetProto.RosterOrBuilder> rosterBuilder_;
       /**
        * <code>required .onet.Roster roster = 2;</code>
        */
       public boolean hasRoster() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required .onet.Roster roster = 2;</code>
@@ -10199,7 +10175,7 @@ public final class ByzCoinProto {
        */
       public Builder mergeRoster(ch.epfl.dedis.lib.proto.OnetProto.Roster value) {
         if (rosterBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               roster_ != null &&
               roster_ != ch.epfl.dedis.lib.proto.OnetProto.Roster.getDefaultInstance()) {
             roster_ =
@@ -10268,7 +10244,7 @@ public final class ByzCoinProto {
        * <code>required sint32 maxblocksize = 3;</code>
        */
       public boolean hasMaxblocksize() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required sint32 maxblocksize = 3;</code>
@@ -10297,7 +10273,7 @@ public final class ByzCoinProto {
 
       private com.google.protobuf.LazyStringList darccontractids_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureDarccontractidsIsMutable() {
-        if (!((bitField0_ & 0x00000008) == 0x00000008)) {
+        if (!((bitField0_ & 0x00000008) != 0)) {
           darccontractids_ = new com.google.protobuf.LazyStringArrayList(darccontractids_);
           bitField0_ |= 0x00000008;
          }
@@ -10601,7 +10577,7 @@ public final class ByzCoinProto {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.TrieProto.Proof.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = inclusionproof_.toBuilder();
               }
               inclusionproof_ = input.readMessage(ch.epfl.dedis.lib.proto.TrieProto.Proof.parser(), extensionRegistry);
@@ -10614,7 +10590,7 @@ public final class ByzCoinProto {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = latest_.toBuilder();
               }
               latest_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.parser(), extensionRegistry);
@@ -10626,7 +10602,7 @@ public final class ByzCoinProto {
               break;
             }
             case 26: {
-              if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+              if (!((mutable_bitField0_ & 0x00000004) != 0)) {
                 links_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink>();
                 mutable_bitField0_ |= 0x00000004;
               }
@@ -10649,7 +10625,7 @@ public final class ByzCoinProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((mutable_bitField0_ & 0x00000004) != 0)) {
           links_ = java.util.Collections.unmodifiableList(links_);
         }
         this.unknownFields = unknownFields.build();
@@ -10680,7 +10656,7 @@ public final class ByzCoinProto {
      * <code>required .trie.Proof inclusionproof = 1;</code>
      */
     public boolean hasInclusionproof() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -10713,7 +10689,7 @@ public final class ByzCoinProto {
      * <code>required .skipchain.SkipBlock latest = 2;</code>
      */
     public boolean hasLatest() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -10837,10 +10813,10 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getInclusionproof());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getLatest());
       }
       for (int i = 0; i < links_.size(); i++) {
@@ -10855,11 +10831,11 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getInclusionproof());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getLatest());
       }
@@ -10882,21 +10858,20 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.Proof other = (ch.epfl.dedis.lib.proto.ByzCoinProto.Proof) obj;
 
-      boolean result = true;
-      result = result && (hasInclusionproof() == other.hasInclusionproof());
+      if (hasInclusionproof() != other.hasInclusionproof()) return false;
       if (hasInclusionproof()) {
-        result = result && getInclusionproof()
-            .equals(other.getInclusionproof());
+        if (!getInclusionproof()
+            .equals(other.getInclusionproof())) return false;
       }
-      result = result && (hasLatest() == other.hasLatest());
+      if (hasLatest() != other.hasLatest()) return false;
       if (hasLatest()) {
-        result = result && getLatest()
-            .equals(other.getLatest());
+        if (!getLatest()
+            .equals(other.getLatest())) return false;
       }
-      result = result && getLinksList()
-          .equals(other.getLinksList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getLinksList()
+          .equals(other.getLinksList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -11111,24 +11086,24 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.Proof result = new ch.epfl.dedis.lib.proto.ByzCoinProto.Proof(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (inclusionproofBuilder_ == null) {
+            result.inclusionproof_ = inclusionproof_;
+          } else {
+            result.inclusionproof_ = inclusionproofBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
         }
-        if (inclusionproofBuilder_ == null) {
-          result.inclusionproof_ = inclusionproof_;
-        } else {
-          result.inclusionproof_ = inclusionproofBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (latestBuilder_ == null) {
+            result.latest_ = latest_;
+          } else {
+            result.latest_ = latestBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
         }
-        if (latestBuilder_ == null) {
-          result.latest_ = latest_;
-        } else {
-          result.latest_ = latestBuilder_.build();
-        }
         if (linksBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004)) {
+          if (((bitField0_ & 0x00000004) != 0)) {
             links_ = java.util.Collections.unmodifiableList(links_);
             bitField0_ = (bitField0_ & ~0x00000004);
           }
@@ -11143,35 +11118,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -11264,7 +11239,7 @@ public final class ByzCoinProto {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.TrieProto.Proof inclusionproof_ = null;
+      private ch.epfl.dedis.lib.proto.TrieProto.Proof inclusionproof_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.TrieProto.Proof, ch.epfl.dedis.lib.proto.TrieProto.Proof.Builder, ch.epfl.dedis.lib.proto.TrieProto.ProofOrBuilder> inclusionproofBuilder_;
       /**
@@ -11275,7 +11250,7 @@ public final class ByzCoinProto {
        * <code>required .trie.Proof inclusionproof = 1;</code>
        */
       public boolean hasInclusionproof() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -11338,7 +11313,7 @@ public final class ByzCoinProto {
        */
       public Builder mergeInclusionproof(ch.epfl.dedis.lib.proto.TrieProto.Proof value) {
         if (inclusionproofBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               inclusionproof_ != null &&
               inclusionproof_ != ch.epfl.dedis.lib.proto.TrieProto.Proof.getDefaultInstance()) {
             inclusionproof_ =
@@ -11418,7 +11393,7 @@ public final class ByzCoinProto {
         return inclusionproofBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock latest_ = null;
+      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock latest_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlockOrBuilder> latestBuilder_;
       /**
@@ -11429,7 +11404,7 @@ public final class ByzCoinProto {
        * <code>required .skipchain.SkipBlock latest = 2;</code>
        */
       public boolean hasLatest() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -11492,7 +11467,7 @@ public final class ByzCoinProto {
        */
       public Builder mergeLatest(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock value) {
         if (latestBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               latest_ != null &&
               latest_ != ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.getDefaultInstance()) {
             latest_ =
@@ -11575,7 +11550,7 @@ public final class ByzCoinProto {
       private java.util.List<ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink> links_ =
         java.util.Collections.emptyList();
       private void ensureLinksIsMutable() {
-        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
+        if (!((bitField0_ & 0x00000004) != 0)) {
           links_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink>(links_);
           bitField0_ |= 0x00000004;
          }
@@ -11912,7 +11887,7 @@ public final class ByzCoinProto {
           linksBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink, ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink.Builder, ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLinkOrBuilder>(
                   links_,
-                  ((bitField0_ & 0x00000004) == 0x00000004),
+                  ((bitField0_ & 0x00000004) != 0),
                   getParentForChildren(),
                   isClean());
           links_ = null;
@@ -12194,7 +12169,7 @@ public final class ByzCoinProto {
     }
     private Instruction() {
       instanceid_ = com.google.protobuf.ByteString.EMPTY;
-      signercounter_ = java.util.Collections.emptyList();
+      signercounter_ = emptyLongList();
       signeridentities_ = java.util.Collections.emptyList();
       signatures_ = java.util.Collections.emptyList();
     }
@@ -12230,7 +12205,7 @@ public final class ByzCoinProto {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.Spawn.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = spawn_.toBuilder();
               }
               spawn_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Spawn.parser(), extensionRegistry);
@@ -12243,7 +12218,7 @@ public final class ByzCoinProto {
             }
             case 26: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.Invoke.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+              if (((bitField0_ & 0x00000004) != 0)) {
                 subBuilder = invoke_.toBuilder();
               }
               invoke_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Invoke.parser(), extensionRegistry);
@@ -12256,7 +12231,7 @@ public final class ByzCoinProto {
             }
             case 34: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.Delete.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000008) == 0x00000008)) {
+              if (((bitField0_ & 0x00000008) != 0)) {
                 subBuilder = delete_.toBuilder();
               }
               delete_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Delete.parser(), extensionRegistry);
@@ -12268,28 +12243,28 @@ public final class ByzCoinProto {
               break;
             }
             case 40: {
-              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-                signercounter_ = new java.util.ArrayList<java.lang.Long>();
+              if (!((mutable_bitField0_ & 0x00000010) != 0)) {
+                signercounter_ = newLongList();
                 mutable_bitField0_ |= 0x00000010;
               }
-              signercounter_.add(input.readUInt64());
+              signercounter_.addLong(input.readUInt64());
               break;
             }
             case 42: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010) && input.getBytesUntilLimit() > 0) {
-                signercounter_ = new java.util.ArrayList<java.lang.Long>();
+              if (!((mutable_bitField0_ & 0x00000010) != 0) && input.getBytesUntilLimit() > 0) {
+                signercounter_ = newLongList();
                 mutable_bitField0_ |= 0x00000010;
               }
               while (input.getBytesUntilLimit() > 0) {
-                signercounter_.add(input.readUInt64());
+                signercounter_.addLong(input.readUInt64());
               }
               input.popLimit(limit);
               break;
             }
             case 50: {
-              if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+              if (!((mutable_bitField0_ & 0x00000020) != 0)) {
                 signeridentities_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.DarcProto.Identity>();
                 mutable_bitField0_ |= 0x00000020;
               }
@@ -12298,7 +12273,7 @@ public final class ByzCoinProto {
               break;
             }
             case 58: {
-              if (!((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
+              if (!((mutable_bitField0_ & 0x00000040) != 0)) {
                 signatures_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
                 mutable_bitField0_ |= 0x00000040;
               }
@@ -12320,14 +12295,14 @@ public final class ByzCoinProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-          signercounter_ = java.util.Collections.unmodifiableList(signercounter_);
+        if (((mutable_bitField0_ & 0x00000010) != 0)) {
+          signercounter_.makeImmutable(); // C
         }
-        if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+        if (((mutable_bitField0_ & 0x00000020) != 0)) {
           signeridentities_ = java.util.Collections.unmodifiableList(signeridentities_);
         }
-        if (((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
-          signatures_ = java.util.Collections.unmodifiableList(signatures_);
+        if (((mutable_bitField0_ & 0x00000040) != 0)) {
+          signatures_ = java.util.Collections.unmodifiableList(signatures_); // C
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -12358,7 +12333,7 @@ public final class ByzCoinProto {
      * <code>required bytes instanceid = 1;</code>
      */
     public boolean hasInstanceid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -12382,7 +12357,7 @@ public final class ByzCoinProto {
      * <code>optional .byzcoin.Spawn spawn = 2;</code>
      */
     public boolean hasSpawn() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -12415,7 +12390,7 @@ public final class ByzCoinProto {
      * <code>optional .byzcoin.Invoke invoke = 3;</code>
      */
     public boolean hasInvoke() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <pre>
@@ -12448,7 +12423,7 @@ public final class ByzCoinProto {
      * <code>optional .byzcoin.Delete delete = 4;</code>
      */
     public boolean hasDelete() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <pre>
@@ -12472,7 +12447,7 @@ public final class ByzCoinProto {
     }
 
     public static final int SIGNERCOUNTER_FIELD_NUMBER = 5;
-    private java.util.List<java.lang.Long> signercounter_;
+    private com.google.protobuf.Internal.LongList signercounter_;
     /**
      * <pre>
      * SignerCounter must be set to a value that is one greater than what
@@ -12511,7 +12486,7 @@ public final class ByzCoinProto {
      * <code>repeated uint64 signercounter = 5 [packed = true];</code>
      */
     public long getSignercounter(int index) {
-      return signercounter_.get(index);
+      return signercounter_.getLong(index);
     }
     private int signercounterMemoizedSerializedSize = -1;
 
@@ -12650,16 +12625,16 @@ public final class ByzCoinProto {
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, instanceid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getSpawn());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeMessage(3, getInvoke());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeMessage(4, getDelete());
       }
       if (getSignercounterList().size() > 0) {
@@ -12667,7 +12642,7 @@ public final class ByzCoinProto {
         output.writeUInt32NoTag(signercounterMemoizedSerializedSize);
       }
       for (int i = 0; i < signercounter_.size(); i++) {
-        output.writeUInt64NoTag(signercounter_.get(i));
+        output.writeUInt64NoTag(signercounter_.getLong(i));
       }
       for (int i = 0; i < signeridentities_.size(); i++) {
         output.writeMessage(6, signeridentities_.get(i));
@@ -12684,19 +12659,19 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, instanceid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getSpawn());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, getInvoke());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(4, getDelete());
       }
@@ -12704,7 +12679,7 @@ public final class ByzCoinProto {
         int dataSize = 0;
         for (int i = 0; i < signercounter_.size(); i++) {
           dataSize += com.google.protobuf.CodedOutputStream
-            .computeUInt64SizeNoTag(signercounter_.get(i));
+            .computeUInt64SizeNoTag(signercounter_.getLong(i));
         }
         size += dataSize;
         if (!getSignercounterList().isEmpty()) {
@@ -12742,35 +12717,34 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.Instruction other = (ch.epfl.dedis.lib.proto.ByzCoinProto.Instruction) obj;
 
-      boolean result = true;
-      result = result && (hasInstanceid() == other.hasInstanceid());
+      if (hasInstanceid() != other.hasInstanceid()) return false;
       if (hasInstanceid()) {
-        result = result && getInstanceid()
-            .equals(other.getInstanceid());
+        if (!getInstanceid()
+            .equals(other.getInstanceid())) return false;
       }
-      result = result && (hasSpawn() == other.hasSpawn());
+      if (hasSpawn() != other.hasSpawn()) return false;
       if (hasSpawn()) {
-        result = result && getSpawn()
-            .equals(other.getSpawn());
+        if (!getSpawn()
+            .equals(other.getSpawn())) return false;
       }
-      result = result && (hasInvoke() == other.hasInvoke());
+      if (hasInvoke() != other.hasInvoke()) return false;
       if (hasInvoke()) {
-        result = result && getInvoke()
-            .equals(other.getInvoke());
+        if (!getInvoke()
+            .equals(other.getInvoke())) return false;
       }
-      result = result && (hasDelete() == other.hasDelete());
+      if (hasDelete() != other.hasDelete()) return false;
       if (hasDelete()) {
-        result = result && getDelete()
-            .equals(other.getDelete());
+        if (!getDelete()
+            .equals(other.getDelete())) return false;
       }
-      result = result && getSignercounterList()
-          .equals(other.getSignercounterList());
-      result = result && getSigneridentitiesList()
-          .equals(other.getSigneridentitiesList());
-      result = result && getSignaturesList()
-          .equals(other.getSignaturesList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getSignercounterList()
+          .equals(other.getSignercounterList())) return false;
+      if (!getSigneridentitiesList()
+          .equals(other.getSigneridentitiesList())) return false;
+      if (!getSignaturesList()
+          .equals(other.getSignaturesList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -12969,7 +12943,7 @@ public final class ByzCoinProto {
           deleteBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000008);
-        signercounter_ = java.util.Collections.emptyList();
+        signercounter_ = emptyLongList();
         bitField0_ = (bitField0_ & ~0x00000010);
         if (signeridentitiesBuilder_ == null) {
           signeridentities_ = java.util.Collections.emptyList();
@@ -13007,41 +12981,41 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.Instruction result = new ch.epfl.dedis.lib.proto.ByzCoinProto.Instruction(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.instanceid_ = instanceid_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (spawnBuilder_ == null) {
+            result.spawn_ = spawn_;
+          } else {
+            result.spawn_ = spawnBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
         }
-        if (spawnBuilder_ == null) {
-          result.spawn_ = spawn_;
-        } else {
-          result.spawn_ = spawnBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          if (invokeBuilder_ == null) {
+            result.invoke_ = invoke_;
+          } else {
+            result.invoke_ = invokeBuilder_.build();
+          }
           to_bitField0_ |= 0x00000004;
         }
-        if (invokeBuilder_ == null) {
-          result.invoke_ = invoke_;
-        } else {
-          result.invoke_ = invokeBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          if (deleteBuilder_ == null) {
+            result.delete_ = delete_;
+          } else {
+            result.delete_ = deleteBuilder_.build();
+          }
           to_bitField0_ |= 0x00000008;
         }
-        if (deleteBuilder_ == null) {
-          result.delete_ = delete_;
-        } else {
-          result.delete_ = deleteBuilder_.build();
-        }
-        if (((bitField0_ & 0x00000010) == 0x00000010)) {
-          signercounter_ = java.util.Collections.unmodifiableList(signercounter_);
+        if (((bitField0_ & 0x00000010) != 0)) {
+          signercounter_.makeImmutable();
           bitField0_ = (bitField0_ & ~0x00000010);
         }
         result.signercounter_ = signercounter_;
         if (signeridentitiesBuilder_ == null) {
-          if (((bitField0_ & 0x00000020) == 0x00000020)) {
+          if (((bitField0_ & 0x00000020) != 0)) {
             signeridentities_ = java.util.Collections.unmodifiableList(signeridentities_);
             bitField0_ = (bitField0_ & ~0x00000020);
           }
@@ -13049,7 +13023,7 @@ public final class ByzCoinProto {
         } else {
           result.signeridentities_ = signeridentitiesBuilder_.build();
         }
-        if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        if (((bitField0_ & 0x00000040) != 0)) {
           signatures_ = java.util.Collections.unmodifiableList(signatures_);
           bitField0_ = (bitField0_ & ~0x00000040);
         }
@@ -13061,35 +13035,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -13224,7 +13198,7 @@ public final class ByzCoinProto {
        * <code>required bytes instanceid = 1;</code>
        */
       public boolean hasInstanceid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -13269,7 +13243,7 @@ public final class ByzCoinProto {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.Spawn spawn_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.Spawn spawn_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.Spawn, ch.epfl.dedis.lib.proto.ByzCoinProto.Spawn.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.SpawnOrBuilder> spawnBuilder_;
       /**
@@ -13280,7 +13254,7 @@ public final class ByzCoinProto {
        * <code>optional .byzcoin.Spawn spawn = 2;</code>
        */
       public boolean hasSpawn() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -13343,7 +13317,7 @@ public final class ByzCoinProto {
        */
       public Builder mergeSpawn(ch.epfl.dedis.lib.proto.ByzCoinProto.Spawn value) {
         if (spawnBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               spawn_ != null &&
               spawn_ != ch.epfl.dedis.lib.proto.ByzCoinProto.Spawn.getDefaultInstance()) {
             spawn_ =
@@ -13423,7 +13397,7 @@ public final class ByzCoinProto {
         return spawnBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.Invoke invoke_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.Invoke invoke_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.Invoke, ch.epfl.dedis.lib.proto.ByzCoinProto.Invoke.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.InvokeOrBuilder> invokeBuilder_;
       /**
@@ -13434,7 +13408,7 @@ public final class ByzCoinProto {
        * <code>optional .byzcoin.Invoke invoke = 3;</code>
        */
       public boolean hasInvoke() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <pre>
@@ -13497,7 +13471,7 @@ public final class ByzCoinProto {
        */
       public Builder mergeInvoke(ch.epfl.dedis.lib.proto.ByzCoinProto.Invoke value) {
         if (invokeBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004) &&
+          if (((bitField0_ & 0x00000004) != 0) &&
               invoke_ != null &&
               invoke_ != ch.epfl.dedis.lib.proto.ByzCoinProto.Invoke.getDefaultInstance()) {
             invoke_ =
@@ -13577,7 +13551,7 @@ public final class ByzCoinProto {
         return invokeBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.Delete delete_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.Delete delete_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.Delete, ch.epfl.dedis.lib.proto.ByzCoinProto.Delete.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.DeleteOrBuilder> deleteBuilder_;
       /**
@@ -13588,7 +13562,7 @@ public final class ByzCoinProto {
        * <code>optional .byzcoin.Delete delete = 4;</code>
        */
       public boolean hasDelete() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <pre>
@@ -13651,7 +13625,7 @@ public final class ByzCoinProto {
        */
       public Builder mergeDelete(ch.epfl.dedis.lib.proto.ByzCoinProto.Delete value) {
         if (deleteBuilder_ == null) {
-          if (((bitField0_ & 0x00000008) == 0x00000008) &&
+          if (((bitField0_ & 0x00000008) != 0) &&
               delete_ != null &&
               delete_ != ch.epfl.dedis.lib.proto.ByzCoinProto.Delete.getDefaultInstance()) {
             delete_ =
@@ -13731,10 +13705,10 @@ public final class ByzCoinProto {
         return deleteBuilder_;
       }
 
-      private java.util.List<java.lang.Long> signercounter_ = java.util.Collections.emptyList();
+      private com.google.protobuf.Internal.LongList signercounter_ = emptyLongList();
       private void ensureSignercounterIsMutable() {
-        if (!((bitField0_ & 0x00000010) == 0x00000010)) {
-          signercounter_ = new java.util.ArrayList<java.lang.Long>(signercounter_);
+        if (!((bitField0_ & 0x00000010) != 0)) {
+          signercounter_ = mutableCopy(signercounter_);
           bitField0_ |= 0x00000010;
          }
       }
@@ -13750,7 +13724,8 @@ public final class ByzCoinProto {
        */
       public java.util.List<java.lang.Long>
           getSignercounterList() {
-        return java.util.Collections.unmodifiableList(signercounter_);
+        return ((bitField0_ & 0x00000010) != 0) ?
+                 java.util.Collections.unmodifiableList(signercounter_) : signercounter_;
       }
       /**
        * <pre>
@@ -13776,7 +13751,7 @@ public final class ByzCoinProto {
        * <code>repeated uint64 signercounter = 5 [packed = true];</code>
        */
       public long getSignercounter(int index) {
-        return signercounter_.get(index);
+        return signercounter_.getLong(index);
       }
       /**
        * <pre>
@@ -13791,7 +13766,7 @@ public final class ByzCoinProto {
       public Builder setSignercounter(
           int index, long value) {
         ensureSignercounterIsMutable();
-        signercounter_.set(index, value);
+        signercounter_.setLong(index, value);
         onChanged();
         return this;
       }
@@ -13807,7 +13782,7 @@ public final class ByzCoinProto {
        */
       public Builder addSignercounter(long value) {
         ensureSignercounterIsMutable();
-        signercounter_.add(value);
+        signercounter_.addLong(value);
         onChanged();
         return this;
       }
@@ -13840,7 +13815,7 @@ public final class ByzCoinProto {
        * <code>repeated uint64 signercounter = 5 [packed = true];</code>
        */
       public Builder clearSignercounter() {
-        signercounter_ = java.util.Collections.emptyList();
+        signercounter_ = emptyLongList();
         bitField0_ = (bitField0_ & ~0x00000010);
         onChanged();
         return this;
@@ -13849,7 +13824,7 @@ public final class ByzCoinProto {
       private java.util.List<ch.epfl.dedis.lib.proto.DarcProto.Identity> signeridentities_ =
         java.util.Collections.emptyList();
       private void ensureSigneridentitiesIsMutable() {
-        if (!((bitField0_ & 0x00000020) == 0x00000020)) {
+        if (!((bitField0_ & 0x00000020) != 0)) {
           signeridentities_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.DarcProto.Identity>(signeridentities_);
           bitField0_ |= 0x00000020;
          }
@@ -14150,7 +14125,7 @@ public final class ByzCoinProto {
           signeridentitiesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.DarcProto.Identity, ch.epfl.dedis.lib.proto.DarcProto.Identity.Builder, ch.epfl.dedis.lib.proto.DarcProto.IdentityOrBuilder>(
                   signeridentities_,
-                  ((bitField0_ & 0x00000020) == 0x00000020),
+                  ((bitField0_ & 0x00000020) != 0),
                   getParentForChildren(),
                   isClean());
           signeridentities_ = null;
@@ -14160,7 +14135,7 @@ public final class ByzCoinProto {
 
       private java.util.List<com.google.protobuf.ByteString> signatures_ = java.util.Collections.emptyList();
       private void ensureSignaturesIsMutable() {
-        if (!((bitField0_ & 0x00000040) == 0x00000040)) {
+        if (!((bitField0_ & 0x00000040) != 0)) {
           signatures_ = new java.util.ArrayList<com.google.protobuf.ByteString>(signatures_);
           bitField0_ |= 0x00000040;
          }
@@ -14175,7 +14150,8 @@ public final class ByzCoinProto {
        */
       public java.util.List<com.google.protobuf.ByteString>
           getSignaturesList() {
-        return java.util.Collections.unmodifiableList(signatures_);
+        return ((bitField0_ & 0x00000040) != 0) ?
+                 java.util.Collections.unmodifiableList(signatures_) : signatures_;
       }
       /**
        * <pre>
@@ -14443,7 +14419,7 @@ public final class ByzCoinProto {
               break;
             }
             case 18: {
-              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
                 args_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.Argument>();
                 mutable_bitField0_ |= 0x00000002;
               }
@@ -14466,7 +14442,7 @@ public final class ByzCoinProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((mutable_bitField0_ & 0x00000002) != 0)) {
           args_ = java.util.Collections.unmodifiableList(args_);
         }
         this.unknownFields = unknownFields.build();
@@ -14497,7 +14473,7 @@ public final class ByzCoinProto {
      * <code>required string contractid = 1;</code>
      */
     public boolean hasContractid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -14620,7 +14596,7 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, contractid_);
       }
       for (int i = 0; i < args_.size(); i++) {
@@ -14635,7 +14611,7 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, contractid_);
       }
       for (int i = 0; i < args_.size(); i++) {
@@ -14657,16 +14633,15 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.Spawn other = (ch.epfl.dedis.lib.proto.ByzCoinProto.Spawn) obj;
 
-      boolean result = true;
-      result = result && (hasContractid() == other.hasContractid());
+      if (hasContractid() != other.hasContractid()) return false;
       if (hasContractid()) {
-        result = result && getContractid()
-            .equals(other.getContractid());
+        if (!getContractid()
+            .equals(other.getContractid())) return false;
       }
-      result = result && getArgsList()
-          .equals(other.getArgsList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getArgsList()
+          .equals(other.getArgsList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -14858,12 +14833,12 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.Spawn result = new ch.epfl.dedis.lib.proto.ByzCoinProto.Spawn(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.contractid_ = contractid_;
         if (argsBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          if (((bitField0_ & 0x00000002) != 0)) {
             args_ = java.util.Collections.unmodifiableList(args_);
             bitField0_ = (bitField0_ & ~0x00000002);
           }
@@ -14878,35 +14853,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -14998,7 +14973,7 @@ public final class ByzCoinProto {
        * <code>required string contractid = 1;</code>
        */
       public boolean hasContractid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -15092,7 +15067,7 @@ public final class ByzCoinProto {
       private java.util.List<ch.epfl.dedis.lib.proto.ByzCoinProto.Argument> args_ =
         java.util.Collections.emptyList();
       private void ensureArgsIsMutable() {
-        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+        if (!((bitField0_ & 0x00000002) != 0)) {
           args_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.Argument>(args_);
           bitField0_ |= 0x00000002;
          }
@@ -15393,7 +15368,7 @@ public final class ByzCoinProto {
           argsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.ByzCoinProto.Argument, ch.epfl.dedis.lib.proto.ByzCoinProto.Argument.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.ArgumentOrBuilder>(
                   args_,
-                  ((bitField0_ & 0x00000002) == 0x00000002),
+                  ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
                   isClean());
           args_ = null;
@@ -15613,7 +15588,7 @@ public final class ByzCoinProto {
               break;
             }
             case 26: {
-              if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+              if (!((mutable_bitField0_ & 0x00000004) != 0)) {
                 args_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.Argument>();
                 mutable_bitField0_ |= 0x00000004;
               }
@@ -15636,7 +15611,7 @@ public final class ByzCoinProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((mutable_bitField0_ & 0x00000004) != 0)) {
           args_ = java.util.Collections.unmodifiableList(args_);
         }
         this.unknownFields = unknownFields.build();
@@ -15667,7 +15642,7 @@ public final class ByzCoinProto {
      * <code>required string contractid = 1;</code>
      */
     public boolean hasContractid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -15721,7 +15696,7 @@ public final class ByzCoinProto {
      * <code>required string command = 2;</code>
      */
     public boolean hasCommand() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -15848,10 +15823,10 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, contractid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, command_);
       }
       for (int i = 0; i < args_.size(); i++) {
@@ -15866,10 +15841,10 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, contractid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, command_);
       }
       for (int i = 0; i < args_.size(); i++) {
@@ -15891,21 +15866,20 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.Invoke other = (ch.epfl.dedis.lib.proto.ByzCoinProto.Invoke) obj;
 
-      boolean result = true;
-      result = result && (hasContractid() == other.hasContractid());
+      if (hasContractid() != other.hasContractid()) return false;
       if (hasContractid()) {
-        result = result && getContractid()
-            .equals(other.getContractid());
+        if (!getContractid()
+            .equals(other.getContractid())) return false;
       }
-      result = result && (hasCommand() == other.hasCommand());
+      if (hasCommand() != other.hasCommand()) return false;
       if (hasCommand()) {
-        result = result && getCommand()
-            .equals(other.getCommand());
+        if (!getCommand()
+            .equals(other.getCommand())) return false;
       }
-      result = result && getArgsList()
-          .equals(other.getArgsList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getArgsList()
+          .equals(other.getArgsList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -16104,16 +16078,16 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.Invoke result = new ch.epfl.dedis.lib.proto.ByzCoinProto.Invoke(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.contractid_ = contractid_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.command_ = command_;
         if (argsBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004)) {
+          if (((bitField0_ & 0x00000004) != 0)) {
             args_ = java.util.Collections.unmodifiableList(args_);
             bitField0_ = (bitField0_ & ~0x00000004);
           }
@@ -16128,35 +16102,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -16256,7 +16230,7 @@ public final class ByzCoinProto {
        * <code>required string contractid = 1;</code>
        */
       public boolean hasContractid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -16356,7 +16330,7 @@ public final class ByzCoinProto {
        * <code>required string command = 2;</code>
        */
       public boolean hasCommand() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -16450,7 +16424,7 @@ public final class ByzCoinProto {
       private java.util.List<ch.epfl.dedis.lib.proto.ByzCoinProto.Argument> args_ =
         java.util.Collections.emptyList();
       private void ensureArgsIsMutable() {
-        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
+        if (!((bitField0_ & 0x00000004) != 0)) {
           args_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.Argument>(args_);
           bitField0_ |= 0x00000004;
          }
@@ -16751,7 +16725,7 @@ public final class ByzCoinProto {
           argsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.ByzCoinProto.Argument, ch.epfl.dedis.lib.proto.ByzCoinProto.Argument.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.ArgumentOrBuilder>(
                   args_,
-                  ((bitField0_ & 0x00000004) == 0x00000004),
+                  ((bitField0_ & 0x00000004) != 0),
                   getParentForChildren(),
                   isClean());
           args_ = null;
@@ -16935,7 +16909,7 @@ public final class ByzCoinProto {
      * <code>required string contractid = 1;</code>
      */
     public boolean hasContractid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -16997,7 +16971,7 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, contractid_);
       }
       unknownFields.writeTo(output);
@@ -17009,7 +16983,7 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, contractid_);
       }
       size += unknownFields.getSerializedSize();
@@ -17027,14 +17001,13 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.Delete other = (ch.epfl.dedis.lib.proto.ByzCoinProto.Delete) obj;
 
-      boolean result = true;
-      result = result && (hasContractid() == other.hasContractid());
+      if (hasContractid() != other.hasContractid()) return false;
       if (hasContractid()) {
-        result = result && getContractid()
-            .equals(other.getContractid());
+        if (!getContractid()
+            .equals(other.getContractid())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -17216,7 +17189,7 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.Delete result = new ch.epfl.dedis.lib.proto.ByzCoinProto.Delete(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.contractid_ = contractid_;
@@ -17227,35 +17200,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -17316,7 +17289,7 @@ public final class ByzCoinProto {
        * <code>required string contractid = 1;</code>
        */
       public boolean hasContractid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -17605,7 +17578,7 @@ public final class ByzCoinProto {
      * <code>required string name = 1;</code>
      */
     public boolean hasName() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -17659,7 +17632,7 @@ public final class ByzCoinProto {
      * <code>required bytes value = 2;</code>
      */
     public boolean hasValue() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -17694,10 +17667,10 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, value_);
       }
       unknownFields.writeTo(output);
@@ -17709,10 +17682,10 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, value_);
       }
@@ -17731,19 +17704,18 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.Argument other = (ch.epfl.dedis.lib.proto.ByzCoinProto.Argument) obj;
 
-      boolean result = true;
-      result = result && (hasName() == other.hasName());
+      if (hasName() != other.hasName()) return false;
       if (hasName()) {
-        result = result && getName()
-            .equals(other.getName());
+        if (!getName()
+            .equals(other.getName())) return false;
       }
-      result = result && (hasValue() == other.hasValue());
+      if (hasValue() != other.hasValue()) return false;
       if (hasValue()) {
-        result = result && getValue()
-            .equals(other.getValue());
+        if (!getValue()
+            .equals(other.getValue())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -17930,11 +17902,11 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.Argument result = new ch.epfl.dedis.lib.proto.ByzCoinProto.Argument(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.name_ = name_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.value_ = value_;
@@ -17945,35 +17917,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -18040,7 +18012,7 @@ public final class ByzCoinProto {
        * <code>required string name = 1;</code>
        */
       public boolean hasName() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -18140,7 +18112,7 @@ public final class ByzCoinProto {
        * <code>required bytes value = 2;</code>
        */
       public boolean hasValue() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -18311,7 +18283,7 @@ public final class ByzCoinProto {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 instructions_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.Instruction>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -18334,7 +18306,7 @@ public final class ByzCoinProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           instructions_ = java.util.Collections.unmodifiableList(instructions_);
         }
         this.unknownFields = unknownFields.build();
@@ -18440,11 +18412,10 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction other = (ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction) obj;
 
-      boolean result = true;
-      result = result && getInstructionsList()
-          .equals(other.getInstructionsList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getInstructionsList()
+          .equals(other.getInstructionsList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -18634,7 +18605,7 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction result = new ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction(this);
         int from_bitField0_ = bitField0_;
         if (instructionsBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             instructions_ = java.util.Collections.unmodifiableList(instructions_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -18648,35 +18619,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -18754,7 +18725,7 @@ public final class ByzCoinProto {
       private java.util.List<ch.epfl.dedis.lib.proto.ByzCoinProto.Instruction> instructions_ =
         java.util.Collections.emptyList();
       private void ensureInstructionsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           instructions_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.Instruction>(instructions_);
           bitField0_ |= 0x00000001;
          }
@@ -18983,7 +18954,7 @@ public final class ByzCoinProto {
           instructionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.ByzCoinProto.Instruction, ch.epfl.dedis.lib.proto.ByzCoinProto.Instruction.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.InstructionOrBuilder>(
                   instructions_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           instructions_ = null;
@@ -19086,7 +19057,6 @@ public final class ByzCoinProto {
       super(builder);
     }
     private TxResult() {
-      accepted_ = false;
     }
 
     @java.lang.Override
@@ -19115,7 +19085,7 @@ public final class ByzCoinProto {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = clienttransaction_.toBuilder();
               }
               clienttransaction_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction.parser(), extensionRegistry);
@@ -19170,7 +19140,7 @@ public final class ByzCoinProto {
      * <code>required .byzcoin.ClientTransaction clienttransaction = 1;</code>
      */
     public boolean hasClienttransaction() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required .byzcoin.ClientTransaction clienttransaction = 1;</code>
@@ -19191,7 +19161,7 @@ public final class ByzCoinProto {
      * <code>required bool accepted = 2;</code>
      */
     public boolean hasAccepted() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bool accepted = 2;</code>
@@ -19226,10 +19196,10 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getClienttransaction());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBool(2, accepted_);
       }
       unknownFields.writeTo(output);
@@ -19241,11 +19211,11 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getClienttransaction());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(2, accepted_);
       }
@@ -19264,19 +19234,18 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.TxResult other = (ch.epfl.dedis.lib.proto.ByzCoinProto.TxResult) obj;
 
-      boolean result = true;
-      result = result && (hasClienttransaction() == other.hasClienttransaction());
+      if (hasClienttransaction() != other.hasClienttransaction()) return false;
       if (hasClienttransaction()) {
-        result = result && getClienttransaction()
-            .equals(other.getClienttransaction());
+        if (!getClienttransaction()
+            .equals(other.getClienttransaction())) return false;
       }
-      result = result && (hasAccepted() == other.hasAccepted());
+      if (hasAccepted() != other.hasAccepted()) return false;
       if (hasAccepted()) {
-        result = result && (getAccepted()
-            == other.getAccepted());
+        if (getAccepted()
+            != other.getAccepted()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -19469,18 +19438,18 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.TxResult result = new ch.epfl.dedis.lib.proto.ByzCoinProto.TxResult(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (clienttransactionBuilder_ == null) {
+            result.clienttransaction_ = clienttransaction_;
+          } else {
+            result.clienttransaction_ = clienttransactionBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
         }
-        if (clienttransactionBuilder_ == null) {
-          result.clienttransaction_ = clienttransaction_;
-        } else {
-          result.clienttransaction_ = clienttransactionBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.accepted_ = accepted_;
           to_bitField0_ |= 0x00000002;
         }
-        result.accepted_ = accepted_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -19488,35 +19457,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -19575,14 +19544,14 @@ public final class ByzCoinProto {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction clienttransaction_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction clienttransaction_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction, ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransactionOrBuilder> clienttransactionBuilder_;
       /**
        * <code>required .byzcoin.ClientTransaction clienttransaction = 1;</code>
        */
       public boolean hasClienttransaction() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required .byzcoin.ClientTransaction clienttransaction = 1;</code>
@@ -19629,7 +19598,7 @@ public final class ByzCoinProto {
        */
       public Builder mergeClienttransaction(ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction value) {
         if (clienttransactionBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               clienttransaction_ != null &&
               clienttransaction_ != ch.epfl.dedis.lib.proto.ByzCoinProto.ClientTransaction.getDefaultInstance()) {
             clienttransaction_ =
@@ -19698,7 +19667,7 @@ public final class ByzCoinProto {
        * <code>required bool accepted = 2;</code>
        */
       public boolean hasAccepted() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bool accepted = 2;</code>
@@ -19909,12 +19878,10 @@ public final class ByzCoinProto {
       super(builder);
     }
     private StateChange() {
-      stateaction_ = 0;
       instanceid_ = com.google.protobuf.ByteString.EMPTY;
       contractid_ = "";
       value_ = com.google.protobuf.ByteString.EMPTY;
       darcid_ = com.google.protobuf.ByteString.EMPTY;
-      version_ = 0L;
     }
 
     @java.lang.Override
@@ -20015,7 +19982,7 @@ public final class ByzCoinProto {
      * <code>required sint32 stateaction = 1;</code>
      */
     public boolean hasStateaction() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -20038,7 +20005,7 @@ public final class ByzCoinProto {
      * <code>required bytes instanceid = 2;</code>
      */
     public boolean hasInstanceid() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -20061,7 +20028,7 @@ public final class ByzCoinProto {
      * <code>required string contractid = 3;</code>
      */
     public boolean hasContractid() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <pre>
@@ -20115,7 +20082,7 @@ public final class ByzCoinProto {
      * <code>required bytes value = 4;</code>
      */
     public boolean hasValue() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <pre>
@@ -20138,7 +20105,7 @@ public final class ByzCoinProto {
      * <code>required bytes darcid = 5;</code>
      */
     public boolean hasDarcid() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000010) != 0);
     }
     /**
      * <pre>
@@ -20161,7 +20128,7 @@ public final class ByzCoinProto {
      * <code>required uint64 version = 6;</code>
      */
     public boolean hasVersion() {
-      return ((bitField0_ & 0x00000020) == 0x00000020);
+      return ((bitField0_ & 0x00000020) != 0);
     }
     /**
      * <pre>
@@ -20212,22 +20179,22 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeSInt32(1, stateaction_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, instanceid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 3, contractid_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeBytes(4, value_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         output.writeBytes(5, darcid_);
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if (((bitField0_ & 0x00000020) != 0)) {
         output.writeUInt64(6, version_);
       }
       unknownFields.writeTo(output);
@@ -20239,26 +20206,26 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(1, stateaction_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, instanceid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, contractid_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(4, value_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(5, darcid_);
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if (((bitField0_ & 0x00000020) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(6, version_);
       }
@@ -20277,39 +20244,38 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.StateChange other = (ch.epfl.dedis.lib.proto.ByzCoinProto.StateChange) obj;
 
-      boolean result = true;
-      result = result && (hasStateaction() == other.hasStateaction());
+      if (hasStateaction() != other.hasStateaction()) return false;
       if (hasStateaction()) {
-        result = result && (getStateaction()
-            == other.getStateaction());
+        if (getStateaction()
+            != other.getStateaction()) return false;
       }
-      result = result && (hasInstanceid() == other.hasInstanceid());
+      if (hasInstanceid() != other.hasInstanceid()) return false;
       if (hasInstanceid()) {
-        result = result && getInstanceid()
-            .equals(other.getInstanceid());
+        if (!getInstanceid()
+            .equals(other.getInstanceid())) return false;
       }
-      result = result && (hasContractid() == other.hasContractid());
+      if (hasContractid() != other.hasContractid()) return false;
       if (hasContractid()) {
-        result = result && getContractid()
-            .equals(other.getContractid());
+        if (!getContractid()
+            .equals(other.getContractid())) return false;
       }
-      result = result && (hasValue() == other.hasValue());
+      if (hasValue() != other.hasValue()) return false;
       if (hasValue()) {
-        result = result && getValue()
-            .equals(other.getValue());
+        if (!getValue()
+            .equals(other.getValue())) return false;
       }
-      result = result && (hasDarcid() == other.hasDarcid());
+      if (hasDarcid() != other.hasDarcid()) return false;
       if (hasDarcid()) {
-        result = result && getDarcid()
-            .equals(other.getDarcid());
+        if (!getDarcid()
+            .equals(other.getDarcid())) return false;
       }
-      result = result && (hasVersion() == other.hasVersion());
+      if (hasVersion() != other.hasVersion()) return false;
       if (hasVersion()) {
-        result = result && (getVersion()
-            == other.getVersion());
+        if (getVersion()
+            != other.getVersion()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -20521,30 +20487,30 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.StateChange result = new ch.epfl.dedis.lib.proto.ByzCoinProto.StateChange(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.stateaction_ = stateaction_;
           to_bitField0_ |= 0x00000001;
         }
-        result.stateaction_ = stateaction_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.instanceid_ = instanceid_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.contractid_ = contractid_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
           to_bitField0_ |= 0x00000008;
         }
         result.value_ = value_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((from_bitField0_ & 0x00000010) != 0)) {
           to_bitField0_ |= 0x00000010;
         }
         result.darcid_ = darcid_;
-        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+        if (((from_bitField0_ & 0x00000020) != 0)) {
+          result.version_ = version_;
           to_bitField0_ |= 0x00000020;
         }
-        result.version_ = version_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -20552,35 +20518,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -20671,7 +20637,7 @@ public final class ByzCoinProto {
        * <code>required sint32 stateaction = 1;</code>
        */
       public boolean hasStateaction() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -20719,7 +20685,7 @@ public final class ByzCoinProto {
        * <code>required bytes instanceid = 2;</code>
        */
       public boolean hasInstanceid() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -20770,7 +20736,7 @@ public final class ByzCoinProto {
        * <code>required string contractid = 3;</code>
        */
       public boolean hasContractid() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <pre>
@@ -20870,7 +20836,7 @@ public final class ByzCoinProto {
        * <code>required bytes value = 4;</code>
        */
       public boolean hasValue() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <pre>
@@ -20921,7 +20887,7 @@ public final class ByzCoinProto {
        * <code>required bytes darcid = 5;</code>
        */
       public boolean hasDarcid() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return ((bitField0_ & 0x00000010) != 0);
       }
       /**
        * <pre>
@@ -20972,7 +20938,7 @@ public final class ByzCoinProto {
        * <code>required uint64 version = 6;</code>
        */
       public boolean hasVersion() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
+        return ((bitField0_ & 0x00000020) != 0);
       }
       /**
        * <pre>
@@ -21120,7 +21086,6 @@ public final class ByzCoinProto {
     }
     private Coin() {
       name_ = com.google.protobuf.ByteString.EMPTY;
-      value_ = 0L;
     }
 
     @java.lang.Override
@@ -21200,7 +21165,7 @@ public final class ByzCoinProto {
      * <code>required bytes name = 1;</code>
      */
     public boolean hasName() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -21223,7 +21188,7 @@ public final class ByzCoinProto {
      * <code>required uint64 value = 2;</code>
      */
     public boolean hasValue() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -21258,10 +21223,10 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, name_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeUInt64(2, value_);
       }
       unknownFields.writeTo(output);
@@ -21273,11 +21238,11 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, name_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(2, value_);
       }
@@ -21296,19 +21261,18 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.Coin other = (ch.epfl.dedis.lib.proto.ByzCoinProto.Coin) obj;
 
-      boolean result = true;
-      result = result && (hasName() == other.hasName());
+      if (hasName() != other.hasName()) return false;
       if (hasName()) {
-        result = result && getName()
-            .equals(other.getName());
+        if (!getName()
+            .equals(other.getName())) return false;
       }
-      result = result && (hasValue() == other.hasValue());
+      if (hasValue() != other.hasValue()) return false;
       if (hasValue()) {
-        result = result && (getValue()
-            == other.getValue());
+        if (getValue()
+            != other.getValue()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -21497,14 +21461,14 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.Coin result = new ch.epfl.dedis.lib.proto.ByzCoinProto.Coin(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.name_ = name_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.value_ = value_;
           to_bitField0_ |= 0x00000002;
         }
-        result.value_ = value_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -21512,35 +21476,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -21605,7 +21569,7 @@ public final class ByzCoinProto {
        * <code>required bytes name = 1;</code>
        */
       public boolean hasName() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -21656,7 +21620,7 @@ public final class ByzCoinProto {
        * <code>required uint64 value = 2;</code>
        */
       public boolean hasValue() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -21849,7 +21813,7 @@ public final class ByzCoinProto {
      * <code>required bytes id = 1;</code>
      */
     public boolean hasId() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes id = 1;</code>
@@ -21876,7 +21840,7 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, id_);
       }
       unknownFields.writeTo(output);
@@ -21888,7 +21852,7 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, id_);
       }
@@ -21907,14 +21871,13 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.StreamingRequest other = (ch.epfl.dedis.lib.proto.ByzCoinProto.StreamingRequest) obj;
 
-      boolean result = true;
-      result = result && (hasId() == other.hasId());
+      if (hasId() != other.hasId()) return false;
       if (hasId()) {
-        result = result && getId()
-            .equals(other.getId());
+        if (!getId()
+            .equals(other.getId())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -22096,7 +22059,7 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.StreamingRequest result = new ch.epfl.dedis.lib.proto.ByzCoinProto.StreamingRequest(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.id_ = id_;
@@ -22107,35 +22070,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -22190,7 +22153,7 @@ public final class ByzCoinProto {
        * <code>required bytes id = 1;</code>
        */
       public boolean hasId() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes id = 1;</code>
@@ -22334,7 +22297,7 @@ public final class ByzCoinProto {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = block_.toBuilder();
               }
               block_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.parser(), extensionRegistry);
@@ -22384,7 +22347,7 @@ public final class ByzCoinProto {
      * <code>optional .skipchain.SkipBlock block = 1;</code>
      */
     public boolean hasBlock() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>optional .skipchain.SkipBlock block = 1;</code>
@@ -22419,7 +22382,7 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getBlock());
       }
       unknownFields.writeTo(output);
@@ -22431,7 +22394,7 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getBlock());
       }
@@ -22450,14 +22413,13 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.StreamingResponse other = (ch.epfl.dedis.lib.proto.ByzCoinProto.StreamingResponse) obj;
 
-      boolean result = true;
-      result = result && (hasBlock() == other.hasBlock());
+      if (hasBlock() != other.hasBlock()) return false;
       if (hasBlock()) {
-        result = result && getBlock()
-            .equals(other.getBlock());
+        if (!getBlock()
+            .equals(other.getBlock())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -22643,13 +22605,13 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.StreamingResponse result = new ch.epfl.dedis.lib.proto.ByzCoinProto.StreamingResponse(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (blockBuilder_ == null) {
+            result.block_ = block_;
+          } else {
+            result.block_ = blockBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
-        }
-        if (blockBuilder_ == null) {
-          result.block_ = block_;
-        } else {
-          result.block_ = blockBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -22658,35 +22620,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -22738,14 +22700,14 @@ public final class ByzCoinProto {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock block_ = null;
+      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock block_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlockOrBuilder> blockBuilder_;
       /**
        * <code>optional .skipchain.SkipBlock block = 1;</code>
        */
       public boolean hasBlock() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>optional .skipchain.SkipBlock block = 1;</code>
@@ -22792,7 +22754,7 @@ public final class ByzCoinProto {
        */
       public Builder mergeBlock(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock value) {
         if (blockBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               block_ != null &&
               block_ != ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.getDefaultInstance()) {
             block_ =
@@ -22994,8 +22956,6 @@ public final class ByzCoinProto {
     }
     private DownloadState() {
       byzcoinid_ = com.google.protobuf.ByteString.EMPTY;
-      nonce_ = 0L;
-      length_ = 0;
     }
 
     @java.lang.Override
@@ -23080,7 +23040,7 @@ public final class ByzCoinProto {
      * <code>required bytes byzcoinid = 1;</code>
      */
     public boolean hasByzcoinid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -23108,7 +23068,7 @@ public final class ByzCoinProto {
      * <code>required uint64 nonce = 2;</code>
      */
     public boolean hasNonce() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -23136,7 +23096,7 @@ public final class ByzCoinProto {
      * <code>required sint32 length = 3;</code>
      */
     public boolean hasLength() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <pre>
@@ -23175,13 +23135,13 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, byzcoinid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeUInt64(2, nonce_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeSInt32(3, length_);
       }
       unknownFields.writeTo(output);
@@ -23193,15 +23153,15 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, byzcoinid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(2, nonce_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(3, length_);
       }
@@ -23220,24 +23180,23 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.DownloadState other = (ch.epfl.dedis.lib.proto.ByzCoinProto.DownloadState) obj;
 
-      boolean result = true;
-      result = result && (hasByzcoinid() == other.hasByzcoinid());
+      if (hasByzcoinid() != other.hasByzcoinid()) return false;
       if (hasByzcoinid()) {
-        result = result && getByzcoinid()
-            .equals(other.getByzcoinid());
+        if (!getByzcoinid()
+            .equals(other.getByzcoinid())) return false;
       }
-      result = result && (hasNonce() == other.hasNonce());
+      if (hasNonce() != other.hasNonce()) return false;
       if (hasNonce()) {
-        result = result && (getNonce()
-            == other.getNonce());
+        if (getNonce()
+            != other.getNonce()) return false;
       }
-      result = result && (hasLength() == other.hasLength());
+      if (hasLength() != other.hasLength()) return false;
       if (hasLength()) {
-        result = result && (getLength()
-            == other.getLength());
+        if (getLength()
+            != other.getLength()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -23434,18 +23393,18 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.DownloadState result = new ch.epfl.dedis.lib.proto.ByzCoinProto.DownloadState(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.byzcoinid_ = byzcoinid_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.nonce_ = nonce_;
           to_bitField0_ |= 0x00000002;
         }
-        result.nonce_ = nonce_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.length_ = length_;
           to_bitField0_ |= 0x00000004;
         }
-        result.length_ = length_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -23453,35 +23412,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -23552,7 +23511,7 @@ public final class ByzCoinProto {
        * <code>required bytes byzcoinid = 1;</code>
        */
       public boolean hasByzcoinid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -23608,7 +23567,7 @@ public final class ByzCoinProto {
        * <code>required uint64 nonce = 2;</code>
        */
       public boolean hasNonce() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -23671,7 +23630,7 @@ public final class ByzCoinProto {
        * <code>required sint32 length = 3;</code>
        */
       public boolean hasLength() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <pre>
@@ -23855,7 +23814,6 @@ public final class ByzCoinProto {
     }
     private DownloadStateResponse() {
       keyvalues_ = java.util.Collections.emptyList();
-      nonce_ = 0L;
     }
 
     @java.lang.Override
@@ -23883,7 +23841,7 @@ public final class ByzCoinProto {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 keyvalues_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.DBKeyValue>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -23911,7 +23869,7 @@ public final class ByzCoinProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           keyvalues_ = java.util.Collections.unmodifiableList(keyvalues_);
         }
         this.unknownFields = unknownFields.build();
@@ -24004,7 +23962,7 @@ public final class ByzCoinProto {
      * <code>required uint64 nonce = 2;</code>
      */
     public boolean hasNonce() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -24046,7 +24004,7 @@ public final class ByzCoinProto {
       for (int i = 0; i < keyvalues_.size(); i++) {
         output.writeMessage(1, keyvalues_.get(i));
       }
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeUInt64(2, nonce_);
       }
       unknownFields.writeTo(output);
@@ -24062,7 +24020,7 @@ public final class ByzCoinProto {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, keyvalues_.get(i));
       }
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(2, nonce_);
       }
@@ -24081,16 +24039,15 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.DownloadStateResponse other = (ch.epfl.dedis.lib.proto.ByzCoinProto.DownloadStateResponse) obj;
 
-      boolean result = true;
-      result = result && getKeyvaluesList()
-          .equals(other.getKeyvaluesList());
-      result = result && (hasNonce() == other.hasNonce());
+      if (!getKeyvaluesList()
+          .equals(other.getKeyvaluesList())) return false;
+      if (hasNonce() != other.hasNonce()) return false;
       if (hasNonce()) {
-        result = result && (getNonce()
-            == other.getNonce());
+        if (getNonce()
+            != other.getNonce()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -24285,7 +24242,7 @@ public final class ByzCoinProto {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (keyvaluesBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             keyvalues_ = java.util.Collections.unmodifiableList(keyvalues_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -24293,10 +24250,10 @@ public final class ByzCoinProto {
         } else {
           result.keyvalues_ = keyvaluesBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.nonce_ = nonce_;
           to_bitField0_ |= 0x00000001;
         }
-        result.nonce_ = nonce_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -24304,35 +24261,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -24416,7 +24373,7 @@ public final class ByzCoinProto {
       private java.util.List<ch.epfl.dedis.lib.proto.ByzCoinProto.DBKeyValue> keyvalues_ =
         java.util.Collections.emptyList();
       private void ensureKeyvaluesIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           keyvalues_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.DBKeyValue>(keyvalues_);
           bitField0_ |= 0x00000001;
          }
@@ -24735,7 +24692,7 @@ public final class ByzCoinProto {
           keyvaluesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.ByzCoinProto.DBKeyValue, ch.epfl.dedis.lib.proto.ByzCoinProto.DBKeyValue.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.DBKeyValueOrBuilder>(
                   keyvalues_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           keyvalues_ = null;
@@ -24754,7 +24711,7 @@ public final class ByzCoinProto {
        * <code>required uint64 nonce = 2;</code>
        */
       public boolean hasNonce() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -24967,7 +24924,7 @@ public final class ByzCoinProto {
      * <code>required bytes key = 1;</code>
      */
     public boolean hasKey() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes key = 1;</code>
@@ -24982,7 +24939,7 @@ public final class ByzCoinProto {
      * <code>required bytes value = 2;</code>
      */
     public boolean hasValue() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes value = 2;</code>
@@ -25013,10 +24970,10 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, key_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, value_);
       }
       unknownFields.writeTo(output);
@@ -25028,11 +24985,11 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, key_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, value_);
       }
@@ -25051,19 +25008,18 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.DBKeyValue other = (ch.epfl.dedis.lib.proto.ByzCoinProto.DBKeyValue) obj;
 
-      boolean result = true;
-      result = result && (hasKey() == other.hasKey());
+      if (hasKey() != other.hasKey()) return false;
       if (hasKey()) {
-        result = result && getKey()
-            .equals(other.getKey());
+        if (!getKey()
+            .equals(other.getKey())) return false;
       }
-      result = result && (hasValue() == other.hasValue());
+      if (hasValue() != other.hasValue()) return false;
       if (hasValue()) {
-        result = result && getValue()
-            .equals(other.getValue());
+        if (!getValue()
+            .equals(other.getValue())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -25250,11 +25206,11 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.DBKeyValue result = new ch.epfl.dedis.lib.proto.ByzCoinProto.DBKeyValue(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.key_ = key_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.value_ = value_;
@@ -25265,35 +25221,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -25354,7 +25310,7 @@ public final class ByzCoinProto {
        * <code>required bytes key = 1;</code>
        */
       public boolean hasKey() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes key = 1;</code>
@@ -25389,7 +25345,7 @@ public final class ByzCoinProto {
        * <code>required bytes value = 2;</code>
        */
       public boolean hasValue() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes value = 2;</code>
@@ -25543,10 +25499,8 @@ public final class ByzCoinProto {
       super(builder);
     }
     private StateChangeBody() {
-      stateaction_ = 0;
       contractid_ = "";
       value_ = com.google.protobuf.ByteString.EMPTY;
-      version_ = 0L;
       darcid_ = com.google.protobuf.ByteString.EMPTY;
     }
 
@@ -25639,7 +25593,7 @@ public final class ByzCoinProto {
      * <code>required sint32 stateaction = 1;</code>
      */
     public boolean hasStateaction() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required sint32 stateaction = 1;</code>
@@ -25654,7 +25608,7 @@ public final class ByzCoinProto {
      * <code>required string contractid = 2;</code>
      */
     public boolean hasContractid() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required string contractid = 2;</code>
@@ -25696,7 +25650,7 @@ public final class ByzCoinProto {
      * <code>required bytes value = 3;</code>
      */
     public boolean hasValue() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required bytes value = 3;</code>
@@ -25711,7 +25665,7 @@ public final class ByzCoinProto {
      * <code>required uint64 version = 4;</code>
      */
     public boolean hasVersion() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <code>required uint64 version = 4;</code>
@@ -25726,7 +25680,7 @@ public final class ByzCoinProto {
      * <code>required bytes darcid = 5;</code>
      */
     public boolean hasDarcid() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000010) != 0);
     }
     /**
      * <code>required bytes darcid = 5;</code>
@@ -25769,19 +25723,19 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeSInt32(1, stateaction_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, contractid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(3, value_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeUInt64(4, version_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         output.writeBytes(5, darcid_);
       }
       unknownFields.writeTo(output);
@@ -25793,22 +25747,22 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(1, stateaction_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, contractid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, value_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(4, version_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(5, darcid_);
       }
@@ -25827,34 +25781,33 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.StateChangeBody other = (ch.epfl.dedis.lib.proto.ByzCoinProto.StateChangeBody) obj;
 
-      boolean result = true;
-      result = result && (hasStateaction() == other.hasStateaction());
+      if (hasStateaction() != other.hasStateaction()) return false;
       if (hasStateaction()) {
-        result = result && (getStateaction()
-            == other.getStateaction());
+        if (getStateaction()
+            != other.getStateaction()) return false;
       }
-      result = result && (hasContractid() == other.hasContractid());
+      if (hasContractid() != other.hasContractid()) return false;
       if (hasContractid()) {
-        result = result && getContractid()
-            .equals(other.getContractid());
+        if (!getContractid()
+            .equals(other.getContractid())) return false;
       }
-      result = result && (hasValue() == other.hasValue());
+      if (hasValue() != other.hasValue()) return false;
       if (hasValue()) {
-        result = result && getValue()
-            .equals(other.getValue());
+        if (!getValue()
+            .equals(other.getValue())) return false;
       }
-      result = result && (hasVersion() == other.hasVersion());
+      if (hasVersion() != other.hasVersion()) return false;
       if (hasVersion()) {
-        result = result && (getVersion()
-            == other.getVersion());
+        if (getVersion()
+            != other.getVersion()) return false;
       }
-      result = result && (hasDarcid() == other.hasDarcid());
+      if (hasDarcid() != other.hasDarcid()) return false;
       if (hasDarcid()) {
-        result = result && getDarcid()
-            .equals(other.getDarcid());
+        if (!getDarcid()
+            .equals(other.getDarcid())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -26061,23 +26014,23 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.StateChangeBody result = new ch.epfl.dedis.lib.proto.ByzCoinProto.StateChangeBody(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.stateaction_ = stateaction_;
           to_bitField0_ |= 0x00000001;
         }
-        result.stateaction_ = stateaction_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.contractid_ = contractid_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.value_ = value_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          result.version_ = version_;
           to_bitField0_ |= 0x00000008;
         }
-        result.version_ = version_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((from_bitField0_ & 0x00000010) != 0)) {
           to_bitField0_ |= 0x00000010;
         }
         result.darcid_ = darcid_;
@@ -26088,35 +26041,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -26197,7 +26150,7 @@ public final class ByzCoinProto {
        * <code>required sint32 stateaction = 1;</code>
        */
       public boolean hasStateaction() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required sint32 stateaction = 1;</code>
@@ -26229,7 +26182,7 @@ public final class ByzCoinProto {
        * <code>required string contractid = 2;</code>
        */
       public boolean hasContractid() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required string contractid = 2;</code>
@@ -26305,7 +26258,7 @@ public final class ByzCoinProto {
        * <code>required bytes value = 3;</code>
        */
       public boolean hasValue() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required bytes value = 3;</code>
@@ -26340,7 +26293,7 @@ public final class ByzCoinProto {
        * <code>required uint64 version = 4;</code>
        */
       public boolean hasVersion() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <code>required uint64 version = 4;</code>
@@ -26372,7 +26325,7 @@ public final class ByzCoinProto {
        * <code>required bytes darcid = 5;</code>
        */
       public boolean hasDarcid() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return ((bitField0_ & 0x00000010) != 0);
       }
       /**
        * <code>required bytes darcid = 5;</code>
@@ -26534,7 +26487,7 @@ public final class ByzCoinProto {
               break;
             case 10: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 signerids_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -26561,7 +26514,7 @@ public final class ByzCoinProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           signerids_ = signerids_.getUnmodifiableView();
         }
         this.unknownFields = unknownFields.build();
@@ -26617,7 +26570,7 @@ public final class ByzCoinProto {
      * <code>required bytes skipchainid = 2;</code>
      */
     public boolean hasSkipchainid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes skipchainid = 2;</code>
@@ -26647,7 +26600,7 @@ public final class ByzCoinProto {
       for (int i = 0; i < signerids_.size(); i++) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, signerids_.getRaw(i));
       }
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(2, skipchainid_);
       }
       unknownFields.writeTo(output);
@@ -26667,7 +26620,7 @@ public final class ByzCoinProto {
         size += dataSize;
         size += 1 * getSigneridsList().size();
       }
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, skipchainid_);
       }
@@ -26686,16 +26639,15 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.GetSignerCounters other = (ch.epfl.dedis.lib.proto.ByzCoinProto.GetSignerCounters) obj;
 
-      boolean result = true;
-      result = result && getSigneridsList()
-          .equals(other.getSigneridsList());
-      result = result && (hasSkipchainid() == other.hasSkipchainid());
+      if (!getSigneridsList()
+          .equals(other.getSigneridsList())) return false;
+      if (hasSkipchainid() != other.hasSkipchainid()) return false;
       if (hasSkipchainid()) {
-        result = result && getSkipchainid()
-            .equals(other.getSkipchainid());
+        if (!getSkipchainid()
+            .equals(other.getSkipchainid())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -26883,12 +26835,12 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.GetSignerCounters result = new ch.epfl.dedis.lib.proto.ByzCoinProto.GetSignerCounters(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((bitField0_ & 0x00000001) != 0)) {
           signerids_ = signerids_.getUnmodifiableView();
           bitField0_ = (bitField0_ & ~0x00000001);
         }
         result.signerids_ = signerids_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.skipchainid_ = skipchainid_;
@@ -26899,35 +26851,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -26989,7 +26941,7 @@ public final class ByzCoinProto {
 
       private com.google.protobuf.LazyStringList signerids_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureSigneridsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           signerids_ = new com.google.protobuf.LazyStringArrayList(signerids_);
           bitField0_ |= 0x00000001;
          }
@@ -27085,7 +27037,7 @@ public final class ByzCoinProto {
        * <code>required bytes skipchainid = 2;</code>
        */
       public boolean hasSkipchainid() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes skipchainid = 2;</code>
@@ -27202,7 +27154,7 @@ public final class ByzCoinProto {
       super(builder);
     }
     private GetSignerCountersResponse() {
-      counters_ = java.util.Collections.emptyList();
+      counters_ = emptyLongList();
     }
 
     @java.lang.Override
@@ -27230,22 +27182,22 @@ public final class ByzCoinProto {
               done = true;
               break;
             case 8: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                counters_ = new java.util.ArrayList<java.lang.Long>();
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                counters_ = newLongList();
                 mutable_bitField0_ |= 0x00000001;
               }
-              counters_.add(input.readUInt64());
+              counters_.addLong(input.readUInt64());
               break;
             }
             case 10: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001) && input.getBytesUntilLimit() > 0) {
-                counters_ = new java.util.ArrayList<java.lang.Long>();
+              if (!((mutable_bitField0_ & 0x00000001) != 0) && input.getBytesUntilLimit() > 0) {
+                counters_ = newLongList();
                 mutable_bitField0_ |= 0x00000001;
               }
               while (input.getBytesUntilLimit() > 0) {
-                counters_.add(input.readUInt64());
+                counters_.addLong(input.readUInt64());
               }
               input.popLimit(limit);
               break;
@@ -27265,8 +27217,8 @@ public final class ByzCoinProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          counters_ = java.util.Collections.unmodifiableList(counters_);
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
+          counters_.makeImmutable(); // C
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -27286,7 +27238,7 @@ public final class ByzCoinProto {
     }
 
     public static final int COUNTERS_FIELD_NUMBER = 1;
-    private java.util.List<java.lang.Long> counters_;
+    private com.google.protobuf.Internal.LongList counters_;
     /**
      * <code>repeated uint64 counters = 1 [packed = true];</code>
      */
@@ -27304,7 +27256,7 @@ public final class ByzCoinProto {
      * <code>repeated uint64 counters = 1 [packed = true];</code>
      */
     public long getCounters(int index) {
-      return counters_.get(index);
+      return counters_.getLong(index);
     }
     private int countersMemoizedSerializedSize = -1;
 
@@ -27328,7 +27280,7 @@ public final class ByzCoinProto {
         output.writeUInt32NoTag(countersMemoizedSerializedSize);
       }
       for (int i = 0; i < counters_.size(); i++) {
-        output.writeUInt64NoTag(counters_.get(i));
+        output.writeUInt64NoTag(counters_.getLong(i));
       }
       unknownFields.writeTo(output);
     }
@@ -27343,7 +27295,7 @@ public final class ByzCoinProto {
         int dataSize = 0;
         for (int i = 0; i < counters_.size(); i++) {
           dataSize += com.google.protobuf.CodedOutputStream
-            .computeUInt64SizeNoTag(counters_.get(i));
+            .computeUInt64SizeNoTag(counters_.getLong(i));
         }
         size += dataSize;
         if (!getCountersList().isEmpty()) {
@@ -27368,11 +27320,10 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.GetSignerCountersResponse other = (ch.epfl.dedis.lib.proto.ByzCoinProto.GetSignerCountersResponse) obj;
 
-      boolean result = true;
-      result = result && getCountersList()
-          .equals(other.getCountersList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getCountersList()
+          .equals(other.getCountersList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -27524,7 +27475,7 @@ public final class ByzCoinProto {
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        counters_ = java.util.Collections.emptyList();
+        counters_ = emptyLongList();
         bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
@@ -27553,8 +27504,8 @@ public final class ByzCoinProto {
       public ch.epfl.dedis.lib.proto.ByzCoinProto.GetSignerCountersResponse buildPartial() {
         ch.epfl.dedis.lib.proto.ByzCoinProto.GetSignerCountersResponse result = new ch.epfl.dedis.lib.proto.ByzCoinProto.GetSignerCountersResponse(this);
         int from_bitField0_ = bitField0_;
-        if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          counters_ = java.util.Collections.unmodifiableList(counters_);
+        if (((bitField0_ & 0x00000001) != 0)) {
+          counters_.makeImmutable();
           bitField0_ = (bitField0_ & ~0x00000001);
         }
         result.counters_ = counters_;
@@ -27564,35 +27515,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -27646,10 +27597,10 @@ public final class ByzCoinProto {
       }
       private int bitField0_;
 
-      private java.util.List<java.lang.Long> counters_ = java.util.Collections.emptyList();
+      private com.google.protobuf.Internal.LongList counters_ = emptyLongList();
       private void ensureCountersIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          counters_ = new java.util.ArrayList<java.lang.Long>(counters_);
+        if (!((bitField0_ & 0x00000001) != 0)) {
+          counters_ = mutableCopy(counters_);
           bitField0_ |= 0x00000001;
          }
       }
@@ -27658,7 +27609,8 @@ public final class ByzCoinProto {
        */
       public java.util.List<java.lang.Long>
           getCountersList() {
-        return java.util.Collections.unmodifiableList(counters_);
+        return ((bitField0_ & 0x00000001) != 0) ?
+                 java.util.Collections.unmodifiableList(counters_) : counters_;
       }
       /**
        * <code>repeated uint64 counters = 1 [packed = true];</code>
@@ -27670,7 +27622,7 @@ public final class ByzCoinProto {
        * <code>repeated uint64 counters = 1 [packed = true];</code>
        */
       public long getCounters(int index) {
-        return counters_.get(index);
+        return counters_.getLong(index);
       }
       /**
        * <code>repeated uint64 counters = 1 [packed = true];</code>
@@ -27678,7 +27630,7 @@ public final class ByzCoinProto {
       public Builder setCounters(
           int index, long value) {
         ensureCountersIsMutable();
-        counters_.set(index, value);
+        counters_.setLong(index, value);
         onChanged();
         return this;
       }
@@ -27687,7 +27639,7 @@ public final class ByzCoinProto {
        */
       public Builder addCounters(long value) {
         ensureCountersIsMutable();
-        counters_.add(value);
+        counters_.addLong(value);
         onChanged();
         return this;
       }
@@ -27706,7 +27658,7 @@ public final class ByzCoinProto {
        * <code>repeated uint64 counters = 1 [packed = true];</code>
        */
       public Builder clearCounters() {
-        counters_ = java.util.Collections.emptyList();
+        counters_ = emptyLongList();
         bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
@@ -27815,7 +27767,6 @@ public final class ByzCoinProto {
     private GetInstanceVersion() {
       skipchainid_ = com.google.protobuf.ByteString.EMPTY;
       instanceid_ = com.google.protobuf.ByteString.EMPTY;
-      version_ = 0L;
     }
 
     @java.lang.Override
@@ -27896,7 +27847,7 @@ public final class ByzCoinProto {
      * <code>required bytes skipchainid = 1;</code>
      */
     public boolean hasSkipchainid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes skipchainid = 1;</code>
@@ -27911,7 +27862,7 @@ public final class ByzCoinProto {
      * <code>required bytes instanceid = 2;</code>
      */
     public boolean hasInstanceid() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes instanceid = 2;</code>
@@ -27926,7 +27877,7 @@ public final class ByzCoinProto {
      * <code>required uint64 version = 3;</code>
      */
     public boolean hasVersion() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required uint64 version = 3;</code>
@@ -27961,13 +27912,13 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, skipchainid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, instanceid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeUInt64(3, version_);
       }
       unknownFields.writeTo(output);
@@ -27979,15 +27930,15 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, skipchainid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, instanceid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(3, version_);
       }
@@ -28006,24 +27957,23 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.GetInstanceVersion other = (ch.epfl.dedis.lib.proto.ByzCoinProto.GetInstanceVersion) obj;
 
-      boolean result = true;
-      result = result && (hasSkipchainid() == other.hasSkipchainid());
+      if (hasSkipchainid() != other.hasSkipchainid()) return false;
       if (hasSkipchainid()) {
-        result = result && getSkipchainid()
-            .equals(other.getSkipchainid());
+        if (!getSkipchainid()
+            .equals(other.getSkipchainid())) return false;
       }
-      result = result && (hasInstanceid() == other.hasInstanceid());
+      if (hasInstanceid() != other.hasInstanceid()) return false;
       if (hasInstanceid()) {
-        result = result && getInstanceid()
-            .equals(other.getInstanceid());
+        if (!getInstanceid()
+            .equals(other.getInstanceid())) return false;
       }
-      result = result && (hasVersion() == other.hasVersion());
+      if (hasVersion() != other.hasVersion()) return false;
       if (hasVersion()) {
-        result = result && (getVersion()
-            == other.getVersion());
+        if (getVersion()
+            != other.getVersion()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -28218,18 +28168,18 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.GetInstanceVersion result = new ch.epfl.dedis.lib.proto.ByzCoinProto.GetInstanceVersion(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.skipchainid_ = skipchainid_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.instanceid_ = instanceid_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.version_ = version_;
           to_bitField0_ |= 0x00000004;
         }
-        result.version_ = version_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -28237,35 +28187,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -28332,7 +28282,7 @@ public final class ByzCoinProto {
        * <code>required bytes skipchainid = 1;</code>
        */
       public boolean hasSkipchainid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes skipchainid = 1;</code>
@@ -28367,7 +28317,7 @@ public final class ByzCoinProto {
        * <code>required bytes instanceid = 2;</code>
        */
       public boolean hasInstanceid() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes instanceid = 2;</code>
@@ -28402,7 +28352,7 @@ public final class ByzCoinProto {
        * <code>required uint64 version = 3;</code>
        */
       public boolean hasVersion() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required uint64 version = 3;</code>
@@ -28598,7 +28548,7 @@ public final class ByzCoinProto {
      * <code>required bytes skipchainid = 1;</code>
      */
     public boolean hasSkipchainid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes skipchainid = 1;</code>
@@ -28613,7 +28563,7 @@ public final class ByzCoinProto {
      * <code>required bytes instanceid = 2;</code>
      */
     public boolean hasInstanceid() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes instanceid = 2;</code>
@@ -28644,10 +28594,10 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, skipchainid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, instanceid_);
       }
       unknownFields.writeTo(output);
@@ -28659,11 +28609,11 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, skipchainid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, instanceid_);
       }
@@ -28682,19 +28632,18 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.GetLastInstanceVersion other = (ch.epfl.dedis.lib.proto.ByzCoinProto.GetLastInstanceVersion) obj;
 
-      boolean result = true;
-      result = result && (hasSkipchainid() == other.hasSkipchainid());
+      if (hasSkipchainid() != other.hasSkipchainid()) return false;
       if (hasSkipchainid()) {
-        result = result && getSkipchainid()
-            .equals(other.getSkipchainid());
+        if (!getSkipchainid()
+            .equals(other.getSkipchainid())) return false;
       }
-      result = result && (hasInstanceid() == other.hasInstanceid());
+      if (hasInstanceid() != other.hasInstanceid()) return false;
       if (hasInstanceid()) {
-        result = result && getInstanceid()
-            .equals(other.getInstanceid());
+        if (!getInstanceid()
+            .equals(other.getInstanceid())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -28882,11 +28831,11 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.GetLastInstanceVersion result = new ch.epfl.dedis.lib.proto.ByzCoinProto.GetLastInstanceVersion(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.skipchainid_ = skipchainid_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.instanceid_ = instanceid_;
@@ -28897,35 +28846,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -28986,7 +28935,7 @@ public final class ByzCoinProto {
        * <code>required bytes skipchainid = 1;</code>
        */
       public boolean hasSkipchainid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes skipchainid = 1;</code>
@@ -29021,7 +28970,7 @@ public final class ByzCoinProto {
        * <code>required bytes instanceid = 2;</code>
        */
       public boolean hasInstanceid() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes instanceid = 2;</code>
@@ -29149,7 +29098,6 @@ public final class ByzCoinProto {
       super(builder);
     }
     private GetInstanceVersionResponse() {
-      blockindex_ = 0;
     }
 
     @java.lang.Override
@@ -29178,7 +29126,7 @@ public final class ByzCoinProto {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.StateChange.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = statechange_.toBuilder();
               }
               statechange_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.StateChange.parser(), extensionRegistry);
@@ -29233,7 +29181,7 @@ public final class ByzCoinProto {
      * <code>required .byzcoin.StateChange statechange = 1;</code>
      */
     public boolean hasStatechange() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required .byzcoin.StateChange statechange = 1;</code>
@@ -29254,7 +29202,7 @@ public final class ByzCoinProto {
      * <code>required sint32 blockindex = 2;</code>
      */
     public boolean hasBlockindex() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required sint32 blockindex = 2;</code>
@@ -29289,10 +29237,10 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getStatechange());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeSInt32(2, blockindex_);
       }
       unknownFields.writeTo(output);
@@ -29304,11 +29252,11 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getStatechange());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(2, blockindex_);
       }
@@ -29327,19 +29275,18 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.GetInstanceVersionResponse other = (ch.epfl.dedis.lib.proto.ByzCoinProto.GetInstanceVersionResponse) obj;
 
-      boolean result = true;
-      result = result && (hasStatechange() == other.hasStatechange());
+      if (hasStatechange() != other.hasStatechange()) return false;
       if (hasStatechange()) {
-        result = result && getStatechange()
-            .equals(other.getStatechange());
+        if (!getStatechange()
+            .equals(other.getStatechange())) return false;
       }
-      result = result && (hasBlockindex() == other.hasBlockindex());
+      if (hasBlockindex() != other.hasBlockindex()) return false;
       if (hasBlockindex()) {
-        result = result && (getBlockindex()
-            == other.getBlockindex());
+        if (getBlockindex()
+            != other.getBlockindex()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -29534,18 +29481,18 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.GetInstanceVersionResponse result = new ch.epfl.dedis.lib.proto.ByzCoinProto.GetInstanceVersionResponse(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (statechangeBuilder_ == null) {
+            result.statechange_ = statechange_;
+          } else {
+            result.statechange_ = statechangeBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
         }
-        if (statechangeBuilder_ == null) {
-          result.statechange_ = statechange_;
-        } else {
-          result.statechange_ = statechangeBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.blockindex_ = blockindex_;
           to_bitField0_ |= 0x00000002;
         }
-        result.blockindex_ = blockindex_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -29553,35 +29500,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -29640,14 +29587,14 @@ public final class ByzCoinProto {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.StateChange statechange_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.StateChange statechange_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.StateChange, ch.epfl.dedis.lib.proto.ByzCoinProto.StateChange.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.StateChangeOrBuilder> statechangeBuilder_;
       /**
        * <code>required .byzcoin.StateChange statechange = 1;</code>
        */
       public boolean hasStatechange() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required .byzcoin.StateChange statechange = 1;</code>
@@ -29694,7 +29641,7 @@ public final class ByzCoinProto {
        */
       public Builder mergeStatechange(ch.epfl.dedis.lib.proto.ByzCoinProto.StateChange value) {
         if (statechangeBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               statechange_ != null &&
               statechange_ != ch.epfl.dedis.lib.proto.ByzCoinProto.StateChange.getDefaultInstance()) {
             statechange_ =
@@ -29763,7 +29710,7 @@ public final class ByzCoinProto {
        * <code>required sint32 blockindex = 2;</code>
        */
       public boolean hasBlockindex() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required sint32 blockindex = 2;</code>
@@ -29959,7 +29906,7 @@ public final class ByzCoinProto {
      * <code>required bytes skipchainid = 1;</code>
      */
     public boolean hasSkipchainid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes skipchainid = 1;</code>
@@ -29974,7 +29921,7 @@ public final class ByzCoinProto {
      * <code>required bytes instanceid = 2;</code>
      */
     public boolean hasInstanceid() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes instanceid = 2;</code>
@@ -30005,10 +29952,10 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, skipchainid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, instanceid_);
       }
       unknownFields.writeTo(output);
@@ -30020,11 +29967,11 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, skipchainid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, instanceid_);
       }
@@ -30043,19 +29990,18 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.GetAllInstanceVersion other = (ch.epfl.dedis.lib.proto.ByzCoinProto.GetAllInstanceVersion) obj;
 
-      boolean result = true;
-      result = result && (hasSkipchainid() == other.hasSkipchainid());
+      if (hasSkipchainid() != other.hasSkipchainid()) return false;
       if (hasSkipchainid()) {
-        result = result && getSkipchainid()
-            .equals(other.getSkipchainid());
+        if (!getSkipchainid()
+            .equals(other.getSkipchainid())) return false;
       }
-      result = result && (hasInstanceid() == other.hasInstanceid());
+      if (hasInstanceid() != other.hasInstanceid()) return false;
       if (hasInstanceid()) {
-        result = result && getInstanceid()
-            .equals(other.getInstanceid());
+        if (!getInstanceid()
+            .equals(other.getInstanceid())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -30243,11 +30189,11 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.GetAllInstanceVersion result = new ch.epfl.dedis.lib.proto.ByzCoinProto.GetAllInstanceVersion(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.skipchainid_ = skipchainid_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.instanceid_ = instanceid_;
@@ -30258,35 +30204,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -30347,7 +30293,7 @@ public final class ByzCoinProto {
        * <code>required bytes skipchainid = 1;</code>
        */
       public boolean hasSkipchainid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes skipchainid = 1;</code>
@@ -30382,7 +30328,7 @@ public final class ByzCoinProto {
        * <code>required bytes instanceid = 2;</code>
        */
       public boolean hasInstanceid() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes instanceid = 2;</code>
@@ -30538,7 +30484,7 @@ public final class ByzCoinProto {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 statechanges_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.GetInstanceVersionResponse>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -30561,7 +30507,7 @@ public final class ByzCoinProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           statechanges_ = java.util.Collections.unmodifiableList(statechanges_);
         }
         this.unknownFields = unknownFields.build();
@@ -30667,11 +30613,10 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.GetAllInstanceVersionResponse other = (ch.epfl.dedis.lib.proto.ByzCoinProto.GetAllInstanceVersionResponse) obj;
 
-      boolean result = true;
-      result = result && getStatechangesList()
-          .equals(other.getStatechangesList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getStatechangesList()
+          .equals(other.getStatechangesList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -30858,7 +30803,7 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.GetAllInstanceVersionResponse result = new ch.epfl.dedis.lib.proto.ByzCoinProto.GetAllInstanceVersionResponse(this);
         int from_bitField0_ = bitField0_;
         if (statechangesBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             statechanges_ = java.util.Collections.unmodifiableList(statechanges_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -30872,35 +30817,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -30978,7 +30923,7 @@ public final class ByzCoinProto {
       private java.util.List<ch.epfl.dedis.lib.proto.ByzCoinProto.GetInstanceVersionResponse> statechanges_ =
         java.util.Collections.emptyList();
       private void ensureStatechangesIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           statechanges_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.GetInstanceVersionResponse>(statechanges_);
           bitField0_ |= 0x00000001;
          }
@@ -31207,7 +31152,7 @@ public final class ByzCoinProto {
           statechangesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.ByzCoinProto.GetInstanceVersionResponse, ch.epfl.dedis.lib.proto.ByzCoinProto.GetInstanceVersionResponse.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.GetInstanceVersionResponseOrBuilder>(
                   statechanges_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           statechanges_ = null;
@@ -31319,7 +31264,6 @@ public final class ByzCoinProto {
     private CheckStateChangeValidity() {
       skipchainid_ = com.google.protobuf.ByteString.EMPTY;
       instanceid_ = com.google.protobuf.ByteString.EMPTY;
-      version_ = 0L;
     }
 
     @java.lang.Override
@@ -31400,7 +31344,7 @@ public final class ByzCoinProto {
      * <code>required bytes skipchainid = 1;</code>
      */
     public boolean hasSkipchainid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes skipchainid = 1;</code>
@@ -31415,7 +31359,7 @@ public final class ByzCoinProto {
      * <code>required bytes instanceid = 2;</code>
      */
     public boolean hasInstanceid() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes instanceid = 2;</code>
@@ -31430,7 +31374,7 @@ public final class ByzCoinProto {
      * <code>required uint64 version = 3;</code>
      */
     public boolean hasVersion() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required uint64 version = 3;</code>
@@ -31465,13 +31409,13 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, skipchainid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, instanceid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeUInt64(3, version_);
       }
       unknownFields.writeTo(output);
@@ -31483,15 +31427,15 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, skipchainid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, instanceid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(3, version_);
       }
@@ -31510,24 +31454,23 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.CheckStateChangeValidity other = (ch.epfl.dedis.lib.proto.ByzCoinProto.CheckStateChangeValidity) obj;
 
-      boolean result = true;
-      result = result && (hasSkipchainid() == other.hasSkipchainid());
+      if (hasSkipchainid() != other.hasSkipchainid()) return false;
       if (hasSkipchainid()) {
-        result = result && getSkipchainid()
-            .equals(other.getSkipchainid());
+        if (!getSkipchainid()
+            .equals(other.getSkipchainid())) return false;
       }
-      result = result && (hasInstanceid() == other.hasInstanceid());
+      if (hasInstanceid() != other.hasInstanceid()) return false;
       if (hasInstanceid()) {
-        result = result && getInstanceid()
-            .equals(other.getInstanceid());
+        if (!getInstanceid()
+            .equals(other.getInstanceid())) return false;
       }
-      result = result && (hasVersion() == other.hasVersion());
+      if (hasVersion() != other.hasVersion()) return false;
       if (hasVersion()) {
-        result = result && (getVersion()
-            == other.getVersion());
+        if (getVersion()
+            != other.getVersion()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -31723,18 +31666,18 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.CheckStateChangeValidity result = new ch.epfl.dedis.lib.proto.ByzCoinProto.CheckStateChangeValidity(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.skipchainid_ = skipchainid_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.instanceid_ = instanceid_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.version_ = version_;
           to_bitField0_ |= 0x00000004;
         }
-        result.version_ = version_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -31742,35 +31685,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -31837,7 +31780,7 @@ public final class ByzCoinProto {
        * <code>required bytes skipchainid = 1;</code>
        */
       public boolean hasSkipchainid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes skipchainid = 1;</code>
@@ -31872,7 +31815,7 @@ public final class ByzCoinProto {
        * <code>required bytes instanceid = 2;</code>
        */
       public boolean hasInstanceid() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes instanceid = 2;</code>
@@ -31907,7 +31850,7 @@ public final class ByzCoinProto {
        * <code>required uint64 version = 3;</code>
        */
       public boolean hasVersion() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required uint64 version = 3;</code>
@@ -32071,7 +32014,7 @@ public final class ByzCoinProto {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 statechanges_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.StateChange>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -32099,7 +32042,7 @@ public final class ByzCoinProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           statechanges_ = java.util.Collections.unmodifiableList(statechanges_);
         }
         this.unknownFields = unknownFields.build();
@@ -32161,7 +32104,7 @@ public final class ByzCoinProto {
      * <code>required bytes blockid = 2;</code>
      */
     public boolean hasBlockid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes blockid = 2;</code>
@@ -32197,7 +32140,7 @@ public final class ByzCoinProto {
       for (int i = 0; i < statechanges_.size(); i++) {
         output.writeMessage(1, statechanges_.get(i));
       }
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(2, blockid_);
       }
       unknownFields.writeTo(output);
@@ -32213,7 +32156,7 @@ public final class ByzCoinProto {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, statechanges_.get(i));
       }
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, blockid_);
       }
@@ -32232,16 +32175,15 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.CheckStateChangeValidityResponse other = (ch.epfl.dedis.lib.proto.ByzCoinProto.CheckStateChangeValidityResponse) obj;
 
-      boolean result = true;
-      result = result && getStatechangesList()
-          .equals(other.getStatechangesList());
-      result = result && (hasBlockid() == other.hasBlockid());
+      if (!getStatechangesList()
+          .equals(other.getStatechangesList())) return false;
+      if (hasBlockid() != other.hasBlockid()) return false;
       if (hasBlockid()) {
-        result = result && getBlockid()
-            .equals(other.getBlockid());
+        if (!getBlockid()
+            .equals(other.getBlockid())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -32436,7 +32378,7 @@ public final class ByzCoinProto {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (statechangesBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             statechanges_ = java.util.Collections.unmodifiableList(statechanges_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -32444,7 +32386,7 @@ public final class ByzCoinProto {
         } else {
           result.statechanges_ = statechangesBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.blockid_ = blockid_;
@@ -32455,35 +32397,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -32567,7 +32509,7 @@ public final class ByzCoinProto {
       private java.util.List<ch.epfl.dedis.lib.proto.ByzCoinProto.StateChange> statechanges_ =
         java.util.Collections.emptyList();
       private void ensureStatechangesIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           statechanges_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.StateChange>(statechanges_);
           bitField0_ |= 0x00000001;
          }
@@ -32796,7 +32738,7 @@ public final class ByzCoinProto {
           statechangesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.ByzCoinProto.StateChange, ch.epfl.dedis.lib.proto.ByzCoinProto.StateChange.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.StateChangeOrBuilder>(
                   statechanges_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           statechanges_ = null;
@@ -32809,7 +32751,7 @@ public final class ByzCoinProto {
        * <code>required bytes blockid = 2;</code>
        */
       public boolean hasBlockid() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes blockid = 2;</code>
@@ -32993,7 +32935,7 @@ public final class ByzCoinProto {
      * <code>optional bytes byzcoinid = 1;</code>
      */
     public boolean hasByzcoinid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>optional bytes byzcoinid = 1;</code>
@@ -33016,7 +32958,7 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, byzcoinid_);
       }
       unknownFields.writeTo(output);
@@ -33028,7 +32970,7 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, byzcoinid_);
       }
@@ -33047,14 +32989,13 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.DebugRequest other = (ch.epfl.dedis.lib.proto.ByzCoinProto.DebugRequest) obj;
 
-      boolean result = true;
-      result = result && (hasByzcoinid() == other.hasByzcoinid());
+      if (hasByzcoinid() != other.hasByzcoinid()) return false;
       if (hasByzcoinid()) {
-        result = result && getByzcoinid()
-            .equals(other.getByzcoinid());
+        if (!getByzcoinid()
+            .equals(other.getByzcoinid())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -33236,7 +33177,7 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.DebugRequest result = new ch.epfl.dedis.lib.proto.ByzCoinProto.DebugRequest(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.byzcoinid_ = byzcoinid_;
@@ -33247,35 +33188,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -33327,7 +33268,7 @@ public final class ByzCoinProto {
        * <code>optional bytes byzcoinid = 1;</code>
        */
       public boolean hasByzcoinid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>optional bytes byzcoinid = 1;</code>
@@ -33509,7 +33450,7 @@ public final class ByzCoinProto {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 byzcoins_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseByzcoin>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -33518,7 +33459,7 @@ public final class ByzCoinProto {
               break;
             }
             case 18: {
-              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
                 dump_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseState>();
                 mutable_bitField0_ |= 0x00000002;
               }
@@ -33541,10 +33482,10 @@ public final class ByzCoinProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           byzcoins_ = java.util.Collections.unmodifiableList(byzcoins_);
         }
-        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((mutable_bitField0_ & 0x00000002) != 0)) {
           dump_ = java.util.Collections.unmodifiableList(dump_);
         }
         this.unknownFields = unknownFields.build();
@@ -33698,13 +33639,12 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponse other = (ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponse) obj;
 
-      boolean result = true;
-      result = result && getByzcoinsList()
-          .equals(other.getByzcoinsList());
-      result = result && getDumpList()
-          .equals(other.getDumpList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getByzcoinsList()
+          .equals(other.getByzcoinsList())) return false;
+      if (!getDumpList()
+          .equals(other.getDumpList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -33903,7 +33843,7 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponse result = new ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponse(this);
         int from_bitField0_ = bitField0_;
         if (byzcoinsBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             byzcoins_ = java.util.Collections.unmodifiableList(byzcoins_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -33912,7 +33852,7 @@ public final class ByzCoinProto {
           result.byzcoins_ = byzcoinsBuilder_.build();
         }
         if (dumpBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          if (((bitField0_ & 0x00000002) != 0)) {
             dump_ = java.util.Collections.unmodifiableList(dump_);
             bitField0_ = (bitField0_ & ~0x00000002);
           }
@@ -33926,35 +33866,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -34063,7 +34003,7 @@ public final class ByzCoinProto {
       private java.util.List<ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseByzcoin> byzcoins_ =
         java.util.Collections.emptyList();
       private void ensureByzcoinsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           byzcoins_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseByzcoin>(byzcoins_);
           bitField0_ |= 0x00000001;
          }
@@ -34292,7 +34232,7 @@ public final class ByzCoinProto {
           byzcoinsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseByzcoin, ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseByzcoin.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseByzcoinOrBuilder>(
                   byzcoins_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           byzcoins_ = null;
@@ -34303,7 +34243,7 @@ public final class ByzCoinProto {
       private java.util.List<ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseState> dump_ =
         java.util.Collections.emptyList();
       private void ensureDumpIsMutable() {
-        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+        if (!((bitField0_ & 0x00000002) != 0)) {
           dump_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseState>(dump_);
           bitField0_ |= 0x00000002;
          }
@@ -34532,7 +34472,7 @@ public final class ByzCoinProto {
           dumpBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseState, ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseState.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseStateOrBuilder>(
                   dump_,
-                  ((bitField0_ & 0x00000002) == 0x00000002),
+                  ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
                   isClean());
           dump_ = null;
@@ -34683,7 +34623,7 @@ public final class ByzCoinProto {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = genesis_.toBuilder();
               }
               genesis_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.parser(), extensionRegistry);
@@ -34696,7 +34636,7 @@ public final class ByzCoinProto {
             }
             case 26: {
               ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+              if (((bitField0_ & 0x00000004) != 0)) {
                 subBuilder = latest_.toBuilder();
               }
               latest_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.parser(), extensionRegistry);
@@ -34746,7 +34686,7 @@ public final class ByzCoinProto {
      * <code>required bytes byzcoinid = 1;</code>
      */
     public boolean hasByzcoinid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes byzcoinid = 1;</code>
@@ -34761,7 +34701,7 @@ public final class ByzCoinProto {
      * <code>optional .skipchain.SkipBlock genesis = 2;</code>
      */
     public boolean hasGenesis() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>optional .skipchain.SkipBlock genesis = 2;</code>
@@ -34782,7 +34722,7 @@ public final class ByzCoinProto {
      * <code>optional .skipchain.SkipBlock latest = 3;</code>
      */
     public boolean hasLatest() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>optional .skipchain.SkipBlock latest = 3;</code>
@@ -34827,13 +34767,13 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, byzcoinid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getGenesis());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeMessage(3, getLatest());
       }
       unknownFields.writeTo(output);
@@ -34845,15 +34785,15 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, byzcoinid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getGenesis());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, getLatest());
       }
@@ -34872,24 +34812,23 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseByzcoin other = (ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseByzcoin) obj;
 
-      boolean result = true;
-      result = result && (hasByzcoinid() == other.hasByzcoinid());
+      if (hasByzcoinid() != other.hasByzcoinid()) return false;
       if (hasByzcoinid()) {
-        result = result && getByzcoinid()
-            .equals(other.getByzcoinid());
+        if (!getByzcoinid()
+            .equals(other.getByzcoinid())) return false;
       }
-      result = result && (hasGenesis() == other.hasGenesis());
+      if (hasGenesis() != other.hasGenesis()) return false;
       if (hasGenesis()) {
-        result = result && getGenesis()
-            .equals(other.getGenesis());
+        if (!getGenesis()
+            .equals(other.getGenesis())) return false;
       }
-      result = result && (hasLatest() == other.hasLatest());
+      if (hasLatest() != other.hasLatest()) return false;
       if (hasLatest()) {
-        result = result && getLatest()
-            .equals(other.getLatest());
+        if (!getLatest()
+            .equals(other.getLatest())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -35093,25 +35032,25 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseByzcoin result = new ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseByzcoin(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.byzcoinid_ = byzcoinid_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (genesisBuilder_ == null) {
+            result.genesis_ = genesis_;
+          } else {
+            result.genesis_ = genesisBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
         }
-        if (genesisBuilder_ == null) {
-          result.genesis_ = genesis_;
-        } else {
-          result.genesis_ = genesisBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          if (latestBuilder_ == null) {
+            result.latest_ = latest_;
+          } else {
+            result.latest_ = latestBuilder_.build();
+          }
           to_bitField0_ |= 0x00000004;
-        }
-        if (latestBuilder_ == null) {
-          result.latest_ = latest_;
-        } else {
-          result.latest_ = latestBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -35120,35 +35059,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -35219,7 +35158,7 @@ public final class ByzCoinProto {
        * <code>required bytes byzcoinid = 1;</code>
        */
       public boolean hasByzcoinid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes byzcoinid = 1;</code>
@@ -35249,14 +35188,14 @@ public final class ByzCoinProto {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock genesis_ = null;
+      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock genesis_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlockOrBuilder> genesisBuilder_;
       /**
        * <code>optional .skipchain.SkipBlock genesis = 2;</code>
        */
       public boolean hasGenesis() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>optional .skipchain.SkipBlock genesis = 2;</code>
@@ -35303,7 +35242,7 @@ public final class ByzCoinProto {
        */
       public Builder mergeGenesis(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock value) {
         if (genesisBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               genesis_ != null &&
               genesis_ != ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.getDefaultInstance()) {
             genesis_ =
@@ -35367,14 +35306,14 @@ public final class ByzCoinProto {
         return genesisBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock latest_ = null;
+      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock latest_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlockOrBuilder> latestBuilder_;
       /**
        * <code>optional .skipchain.SkipBlock latest = 3;</code>
        */
       public boolean hasLatest() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>optional .skipchain.SkipBlock latest = 3;</code>
@@ -35421,7 +35360,7 @@ public final class ByzCoinProto {
        */
       public Builder mergeLatest(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock value) {
         if (latestBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004) &&
+          if (((bitField0_ & 0x00000004) != 0) &&
               latest_ != null &&
               latest_ != ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.getDefaultInstance()) {
             latest_ =
@@ -35614,7 +35553,7 @@ public final class ByzCoinProto {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.StateChangeBody.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = state_.toBuilder();
               }
               state_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.StateChangeBody.parser(), extensionRegistry);
@@ -35664,7 +35603,7 @@ public final class ByzCoinProto {
      * <code>required bytes key = 1;</code>
      */
     public boolean hasKey() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes key = 1;</code>
@@ -35679,7 +35618,7 @@ public final class ByzCoinProto {
      * <code>required .byzcoin.StateChangeBody state = 2;</code>
      */
     public boolean hasState() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required .byzcoin.StateChangeBody state = 2;</code>
@@ -35720,10 +35659,10 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, key_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getState());
       }
       unknownFields.writeTo(output);
@@ -35735,11 +35674,11 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, key_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getState());
       }
@@ -35758,19 +35697,18 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseState other = (ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseState) obj;
 
-      boolean result = true;
-      result = result && (hasKey() == other.hasKey());
+      if (hasKey() != other.hasKey()) return false;
       if (hasKey()) {
-        result = result && getKey()
-            .equals(other.getKey());
+        if (!getKey()
+            .equals(other.getKey())) return false;
       }
-      result = result && (hasState() == other.hasState());
+      if (hasState() != other.hasState()) return false;
       if (hasState()) {
-        result = result && getState()
-            .equals(other.getState());
+        if (!getState()
+            .equals(other.getState())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -35962,17 +35900,17 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseState result = new ch.epfl.dedis.lib.proto.ByzCoinProto.DebugResponseState(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.key_ = key_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (stateBuilder_ == null) {
+            result.state_ = state_;
+          } else {
+            result.state_ = stateBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
-        }
-        if (stateBuilder_ == null) {
-          result.state_ = state_;
-        } else {
-          result.state_ = stateBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -35981,35 +35919,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -36073,7 +36011,7 @@ public final class ByzCoinProto {
        * <code>required bytes key = 1;</code>
        */
       public boolean hasKey() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes key = 1;</code>
@@ -36103,14 +36041,14 @@ public final class ByzCoinProto {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.StateChangeBody state_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.StateChangeBody state_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.StateChangeBody, ch.epfl.dedis.lib.proto.ByzCoinProto.StateChangeBody.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.StateChangeBodyOrBuilder> stateBuilder_;
       /**
        * <code>required .byzcoin.StateChangeBody state = 2;</code>
        */
       public boolean hasState() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required .byzcoin.StateChangeBody state = 2;</code>
@@ -36157,7 +36095,7 @@ public final class ByzCoinProto {
        */
       public Builder mergeState(ch.epfl.dedis.lib.proto.ByzCoinProto.StateChangeBody value) {
         if (stateBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               state_ != null &&
               state_ != ch.epfl.dedis.lib.proto.ByzCoinProto.StateChangeBody.getDefaultInstance()) {
             state_ =
@@ -36390,7 +36328,7 @@ public final class ByzCoinProto {
      * <code>required bytes byzcoinid = 1;</code>
      */
     public boolean hasByzcoinid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes byzcoinid = 1;</code>
@@ -36405,7 +36343,7 @@ public final class ByzCoinProto {
      * <code>required bytes signature = 2;</code>
      */
     public boolean hasSignature() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes signature = 2;</code>
@@ -36436,10 +36374,10 @@ public final class ByzCoinProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, byzcoinid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, signature_);
       }
       unknownFields.writeTo(output);
@@ -36451,11 +36389,11 @@ public final class ByzCoinProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, byzcoinid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, signature_);
       }
@@ -36474,19 +36412,18 @@ public final class ByzCoinProto {
       }
       ch.epfl.dedis.lib.proto.ByzCoinProto.DebugRemoveRequest other = (ch.epfl.dedis.lib.proto.ByzCoinProto.DebugRemoveRequest) obj;
 
-      boolean result = true;
-      result = result && (hasByzcoinid() == other.hasByzcoinid());
+      if (hasByzcoinid() != other.hasByzcoinid()) return false;
       if (hasByzcoinid()) {
-        result = result && getByzcoinid()
-            .equals(other.getByzcoinid());
+        if (!getByzcoinid()
+            .equals(other.getByzcoinid())) return false;
       }
-      result = result && (hasSignature() == other.hasSignature());
+      if (hasSignature() != other.hasSignature()) return false;
       if (hasSignature()) {
-        result = result && getSignature()
-            .equals(other.getSignature());
+        if (!getSignature()
+            .equals(other.getSignature())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -36674,11 +36611,11 @@ public final class ByzCoinProto {
         ch.epfl.dedis.lib.proto.ByzCoinProto.DebugRemoveRequest result = new ch.epfl.dedis.lib.proto.ByzCoinProto.DebugRemoveRequest(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.byzcoinid_ = byzcoinid_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.signature_ = signature_;
@@ -36689,35 +36626,35 @@ public final class ByzCoinProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -36778,7 +36715,7 @@ public final class ByzCoinProto {
        * <code>required bytes byzcoinid = 1;</code>
        */
       public boolean hasByzcoinid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes byzcoinid = 1;</code>
@@ -36813,7 +36750,7 @@ public final class ByzCoinProto {
        * <code>required bytes signature = 2;</code>
        */
       public boolean hasSignature() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes signature = 2;</code>

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/Calypso.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/Calypso.java
@@ -302,7 +302,7 @@ public final class Calypso {
      * <code>required bytes data = 1;</code>
      */
     public boolean hasData() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -326,7 +326,7 @@ public final class Calypso {
      * <code>required bytes u = 2;</code>
      */
     public boolean hasU() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -352,7 +352,7 @@ public final class Calypso {
      * <code>required bytes ubar = 3;</code>
      */
     public boolean hasUbar() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <pre>
@@ -378,7 +378,7 @@ public final class Calypso {
      * <code>required bytes e = 4;</code>
      */
     public boolean hasE() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <pre>
@@ -402,7 +402,7 @@ public final class Calypso {
      * <code>required bytes f = 5;</code>
      */
     public boolean hasF() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000010) != 0);
     }
     /**
      * <pre>
@@ -427,7 +427,7 @@ public final class Calypso {
      * <code>required bytes c = 6;</code>
      */
     public boolean hasC() {
-      return ((bitField0_ & 0x00000020) == 0x00000020);
+      return ((bitField0_ & 0x00000020) != 0);
     }
     /**
      * <pre>
@@ -451,7 +451,7 @@ public final class Calypso {
      * <code>optional bytes extradata = 7;</code>
      */
     public boolean hasExtradata() {
-      return ((bitField0_ & 0x00000040) == 0x00000040);
+      return ((bitField0_ & 0x00000040) != 0);
     }
     /**
      * <pre>
@@ -474,7 +474,7 @@ public final class Calypso {
      * <code>required bytes ltsid = 8;</code>
      */
     public boolean hasLtsid() {
-      return ((bitField0_ & 0x00000080) == 0x00000080);
+      return ((bitField0_ & 0x00000080) != 0);
     }
     /**
      * <pre>
@@ -529,28 +529,28 @@ public final class Calypso {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, data_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, u_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(3, ubar_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeBytes(4, e_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         output.writeBytes(5, f_);
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if (((bitField0_ & 0x00000020) != 0)) {
         output.writeBytes(6, c_);
       }
-      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+      if (((bitField0_ & 0x00000040) != 0)) {
         output.writeBytes(7, extradata_);
       }
-      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+      if (((bitField0_ & 0x00000080) != 0)) {
         output.writeBytes(8, ltsid_);
       }
       unknownFields.writeTo(output);
@@ -562,35 +562,35 @@ public final class Calypso {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, data_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, u_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, ubar_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(4, e_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(5, f_);
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if (((bitField0_ & 0x00000020) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(6, c_);
       }
-      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+      if (((bitField0_ & 0x00000040) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(7, extradata_);
       }
-      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+      if (((bitField0_ & 0x00000080) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(8, ltsid_);
       }
@@ -609,49 +609,48 @@ public final class Calypso {
       }
       ch.epfl.dedis.lib.proto.Calypso.Write other = (ch.epfl.dedis.lib.proto.Calypso.Write) obj;
 
-      boolean result = true;
-      result = result && (hasData() == other.hasData());
+      if (hasData() != other.hasData()) return false;
       if (hasData()) {
-        result = result && getData()
-            .equals(other.getData());
+        if (!getData()
+            .equals(other.getData())) return false;
       }
-      result = result && (hasU() == other.hasU());
+      if (hasU() != other.hasU()) return false;
       if (hasU()) {
-        result = result && getU()
-            .equals(other.getU());
+        if (!getU()
+            .equals(other.getU())) return false;
       }
-      result = result && (hasUbar() == other.hasUbar());
+      if (hasUbar() != other.hasUbar()) return false;
       if (hasUbar()) {
-        result = result && getUbar()
-            .equals(other.getUbar());
+        if (!getUbar()
+            .equals(other.getUbar())) return false;
       }
-      result = result && (hasE() == other.hasE());
+      if (hasE() != other.hasE()) return false;
       if (hasE()) {
-        result = result && getE()
-            .equals(other.getE());
+        if (!getE()
+            .equals(other.getE())) return false;
       }
-      result = result && (hasF() == other.hasF());
+      if (hasF() != other.hasF()) return false;
       if (hasF()) {
-        result = result && getF()
-            .equals(other.getF());
+        if (!getF()
+            .equals(other.getF())) return false;
       }
-      result = result && (hasC() == other.hasC());
+      if (hasC() != other.hasC()) return false;
       if (hasC()) {
-        result = result && getC()
-            .equals(other.getC());
+        if (!getC()
+            .equals(other.getC())) return false;
       }
-      result = result && (hasExtradata() == other.hasExtradata());
+      if (hasExtradata() != other.hasExtradata()) return false;
       if (hasExtradata()) {
-        result = result && getExtradata()
-            .equals(other.getExtradata());
+        if (!getExtradata()
+            .equals(other.getExtradata())) return false;
       }
-      result = result && (hasLtsid() == other.hasLtsid());
+      if (hasLtsid() != other.hasLtsid()) return false;
       if (hasLtsid()) {
-        result = result && getLtsid()
-            .equals(other.getLtsid());
+        if (!getLtsid()
+            .equals(other.getLtsid())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -875,35 +874,35 @@ public final class Calypso {
         ch.epfl.dedis.lib.proto.Calypso.Write result = new ch.epfl.dedis.lib.proto.Calypso.Write(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.data_ = data_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.u_ = u_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.ubar_ = ubar_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
           to_bitField0_ |= 0x00000008;
         }
         result.e_ = e_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((from_bitField0_ & 0x00000010) != 0)) {
           to_bitField0_ |= 0x00000010;
         }
         result.f_ = f_;
-        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+        if (((from_bitField0_ & 0x00000020) != 0)) {
           to_bitField0_ |= 0x00000020;
         }
         result.c_ = c_;
-        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+        if (((from_bitField0_ & 0x00000040) != 0)) {
           to_bitField0_ |= 0x00000040;
         }
         result.extradata_ = extradata_;
-        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
+        if (((from_bitField0_ & 0x00000080) != 0)) {
           to_bitField0_ |= 0x00000080;
         }
         result.ltsid_ = ltsid_;
@@ -914,35 +913,35 @@ public final class Calypso {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -1041,7 +1040,7 @@ public final class Calypso {
        * <code>required bytes data = 1;</code>
        */
       public boolean hasData() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -1095,7 +1094,7 @@ public final class Calypso {
        * <code>required bytes u = 2;</code>
        */
       public boolean hasU() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -1149,7 +1148,7 @@ public final class Calypso {
        * <code>required bytes ubar = 3;</code>
        */
       public boolean hasUbar() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <pre>
@@ -1209,7 +1208,7 @@ public final class Calypso {
        * <code>required bytes e = 4;</code>
        */
       public boolean hasE() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <pre>
@@ -1261,7 +1260,7 @@ public final class Calypso {
        * <code>required bytes f = 5;</code>
        */
       public boolean hasF() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return ((bitField0_ & 0x00000010) != 0);
       }
       /**
        * <pre>
@@ -1316,7 +1315,7 @@ public final class Calypso {
        * <code>required bytes c = 6;</code>
        */
       public boolean hasC() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
+        return ((bitField0_ & 0x00000020) != 0);
       }
       /**
        * <pre>
@@ -1370,7 +1369,7 @@ public final class Calypso {
        * <code>optional bytes extradata = 7;</code>
        */
       public boolean hasExtradata() {
-        return ((bitField0_ & 0x00000040) == 0x00000040);
+        return ((bitField0_ & 0x00000040) != 0);
       }
       /**
        * <pre>
@@ -1421,7 +1420,7 @@ public final class Calypso {
        * <code>required bytes ltsid = 8;</code>
        */
       public boolean hasLtsid() {
-        return ((bitField0_ & 0x00000080) == 0x00000080);
+        return ((bitField0_ & 0x00000080) != 0);
       }
       /**
        * <pre>
@@ -1632,7 +1631,7 @@ public final class Calypso {
      * <code>required bytes write = 1;</code>
      */
     public boolean hasWrite() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes write = 1;</code>
@@ -1647,7 +1646,7 @@ public final class Calypso {
      * <code>required bytes xc = 2;</code>
      */
     public boolean hasXc() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes xc = 2;</code>
@@ -1678,10 +1677,10 @@ public final class Calypso {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, write_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, xc_);
       }
       unknownFields.writeTo(output);
@@ -1693,11 +1692,11 @@ public final class Calypso {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, write_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, xc_);
       }
@@ -1716,19 +1715,18 @@ public final class Calypso {
       }
       ch.epfl.dedis.lib.proto.Calypso.Read other = (ch.epfl.dedis.lib.proto.Calypso.Read) obj;
 
-      boolean result = true;
-      result = result && (hasWrite() == other.hasWrite());
+      if (hasWrite() != other.hasWrite()) return false;
       if (hasWrite()) {
-        result = result && getWrite()
-            .equals(other.getWrite());
+        if (!getWrite()
+            .equals(other.getWrite())) return false;
       }
-      result = result && (hasXc() == other.hasXc());
+      if (hasXc() != other.hasXc()) return false;
       if (hasXc()) {
-        result = result && getXc()
-            .equals(other.getXc());
+        if (!getXc()
+            .equals(other.getXc())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -1916,11 +1914,11 @@ public final class Calypso {
         ch.epfl.dedis.lib.proto.Calypso.Read result = new ch.epfl.dedis.lib.proto.Calypso.Read(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.write_ = write_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.xc_ = xc_;
@@ -1931,35 +1929,35 @@ public final class Calypso {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -2020,7 +2018,7 @@ public final class Calypso {
        * <code>required bytes write = 1;</code>
        */
       public boolean hasWrite() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes write = 1;</code>
@@ -2055,7 +2053,7 @@ public final class Calypso {
        * <code>required bytes xc = 2;</code>
        */
       public boolean hasXc() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes xc = 2;</code>
@@ -2239,7 +2237,7 @@ public final class Calypso {
      * <code>required bytes byzcoinid = 1;</code>
      */
     public boolean hasByzcoinid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes byzcoinid = 1;</code>
@@ -2266,7 +2264,7 @@ public final class Calypso {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, byzcoinid_);
       }
       unknownFields.writeTo(output);
@@ -2278,7 +2276,7 @@ public final class Calypso {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, byzcoinid_);
       }
@@ -2297,14 +2295,13 @@ public final class Calypso {
       }
       ch.epfl.dedis.lib.proto.Calypso.Authorise other = (ch.epfl.dedis.lib.proto.Calypso.Authorise) obj;
 
-      boolean result = true;
-      result = result && (hasByzcoinid() == other.hasByzcoinid());
+      if (hasByzcoinid() != other.hasByzcoinid()) return false;
       if (hasByzcoinid()) {
-        result = result && getByzcoinid()
-            .equals(other.getByzcoinid());
+        if (!getByzcoinid()
+            .equals(other.getByzcoinid())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -2486,7 +2483,7 @@ public final class Calypso {
         ch.epfl.dedis.lib.proto.Calypso.Authorise result = new ch.epfl.dedis.lib.proto.Calypso.Authorise(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.byzcoinid_ = byzcoinid_;
@@ -2497,35 +2494,35 @@ public final class Calypso {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -2580,7 +2577,7 @@ public final class Calypso {
        * <code>required bytes byzcoinid = 1;</code>
        */
       public boolean hasByzcoinid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes byzcoinid = 1;</code>
@@ -2778,9 +2775,8 @@ public final class Calypso {
       }
       ch.epfl.dedis.lib.proto.Calypso.AuthoriseReply other = (ch.epfl.dedis.lib.proto.Calypso.AuthoriseReply) obj;
 
-      boolean result = true;
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -2959,35 +2955,35 @@ public final class Calypso {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -3146,7 +3142,7 @@ public final class Calypso {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = proof_.toBuilder();
               }
               proof_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.parser(), extensionRegistry);
@@ -3196,7 +3192,7 @@ public final class Calypso {
      * <code>required .byzcoin.Proof proof = 1;</code>
      */
     public boolean hasProof() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required .byzcoin.Proof proof = 1;</code>
@@ -3233,7 +3229,7 @@ public final class Calypso {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getProof());
       }
       unknownFields.writeTo(output);
@@ -3245,7 +3241,7 @@ public final class Calypso {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getProof());
       }
@@ -3264,14 +3260,13 @@ public final class Calypso {
       }
       ch.epfl.dedis.lib.proto.Calypso.CreateLTS other = (ch.epfl.dedis.lib.proto.Calypso.CreateLTS) obj;
 
-      boolean result = true;
-      result = result && (hasProof() == other.hasProof());
+      if (hasProof() != other.hasProof()) return false;
       if (hasProof()) {
-        result = result && getProof()
-            .equals(other.getProof());
+        if (!getProof()
+            .equals(other.getProof())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -3459,13 +3454,13 @@ public final class Calypso {
         ch.epfl.dedis.lib.proto.Calypso.CreateLTS result = new ch.epfl.dedis.lib.proto.Calypso.CreateLTS(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (proofBuilder_ == null) {
+            result.proof_ = proof_;
+          } else {
+            result.proof_ = proofBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
-        }
-        if (proofBuilder_ == null) {
-          result.proof_ = proof_;
-        } else {
-          result.proof_ = proofBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -3474,35 +3469,35 @@ public final class Calypso {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -3555,14 +3550,14 @@ public final class Calypso {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.Proof proof_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.Proof proof_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.Proof, ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.ProofOrBuilder> proofBuilder_;
       /**
        * <code>required .byzcoin.Proof proof = 1;</code>
        */
       public boolean hasProof() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required .byzcoin.Proof proof = 1;</code>
@@ -3609,7 +3604,7 @@ public final class Calypso {
        */
       public Builder mergeProof(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof value) {
         if (proofBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               proof_ != null &&
               proof_ != ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.getDefaultInstance()) {
             proof_ =
@@ -3865,7 +3860,7 @@ public final class Calypso {
      * <code>required bytes byzcoinid = 1;</code>
      */
     public boolean hasByzcoinid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes byzcoinid = 1;</code>
@@ -3880,7 +3875,7 @@ public final class Calypso {
      * <code>required bytes instanceid = 2;</code>
      */
     public boolean hasInstanceid() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes instanceid = 2;</code>
@@ -3899,7 +3894,7 @@ public final class Calypso {
      * <code>required bytes x = 3;</code>
      */
     public boolean hasX() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <pre>
@@ -3938,13 +3933,13 @@ public final class Calypso {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, byzcoinid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, instanceid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(3, x_);
       }
       unknownFields.writeTo(output);
@@ -3956,15 +3951,15 @@ public final class Calypso {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, byzcoinid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, instanceid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, x_);
       }
@@ -3983,24 +3978,23 @@ public final class Calypso {
       }
       ch.epfl.dedis.lib.proto.Calypso.CreateLTSReply other = (ch.epfl.dedis.lib.proto.Calypso.CreateLTSReply) obj;
 
-      boolean result = true;
-      result = result && (hasByzcoinid() == other.hasByzcoinid());
+      if (hasByzcoinid() != other.hasByzcoinid()) return false;
       if (hasByzcoinid()) {
-        result = result && getByzcoinid()
-            .equals(other.getByzcoinid());
+        if (!getByzcoinid()
+            .equals(other.getByzcoinid())) return false;
       }
-      result = result && (hasInstanceid() == other.hasInstanceid());
+      if (hasInstanceid() != other.hasInstanceid()) return false;
       if (hasInstanceid()) {
-        result = result && getInstanceid()
-            .equals(other.getInstanceid());
+        if (!getInstanceid()
+            .equals(other.getInstanceid())) return false;
       }
-      result = result && (hasX() == other.hasX());
+      if (hasX() != other.hasX()) return false;
       if (hasX()) {
-        result = result && getX()
-            .equals(other.getX());
+        if (!getX()
+            .equals(other.getX())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -4194,15 +4188,15 @@ public final class Calypso {
         ch.epfl.dedis.lib.proto.Calypso.CreateLTSReply result = new ch.epfl.dedis.lib.proto.Calypso.CreateLTSReply(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.byzcoinid_ = byzcoinid_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.instanceid_ = instanceid_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.x_ = x_;
@@ -4213,35 +4207,35 @@ public final class Calypso {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -4308,7 +4302,7 @@ public final class Calypso {
        * <code>required bytes byzcoinid = 1;</code>
        */
       public boolean hasByzcoinid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes byzcoinid = 1;</code>
@@ -4343,7 +4337,7 @@ public final class Calypso {
        * <code>required bytes instanceid = 2;</code>
        */
       public boolean hasInstanceid() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes instanceid = 2;</code>
@@ -4382,7 +4376,7 @@ public final class Calypso {
        * <code>required bytes x = 3;</code>
        */
       public boolean hasX() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <pre>
@@ -4540,7 +4534,7 @@ public final class Calypso {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = proof_.toBuilder();
               }
               proof_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.parser(), extensionRegistry);
@@ -4590,7 +4584,7 @@ public final class Calypso {
      * <code>required .byzcoin.Proof proof = 1;</code>
      */
     public boolean hasProof() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required .byzcoin.Proof proof = 1;</code>
@@ -4627,7 +4621,7 @@ public final class Calypso {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getProof());
       }
       unknownFields.writeTo(output);
@@ -4639,7 +4633,7 @@ public final class Calypso {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getProof());
       }
@@ -4658,14 +4652,13 @@ public final class Calypso {
       }
       ch.epfl.dedis.lib.proto.Calypso.ReshareLTS other = (ch.epfl.dedis.lib.proto.Calypso.ReshareLTS) obj;
 
-      boolean result = true;
-      result = result && (hasProof() == other.hasProof());
+      if (hasProof() != other.hasProof()) return false;
       if (hasProof()) {
-        result = result && getProof()
-            .equals(other.getProof());
+        if (!getProof()
+            .equals(other.getProof())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -4853,13 +4846,13 @@ public final class Calypso {
         ch.epfl.dedis.lib.proto.Calypso.ReshareLTS result = new ch.epfl.dedis.lib.proto.Calypso.ReshareLTS(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (proofBuilder_ == null) {
+            result.proof_ = proof_;
+          } else {
+            result.proof_ = proofBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
-        }
-        if (proofBuilder_ == null) {
-          result.proof_ = proof_;
-        } else {
-          result.proof_ = proofBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -4868,35 +4861,35 @@ public final class Calypso {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -4949,14 +4942,14 @@ public final class Calypso {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.Proof proof_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.Proof proof_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.Proof, ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.ProofOrBuilder> proofBuilder_;
       /**
        * <code>required .byzcoin.Proof proof = 1;</code>
        */
       public boolean hasProof() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required .byzcoin.Proof proof = 1;</code>
@@ -5003,7 +4996,7 @@ public final class Calypso {
        */
       public Builder mergeProof(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof value) {
         if (proofBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               proof_ != null &&
               proof_ != ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.getDefaultInstance()) {
             proof_ =
@@ -5236,9 +5229,8 @@ public final class Calypso {
       }
       ch.epfl.dedis.lib.proto.Calypso.ReshareLTSReply other = (ch.epfl.dedis.lib.proto.Calypso.ReshareLTSReply) obj;
 
-      boolean result = true;
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -5418,35 +5410,35 @@ public final class Calypso {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -5641,7 +5633,7 @@ public final class Calypso {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = read_.toBuilder();
               }
               read_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.parser(), extensionRegistry);
@@ -5654,7 +5646,7 @@ public final class Calypso {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = write_.toBuilder();
               }
               write_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.parser(), extensionRegistry);
@@ -5708,7 +5700,7 @@ public final class Calypso {
      * <code>required .byzcoin.Proof read = 1;</code>
      */
     public boolean hasRead() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -5741,7 +5733,7 @@ public final class Calypso {
      * <code>required .byzcoin.Proof write = 2;</code>
      */
     public boolean hasWrite() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -5794,10 +5786,10 @@ public final class Calypso {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getRead());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getWrite());
       }
       unknownFields.writeTo(output);
@@ -5809,11 +5801,11 @@ public final class Calypso {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getRead());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getWrite());
       }
@@ -5832,19 +5824,18 @@ public final class Calypso {
       }
       ch.epfl.dedis.lib.proto.Calypso.DecryptKey other = (ch.epfl.dedis.lib.proto.Calypso.DecryptKey) obj;
 
-      boolean result = true;
-      result = result && (hasRead() == other.hasRead());
+      if (hasRead() != other.hasRead()) return false;
       if (hasRead()) {
-        result = result && getRead()
-            .equals(other.getRead());
+        if (!getRead()
+            .equals(other.getRead())) return false;
       }
-      result = result && (hasWrite() == other.hasWrite());
+      if (hasWrite() != other.hasWrite()) return false;
       if (hasWrite()) {
-        result = result && getWrite()
-            .equals(other.getWrite());
+        if (!getWrite()
+            .equals(other.getWrite())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -6042,21 +6033,21 @@ public final class Calypso {
         ch.epfl.dedis.lib.proto.Calypso.DecryptKey result = new ch.epfl.dedis.lib.proto.Calypso.DecryptKey(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (readBuilder_ == null) {
+            result.read_ = read_;
+          } else {
+            result.read_ = readBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
         }
-        if (readBuilder_ == null) {
-          result.read_ = read_;
-        } else {
-          result.read_ = readBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (writeBuilder_ == null) {
+            result.write_ = write_;
+          } else {
+            result.write_ = writeBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
-        }
-        if (writeBuilder_ == null) {
-          result.write_ = write_;
-        } else {
-          result.write_ = writeBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -6065,35 +6056,35 @@ public final class Calypso {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -6155,7 +6146,7 @@ public final class Calypso {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.Proof read_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.Proof read_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.Proof, ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.ProofOrBuilder> readBuilder_;
       /**
@@ -6166,7 +6157,7 @@ public final class Calypso {
        * <code>required .byzcoin.Proof read = 1;</code>
        */
       public boolean hasRead() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -6229,7 +6220,7 @@ public final class Calypso {
        */
       public Builder mergeRead(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof value) {
         if (readBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               read_ != null &&
               read_ != ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.getDefaultInstance()) {
             read_ =
@@ -6309,7 +6300,7 @@ public final class Calypso {
         return readBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.Proof write_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.Proof write_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.Proof, ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.ProofOrBuilder> writeBuilder_;
       /**
@@ -6320,7 +6311,7 @@ public final class Calypso {
        * <code>required .byzcoin.Proof write = 2;</code>
        */
       public boolean hasWrite() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -6383,7 +6374,7 @@ public final class Calypso {
        */
       public Builder mergeWrite(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof value) {
         if (writeBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               write_ != null &&
               write_ != ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.getDefaultInstance()) {
             write_ =
@@ -6675,7 +6666,7 @@ public final class Calypso {
      * <code>required bytes c = 1;</code>
      */
     public boolean hasC() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -6698,7 +6689,7 @@ public final class Calypso {
      * <code>required bytes xhatenc = 2;</code>
      */
     public boolean hasXhatenc() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -6721,7 +6712,7 @@ public final class Calypso {
      * <code>required bytes x = 3;</code>
      */
     public boolean hasX() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <pre>
@@ -6760,13 +6751,13 @@ public final class Calypso {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, c_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, xhatenc_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(3, x_);
       }
       unknownFields.writeTo(output);
@@ -6778,15 +6769,15 @@ public final class Calypso {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, c_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, xhatenc_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, x_);
       }
@@ -6805,24 +6796,23 @@ public final class Calypso {
       }
       ch.epfl.dedis.lib.proto.Calypso.DecryptKeyReply other = (ch.epfl.dedis.lib.proto.Calypso.DecryptKeyReply) obj;
 
-      boolean result = true;
-      result = result && (hasC() == other.hasC());
+      if (hasC() != other.hasC()) return false;
       if (hasC()) {
-        result = result && getC()
-            .equals(other.getC());
+        if (!getC()
+            .equals(other.getC())) return false;
       }
-      result = result && (hasXhatenc() == other.hasXhatenc());
+      if (hasXhatenc() != other.hasXhatenc()) return false;
       if (hasXhatenc()) {
-        result = result && getXhatenc()
-            .equals(other.getXhatenc());
+        if (!getXhatenc()
+            .equals(other.getXhatenc())) return false;
       }
-      result = result && (hasX() == other.hasX());
+      if (hasX() != other.hasX()) return false;
       if (hasX()) {
-        result = result && getX()
-            .equals(other.getX());
+        if (!getX()
+            .equals(other.getX())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -7016,15 +7006,15 @@ public final class Calypso {
         ch.epfl.dedis.lib.proto.Calypso.DecryptKeyReply result = new ch.epfl.dedis.lib.proto.Calypso.DecryptKeyReply(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.c_ = c_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.xhatenc_ = xhatenc_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.x_ = x_;
@@ -7035,35 +7025,35 @@ public final class Calypso {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -7134,7 +7124,7 @@ public final class Calypso {
        * <code>required bytes c = 1;</code>
        */
       public boolean hasC() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -7185,7 +7175,7 @@ public final class Calypso {
        * <code>required bytes xhatenc = 2;</code>
        */
       public boolean hasXhatenc() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -7236,7 +7226,7 @@ public final class Calypso {
        * <code>required bytes x = 3;</code>
        */
       public boolean hasX() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <pre>
@@ -7443,7 +7433,7 @@ public final class Calypso {
      * <code>required bytes ltsid = 1;</code>
      */
     public boolean hasLtsid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -7474,7 +7464,7 @@ public final class Calypso {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, ltsid_);
       }
       unknownFields.writeTo(output);
@@ -7486,7 +7476,7 @@ public final class Calypso {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, ltsid_);
       }
@@ -7505,14 +7495,13 @@ public final class Calypso {
       }
       ch.epfl.dedis.lib.proto.Calypso.GetLTSReply other = (ch.epfl.dedis.lib.proto.Calypso.GetLTSReply) obj;
 
-      boolean result = true;
-      result = result && (hasLtsid() == other.hasLtsid());
+      if (hasLtsid() != other.hasLtsid()) return false;
       if (hasLtsid()) {
-        result = result && getLtsid()
-            .equals(other.getLtsid());
+        if (!getLtsid()
+            .equals(other.getLtsid())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -7693,7 +7682,7 @@ public final class Calypso {
         ch.epfl.dedis.lib.proto.Calypso.GetLTSReply result = new ch.epfl.dedis.lib.proto.Calypso.GetLTSReply(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.ltsid_ = ltsid_;
@@ -7704,35 +7693,35 @@ public final class Calypso {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -7791,7 +7780,7 @@ public final class Calypso {
        * <code>required bytes ltsid = 1;</code>
        */
       public boolean hasLtsid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -7947,7 +7936,7 @@ public final class Calypso {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.OnetProto.Roster.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = roster_.toBuilder();
               }
               roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.parser(), extensionRegistry);
@@ -7997,7 +7986,7 @@ public final class Calypso {
      * <code>required .onet.Roster roster = 1;</code>
      */
     public boolean hasRoster() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required .onet.Roster roster = 1;</code>
@@ -8034,7 +8023,7 @@ public final class Calypso {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getRoster());
       }
       unknownFields.writeTo(output);
@@ -8046,7 +8035,7 @@ public final class Calypso {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getRoster());
       }
@@ -8065,14 +8054,13 @@ public final class Calypso {
       }
       ch.epfl.dedis.lib.proto.Calypso.LtsInstanceInfo other = (ch.epfl.dedis.lib.proto.Calypso.LtsInstanceInfo) obj;
 
-      boolean result = true;
-      result = result && (hasRoster() == other.hasRoster());
+      if (hasRoster() != other.hasRoster()) return false;
       if (hasRoster()) {
-        result = result && getRoster()
-            .equals(other.getRoster());
+        if (!getRoster()
+            .equals(other.getRoster())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -8258,13 +8246,13 @@ public final class Calypso {
         ch.epfl.dedis.lib.proto.Calypso.LtsInstanceInfo result = new ch.epfl.dedis.lib.proto.Calypso.LtsInstanceInfo(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (rosterBuilder_ == null) {
+            result.roster_ = roster_;
+          } else {
+            result.roster_ = rosterBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
-        }
-        if (rosterBuilder_ == null) {
-          result.roster_ = roster_;
-        } else {
-          result.roster_ = rosterBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -8273,35 +8261,35 @@ public final class Calypso {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -8354,14 +8342,14 @@ public final class Calypso {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.OnetProto.Roster roster_ = null;
+      private ch.epfl.dedis.lib.proto.OnetProto.Roster roster_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.OnetProto.Roster, ch.epfl.dedis.lib.proto.OnetProto.Roster.Builder, ch.epfl.dedis.lib.proto.OnetProto.RosterOrBuilder> rosterBuilder_;
       /**
        * <code>required .onet.Roster roster = 1;</code>
        */
       public boolean hasRoster() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required .onet.Roster roster = 1;</code>
@@ -8408,7 +8396,7 @@ public final class Calypso {
        */
       public Builder mergeRoster(ch.epfl.dedis.lib.proto.OnetProto.Roster value) {
         if (rosterBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               roster_ != null &&
               roster_ != ch.epfl.dedis.lib.proto.OnetProto.Roster.getDefaultInstance()) {
             roster_ =
@@ -8524,6 +8512,4721 @@ public final class Calypso {
 
   }
 
+  public interface AuthOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:calypso.Auth)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional .calypso.AuthByzCoin byzcoin = 1;</code>
+     */
+    boolean hasByzcoin();
+    /**
+     * <code>optional .calypso.AuthByzCoin byzcoin = 1;</code>
+     */
+    ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin getByzcoin();
+    /**
+     * <code>optional .calypso.AuthByzCoin byzcoin = 1;</code>
+     */
+    ch.epfl.dedis.lib.proto.Calypso.AuthByzCoinOrBuilder getByzcoinOrBuilder();
+
+    /**
+     * <code>optional .calypso.AuthX509Cert authx509cert = 2;</code>
+     */
+    boolean hasAuthx509Cert();
+    /**
+     * <code>optional .calypso.AuthX509Cert authx509cert = 2;</code>
+     */
+    ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert getAuthx509Cert();
+    /**
+     * <code>optional .calypso.AuthX509Cert authx509cert = 2;</code>
+     */
+    ch.epfl.dedis.lib.proto.Calypso.AuthX509CertOrBuilder getAuthx509CertOrBuilder();
+  }
+  /**
+   * <pre>
+   * Auth holds all possible authentication structures. When using it to call
+   * Authorise, only one of the fields must be non-nil.
+   * </pre>
+   *
+   * Protobuf type {@code calypso.Auth}
+   */
+  public  static final class Auth extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:calypso.Auth)
+      AuthOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use Auth.newBuilder() to construct.
+    private Auth(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private Auth() {
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private Auth(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000001) != 0)) {
+                subBuilder = byzcoin_.toBuilder();
+              }
+              byzcoin_ = input.readMessage(ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(byzcoin_);
+                byzcoin_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000001;
+              break;
+            }
+            case 18: {
+              ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000002) != 0)) {
+                subBuilder = authx509Cert_.toBuilder();
+              }
+              authx509Cert_ = input.readMessage(ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(authx509Cert_);
+                authx509Cert_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000002;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_Auth_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_Auth_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              ch.epfl.dedis.lib.proto.Calypso.Auth.class, ch.epfl.dedis.lib.proto.Calypso.Auth.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int BYZCOIN_FIELD_NUMBER = 1;
+    private ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin byzcoin_;
+    /**
+     * <code>optional .calypso.AuthByzCoin byzcoin = 1;</code>
+     */
+    public boolean hasByzcoin() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>optional .calypso.AuthByzCoin byzcoin = 1;</code>
+     */
+    public ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin getByzcoin() {
+      return byzcoin_ == null ? ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.getDefaultInstance() : byzcoin_;
+    }
+    /**
+     * <code>optional .calypso.AuthByzCoin byzcoin = 1;</code>
+     */
+    public ch.epfl.dedis.lib.proto.Calypso.AuthByzCoinOrBuilder getByzcoinOrBuilder() {
+      return byzcoin_ == null ? ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.getDefaultInstance() : byzcoin_;
+    }
+
+    public static final int AUTHX509CERT_FIELD_NUMBER = 2;
+    private ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert authx509Cert_;
+    /**
+     * <code>optional .calypso.AuthX509Cert authx509cert = 2;</code>
+     */
+    public boolean hasAuthx509Cert() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <code>optional .calypso.AuthX509Cert authx509cert = 2;</code>
+     */
+    public ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert getAuthx509Cert() {
+      return authx509Cert_ == null ? ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.getDefaultInstance() : authx509Cert_;
+    }
+    /**
+     * <code>optional .calypso.AuthX509Cert authx509cert = 2;</code>
+     */
+    public ch.epfl.dedis.lib.proto.Calypso.AuthX509CertOrBuilder getAuthx509CertOrBuilder() {
+      return authx509Cert_ == null ? ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.getDefaultInstance() : authx509Cert_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (hasByzcoin()) {
+        if (!getByzcoin().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      if (hasAuthx509Cert()) {
+        if (!getAuthx509Cert().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeMessage(1, getByzcoin());
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        output.writeMessage(2, getAuthx509Cert());
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, getByzcoin());
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, getAuthx509Cert());
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof ch.epfl.dedis.lib.proto.Calypso.Auth)) {
+        return super.equals(obj);
+      }
+      ch.epfl.dedis.lib.proto.Calypso.Auth other = (ch.epfl.dedis.lib.proto.Calypso.Auth) obj;
+
+      if (hasByzcoin() != other.hasByzcoin()) return false;
+      if (hasByzcoin()) {
+        if (!getByzcoin()
+            .equals(other.getByzcoin())) return false;
+      }
+      if (hasAuthx509Cert() != other.hasAuthx509Cert()) return false;
+      if (hasAuthx509Cert()) {
+        if (!getAuthx509Cert()
+            .equals(other.getAuthx509Cert())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasByzcoin()) {
+        hash = (37 * hash) + BYZCOIN_FIELD_NUMBER;
+        hash = (53 * hash) + getByzcoin().hashCode();
+      }
+      if (hasAuthx509Cert()) {
+        hash = (37 * hash) + AUTHX509CERT_FIELD_NUMBER;
+        hash = (53 * hash) + getAuthx509Cert().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static ch.epfl.dedis.lib.proto.Calypso.Auth parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Auth parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Auth parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Auth parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Auth parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Auth parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Auth parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Auth parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Auth parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Auth parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Auth parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Auth parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(ch.epfl.dedis.lib.proto.Calypso.Auth prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * Auth holds all possible authentication structures. When using it to call
+     * Authorise, only one of the fields must be non-nil.
+     * </pre>
+     *
+     * Protobuf type {@code calypso.Auth}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:calypso.Auth)
+        ch.epfl.dedis.lib.proto.Calypso.AuthOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_Auth_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_Auth_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                ch.epfl.dedis.lib.proto.Calypso.Auth.class, ch.epfl.dedis.lib.proto.Calypso.Auth.Builder.class);
+      }
+
+      // Construct using ch.epfl.dedis.lib.proto.Calypso.Auth.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+          getByzcoinFieldBuilder();
+          getAuthx509CertFieldBuilder();
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        if (byzcoinBuilder_ == null) {
+          byzcoin_ = null;
+        } else {
+          byzcoinBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000001);
+        if (authx509CertBuilder_ == null) {
+          authx509Cert_ = null;
+        } else {
+          authx509CertBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_Auth_descriptor;
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.Auth getDefaultInstanceForType() {
+        return ch.epfl.dedis.lib.proto.Calypso.Auth.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.Auth build() {
+        ch.epfl.dedis.lib.proto.Calypso.Auth result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.Auth buildPartial() {
+        ch.epfl.dedis.lib.proto.Calypso.Auth result = new ch.epfl.dedis.lib.proto.Calypso.Auth(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (byzcoinBuilder_ == null) {
+            result.byzcoin_ = byzcoin_;
+          } else {
+            result.byzcoin_ = byzcoinBuilder_.build();
+          }
+          to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (authx509CertBuilder_ == null) {
+            result.authx509Cert_ = authx509Cert_;
+          } else {
+            result.authx509Cert_ = authx509CertBuilder_.build();
+          }
+          to_bitField0_ |= 0x00000002;
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof ch.epfl.dedis.lib.proto.Calypso.Auth) {
+          return mergeFrom((ch.epfl.dedis.lib.proto.Calypso.Auth)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(ch.epfl.dedis.lib.proto.Calypso.Auth other) {
+        if (other == ch.epfl.dedis.lib.proto.Calypso.Auth.getDefaultInstance()) return this;
+        if (other.hasByzcoin()) {
+          mergeByzcoin(other.getByzcoin());
+        }
+        if (other.hasAuthx509Cert()) {
+          mergeAuthx509Cert(other.getAuthx509Cert());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        if (hasByzcoin()) {
+          if (!getByzcoin().isInitialized()) {
+            return false;
+          }
+        }
+        if (hasAuthx509Cert()) {
+          if (!getAuthx509Cert().isInitialized()) {
+            return false;
+          }
+        }
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        ch.epfl.dedis.lib.proto.Calypso.Auth parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (ch.epfl.dedis.lib.proto.Calypso.Auth) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin byzcoin_;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin, ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.Builder, ch.epfl.dedis.lib.proto.Calypso.AuthByzCoinOrBuilder> byzcoinBuilder_;
+      /**
+       * <code>optional .calypso.AuthByzCoin byzcoin = 1;</code>
+       */
+      public boolean hasByzcoin() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>optional .calypso.AuthByzCoin byzcoin = 1;</code>
+       */
+      public ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin getByzcoin() {
+        if (byzcoinBuilder_ == null) {
+          return byzcoin_ == null ? ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.getDefaultInstance() : byzcoin_;
+        } else {
+          return byzcoinBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .calypso.AuthByzCoin byzcoin = 1;</code>
+       */
+      public Builder setByzcoin(ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin value) {
+        if (byzcoinBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          byzcoin_ = value;
+          onChanged();
+        } else {
+          byzcoinBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <code>optional .calypso.AuthByzCoin byzcoin = 1;</code>
+       */
+      public Builder setByzcoin(
+          ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.Builder builderForValue) {
+        if (byzcoinBuilder_ == null) {
+          byzcoin_ = builderForValue.build();
+          onChanged();
+        } else {
+          byzcoinBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <code>optional .calypso.AuthByzCoin byzcoin = 1;</code>
+       */
+      public Builder mergeByzcoin(ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin value) {
+        if (byzcoinBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) != 0) &&
+              byzcoin_ != null &&
+              byzcoin_ != ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.getDefaultInstance()) {
+            byzcoin_ =
+              ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.newBuilder(byzcoin_).mergeFrom(value).buildPartial();
+          } else {
+            byzcoin_ = value;
+          }
+          onChanged();
+        } else {
+          byzcoinBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <code>optional .calypso.AuthByzCoin byzcoin = 1;</code>
+       */
+      public Builder clearByzcoin() {
+        if (byzcoinBuilder_ == null) {
+          byzcoin_ = null;
+          onChanged();
+        } else {
+          byzcoinBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+      /**
+       * <code>optional .calypso.AuthByzCoin byzcoin = 1;</code>
+       */
+      public ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.Builder getByzcoinBuilder() {
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return getByzcoinFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .calypso.AuthByzCoin byzcoin = 1;</code>
+       */
+      public ch.epfl.dedis.lib.proto.Calypso.AuthByzCoinOrBuilder getByzcoinOrBuilder() {
+        if (byzcoinBuilder_ != null) {
+          return byzcoinBuilder_.getMessageOrBuilder();
+        } else {
+          return byzcoin_ == null ?
+              ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.getDefaultInstance() : byzcoin_;
+        }
+      }
+      /**
+       * <code>optional .calypso.AuthByzCoin byzcoin = 1;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin, ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.Builder, ch.epfl.dedis.lib.proto.Calypso.AuthByzCoinOrBuilder> 
+          getByzcoinFieldBuilder() {
+        if (byzcoinBuilder_ == null) {
+          byzcoinBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin, ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.Builder, ch.epfl.dedis.lib.proto.Calypso.AuthByzCoinOrBuilder>(
+                  getByzcoin(),
+                  getParentForChildren(),
+                  isClean());
+          byzcoin_ = null;
+        }
+        return byzcoinBuilder_;
+      }
+
+      private ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert authx509Cert_;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert, ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.Builder, ch.epfl.dedis.lib.proto.Calypso.AuthX509CertOrBuilder> authx509CertBuilder_;
+      /**
+       * <code>optional .calypso.AuthX509Cert authx509cert = 2;</code>
+       */
+      public boolean hasAuthx509Cert() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <code>optional .calypso.AuthX509Cert authx509cert = 2;</code>
+       */
+      public ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert getAuthx509Cert() {
+        if (authx509CertBuilder_ == null) {
+          return authx509Cert_ == null ? ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.getDefaultInstance() : authx509Cert_;
+        } else {
+          return authx509CertBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .calypso.AuthX509Cert authx509cert = 2;</code>
+       */
+      public Builder setAuthx509Cert(ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert value) {
+        if (authx509CertBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          authx509Cert_ = value;
+          onChanged();
+        } else {
+          authx509CertBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <code>optional .calypso.AuthX509Cert authx509cert = 2;</code>
+       */
+      public Builder setAuthx509Cert(
+          ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.Builder builderForValue) {
+        if (authx509CertBuilder_ == null) {
+          authx509Cert_ = builderForValue.build();
+          onChanged();
+        } else {
+          authx509CertBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <code>optional .calypso.AuthX509Cert authx509cert = 2;</code>
+       */
+      public Builder mergeAuthx509Cert(ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert value) {
+        if (authx509CertBuilder_ == null) {
+          if (((bitField0_ & 0x00000002) != 0) &&
+              authx509Cert_ != null &&
+              authx509Cert_ != ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.getDefaultInstance()) {
+            authx509Cert_ =
+              ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.newBuilder(authx509Cert_).mergeFrom(value).buildPartial();
+          } else {
+            authx509Cert_ = value;
+          }
+          onChanged();
+        } else {
+          authx509CertBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <code>optional .calypso.AuthX509Cert authx509cert = 2;</code>
+       */
+      public Builder clearAuthx509Cert() {
+        if (authx509CertBuilder_ == null) {
+          authx509Cert_ = null;
+          onChanged();
+        } else {
+          authx509CertBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+      /**
+       * <code>optional .calypso.AuthX509Cert authx509cert = 2;</code>
+       */
+      public ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.Builder getAuthx509CertBuilder() {
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return getAuthx509CertFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .calypso.AuthX509Cert authx509cert = 2;</code>
+       */
+      public ch.epfl.dedis.lib.proto.Calypso.AuthX509CertOrBuilder getAuthx509CertOrBuilder() {
+        if (authx509CertBuilder_ != null) {
+          return authx509CertBuilder_.getMessageOrBuilder();
+        } else {
+          return authx509Cert_ == null ?
+              ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.getDefaultInstance() : authx509Cert_;
+        }
+      }
+      /**
+       * <code>optional .calypso.AuthX509Cert authx509cert = 2;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert, ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.Builder, ch.epfl.dedis.lib.proto.Calypso.AuthX509CertOrBuilder> 
+          getAuthx509CertFieldBuilder() {
+        if (authx509CertBuilder_ == null) {
+          authx509CertBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert, ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.Builder, ch.epfl.dedis.lib.proto.Calypso.AuthX509CertOrBuilder>(
+                  getAuthx509Cert(),
+                  getParentForChildren(),
+                  isClean());
+          authx509Cert_ = null;
+        }
+        return authx509CertBuilder_;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:calypso.Auth)
+    }
+
+    // @@protoc_insertion_point(class_scope:calypso.Auth)
+    private static final ch.epfl.dedis.lib.proto.Calypso.Auth DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new ch.epfl.dedis.lib.proto.Calypso.Auth();
+    }
+
+    public static ch.epfl.dedis.lib.proto.Calypso.Auth getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<Auth>
+        PARSER = new com.google.protobuf.AbstractParser<Auth>() {
+      @java.lang.Override
+      public Auth parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new Auth(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<Auth> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<Auth> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public ch.epfl.dedis.lib.proto.Calypso.Auth getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface AuthByzCoinOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:calypso.AuthByzCoin)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>required bytes byzcoinid = 1;</code>
+     */
+    boolean hasByzcoinid();
+    /**
+     * <code>required bytes byzcoinid = 1;</code>
+     */
+    com.google.protobuf.ByteString getByzcoinid();
+
+    /**
+     * <code>required uint64 ttl = 2;</code>
+     */
+    boolean hasTtl();
+    /**
+     * <code>required uint64 ttl = 2;</code>
+     */
+    long getTtl();
+  }
+  /**
+   * <pre>
+   * AuthByzCoin holds the information necessary to authenticate a byzcoin request.
+   * In the ByzCoin model, all requests are valid as long as they are stored in the
+   * blockchain with the given ID.
+   * The TTL is to avoid that too old requests are re-used. If it is 0, it is disabled.
+   * </pre>
+   *
+   * Protobuf type {@code calypso.AuthByzCoin}
+   */
+  public  static final class AuthByzCoin extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:calypso.AuthByzCoin)
+      AuthByzCoinOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use AuthByzCoin.newBuilder() to construct.
+    private AuthByzCoin(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private AuthByzCoin() {
+      byzcoinid_ = com.google.protobuf.ByteString.EMPTY;
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private AuthByzCoin(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              bitField0_ |= 0x00000001;
+              byzcoinid_ = input.readBytes();
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              ttl_ = input.readUInt64();
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_AuthByzCoin_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_AuthByzCoin_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.class, ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int BYZCOINID_FIELD_NUMBER = 1;
+    private com.google.protobuf.ByteString byzcoinid_;
+    /**
+     * <code>required bytes byzcoinid = 1;</code>
+     */
+    public boolean hasByzcoinid() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>required bytes byzcoinid = 1;</code>
+     */
+    public com.google.protobuf.ByteString getByzcoinid() {
+      return byzcoinid_;
+    }
+
+    public static final int TTL_FIELD_NUMBER = 2;
+    private long ttl_;
+    /**
+     * <code>required uint64 ttl = 2;</code>
+     */
+    public boolean hasTtl() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <code>required uint64 ttl = 2;</code>
+     */
+    public long getTtl() {
+      return ttl_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (!hasByzcoinid()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasTtl()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeBytes(1, byzcoinid_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        output.writeUInt64(2, ttl_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(1, byzcoinid_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(2, ttl_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin)) {
+        return super.equals(obj);
+      }
+      ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin other = (ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin) obj;
+
+      if (hasByzcoinid() != other.hasByzcoinid()) return false;
+      if (hasByzcoinid()) {
+        if (!getByzcoinid()
+            .equals(other.getByzcoinid())) return false;
+      }
+      if (hasTtl() != other.hasTtl()) return false;
+      if (hasTtl()) {
+        if (getTtl()
+            != other.getTtl()) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasByzcoinid()) {
+        hash = (37 * hash) + BYZCOINID_FIELD_NUMBER;
+        hash = (53 * hash) + getByzcoinid().hashCode();
+      }
+      if (hasTtl()) {
+        hash = (37 * hash) + TTL_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            getTtl());
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * AuthByzCoin holds the information necessary to authenticate a byzcoin request.
+     * In the ByzCoin model, all requests are valid as long as they are stored in the
+     * blockchain with the given ID.
+     * The TTL is to avoid that too old requests are re-used. If it is 0, it is disabled.
+     * </pre>
+     *
+     * Protobuf type {@code calypso.AuthByzCoin}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:calypso.AuthByzCoin)
+        ch.epfl.dedis.lib.proto.Calypso.AuthByzCoinOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_AuthByzCoin_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_AuthByzCoin_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.class, ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.Builder.class);
+      }
+
+      // Construct using ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        byzcoinid_ = com.google.protobuf.ByteString.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        ttl_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_AuthByzCoin_descriptor;
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin getDefaultInstanceForType() {
+        return ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin build() {
+        ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin buildPartial() {
+        ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin result = new ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.byzcoinid_ = byzcoinid_;
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.ttl_ = ttl_;
+          to_bitField0_ |= 0x00000002;
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin) {
+          return mergeFrom((ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin other) {
+        if (other == ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin.getDefaultInstance()) return this;
+        if (other.hasByzcoinid()) {
+          setByzcoinid(other.getByzcoinid());
+        }
+        if (other.hasTtl()) {
+          setTtl(other.getTtl());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        if (!hasByzcoinid()) {
+          return false;
+        }
+        if (!hasTtl()) {
+          return false;
+        }
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private com.google.protobuf.ByteString byzcoinid_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>required bytes byzcoinid = 1;</code>
+       */
+      public boolean hasByzcoinid() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>required bytes byzcoinid = 1;</code>
+       */
+      public com.google.protobuf.ByteString getByzcoinid() {
+        return byzcoinid_;
+      }
+      /**
+       * <code>required bytes byzcoinid = 1;</code>
+       */
+      public Builder setByzcoinid(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        byzcoinid_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required bytes byzcoinid = 1;</code>
+       */
+      public Builder clearByzcoinid() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        byzcoinid_ = getDefaultInstance().getByzcoinid();
+        onChanged();
+        return this;
+      }
+
+      private long ttl_ ;
+      /**
+       * <code>required uint64 ttl = 2;</code>
+       */
+      public boolean hasTtl() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <code>required uint64 ttl = 2;</code>
+       */
+      public long getTtl() {
+        return ttl_;
+      }
+      /**
+       * <code>required uint64 ttl = 2;</code>
+       */
+      public Builder setTtl(long value) {
+        bitField0_ |= 0x00000002;
+        ttl_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required uint64 ttl = 2;</code>
+       */
+      public Builder clearTtl() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        ttl_ = 0L;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:calypso.AuthByzCoin)
+    }
+
+    // @@protoc_insertion_point(class_scope:calypso.AuthByzCoin)
+    private static final ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin();
+    }
+
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<AuthByzCoin>
+        PARSER = new com.google.protobuf.AbstractParser<AuthByzCoin>() {
+      @java.lang.Override
+      public AuthByzCoin parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new AuthByzCoin(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<AuthByzCoin> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<AuthByzCoin> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public ch.epfl.dedis.lib.proto.Calypso.AuthByzCoin getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface AuthX509CertOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:calypso.AuthX509Cert)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * Slice of ASN.1 encoded X509 certificates.
+     * </pre>
+     *
+     * <code>repeated bytes ca = 1;</code>
+     */
+    java.util.List<com.google.protobuf.ByteString> getCaList();
+    /**
+     * <pre>
+     * Slice of ASN.1 encoded X509 certificates.
+     * </pre>
+     *
+     * <code>repeated bytes ca = 1;</code>
+     */
+    int getCaCount();
+    /**
+     * <pre>
+     * Slice of ASN.1 encoded X509 certificates.
+     * </pre>
+     *
+     * <code>repeated bytes ca = 1;</code>
+     */
+    com.google.protobuf.ByteString getCa(int index);
+
+    /**
+     * <code>required sint32 threshold = 2;</code>
+     */
+    boolean hasThreshold();
+    /**
+     * <code>required sint32 threshold = 2;</code>
+     */
+    int getThreshold();
+  }
+  /**
+   * <pre>
+   * AuthX509Cert holds the information necessary to authenticate a HyperLedger/Fabric
+   * request. In its simplest form, it is simply the CA that will have to sign the
+   * certificates of the requesters.
+   * The Threshold indicates how many clients must have signed the request before it
+   * is accepted.
+   * </pre>
+   *
+   * Protobuf type {@code calypso.AuthX509Cert}
+   */
+  public  static final class AuthX509Cert extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:calypso.AuthX509Cert)
+      AuthX509CertOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use AuthX509Cert.newBuilder() to construct.
+    private AuthX509Cert(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private AuthX509Cert() {
+      ca_ = java.util.Collections.emptyList();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private AuthX509Cert(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                ca_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              ca_.add(input.readBytes());
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000001;
+              threshold_ = input.readSInt32();
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
+          ca_ = java.util.Collections.unmodifiableList(ca_); // C
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_AuthX509Cert_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_AuthX509Cert_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.class, ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int CA_FIELD_NUMBER = 1;
+    private java.util.List<com.google.protobuf.ByteString> ca_;
+    /**
+     * <pre>
+     * Slice of ASN.1 encoded X509 certificates.
+     * </pre>
+     *
+     * <code>repeated bytes ca = 1;</code>
+     */
+    public java.util.List<com.google.protobuf.ByteString>
+        getCaList() {
+      return ca_;
+    }
+    /**
+     * <pre>
+     * Slice of ASN.1 encoded X509 certificates.
+     * </pre>
+     *
+     * <code>repeated bytes ca = 1;</code>
+     */
+    public int getCaCount() {
+      return ca_.size();
+    }
+    /**
+     * <pre>
+     * Slice of ASN.1 encoded X509 certificates.
+     * </pre>
+     *
+     * <code>repeated bytes ca = 1;</code>
+     */
+    public com.google.protobuf.ByteString getCa(int index) {
+      return ca_.get(index);
+    }
+
+    public static final int THRESHOLD_FIELD_NUMBER = 2;
+    private int threshold_;
+    /**
+     * <code>required sint32 threshold = 2;</code>
+     */
+    public boolean hasThreshold() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>required sint32 threshold = 2;</code>
+     */
+    public int getThreshold() {
+      return threshold_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (!hasThreshold()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      for (int i = 0; i < ca_.size(); i++) {
+        output.writeBytes(1, ca_.get(i));
+      }
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeSInt32(2, threshold_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      {
+        int dataSize = 0;
+        for (int i = 0; i < ca_.size(); i++) {
+          dataSize += com.google.protobuf.CodedOutputStream
+            .computeBytesSizeNoTag(ca_.get(i));
+        }
+        size += dataSize;
+        size += 1 * getCaList().size();
+      }
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeSInt32Size(2, threshold_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert)) {
+        return super.equals(obj);
+      }
+      ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert other = (ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert) obj;
+
+      if (!getCaList()
+          .equals(other.getCaList())) return false;
+      if (hasThreshold() != other.hasThreshold()) return false;
+      if (hasThreshold()) {
+        if (getThreshold()
+            != other.getThreshold()) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (getCaCount() > 0) {
+        hash = (37 * hash) + CA_FIELD_NUMBER;
+        hash = (53 * hash) + getCaList().hashCode();
+      }
+      if (hasThreshold()) {
+        hash = (37 * hash) + THRESHOLD_FIELD_NUMBER;
+        hash = (53 * hash) + getThreshold();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * AuthX509Cert holds the information necessary to authenticate a HyperLedger/Fabric
+     * request. In its simplest form, it is simply the CA that will have to sign the
+     * certificates of the requesters.
+     * The Threshold indicates how many clients must have signed the request before it
+     * is accepted.
+     * </pre>
+     *
+     * Protobuf type {@code calypso.AuthX509Cert}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:calypso.AuthX509Cert)
+        ch.epfl.dedis.lib.proto.Calypso.AuthX509CertOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_AuthX509Cert_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_AuthX509Cert_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.class, ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.Builder.class);
+      }
+
+      // Construct using ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        ca_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000001);
+        threshold_ = 0;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_AuthX509Cert_descriptor;
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert getDefaultInstanceForType() {
+        return ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert build() {
+        ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert buildPartial() {
+        ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert result = new ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((bitField0_ & 0x00000001) != 0)) {
+          ca_ = java.util.Collections.unmodifiableList(ca_);
+          bitField0_ = (bitField0_ & ~0x00000001);
+        }
+        result.ca_ = ca_;
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.threshold_ = threshold_;
+          to_bitField0_ |= 0x00000001;
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert) {
+          return mergeFrom((ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert other) {
+        if (other == ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert.getDefaultInstance()) return this;
+        if (!other.ca_.isEmpty()) {
+          if (ca_.isEmpty()) {
+            ca_ = other.ca_;
+            bitField0_ = (bitField0_ & ~0x00000001);
+          } else {
+            ensureCaIsMutable();
+            ca_.addAll(other.ca_);
+          }
+          onChanged();
+        }
+        if (other.hasThreshold()) {
+          setThreshold(other.getThreshold());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        if (!hasThreshold()) {
+          return false;
+        }
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.util.List<com.google.protobuf.ByteString> ca_ = java.util.Collections.emptyList();
+      private void ensureCaIsMutable() {
+        if (!((bitField0_ & 0x00000001) != 0)) {
+          ca_ = new java.util.ArrayList<com.google.protobuf.ByteString>(ca_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+      /**
+       * <pre>
+       * Slice of ASN.1 encoded X509 certificates.
+       * </pre>
+       *
+       * <code>repeated bytes ca = 1;</code>
+       */
+      public java.util.List<com.google.protobuf.ByteString>
+          getCaList() {
+        return ((bitField0_ & 0x00000001) != 0) ?
+                 java.util.Collections.unmodifiableList(ca_) : ca_;
+      }
+      /**
+       * <pre>
+       * Slice of ASN.1 encoded X509 certificates.
+       * </pre>
+       *
+       * <code>repeated bytes ca = 1;</code>
+       */
+      public int getCaCount() {
+        return ca_.size();
+      }
+      /**
+       * <pre>
+       * Slice of ASN.1 encoded X509 certificates.
+       * </pre>
+       *
+       * <code>repeated bytes ca = 1;</code>
+       */
+      public com.google.protobuf.ByteString getCa(int index) {
+        return ca_.get(index);
+      }
+      /**
+       * <pre>
+       * Slice of ASN.1 encoded X509 certificates.
+       * </pre>
+       *
+       * <code>repeated bytes ca = 1;</code>
+       */
+      public Builder setCa(
+          int index, com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureCaIsMutable();
+        ca_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Slice of ASN.1 encoded X509 certificates.
+       * </pre>
+       *
+       * <code>repeated bytes ca = 1;</code>
+       */
+      public Builder addCa(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureCaIsMutable();
+        ca_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Slice of ASN.1 encoded X509 certificates.
+       * </pre>
+       *
+       * <code>repeated bytes ca = 1;</code>
+       */
+      public Builder addAllCa(
+          java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
+        ensureCaIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, ca_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Slice of ASN.1 encoded X509 certificates.
+       * </pre>
+       *
+       * <code>repeated bytes ca = 1;</code>
+       */
+      public Builder clearCa() {
+        ca_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000001);
+        onChanged();
+        return this;
+      }
+
+      private int threshold_ ;
+      /**
+       * <code>required sint32 threshold = 2;</code>
+       */
+      public boolean hasThreshold() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <code>required sint32 threshold = 2;</code>
+       */
+      public int getThreshold() {
+        return threshold_;
+      }
+      /**
+       * <code>required sint32 threshold = 2;</code>
+       */
+      public Builder setThreshold(int value) {
+        bitField0_ |= 0x00000002;
+        threshold_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required sint32 threshold = 2;</code>
+       */
+      public Builder clearThreshold() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        threshold_ = 0;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:calypso.AuthX509Cert)
+    }
+
+    // @@protoc_insertion_point(class_scope:calypso.AuthX509Cert)
+    private static final ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert();
+    }
+
+    public static ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<AuthX509Cert>
+        PARSER = new com.google.protobuf.AbstractParser<AuthX509Cert>() {
+      @java.lang.Override
+      public AuthX509Cert parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new AuthX509Cert(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<AuthX509Cert> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<AuthX509Cert> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public ch.epfl.dedis.lib.proto.Calypso.AuthX509Cert getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface GrantOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:calypso.Grant)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>optional .calypso.GrantByzCoin byzcoin = 1;</code>
+     */
+    boolean hasByzcoin();
+    /**
+     * <code>optional .calypso.GrantByzCoin byzcoin = 1;</code>
+     */
+    ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin getByzcoin();
+    /**
+     * <code>optional .calypso.GrantByzCoin byzcoin = 1;</code>
+     */
+    ch.epfl.dedis.lib.proto.Calypso.GrantByzCoinOrBuilder getByzcoinOrBuilder();
+
+    /**
+     * <code>optional .calypso.GrantX509Cert x509cert = 2;</code>
+     */
+    boolean hasX509Cert();
+    /**
+     * <code>optional .calypso.GrantX509Cert x509cert = 2;</code>
+     */
+    ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert getX509Cert();
+    /**
+     * <code>optional .calypso.GrantX509Cert x509cert = 2;</code>
+     */
+    ch.epfl.dedis.lib.proto.Calypso.GrantX509CertOrBuilder getX509CertOrBuilder();
+  }
+  /**
+   * <pre>
+   * Grant holds one of the possible grant proofs for a reencryption request. Each
+   * grant proof must hold the secret to be reencrypted, the ephemeral key, as well
+   * as the proof itself that the request is valid. For each of the authentication
+   * schemes, this proof will be different.
+   * </pre>
+   *
+   * Protobuf type {@code calypso.Grant}
+   */
+  public  static final class Grant extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:calypso.Grant)
+      GrantOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use Grant.newBuilder() to construct.
+    private Grant(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private Grant() {
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private Grant(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000001) != 0)) {
+                subBuilder = byzcoin_.toBuilder();
+              }
+              byzcoin_ = input.readMessage(ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(byzcoin_);
+                byzcoin_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000001;
+              break;
+            }
+            case 18: {
+              ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000002) != 0)) {
+                subBuilder = x509Cert_.toBuilder();
+              }
+              x509Cert_ = input.readMessage(ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(x509Cert_);
+                x509Cert_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000002;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_Grant_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_Grant_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              ch.epfl.dedis.lib.proto.Calypso.Grant.class, ch.epfl.dedis.lib.proto.Calypso.Grant.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int BYZCOIN_FIELD_NUMBER = 1;
+    private ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin byzcoin_;
+    /**
+     * <code>optional .calypso.GrantByzCoin byzcoin = 1;</code>
+     */
+    public boolean hasByzcoin() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>optional .calypso.GrantByzCoin byzcoin = 1;</code>
+     */
+    public ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin getByzcoin() {
+      return byzcoin_ == null ? ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.getDefaultInstance() : byzcoin_;
+    }
+    /**
+     * <code>optional .calypso.GrantByzCoin byzcoin = 1;</code>
+     */
+    public ch.epfl.dedis.lib.proto.Calypso.GrantByzCoinOrBuilder getByzcoinOrBuilder() {
+      return byzcoin_ == null ? ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.getDefaultInstance() : byzcoin_;
+    }
+
+    public static final int X509CERT_FIELD_NUMBER = 2;
+    private ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert x509Cert_;
+    /**
+     * <code>optional .calypso.GrantX509Cert x509cert = 2;</code>
+     */
+    public boolean hasX509Cert() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <code>optional .calypso.GrantX509Cert x509cert = 2;</code>
+     */
+    public ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert getX509Cert() {
+      return x509Cert_ == null ? ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.getDefaultInstance() : x509Cert_;
+    }
+    /**
+     * <code>optional .calypso.GrantX509Cert x509cert = 2;</code>
+     */
+    public ch.epfl.dedis.lib.proto.Calypso.GrantX509CertOrBuilder getX509CertOrBuilder() {
+      return x509Cert_ == null ? ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.getDefaultInstance() : x509Cert_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (hasByzcoin()) {
+        if (!getByzcoin().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      if (hasX509Cert()) {
+        if (!getX509Cert().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeMessage(1, getByzcoin());
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        output.writeMessage(2, getX509Cert());
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, getByzcoin());
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, getX509Cert());
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof ch.epfl.dedis.lib.proto.Calypso.Grant)) {
+        return super.equals(obj);
+      }
+      ch.epfl.dedis.lib.proto.Calypso.Grant other = (ch.epfl.dedis.lib.proto.Calypso.Grant) obj;
+
+      if (hasByzcoin() != other.hasByzcoin()) return false;
+      if (hasByzcoin()) {
+        if (!getByzcoin()
+            .equals(other.getByzcoin())) return false;
+      }
+      if (hasX509Cert() != other.hasX509Cert()) return false;
+      if (hasX509Cert()) {
+        if (!getX509Cert()
+            .equals(other.getX509Cert())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasByzcoin()) {
+        hash = (37 * hash) + BYZCOIN_FIELD_NUMBER;
+        hash = (53 * hash) + getByzcoin().hashCode();
+      }
+      if (hasX509Cert()) {
+        hash = (37 * hash) + X509CERT_FIELD_NUMBER;
+        hash = (53 * hash) + getX509Cert().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static ch.epfl.dedis.lib.proto.Calypso.Grant parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Grant parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Grant parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Grant parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Grant parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Grant parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Grant parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Grant parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Grant parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Grant parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Grant parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.Grant parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(ch.epfl.dedis.lib.proto.Calypso.Grant prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * Grant holds one of the possible grant proofs for a reencryption request. Each
+     * grant proof must hold the secret to be reencrypted, the ephemeral key, as well
+     * as the proof itself that the request is valid. For each of the authentication
+     * schemes, this proof will be different.
+     * </pre>
+     *
+     * Protobuf type {@code calypso.Grant}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:calypso.Grant)
+        ch.epfl.dedis.lib.proto.Calypso.GrantOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_Grant_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_Grant_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                ch.epfl.dedis.lib.proto.Calypso.Grant.class, ch.epfl.dedis.lib.proto.Calypso.Grant.Builder.class);
+      }
+
+      // Construct using ch.epfl.dedis.lib.proto.Calypso.Grant.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+          getByzcoinFieldBuilder();
+          getX509CertFieldBuilder();
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        if (byzcoinBuilder_ == null) {
+          byzcoin_ = null;
+        } else {
+          byzcoinBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000001);
+        if (x509CertBuilder_ == null) {
+          x509Cert_ = null;
+        } else {
+          x509CertBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_Grant_descriptor;
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.Grant getDefaultInstanceForType() {
+        return ch.epfl.dedis.lib.proto.Calypso.Grant.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.Grant build() {
+        ch.epfl.dedis.lib.proto.Calypso.Grant result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.Grant buildPartial() {
+        ch.epfl.dedis.lib.proto.Calypso.Grant result = new ch.epfl.dedis.lib.proto.Calypso.Grant(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (byzcoinBuilder_ == null) {
+            result.byzcoin_ = byzcoin_;
+          } else {
+            result.byzcoin_ = byzcoinBuilder_.build();
+          }
+          to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (x509CertBuilder_ == null) {
+            result.x509Cert_ = x509Cert_;
+          } else {
+            result.x509Cert_ = x509CertBuilder_.build();
+          }
+          to_bitField0_ |= 0x00000002;
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof ch.epfl.dedis.lib.proto.Calypso.Grant) {
+          return mergeFrom((ch.epfl.dedis.lib.proto.Calypso.Grant)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(ch.epfl.dedis.lib.proto.Calypso.Grant other) {
+        if (other == ch.epfl.dedis.lib.proto.Calypso.Grant.getDefaultInstance()) return this;
+        if (other.hasByzcoin()) {
+          mergeByzcoin(other.getByzcoin());
+        }
+        if (other.hasX509Cert()) {
+          mergeX509Cert(other.getX509Cert());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        if (hasByzcoin()) {
+          if (!getByzcoin().isInitialized()) {
+            return false;
+          }
+        }
+        if (hasX509Cert()) {
+          if (!getX509Cert().isInitialized()) {
+            return false;
+          }
+        }
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        ch.epfl.dedis.lib.proto.Calypso.Grant parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (ch.epfl.dedis.lib.proto.Calypso.Grant) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin byzcoin_;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin, ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.Builder, ch.epfl.dedis.lib.proto.Calypso.GrantByzCoinOrBuilder> byzcoinBuilder_;
+      /**
+       * <code>optional .calypso.GrantByzCoin byzcoin = 1;</code>
+       */
+      public boolean hasByzcoin() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>optional .calypso.GrantByzCoin byzcoin = 1;</code>
+       */
+      public ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin getByzcoin() {
+        if (byzcoinBuilder_ == null) {
+          return byzcoin_ == null ? ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.getDefaultInstance() : byzcoin_;
+        } else {
+          return byzcoinBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .calypso.GrantByzCoin byzcoin = 1;</code>
+       */
+      public Builder setByzcoin(ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin value) {
+        if (byzcoinBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          byzcoin_ = value;
+          onChanged();
+        } else {
+          byzcoinBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <code>optional .calypso.GrantByzCoin byzcoin = 1;</code>
+       */
+      public Builder setByzcoin(
+          ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.Builder builderForValue) {
+        if (byzcoinBuilder_ == null) {
+          byzcoin_ = builderForValue.build();
+          onChanged();
+        } else {
+          byzcoinBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <code>optional .calypso.GrantByzCoin byzcoin = 1;</code>
+       */
+      public Builder mergeByzcoin(ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin value) {
+        if (byzcoinBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) != 0) &&
+              byzcoin_ != null &&
+              byzcoin_ != ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.getDefaultInstance()) {
+            byzcoin_ =
+              ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.newBuilder(byzcoin_).mergeFrom(value).buildPartial();
+          } else {
+            byzcoin_ = value;
+          }
+          onChanged();
+        } else {
+          byzcoinBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <code>optional .calypso.GrantByzCoin byzcoin = 1;</code>
+       */
+      public Builder clearByzcoin() {
+        if (byzcoinBuilder_ == null) {
+          byzcoin_ = null;
+          onChanged();
+        } else {
+          byzcoinBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+      /**
+       * <code>optional .calypso.GrantByzCoin byzcoin = 1;</code>
+       */
+      public ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.Builder getByzcoinBuilder() {
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return getByzcoinFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .calypso.GrantByzCoin byzcoin = 1;</code>
+       */
+      public ch.epfl.dedis.lib.proto.Calypso.GrantByzCoinOrBuilder getByzcoinOrBuilder() {
+        if (byzcoinBuilder_ != null) {
+          return byzcoinBuilder_.getMessageOrBuilder();
+        } else {
+          return byzcoin_ == null ?
+              ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.getDefaultInstance() : byzcoin_;
+        }
+      }
+      /**
+       * <code>optional .calypso.GrantByzCoin byzcoin = 1;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin, ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.Builder, ch.epfl.dedis.lib.proto.Calypso.GrantByzCoinOrBuilder> 
+          getByzcoinFieldBuilder() {
+        if (byzcoinBuilder_ == null) {
+          byzcoinBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin, ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.Builder, ch.epfl.dedis.lib.proto.Calypso.GrantByzCoinOrBuilder>(
+                  getByzcoin(),
+                  getParentForChildren(),
+                  isClean());
+          byzcoin_ = null;
+        }
+        return byzcoinBuilder_;
+      }
+
+      private ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert x509Cert_;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert, ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.Builder, ch.epfl.dedis.lib.proto.Calypso.GrantX509CertOrBuilder> x509CertBuilder_;
+      /**
+       * <code>optional .calypso.GrantX509Cert x509cert = 2;</code>
+       */
+      public boolean hasX509Cert() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <code>optional .calypso.GrantX509Cert x509cert = 2;</code>
+       */
+      public ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert getX509Cert() {
+        if (x509CertBuilder_ == null) {
+          return x509Cert_ == null ? ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.getDefaultInstance() : x509Cert_;
+        } else {
+          return x509CertBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .calypso.GrantX509Cert x509cert = 2;</code>
+       */
+      public Builder setX509Cert(ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert value) {
+        if (x509CertBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          x509Cert_ = value;
+          onChanged();
+        } else {
+          x509CertBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <code>optional .calypso.GrantX509Cert x509cert = 2;</code>
+       */
+      public Builder setX509Cert(
+          ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.Builder builderForValue) {
+        if (x509CertBuilder_ == null) {
+          x509Cert_ = builderForValue.build();
+          onChanged();
+        } else {
+          x509CertBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <code>optional .calypso.GrantX509Cert x509cert = 2;</code>
+       */
+      public Builder mergeX509Cert(ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert value) {
+        if (x509CertBuilder_ == null) {
+          if (((bitField0_ & 0x00000002) != 0) &&
+              x509Cert_ != null &&
+              x509Cert_ != ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.getDefaultInstance()) {
+            x509Cert_ =
+              ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.newBuilder(x509Cert_).mergeFrom(value).buildPartial();
+          } else {
+            x509Cert_ = value;
+          }
+          onChanged();
+        } else {
+          x509CertBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <code>optional .calypso.GrantX509Cert x509cert = 2;</code>
+       */
+      public Builder clearX509Cert() {
+        if (x509CertBuilder_ == null) {
+          x509Cert_ = null;
+          onChanged();
+        } else {
+          x509CertBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+      /**
+       * <code>optional .calypso.GrantX509Cert x509cert = 2;</code>
+       */
+      public ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.Builder getX509CertBuilder() {
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return getX509CertFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .calypso.GrantX509Cert x509cert = 2;</code>
+       */
+      public ch.epfl.dedis.lib.proto.Calypso.GrantX509CertOrBuilder getX509CertOrBuilder() {
+        if (x509CertBuilder_ != null) {
+          return x509CertBuilder_.getMessageOrBuilder();
+        } else {
+          return x509Cert_ == null ?
+              ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.getDefaultInstance() : x509Cert_;
+        }
+      }
+      /**
+       * <code>optional .calypso.GrantX509Cert x509cert = 2;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert, ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.Builder, ch.epfl.dedis.lib.proto.Calypso.GrantX509CertOrBuilder> 
+          getX509CertFieldBuilder() {
+        if (x509CertBuilder_ == null) {
+          x509CertBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert, ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.Builder, ch.epfl.dedis.lib.proto.Calypso.GrantX509CertOrBuilder>(
+                  getX509Cert(),
+                  getParentForChildren(),
+                  isClean());
+          x509Cert_ = null;
+        }
+        return x509CertBuilder_;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:calypso.Grant)
+    }
+
+    // @@protoc_insertion_point(class_scope:calypso.Grant)
+    private static final ch.epfl.dedis.lib.proto.Calypso.Grant DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new ch.epfl.dedis.lib.proto.Calypso.Grant();
+    }
+
+    public static ch.epfl.dedis.lib.proto.Calypso.Grant getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<Grant>
+        PARSER = new com.google.protobuf.AbstractParser<Grant>() {
+      @java.lang.Override
+      public Grant parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new Grant(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<Grant> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<Grant> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public ch.epfl.dedis.lib.proto.Calypso.Grant getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface GrantByzCoinOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:calypso.GrantByzCoin)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * Write is the proof containing the write request.
+     * </pre>
+     *
+     * <code>required .byzcoin.Proof write = 1;</code>
+     */
+    boolean hasWrite();
+    /**
+     * <pre>
+     * Write is the proof containing the write request.
+     * </pre>
+     *
+     * <code>required .byzcoin.Proof write = 1;</code>
+     */
+    ch.epfl.dedis.lib.proto.ByzCoinProto.Proof getWrite();
+    /**
+     * <pre>
+     * Write is the proof containing the write request.
+     * </pre>
+     *
+     * <code>required .byzcoin.Proof write = 1;</code>
+     */
+    ch.epfl.dedis.lib.proto.ByzCoinProto.ProofOrBuilder getWriteOrBuilder();
+
+    /**
+     * <pre>
+     * Read is the proof that he has been accepted to read the secret.
+     * </pre>
+     *
+     * <code>required .byzcoin.Proof read = 2;</code>
+     */
+    boolean hasRead();
+    /**
+     * <pre>
+     * Read is the proof that he has been accepted to read the secret.
+     * </pre>
+     *
+     * <code>required .byzcoin.Proof read = 2;</code>
+     */
+    ch.epfl.dedis.lib.proto.ByzCoinProto.Proof getRead();
+    /**
+     * <pre>
+     * Read is the proof that he has been accepted to read the secret.
+     * </pre>
+     *
+     * <code>required .byzcoin.Proof read = 2;</code>
+     */
+    ch.epfl.dedis.lib.proto.ByzCoinProto.ProofOrBuilder getReadOrBuilder();
+  }
+  /**
+   * <pre>
+   * GrantByzCoin holds the proof of the write instance, holding the secret itself.
+   * The proof of the read instance holds the ephemeral key. Both proofs can be
+   * verified using one of the stored ByzCoinIDs.
+   * </pre>
+   *
+   * Protobuf type {@code calypso.GrantByzCoin}
+   */
+  public  static final class GrantByzCoin extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:calypso.GrantByzCoin)
+      GrantByzCoinOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use GrantByzCoin.newBuilder() to construct.
+    private GrantByzCoin(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private GrantByzCoin() {
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private GrantByzCoin(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000001) != 0)) {
+                subBuilder = write_.toBuilder();
+              }
+              write_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(write_);
+                write_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000001;
+              break;
+            }
+            case 18: {
+              ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000002) != 0)) {
+                subBuilder = read_.toBuilder();
+              }
+              read_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(read_);
+                read_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000002;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_GrantByzCoin_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_GrantByzCoin_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.class, ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int WRITE_FIELD_NUMBER = 1;
+    private ch.epfl.dedis.lib.proto.ByzCoinProto.Proof write_;
+    /**
+     * <pre>
+     * Write is the proof containing the write request.
+     * </pre>
+     *
+     * <code>required .byzcoin.Proof write = 1;</code>
+     */
+    public boolean hasWrite() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <pre>
+     * Write is the proof containing the write request.
+     * </pre>
+     *
+     * <code>required .byzcoin.Proof write = 1;</code>
+     */
+    public ch.epfl.dedis.lib.proto.ByzCoinProto.Proof getWrite() {
+      return write_ == null ? ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.getDefaultInstance() : write_;
+    }
+    /**
+     * <pre>
+     * Write is the proof containing the write request.
+     * </pre>
+     *
+     * <code>required .byzcoin.Proof write = 1;</code>
+     */
+    public ch.epfl.dedis.lib.proto.ByzCoinProto.ProofOrBuilder getWriteOrBuilder() {
+      return write_ == null ? ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.getDefaultInstance() : write_;
+    }
+
+    public static final int READ_FIELD_NUMBER = 2;
+    private ch.epfl.dedis.lib.proto.ByzCoinProto.Proof read_;
+    /**
+     * <pre>
+     * Read is the proof that he has been accepted to read the secret.
+     * </pre>
+     *
+     * <code>required .byzcoin.Proof read = 2;</code>
+     */
+    public boolean hasRead() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <pre>
+     * Read is the proof that he has been accepted to read the secret.
+     * </pre>
+     *
+     * <code>required .byzcoin.Proof read = 2;</code>
+     */
+    public ch.epfl.dedis.lib.proto.ByzCoinProto.Proof getRead() {
+      return read_ == null ? ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.getDefaultInstance() : read_;
+    }
+    /**
+     * <pre>
+     * Read is the proof that he has been accepted to read the secret.
+     * </pre>
+     *
+     * <code>required .byzcoin.Proof read = 2;</code>
+     */
+    public ch.epfl.dedis.lib.proto.ByzCoinProto.ProofOrBuilder getReadOrBuilder() {
+      return read_ == null ? ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.getDefaultInstance() : read_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (!hasWrite()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasRead()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!getWrite().isInitialized()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!getRead().isInitialized()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeMessage(1, getWrite());
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        output.writeMessage(2, getRead());
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, getWrite());
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, getRead());
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin)) {
+        return super.equals(obj);
+      }
+      ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin other = (ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin) obj;
+
+      if (hasWrite() != other.hasWrite()) return false;
+      if (hasWrite()) {
+        if (!getWrite()
+            .equals(other.getWrite())) return false;
+      }
+      if (hasRead() != other.hasRead()) return false;
+      if (hasRead()) {
+        if (!getRead()
+            .equals(other.getRead())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasWrite()) {
+        hash = (37 * hash) + WRITE_FIELD_NUMBER;
+        hash = (53 * hash) + getWrite().hashCode();
+      }
+      if (hasRead()) {
+        hash = (37 * hash) + READ_FIELD_NUMBER;
+        hash = (53 * hash) + getRead().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * GrantByzCoin holds the proof of the write instance, holding the secret itself.
+     * The proof of the read instance holds the ephemeral key. Both proofs can be
+     * verified using one of the stored ByzCoinIDs.
+     * </pre>
+     *
+     * Protobuf type {@code calypso.GrantByzCoin}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:calypso.GrantByzCoin)
+        ch.epfl.dedis.lib.proto.Calypso.GrantByzCoinOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_GrantByzCoin_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_GrantByzCoin_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.class, ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.Builder.class);
+      }
+
+      // Construct using ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+          getWriteFieldBuilder();
+          getReadFieldBuilder();
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        if (writeBuilder_ == null) {
+          write_ = null;
+        } else {
+          writeBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000001);
+        if (readBuilder_ == null) {
+          read_ = null;
+        } else {
+          readBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_GrantByzCoin_descriptor;
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin getDefaultInstanceForType() {
+        return ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin build() {
+        ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin buildPartial() {
+        ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin result = new ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (writeBuilder_ == null) {
+            result.write_ = write_;
+          } else {
+            result.write_ = writeBuilder_.build();
+          }
+          to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (readBuilder_ == null) {
+            result.read_ = read_;
+          } else {
+            result.read_ = readBuilder_.build();
+          }
+          to_bitField0_ |= 0x00000002;
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin) {
+          return mergeFrom((ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin other) {
+        if (other == ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin.getDefaultInstance()) return this;
+        if (other.hasWrite()) {
+          mergeWrite(other.getWrite());
+        }
+        if (other.hasRead()) {
+          mergeRead(other.getRead());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        if (!hasWrite()) {
+          return false;
+        }
+        if (!hasRead()) {
+          return false;
+        }
+        if (!getWrite().isInitialized()) {
+          return false;
+        }
+        if (!getRead().isInitialized()) {
+          return false;
+        }
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.Proof write_;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          ch.epfl.dedis.lib.proto.ByzCoinProto.Proof, ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.ProofOrBuilder> writeBuilder_;
+      /**
+       * <pre>
+       * Write is the proof containing the write request.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof write = 1;</code>
+       */
+      public boolean hasWrite() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <pre>
+       * Write is the proof containing the write request.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof write = 1;</code>
+       */
+      public ch.epfl.dedis.lib.proto.ByzCoinProto.Proof getWrite() {
+        if (writeBuilder_ == null) {
+          return write_ == null ? ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.getDefaultInstance() : write_;
+        } else {
+          return writeBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       * Write is the proof containing the write request.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof write = 1;</code>
+       */
+      public Builder setWrite(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof value) {
+        if (writeBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          write_ = value;
+          onChanged();
+        } else {
+          writeBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <pre>
+       * Write is the proof containing the write request.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof write = 1;</code>
+       */
+      public Builder setWrite(
+          ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder builderForValue) {
+        if (writeBuilder_ == null) {
+          write_ = builderForValue.build();
+          onChanged();
+        } else {
+          writeBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <pre>
+       * Write is the proof containing the write request.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof write = 1;</code>
+       */
+      public Builder mergeWrite(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof value) {
+        if (writeBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) != 0) &&
+              write_ != null &&
+              write_ != ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.getDefaultInstance()) {
+            write_ =
+              ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.newBuilder(write_).mergeFrom(value).buildPartial();
+          } else {
+            write_ = value;
+          }
+          onChanged();
+        } else {
+          writeBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000001;
+        return this;
+      }
+      /**
+       * <pre>
+       * Write is the proof containing the write request.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof write = 1;</code>
+       */
+      public Builder clearWrite() {
+        if (writeBuilder_ == null) {
+          write_ = null;
+          onChanged();
+        } else {
+          writeBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+      /**
+       * <pre>
+       * Write is the proof containing the write request.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof write = 1;</code>
+       */
+      public ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder getWriteBuilder() {
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return getWriteFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       * Write is the proof containing the write request.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof write = 1;</code>
+       */
+      public ch.epfl.dedis.lib.proto.ByzCoinProto.ProofOrBuilder getWriteOrBuilder() {
+        if (writeBuilder_ != null) {
+          return writeBuilder_.getMessageOrBuilder();
+        } else {
+          return write_ == null ?
+              ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.getDefaultInstance() : write_;
+        }
+      }
+      /**
+       * <pre>
+       * Write is the proof containing the write request.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof write = 1;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          ch.epfl.dedis.lib.proto.ByzCoinProto.Proof, ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.ProofOrBuilder> 
+          getWriteFieldBuilder() {
+        if (writeBuilder_ == null) {
+          writeBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              ch.epfl.dedis.lib.proto.ByzCoinProto.Proof, ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.ProofOrBuilder>(
+                  getWrite(),
+                  getParentForChildren(),
+                  isClean());
+          write_ = null;
+        }
+        return writeBuilder_;
+      }
+
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.Proof read_;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          ch.epfl.dedis.lib.proto.ByzCoinProto.Proof, ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.ProofOrBuilder> readBuilder_;
+      /**
+       * <pre>
+       * Read is the proof that he has been accepted to read the secret.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof read = 2;</code>
+       */
+      public boolean hasRead() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <pre>
+       * Read is the proof that he has been accepted to read the secret.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof read = 2;</code>
+       */
+      public ch.epfl.dedis.lib.proto.ByzCoinProto.Proof getRead() {
+        if (readBuilder_ == null) {
+          return read_ == null ? ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.getDefaultInstance() : read_;
+        } else {
+          return readBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       * Read is the proof that he has been accepted to read the secret.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof read = 2;</code>
+       */
+      public Builder setRead(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof value) {
+        if (readBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          read_ = value;
+          onChanged();
+        } else {
+          readBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <pre>
+       * Read is the proof that he has been accepted to read the secret.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof read = 2;</code>
+       */
+      public Builder setRead(
+          ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder builderForValue) {
+        if (readBuilder_ == null) {
+          read_ = builderForValue.build();
+          onChanged();
+        } else {
+          readBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <pre>
+       * Read is the proof that he has been accepted to read the secret.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof read = 2;</code>
+       */
+      public Builder mergeRead(ch.epfl.dedis.lib.proto.ByzCoinProto.Proof value) {
+        if (readBuilder_ == null) {
+          if (((bitField0_ & 0x00000002) != 0) &&
+              read_ != null &&
+              read_ != ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.getDefaultInstance()) {
+            read_ =
+              ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.newBuilder(read_).mergeFrom(value).buildPartial();
+          } else {
+            read_ = value;
+          }
+          onChanged();
+        } else {
+          readBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <pre>
+       * Read is the proof that he has been accepted to read the secret.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof read = 2;</code>
+       */
+      public Builder clearRead() {
+        if (readBuilder_ == null) {
+          read_ = null;
+          onChanged();
+        } else {
+          readBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+      /**
+       * <pre>
+       * Read is the proof that he has been accepted to read the secret.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof read = 2;</code>
+       */
+      public ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder getReadBuilder() {
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return getReadFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       * Read is the proof that he has been accepted to read the secret.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof read = 2;</code>
+       */
+      public ch.epfl.dedis.lib.proto.ByzCoinProto.ProofOrBuilder getReadOrBuilder() {
+        if (readBuilder_ != null) {
+          return readBuilder_.getMessageOrBuilder();
+        } else {
+          return read_ == null ?
+              ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.getDefaultInstance() : read_;
+        }
+      }
+      /**
+       * <pre>
+       * Read is the proof that he has been accepted to read the secret.
+       * </pre>
+       *
+       * <code>required .byzcoin.Proof read = 2;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          ch.epfl.dedis.lib.proto.ByzCoinProto.Proof, ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.ProofOrBuilder> 
+          getReadFieldBuilder() {
+        if (readBuilder_ == null) {
+          readBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              ch.epfl.dedis.lib.proto.ByzCoinProto.Proof, ch.epfl.dedis.lib.proto.ByzCoinProto.Proof.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.ProofOrBuilder>(
+                  getRead(),
+                  getParentForChildren(),
+                  isClean());
+          read_ = null;
+        }
+        return readBuilder_;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:calypso.GrantByzCoin)
+    }
+
+    // @@protoc_insertion_point(class_scope:calypso.GrantByzCoin)
+    private static final ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin();
+    }
+
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<GrantByzCoin>
+        PARSER = new com.google.protobuf.AbstractParser<GrantByzCoin>() {
+      @java.lang.Override
+      public GrantByzCoin parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new GrantByzCoin(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<GrantByzCoin> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<GrantByzCoin> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public ch.epfl.dedis.lib.proto.Calypso.GrantByzCoin getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface GrantX509CertOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:calypso.GrantX509Cert)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>required bytes secret = 1;</code>
+     */
+    boolean hasSecret();
+    /**
+     * <code>required bytes secret = 1;</code>
+     */
+    com.google.protobuf.ByteString getSecret();
+
+    /**
+     * <code>repeated bytes certificates = 2;</code>
+     */
+    java.util.List<com.google.protobuf.ByteString> getCertificatesList();
+    /**
+     * <code>repeated bytes certificates = 2;</code>
+     */
+    int getCertificatesCount();
+    /**
+     * <code>repeated bytes certificates = 2;</code>
+     */
+    com.google.protobuf.ByteString getCertificates(int index);
+  }
+  /**
+   * <pre>
+   * GrantX509Cert holds the proof that at least a threshold number of clients
+   * accepted the reencryption.
+   * For each client, there must exist a certificate that can be verified by the
+   * CA certificate from AuthX509Cert. Additionally, each client must sign the
+   * following message:
+   *   sha256( Secret | Ephemeral | Time )
+   * </pre>
+   *
+   * Protobuf type {@code calypso.GrantX509Cert}
+   */
+  public  static final class GrantX509Cert extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:calypso.GrantX509Cert)
+      GrantX509CertOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use GrantX509Cert.newBuilder() to construct.
+    private GrantX509Cert(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private GrantX509Cert() {
+      secret_ = com.google.protobuf.ByteString.EMPTY;
+      certificates_ = java.util.Collections.emptyList();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private GrantX509Cert(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              bitField0_ |= 0x00000001;
+              secret_ = input.readBytes();
+              break;
+            }
+            case 18: {
+              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
+                certificates_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
+                mutable_bitField0_ |= 0x00000002;
+              }
+              certificates_.add(input.readBytes());
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000002) != 0)) {
+          certificates_ = java.util.Collections.unmodifiableList(certificates_); // C
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_GrantX509Cert_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_GrantX509Cert_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.class, ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int SECRET_FIELD_NUMBER = 1;
+    private com.google.protobuf.ByteString secret_;
+    /**
+     * <code>required bytes secret = 1;</code>
+     */
+    public boolean hasSecret() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>required bytes secret = 1;</code>
+     */
+    public com.google.protobuf.ByteString getSecret() {
+      return secret_;
+    }
+
+    public static final int CERTIFICATES_FIELD_NUMBER = 2;
+    private java.util.List<com.google.protobuf.ByteString> certificates_;
+    /**
+     * <code>repeated bytes certificates = 2;</code>
+     */
+    public java.util.List<com.google.protobuf.ByteString>
+        getCertificatesList() {
+      return certificates_;
+    }
+    /**
+     * <code>repeated bytes certificates = 2;</code>
+     */
+    public int getCertificatesCount() {
+      return certificates_.size();
+    }
+    /**
+     * <code>repeated bytes certificates = 2;</code>
+     */
+    public com.google.protobuf.ByteString getCertificates(int index) {
+      return certificates_.get(index);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (!hasSecret()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeBytes(1, secret_);
+      }
+      for (int i = 0; i < certificates_.size(); i++) {
+        output.writeBytes(2, certificates_.get(i));
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(1, secret_);
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < certificates_.size(); i++) {
+          dataSize += com.google.protobuf.CodedOutputStream
+            .computeBytesSizeNoTag(certificates_.get(i));
+        }
+        size += dataSize;
+        size += 1 * getCertificatesList().size();
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert)) {
+        return super.equals(obj);
+      }
+      ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert other = (ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert) obj;
+
+      if (hasSecret() != other.hasSecret()) return false;
+      if (hasSecret()) {
+        if (!getSecret()
+            .equals(other.getSecret())) return false;
+      }
+      if (!getCertificatesList()
+          .equals(other.getCertificatesList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasSecret()) {
+        hash = (37 * hash) + SECRET_FIELD_NUMBER;
+        hash = (53 * hash) + getSecret().hashCode();
+      }
+      if (getCertificatesCount() > 0) {
+        hash = (37 * hash) + CERTIFICATES_FIELD_NUMBER;
+        hash = (53 * hash) + getCertificatesList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * GrantX509Cert holds the proof that at least a threshold number of clients
+     * accepted the reencryption.
+     * For each client, there must exist a certificate that can be verified by the
+     * CA certificate from AuthX509Cert. Additionally, each client must sign the
+     * following message:
+     *   sha256( Secret | Ephemeral | Time )
+     * </pre>
+     *
+     * Protobuf type {@code calypso.GrantX509Cert}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:calypso.GrantX509Cert)
+        ch.epfl.dedis.lib.proto.Calypso.GrantX509CertOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_GrantX509Cert_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_GrantX509Cert_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.class, ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.Builder.class);
+      }
+
+      // Construct using ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        secret_ = com.google.protobuf.ByteString.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        certificates_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return ch.epfl.dedis.lib.proto.Calypso.internal_static_calypso_GrantX509Cert_descriptor;
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert getDefaultInstanceForType() {
+        return ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert build() {
+        ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert buildPartial() {
+        ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert result = new ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.secret_ = secret_;
+        if (((bitField0_ & 0x00000002) != 0)) {
+          certificates_ = java.util.Collections.unmodifiableList(certificates_);
+          bitField0_ = (bitField0_ & ~0x00000002);
+        }
+        result.certificates_ = certificates_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert) {
+          return mergeFrom((ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert other) {
+        if (other == ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert.getDefaultInstance()) return this;
+        if (other.hasSecret()) {
+          setSecret(other.getSecret());
+        }
+        if (!other.certificates_.isEmpty()) {
+          if (certificates_.isEmpty()) {
+            certificates_ = other.certificates_;
+            bitField0_ = (bitField0_ & ~0x00000002);
+          } else {
+            ensureCertificatesIsMutable();
+            certificates_.addAll(other.certificates_);
+          }
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        if (!hasSecret()) {
+          return false;
+        }
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private com.google.protobuf.ByteString secret_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>required bytes secret = 1;</code>
+       */
+      public boolean hasSecret() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>required bytes secret = 1;</code>
+       */
+      public com.google.protobuf.ByteString getSecret() {
+        return secret_;
+      }
+      /**
+       * <code>required bytes secret = 1;</code>
+       */
+      public Builder setSecret(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        secret_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required bytes secret = 1;</code>
+       */
+      public Builder clearSecret() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        secret_ = getDefaultInstance().getSecret();
+        onChanged();
+        return this;
+      }
+
+      private java.util.List<com.google.protobuf.ByteString> certificates_ = java.util.Collections.emptyList();
+      private void ensureCertificatesIsMutable() {
+        if (!((bitField0_ & 0x00000002) != 0)) {
+          certificates_ = new java.util.ArrayList<com.google.protobuf.ByteString>(certificates_);
+          bitField0_ |= 0x00000002;
+         }
+      }
+      /**
+       * <code>repeated bytes certificates = 2;</code>
+       */
+      public java.util.List<com.google.protobuf.ByteString>
+          getCertificatesList() {
+        return ((bitField0_ & 0x00000002) != 0) ?
+                 java.util.Collections.unmodifiableList(certificates_) : certificates_;
+      }
+      /**
+       * <code>repeated bytes certificates = 2;</code>
+       */
+      public int getCertificatesCount() {
+        return certificates_.size();
+      }
+      /**
+       * <code>repeated bytes certificates = 2;</code>
+       */
+      public com.google.protobuf.ByteString getCertificates(int index) {
+        return certificates_.get(index);
+      }
+      /**
+       * <code>repeated bytes certificates = 2;</code>
+       */
+      public Builder setCertificates(
+          int index, com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureCertificatesIsMutable();
+        certificates_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated bytes certificates = 2;</code>
+       */
+      public Builder addCertificates(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureCertificatesIsMutable();
+        certificates_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated bytes certificates = 2;</code>
+       */
+      public Builder addAllCertificates(
+          java.lang.Iterable<? extends com.google.protobuf.ByteString> values) {
+        ensureCertificatesIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, certificates_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated bytes certificates = 2;</code>
+       */
+      public Builder clearCertificates() {
+        certificates_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000002);
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:calypso.GrantX509Cert)
+    }
+
+    // @@protoc_insertion_point(class_scope:calypso.GrantX509Cert)
+    private static final ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert();
+    }
+
+    public static ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<GrantX509Cert>
+        PARSER = new com.google.protobuf.AbstractParser<GrantX509Cert>() {
+      @java.lang.Override
+      public GrantX509Cert parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new GrantX509Cert(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<GrantX509Cert> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<GrantX509Cert> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public ch.epfl.dedis.lib.proto.Calypso.GrantX509Cert getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_calypso_Write_descriptor;
   private static final 
@@ -8584,6 +13287,36 @@ public final class Calypso {
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_calypso_LtsInstanceInfo_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_calypso_Auth_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_calypso_Auth_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_calypso_AuthByzCoin_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_calypso_AuthByzCoin_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_calypso_AuthX509Cert_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_calypso_AuthX509Cert_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_calypso_Grant_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_calypso_Grant_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_calypso_GrantByzCoin_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_calypso_GrantByzCoin_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_calypso_GrantX509Cert_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_calypso_GrantX509Cert_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -8608,8 +13341,19 @@ public final class Calypso {
       "\030\002 \002(\0132\016.byzcoin.Proof\"8\n\017DecryptKeyRepl" +
       "y\022\t\n\001c\030\001 \002(\014\022\017\n\007xhatenc\030\002 \002(\014\022\t\n\001x\030\003 \002(\014" +
       "\"\034\n\013GetLTSReply\022\r\n\005ltsid\030\001 \002(\014\"/\n\017LtsIns" +
-      "tanceInfo\022\034\n\006roster\030\001 \002(\0132\014.onet.RosterB" +
-      "\"\n\027ch.epfl.dedis.lib.protoB\007Calypso"
+      "tanceInfo\022\034\n\006roster\030\001 \002(\0132\014.onet.Roster\"" +
+      "Z\n\004Auth\022%\n\007byzcoin\030\001 \001(\0132\024.calypso.AuthB" +
+      "yzCoin\022+\n\014authx509cert\030\002 \001(\0132\025.calypso.A" +
+      "uthX509Cert\"-\n\013AuthByzCoin\022\021\n\tbyzcoinid\030" +
+      "\001 \002(\014\022\013\n\003ttl\030\002 \002(\004\"-\n\014AuthX509Cert\022\n\n\002ca" +
+      "\030\001 \003(\014\022\021\n\tthreshold\030\002 \002(\021\"Y\n\005Grant\022&\n\007by" +
+      "zcoin\030\001 \001(\0132\025.calypso.GrantByzCoin\022(\n\010x5" +
+      "09cert\030\002 \001(\0132\026.calypso.GrantX509Cert\"K\n\014" +
+      "GrantByzCoin\022\035\n\005write\030\001 \002(\0132\016.byzcoin.Pr" +
+      "oof\022\034\n\004read\030\002 \002(\0132\016.byzcoin.Proof\"5\n\rGra" +
+      "ntX509Cert\022\016\n\006secret\030\001 \002(\014\022\024\n\014certificat" +
+      "es\030\002 \003(\014B\"\n\027ch.epfl.dedis.lib.protoB\007Cal" +
+      "ypso"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -8697,6 +13441,42 @@ public final class Calypso {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_calypso_LtsInstanceInfo_descriptor,
         new java.lang.String[] { "Roster", });
+    internal_static_calypso_Auth_descriptor =
+      getDescriptor().getMessageTypes().get(12);
+    internal_static_calypso_Auth_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_calypso_Auth_descriptor,
+        new java.lang.String[] { "Byzcoin", "Authx509Cert", });
+    internal_static_calypso_AuthByzCoin_descriptor =
+      getDescriptor().getMessageTypes().get(13);
+    internal_static_calypso_AuthByzCoin_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_calypso_AuthByzCoin_descriptor,
+        new java.lang.String[] { "Byzcoinid", "Ttl", });
+    internal_static_calypso_AuthX509Cert_descriptor =
+      getDescriptor().getMessageTypes().get(14);
+    internal_static_calypso_AuthX509Cert_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_calypso_AuthX509Cert_descriptor,
+        new java.lang.String[] { "Ca", "Threshold", });
+    internal_static_calypso_Grant_descriptor =
+      getDescriptor().getMessageTypes().get(15);
+    internal_static_calypso_Grant_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_calypso_Grant_descriptor,
+        new java.lang.String[] { "Byzcoin", "X509Cert", });
+    internal_static_calypso_GrantByzCoin_descriptor =
+      getDescriptor().getMessageTypes().get(16);
+    internal_static_calypso_GrantByzCoin_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_calypso_GrantByzCoin_descriptor,
+        new java.lang.String[] { "Write", "Read", });
+    internal_static_calypso_GrantX509Cert_descriptor =
+      getDescriptor().getMessageTypes().get(17);
+    internal_static_calypso_GrantX509Cert_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_calypso_GrantX509Cert_descriptor,
+        new java.lang.String[] { "Secret", "Certificates", });
     ch.epfl.dedis.lib.proto.ByzCoinProto.getDescriptor();
     ch.epfl.dedis.lib.proto.OnetProto.getDescriptor();
   }

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/DarcProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/DarcProto.java
@@ -246,7 +246,6 @@ public final class DarcProto {
       super(builder);
     }
     private Darc() {
-      version_ = 0L;
       description_ = com.google.protobuf.ByteString.EMPTY;
       baseid_ = com.google.protobuf.ByteString.EMPTY;
       previd_ = com.google.protobuf.ByteString.EMPTY;
@@ -300,7 +299,7 @@ public final class DarcProto {
             }
             case 42: {
               ch.epfl.dedis.lib.proto.DarcProto.Rules.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000010) == 0x00000010)) {
+              if (((bitField0_ & 0x00000010) != 0)) {
                 subBuilder = rules_.toBuilder();
               }
               rules_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Rules.parser(), extensionRegistry);
@@ -312,7 +311,7 @@ public final class DarcProto {
               break;
             }
             case 50: {
-              if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+              if (!((mutable_bitField0_ & 0x00000020) != 0)) {
                 signatures_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.DarcProto.Signature>();
                 mutable_bitField0_ |= 0x00000020;
               }
@@ -321,7 +320,7 @@ public final class DarcProto {
               break;
             }
             case 58: {
-              if (!((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
+              if (!((mutable_bitField0_ & 0x00000040) != 0)) {
                 verificationdarcs_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.DarcProto.Darc>();
                 mutable_bitField0_ |= 0x00000040;
               }
@@ -344,10 +343,10 @@ public final class DarcProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+        if (((mutable_bitField0_ & 0x00000020) != 0)) {
           signatures_ = java.util.Collections.unmodifiableList(signatures_);
         }
-        if (((mutable_bitField0_ & 0x00000040) == 0x00000040)) {
+        if (((mutable_bitField0_ & 0x00000040) != 0)) {
           verificationdarcs_ = java.util.Collections.unmodifiableList(verificationdarcs_);
         }
         this.unknownFields = unknownFields.build();
@@ -379,7 +378,7 @@ public final class DarcProto {
      * <code>required uint64 version = 1;</code>
      */
     public boolean hasVersion() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -405,7 +404,7 @@ public final class DarcProto {
      * <code>required bytes description = 2;</code>
      */
     public boolean hasDescription() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -431,7 +430,7 @@ public final class DarcProto {
      * <code>optional bytes baseid = 3;</code>
      */
     public boolean hasBaseid() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <pre>
@@ -455,7 +454,7 @@ public final class DarcProto {
      * <code>required bytes previd = 4;</code>
      */
     public boolean hasPrevid() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <pre>
@@ -478,7 +477,7 @@ public final class DarcProto {
      * <code>required .darc.Rules rules = 5;</code>
      */
     public boolean hasRules() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000010) != 0);
     }
     /**
      * <pre>
@@ -677,19 +676,19 @@ public final class DarcProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeUInt64(1, version_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, description_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(3, baseid_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeBytes(4, previd_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         output.writeMessage(5, getRules());
       }
       for (int i = 0; i < signatures_.size(); i++) {
@@ -707,23 +706,23 @@ public final class DarcProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(1, version_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, description_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, baseid_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(4, previd_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(5, getRules());
       }
@@ -750,38 +749,37 @@ public final class DarcProto {
       }
       ch.epfl.dedis.lib.proto.DarcProto.Darc other = (ch.epfl.dedis.lib.proto.DarcProto.Darc) obj;
 
-      boolean result = true;
-      result = result && (hasVersion() == other.hasVersion());
+      if (hasVersion() != other.hasVersion()) return false;
       if (hasVersion()) {
-        result = result && (getVersion()
-            == other.getVersion());
+        if (getVersion()
+            != other.getVersion()) return false;
       }
-      result = result && (hasDescription() == other.hasDescription());
+      if (hasDescription() != other.hasDescription()) return false;
       if (hasDescription()) {
-        result = result && getDescription()
-            .equals(other.getDescription());
+        if (!getDescription()
+            .equals(other.getDescription())) return false;
       }
-      result = result && (hasBaseid() == other.hasBaseid());
+      if (hasBaseid() != other.hasBaseid()) return false;
       if (hasBaseid()) {
-        result = result && getBaseid()
-            .equals(other.getBaseid());
+        if (!getBaseid()
+            .equals(other.getBaseid())) return false;
       }
-      result = result && (hasPrevid() == other.hasPrevid());
+      if (hasPrevid() != other.hasPrevid()) return false;
       if (hasPrevid()) {
-        result = result && getPrevid()
-            .equals(other.getPrevid());
+        if (!getPrevid()
+            .equals(other.getPrevid())) return false;
       }
-      result = result && (hasRules() == other.hasRules());
+      if (hasRules() != other.hasRules()) return false;
       if (hasRules()) {
-        result = result && getRules()
-            .equals(other.getRules());
+        if (!getRules()
+            .equals(other.getRules())) return false;
       }
-      result = result && getSignaturesList()
-          .equals(other.getSignaturesList());
-      result = result && getVerificationdarcsList()
-          .equals(other.getVerificationdarcsList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getSignaturesList()
+          .equals(other.getSignaturesList())) return false;
+      if (!getVerificationdarcsList()
+          .equals(other.getVerificationdarcsList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -1016,32 +1014,32 @@ public final class DarcProto {
         ch.epfl.dedis.lib.proto.DarcProto.Darc result = new ch.epfl.dedis.lib.proto.DarcProto.Darc(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.version_ = version_;
           to_bitField0_ |= 0x00000001;
         }
-        result.version_ = version_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.description_ = description_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.baseid_ = baseid_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
           to_bitField0_ |= 0x00000008;
         }
         result.previd_ = previd_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((from_bitField0_ & 0x00000010) != 0)) {
+          if (rulesBuilder_ == null) {
+            result.rules_ = rules_;
+          } else {
+            result.rules_ = rulesBuilder_.build();
+          }
           to_bitField0_ |= 0x00000010;
         }
-        if (rulesBuilder_ == null) {
-          result.rules_ = rules_;
-        } else {
-          result.rules_ = rulesBuilder_.build();
-        }
         if (signaturesBuilder_ == null) {
-          if (((bitField0_ & 0x00000020) == 0x00000020)) {
+          if (((bitField0_ & 0x00000020) != 0)) {
             signatures_ = java.util.Collections.unmodifiableList(signatures_);
             bitField0_ = (bitField0_ & ~0x00000020);
           }
@@ -1050,7 +1048,7 @@ public final class DarcProto {
           result.signatures_ = signaturesBuilder_.build();
         }
         if (verificationdarcsBuilder_ == null) {
-          if (((bitField0_ & 0x00000040) == 0x00000040)) {
+          if (((bitField0_ & 0x00000040) != 0)) {
             verificationdarcs_ = java.util.Collections.unmodifiableList(verificationdarcs_);
             bitField0_ = (bitField0_ & ~0x00000040);
           }
@@ -1065,35 +1063,35 @@ public final class DarcProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -1239,7 +1237,7 @@ public final class DarcProto {
        * <code>required uint64 version = 1;</code>
        */
       public boolean hasVersion() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -1292,7 +1290,7 @@ public final class DarcProto {
        * <code>required bytes description = 2;</code>
        */
       public boolean hasDescription() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -1350,7 +1348,7 @@ public final class DarcProto {
        * <code>optional bytes baseid = 3;</code>
        */
       public boolean hasBaseid() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <pre>
@@ -1404,7 +1402,7 @@ public final class DarcProto {
        * <code>required bytes previd = 4;</code>
        */
       public boolean hasPrevid() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <pre>
@@ -1446,7 +1444,7 @@ public final class DarcProto {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.DarcProto.Rules rules_ = null;
+      private ch.epfl.dedis.lib.proto.DarcProto.Rules rules_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.DarcProto.Rules, ch.epfl.dedis.lib.proto.DarcProto.Rules.Builder, ch.epfl.dedis.lib.proto.DarcProto.RulesOrBuilder> rulesBuilder_;
       /**
@@ -1457,7 +1455,7 @@ public final class DarcProto {
        * <code>required .darc.Rules rules = 5;</code>
        */
       public boolean hasRules() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return ((bitField0_ & 0x00000010) != 0);
       }
       /**
        * <pre>
@@ -1520,7 +1518,7 @@ public final class DarcProto {
        */
       public Builder mergeRules(ch.epfl.dedis.lib.proto.DarcProto.Rules value) {
         if (rulesBuilder_ == null) {
-          if (((bitField0_ & 0x00000010) == 0x00000010) &&
+          if (((bitField0_ & 0x00000010) != 0) &&
               rules_ != null &&
               rules_ != ch.epfl.dedis.lib.proto.DarcProto.Rules.getDefaultInstance()) {
             rules_ =
@@ -1603,7 +1601,7 @@ public final class DarcProto {
       private java.util.List<ch.epfl.dedis.lib.proto.DarcProto.Signature> signatures_ =
         java.util.Collections.emptyList();
       private void ensureSignaturesIsMutable() {
-        if (!((bitField0_ & 0x00000020) == 0x00000020)) {
+        if (!((bitField0_ & 0x00000020) != 0)) {
           signatures_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.DarcProto.Signature>(signatures_);
           bitField0_ |= 0x00000020;
          }
@@ -1940,7 +1938,7 @@ public final class DarcProto {
           signaturesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.DarcProto.Signature, ch.epfl.dedis.lib.proto.DarcProto.Signature.Builder, ch.epfl.dedis.lib.proto.DarcProto.SignatureOrBuilder>(
                   signatures_,
-                  ((bitField0_ & 0x00000020) == 0x00000020),
+                  ((bitField0_ & 0x00000020) != 0),
                   getParentForChildren(),
                   isClean());
           signatures_ = null;
@@ -1951,7 +1949,7 @@ public final class DarcProto {
       private java.util.List<ch.epfl.dedis.lib.proto.DarcProto.Darc> verificationdarcs_ =
         java.util.Collections.emptyList();
       private void ensureVerificationdarcsIsMutable() {
-        if (!((bitField0_ & 0x00000040) == 0x00000040)) {
+        if (!((bitField0_ & 0x00000040) != 0)) {
           verificationdarcs_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.DarcProto.Darc>(verificationdarcs_);
           bitField0_ |= 0x00000040;
          }
@@ -2288,7 +2286,7 @@ public final class DarcProto {
           verificationdarcsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.DarcProto.Darc, ch.epfl.dedis.lib.proto.DarcProto.Darc.Builder, ch.epfl.dedis.lib.proto.DarcProto.DarcOrBuilder>(
                   verificationdarcs_,
-                  ((bitField0_ & 0x00000040) == 0x00000040),
+                  ((bitField0_ & 0x00000040) != 0),
                   getParentForChildren(),
                   isClean());
           verificationdarcs_ = null;
@@ -2498,7 +2496,7 @@ public final class DarcProto {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.DarcProto.IdentityDarc.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = darc_.toBuilder();
               }
               darc_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.IdentityDarc.parser(), extensionRegistry);
@@ -2511,7 +2509,7 @@ public final class DarcProto {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.DarcProto.IdentityEd25519.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = ed25519_.toBuilder();
               }
               ed25519_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.IdentityEd25519.parser(), extensionRegistry);
@@ -2524,7 +2522,7 @@ public final class DarcProto {
             }
             case 26: {
               ch.epfl.dedis.lib.proto.DarcProto.IdentityX509EC.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+              if (((bitField0_ & 0x00000004) != 0)) {
                 subBuilder = x509Ec_.toBuilder();
               }
               x509Ec_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.IdentityX509EC.parser(), extensionRegistry);
@@ -2537,7 +2535,7 @@ public final class DarcProto {
             }
             case 34: {
               ch.epfl.dedis.lib.proto.DarcProto.IdentityProxy.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000008) == 0x00000008)) {
+              if (((bitField0_ & 0x00000008) != 0)) {
                 subBuilder = proxy_.toBuilder();
               }
               proxy_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.IdentityProxy.parser(), extensionRegistry);
@@ -2591,7 +2589,7 @@ public final class DarcProto {
      * <code>optional .darc.IdentityDarc darc = 1;</code>
      */
     public boolean hasDarc() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -2624,7 +2622,7 @@ public final class DarcProto {
      * <code>optional .darc.IdentityEd25519 ed25519 = 2;</code>
      */
     public boolean hasEd25519() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -2657,7 +2655,7 @@ public final class DarcProto {
      * <code>optional .darc.IdentityX509EC x509ec = 3;</code>
      */
     public boolean hasX509Ec() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <pre>
@@ -2690,7 +2688,7 @@ public final class DarcProto {
      * <code>optional .darc.IdentityProxy proxy = 4;</code>
      */
     public boolean hasProxy() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <pre>
@@ -2751,16 +2749,16 @@ public final class DarcProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getDarc());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getEd25519());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeMessage(3, getX509Ec());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeMessage(4, getProxy());
       }
       unknownFields.writeTo(output);
@@ -2772,19 +2770,19 @@ public final class DarcProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getDarc());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getEd25519());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, getX509Ec());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(4, getProxy());
       }
@@ -2803,29 +2801,28 @@ public final class DarcProto {
       }
       ch.epfl.dedis.lib.proto.DarcProto.Identity other = (ch.epfl.dedis.lib.proto.DarcProto.Identity) obj;
 
-      boolean result = true;
-      result = result && (hasDarc() == other.hasDarc());
+      if (hasDarc() != other.hasDarc()) return false;
       if (hasDarc()) {
-        result = result && getDarc()
-            .equals(other.getDarc());
+        if (!getDarc()
+            .equals(other.getDarc())) return false;
       }
-      result = result && (hasEd25519() == other.hasEd25519());
+      if (hasEd25519() != other.hasEd25519()) return false;
       if (hasEd25519()) {
-        result = result && getEd25519()
-            .equals(other.getEd25519());
+        if (!getEd25519()
+            .equals(other.getEd25519())) return false;
       }
-      result = result && (hasX509Ec() == other.hasX509Ec());
+      if (hasX509Ec() != other.hasX509Ec()) return false;
       if (hasX509Ec()) {
-        result = result && getX509Ec()
-            .equals(other.getX509Ec());
+        if (!getX509Ec()
+            .equals(other.getX509Ec())) return false;
       }
-      result = result && (hasProxy() == other.hasProxy());
+      if (hasProxy() != other.hasProxy()) return false;
       if (hasProxy()) {
-        result = result && getProxy()
-            .equals(other.getProxy());
+        if (!getProxy()
+            .equals(other.getProxy())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -3045,37 +3042,37 @@ public final class DarcProto {
         ch.epfl.dedis.lib.proto.DarcProto.Identity result = new ch.epfl.dedis.lib.proto.DarcProto.Identity(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (darcBuilder_ == null) {
+            result.darc_ = darc_;
+          } else {
+            result.darc_ = darcBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
         }
-        if (darcBuilder_ == null) {
-          result.darc_ = darc_;
-        } else {
-          result.darc_ = darcBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (ed25519Builder_ == null) {
+            result.ed25519_ = ed25519_;
+          } else {
+            result.ed25519_ = ed25519Builder_.build();
+          }
           to_bitField0_ |= 0x00000002;
         }
-        if (ed25519Builder_ == null) {
-          result.ed25519_ = ed25519_;
-        } else {
-          result.ed25519_ = ed25519Builder_.build();
-        }
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          if (x509EcBuilder_ == null) {
+            result.x509Ec_ = x509Ec_;
+          } else {
+            result.x509Ec_ = x509EcBuilder_.build();
+          }
           to_bitField0_ |= 0x00000004;
         }
-        if (x509EcBuilder_ == null) {
-          result.x509Ec_ = x509Ec_;
-        } else {
-          result.x509Ec_ = x509EcBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          if (proxyBuilder_ == null) {
+            result.proxy_ = proxy_;
+          } else {
+            result.proxy_ = proxyBuilder_.build();
+          }
           to_bitField0_ |= 0x00000008;
-        }
-        if (proxyBuilder_ == null) {
-          result.proxy_ = proxy_;
-        } else {
-          result.proxy_ = proxyBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -3084,35 +3081,35 @@ public final class DarcProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -3188,7 +3185,7 @@ public final class DarcProto {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.DarcProto.IdentityDarc darc_ = null;
+      private ch.epfl.dedis.lib.proto.DarcProto.IdentityDarc darc_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.DarcProto.IdentityDarc, ch.epfl.dedis.lib.proto.DarcProto.IdentityDarc.Builder, ch.epfl.dedis.lib.proto.DarcProto.IdentityDarcOrBuilder> darcBuilder_;
       /**
@@ -3199,7 +3196,7 @@ public final class DarcProto {
        * <code>optional .darc.IdentityDarc darc = 1;</code>
        */
       public boolean hasDarc() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -3262,7 +3259,7 @@ public final class DarcProto {
        */
       public Builder mergeDarc(ch.epfl.dedis.lib.proto.DarcProto.IdentityDarc value) {
         if (darcBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               darc_ != null &&
               darc_ != ch.epfl.dedis.lib.proto.DarcProto.IdentityDarc.getDefaultInstance()) {
             darc_ =
@@ -3342,7 +3339,7 @@ public final class DarcProto {
         return darcBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.DarcProto.IdentityEd25519 ed25519_ = null;
+      private ch.epfl.dedis.lib.proto.DarcProto.IdentityEd25519 ed25519_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.DarcProto.IdentityEd25519, ch.epfl.dedis.lib.proto.DarcProto.IdentityEd25519.Builder, ch.epfl.dedis.lib.proto.DarcProto.IdentityEd25519OrBuilder> ed25519Builder_;
       /**
@@ -3353,7 +3350,7 @@ public final class DarcProto {
        * <code>optional .darc.IdentityEd25519 ed25519 = 2;</code>
        */
       public boolean hasEd25519() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -3416,7 +3413,7 @@ public final class DarcProto {
        */
       public Builder mergeEd25519(ch.epfl.dedis.lib.proto.DarcProto.IdentityEd25519 value) {
         if (ed25519Builder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               ed25519_ != null &&
               ed25519_ != ch.epfl.dedis.lib.proto.DarcProto.IdentityEd25519.getDefaultInstance()) {
             ed25519_ =
@@ -3496,7 +3493,7 @@ public final class DarcProto {
         return ed25519Builder_;
       }
 
-      private ch.epfl.dedis.lib.proto.DarcProto.IdentityX509EC x509Ec_ = null;
+      private ch.epfl.dedis.lib.proto.DarcProto.IdentityX509EC x509Ec_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.DarcProto.IdentityX509EC, ch.epfl.dedis.lib.proto.DarcProto.IdentityX509EC.Builder, ch.epfl.dedis.lib.proto.DarcProto.IdentityX509ECOrBuilder> x509EcBuilder_;
       /**
@@ -3507,7 +3504,7 @@ public final class DarcProto {
        * <code>optional .darc.IdentityX509EC x509ec = 3;</code>
        */
       public boolean hasX509Ec() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <pre>
@@ -3570,7 +3567,7 @@ public final class DarcProto {
        */
       public Builder mergeX509Ec(ch.epfl.dedis.lib.proto.DarcProto.IdentityX509EC value) {
         if (x509EcBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004) &&
+          if (((bitField0_ & 0x00000004) != 0) &&
               x509Ec_ != null &&
               x509Ec_ != ch.epfl.dedis.lib.proto.DarcProto.IdentityX509EC.getDefaultInstance()) {
             x509Ec_ =
@@ -3650,7 +3647,7 @@ public final class DarcProto {
         return x509EcBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.DarcProto.IdentityProxy proxy_ = null;
+      private ch.epfl.dedis.lib.proto.DarcProto.IdentityProxy proxy_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.DarcProto.IdentityProxy, ch.epfl.dedis.lib.proto.DarcProto.IdentityProxy.Builder, ch.epfl.dedis.lib.proto.DarcProto.IdentityProxyOrBuilder> proxyBuilder_;
       /**
@@ -3661,7 +3658,7 @@ public final class DarcProto {
        * <code>optional .darc.IdentityProxy proxy = 4;</code>
        */
       public boolean hasProxy() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <pre>
@@ -3724,7 +3721,7 @@ public final class DarcProto {
        */
       public Builder mergeProxy(ch.epfl.dedis.lib.proto.DarcProto.IdentityProxy value) {
         if (proxyBuilder_ == null) {
-          if (((bitField0_ & 0x00000008) == 0x00000008) &&
+          if (((bitField0_ & 0x00000008) != 0) &&
               proxy_ != null &&
               proxy_ != ch.epfl.dedis.lib.proto.DarcProto.IdentityProxy.getDefaultInstance()) {
             proxy_ =
@@ -3957,7 +3954,7 @@ public final class DarcProto {
      * <code>required bytes point = 1;</code>
      */
     public boolean hasPoint() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes point = 1;</code>
@@ -3984,7 +3981,7 @@ public final class DarcProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, point_);
       }
       unknownFields.writeTo(output);
@@ -3996,7 +3993,7 @@ public final class DarcProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, point_);
       }
@@ -4015,14 +4012,13 @@ public final class DarcProto {
       }
       ch.epfl.dedis.lib.proto.DarcProto.IdentityEd25519 other = (ch.epfl.dedis.lib.proto.DarcProto.IdentityEd25519) obj;
 
-      boolean result = true;
-      result = result && (hasPoint() == other.hasPoint());
+      if (hasPoint() != other.hasPoint()) return false;
       if (hasPoint()) {
-        result = result && getPoint()
-            .equals(other.getPoint());
+        if (!getPoint()
+            .equals(other.getPoint())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -4203,7 +4199,7 @@ public final class DarcProto {
         ch.epfl.dedis.lib.proto.DarcProto.IdentityEd25519 result = new ch.epfl.dedis.lib.proto.DarcProto.IdentityEd25519(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.point_ = point_;
@@ -4214,35 +4210,35 @@ public final class DarcProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -4297,7 +4293,7 @@ public final class DarcProto {
        * <code>required bytes point = 1;</code>
        */
       public boolean hasPoint() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes point = 1;</code>
@@ -4480,7 +4476,7 @@ public final class DarcProto {
      * <code>required bytes public = 1;</code>
      */
     public boolean hasPublic() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes public = 1;</code>
@@ -4507,7 +4503,7 @@ public final class DarcProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, public_);
       }
       unknownFields.writeTo(output);
@@ -4519,7 +4515,7 @@ public final class DarcProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, public_);
       }
@@ -4538,14 +4534,13 @@ public final class DarcProto {
       }
       ch.epfl.dedis.lib.proto.DarcProto.IdentityX509EC other = (ch.epfl.dedis.lib.proto.DarcProto.IdentityX509EC) obj;
 
-      boolean result = true;
-      result = result && (hasPublic() == other.hasPublic());
+      if (hasPublic() != other.hasPublic()) return false;
       if (hasPublic()) {
-        result = result && getPublic()
-            .equals(other.getPublic());
+        if (!getPublic()
+            .equals(other.getPublic())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -4726,7 +4721,7 @@ public final class DarcProto {
         ch.epfl.dedis.lib.proto.DarcProto.IdentityX509EC result = new ch.epfl.dedis.lib.proto.DarcProto.IdentityX509EC(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.public_ = public_;
@@ -4737,35 +4732,35 @@ public final class DarcProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -4820,7 +4815,7 @@ public final class DarcProto {
        * <code>required bytes public = 1;</code>
        */
       public boolean hasPublic() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes public = 1;</code>
@@ -5025,7 +5020,7 @@ public final class DarcProto {
      * <code>required string data = 1;</code>
      */
     public boolean hasData() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required string data = 1;</code>
@@ -5067,7 +5062,7 @@ public final class DarcProto {
      * <code>required bytes public = 2;</code>
      */
     public boolean hasPublic() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes public = 2;</code>
@@ -5098,10 +5093,10 @@ public final class DarcProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, data_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, public_);
       }
       unknownFields.writeTo(output);
@@ -5113,10 +5108,10 @@ public final class DarcProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, data_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, public_);
       }
@@ -5135,19 +5130,18 @@ public final class DarcProto {
       }
       ch.epfl.dedis.lib.proto.DarcProto.IdentityProxy other = (ch.epfl.dedis.lib.proto.DarcProto.IdentityProxy) obj;
 
-      boolean result = true;
-      result = result && (hasData() == other.hasData());
+      if (hasData() != other.hasData()) return false;
       if (hasData()) {
-        result = result && getData()
-            .equals(other.getData());
+        if (!getData()
+            .equals(other.getData())) return false;
       }
-      result = result && (hasPublic() == other.hasPublic());
+      if (hasPublic() != other.hasPublic()) return false;
       if (hasPublic()) {
-        result = result && getPublic()
-            .equals(other.getPublic());
+        if (!getPublic()
+            .equals(other.getPublic())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -5335,11 +5329,11 @@ public final class DarcProto {
         ch.epfl.dedis.lib.proto.DarcProto.IdentityProxy result = new ch.epfl.dedis.lib.proto.DarcProto.IdentityProxy(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.data_ = data_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.public_ = public_;
@@ -5350,35 +5344,35 @@ public final class DarcProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -5441,7 +5435,7 @@ public final class DarcProto {
        * <code>required string data = 1;</code>
        */
       public boolean hasData() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required string data = 1;</code>
@@ -5517,7 +5511,7 @@ public final class DarcProto {
        * <code>required bytes public = 2;</code>
        */
       public boolean hasPublic() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes public = 2;</code>
@@ -5713,7 +5707,7 @@ public final class DarcProto {
      * <code>required bytes id = 1;</code>
      */
     public boolean hasId() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -5744,7 +5738,7 @@ public final class DarcProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, id_);
       }
       unknownFields.writeTo(output);
@@ -5756,7 +5750,7 @@ public final class DarcProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, id_);
       }
@@ -5775,14 +5769,13 @@ public final class DarcProto {
       }
       ch.epfl.dedis.lib.proto.DarcProto.IdentityDarc other = (ch.epfl.dedis.lib.proto.DarcProto.IdentityDarc) obj;
 
-      boolean result = true;
-      result = result && (hasId() == other.hasId());
+      if (hasId() != other.hasId()) return false;
       if (hasId()) {
-        result = result && getId()
-            .equals(other.getId());
+        if (!getId()
+            .equals(other.getId())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -5964,7 +5957,7 @@ public final class DarcProto {
         ch.epfl.dedis.lib.proto.DarcProto.IdentityDarc result = new ch.epfl.dedis.lib.proto.DarcProto.IdentityDarc(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.id_ = id_;
@@ -5975,35 +5968,35 @@ public final class DarcProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -6062,7 +6055,7 @@ public final class DarcProto {
        * <code>required bytes id = 1;</code>
        */
       public boolean hasId() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -6254,7 +6247,7 @@ public final class DarcProto {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.DarcProto.Identity.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = signer_.toBuilder();
               }
               signer_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.Identity.parser(), extensionRegistry);
@@ -6308,7 +6301,7 @@ public final class DarcProto {
      * <code>required bytes signature = 1;</code>
      */
     public boolean hasSignature() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -6331,7 +6324,7 @@ public final class DarcProto {
      * <code>required .darc.Identity signer = 2;</code>
      */
     public boolean hasSigner() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -6380,10 +6373,10 @@ public final class DarcProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, signature_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getSigner());
       }
       unknownFields.writeTo(output);
@@ -6395,11 +6388,11 @@ public final class DarcProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, signature_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getSigner());
       }
@@ -6418,19 +6411,18 @@ public final class DarcProto {
       }
       ch.epfl.dedis.lib.proto.DarcProto.Signature other = (ch.epfl.dedis.lib.proto.DarcProto.Signature) obj;
 
-      boolean result = true;
-      result = result && (hasSignature() == other.hasSignature());
+      if (hasSignature() != other.hasSignature()) return false;
       if (hasSignature()) {
-        result = result && getSignature()
-            .equals(other.getSignature());
+        if (!getSignature()
+            .equals(other.getSignature())) return false;
       }
-      result = result && (hasSigner() == other.hasSigner());
+      if (hasSigner() != other.hasSigner()) return false;
       if (hasSigner()) {
-        result = result && getSigner()
-            .equals(other.getSigner());
+        if (!getSigner()
+            .equals(other.getSigner())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -6623,17 +6615,17 @@ public final class DarcProto {
         ch.epfl.dedis.lib.proto.DarcProto.Signature result = new ch.epfl.dedis.lib.proto.DarcProto.Signature(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.signature_ = signature_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (signerBuilder_ == null) {
+            result.signer_ = signer_;
+          } else {
+            result.signer_ = signerBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
-        }
-        if (signerBuilder_ == null) {
-          result.signer_ = signer_;
-        } else {
-          result.signer_ = signerBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -6642,35 +6634,35 @@ public final class DarcProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -6738,7 +6730,7 @@ public final class DarcProto {
        * <code>required bytes signature = 1;</code>
        */
       public boolean hasSignature() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -6780,7 +6772,7 @@ public final class DarcProto {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.DarcProto.Identity signer_ = null;
+      private ch.epfl.dedis.lib.proto.DarcProto.Identity signer_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.DarcProto.Identity, ch.epfl.dedis.lib.proto.DarcProto.Identity.Builder, ch.epfl.dedis.lib.proto.DarcProto.IdentityOrBuilder> signerBuilder_;
       /**
@@ -6791,7 +6783,7 @@ public final class DarcProto {
        * <code>required .darc.Identity signer = 2;</code>
        */
       public boolean hasSigner() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -6854,7 +6846,7 @@ public final class DarcProto {
        */
       public Builder mergeSigner(ch.epfl.dedis.lib.proto.DarcProto.Identity value) {
         if (signerBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               signer_ != null &&
               signer_ != ch.epfl.dedis.lib.proto.DarcProto.Identity.getDefaultInstance()) {
             signer_ =
@@ -7074,7 +7066,7 @@ public final class DarcProto {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.DarcProto.SignerEd25519.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = ed25519_.toBuilder();
               }
               ed25519_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.SignerEd25519.parser(), extensionRegistry);
@@ -7087,7 +7079,7 @@ public final class DarcProto {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.DarcProto.SignerX509EC.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = x509Ec_.toBuilder();
               }
               x509Ec_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.SignerX509EC.parser(), extensionRegistry);
@@ -7100,7 +7092,7 @@ public final class DarcProto {
             }
             case 26: {
               ch.epfl.dedis.lib.proto.DarcProto.SignerProxy.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+              if (((bitField0_ & 0x00000004) != 0)) {
                 subBuilder = proxy_.toBuilder();
               }
               proxy_ = input.readMessage(ch.epfl.dedis.lib.proto.DarcProto.SignerProxy.parser(), extensionRegistry);
@@ -7150,7 +7142,7 @@ public final class DarcProto {
      * <code>optional .darc.SignerEd25519 ed25519 = 1;</code>
      */
     public boolean hasEd25519() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>optional .darc.SignerEd25519 ed25519 = 1;</code>
@@ -7171,7 +7163,7 @@ public final class DarcProto {
      * <code>optional .darc.SignerX509EC x509ec = 2;</code>
      */
     public boolean hasX509Ec() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>optional .darc.SignerX509EC x509ec = 2;</code>
@@ -7192,7 +7184,7 @@ public final class DarcProto {
      * <code>optional .darc.SignerProxy proxy = 3;</code>
      */
     public boolean hasProxy() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>optional .darc.SignerProxy proxy = 3;</code>
@@ -7239,13 +7231,13 @@ public final class DarcProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getEd25519());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getX509Ec());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeMessage(3, getProxy());
       }
       unknownFields.writeTo(output);
@@ -7257,15 +7249,15 @@ public final class DarcProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getEd25519());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getX509Ec());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, getProxy());
       }
@@ -7284,24 +7276,23 @@ public final class DarcProto {
       }
       ch.epfl.dedis.lib.proto.DarcProto.Signer other = (ch.epfl.dedis.lib.proto.DarcProto.Signer) obj;
 
-      boolean result = true;
-      result = result && (hasEd25519() == other.hasEd25519());
+      if (hasEd25519() != other.hasEd25519()) return false;
       if (hasEd25519()) {
-        result = result && getEd25519()
-            .equals(other.getEd25519());
+        if (!getEd25519()
+            .equals(other.getEd25519())) return false;
       }
-      result = result && (hasX509Ec() == other.hasX509Ec());
+      if (hasX509Ec() != other.hasX509Ec()) return false;
       if (hasX509Ec()) {
-        result = result && getX509Ec()
-            .equals(other.getX509Ec());
+        if (!getX509Ec()
+            .equals(other.getX509Ec())) return false;
       }
-      result = result && (hasProxy() == other.hasProxy());
+      if (hasProxy() != other.hasProxy()) return false;
       if (hasProxy()) {
-        result = result && getProxy()
-            .equals(other.getProxy());
+        if (!getProxy()
+            .equals(other.getProxy())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -7509,29 +7500,29 @@ public final class DarcProto {
         ch.epfl.dedis.lib.proto.DarcProto.Signer result = new ch.epfl.dedis.lib.proto.DarcProto.Signer(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (ed25519Builder_ == null) {
+            result.ed25519_ = ed25519_;
+          } else {
+            result.ed25519_ = ed25519Builder_.build();
+          }
           to_bitField0_ |= 0x00000001;
         }
-        if (ed25519Builder_ == null) {
-          result.ed25519_ = ed25519_;
-        } else {
-          result.ed25519_ = ed25519Builder_.build();
-        }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (x509EcBuilder_ == null) {
+            result.x509Ec_ = x509Ec_;
+          } else {
+            result.x509Ec_ = x509EcBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
         }
-        if (x509EcBuilder_ == null) {
-          result.x509Ec_ = x509Ec_;
-        } else {
-          result.x509Ec_ = x509EcBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          if (proxyBuilder_ == null) {
+            result.proxy_ = proxy_;
+          } else {
+            result.proxy_ = proxyBuilder_.build();
+          }
           to_bitField0_ |= 0x00000004;
-        }
-        if (proxyBuilder_ == null) {
-          result.proxy_ = proxy_;
-        } else {
-          result.proxy_ = proxyBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -7540,35 +7531,35 @@ public final class DarcProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -7636,14 +7627,14 @@ public final class DarcProto {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.DarcProto.SignerEd25519 ed25519_ = null;
+      private ch.epfl.dedis.lib.proto.DarcProto.SignerEd25519 ed25519_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.DarcProto.SignerEd25519, ch.epfl.dedis.lib.proto.DarcProto.SignerEd25519.Builder, ch.epfl.dedis.lib.proto.DarcProto.SignerEd25519OrBuilder> ed25519Builder_;
       /**
        * <code>optional .darc.SignerEd25519 ed25519 = 1;</code>
        */
       public boolean hasEd25519() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>optional .darc.SignerEd25519 ed25519 = 1;</code>
@@ -7690,7 +7681,7 @@ public final class DarcProto {
        */
       public Builder mergeEd25519(ch.epfl.dedis.lib.proto.DarcProto.SignerEd25519 value) {
         if (ed25519Builder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               ed25519_ != null &&
               ed25519_ != ch.epfl.dedis.lib.proto.DarcProto.SignerEd25519.getDefaultInstance()) {
             ed25519_ =
@@ -7754,14 +7745,14 @@ public final class DarcProto {
         return ed25519Builder_;
       }
 
-      private ch.epfl.dedis.lib.proto.DarcProto.SignerX509EC x509Ec_ = null;
+      private ch.epfl.dedis.lib.proto.DarcProto.SignerX509EC x509Ec_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.DarcProto.SignerX509EC, ch.epfl.dedis.lib.proto.DarcProto.SignerX509EC.Builder, ch.epfl.dedis.lib.proto.DarcProto.SignerX509ECOrBuilder> x509EcBuilder_;
       /**
        * <code>optional .darc.SignerX509EC x509ec = 2;</code>
        */
       public boolean hasX509Ec() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>optional .darc.SignerX509EC x509ec = 2;</code>
@@ -7808,7 +7799,7 @@ public final class DarcProto {
        */
       public Builder mergeX509Ec(ch.epfl.dedis.lib.proto.DarcProto.SignerX509EC value) {
         if (x509EcBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               x509Ec_ != null &&
               x509Ec_ != ch.epfl.dedis.lib.proto.DarcProto.SignerX509EC.getDefaultInstance()) {
             x509Ec_ =
@@ -7872,14 +7863,14 @@ public final class DarcProto {
         return x509EcBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.DarcProto.SignerProxy proxy_ = null;
+      private ch.epfl.dedis.lib.proto.DarcProto.SignerProxy proxy_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.DarcProto.SignerProxy, ch.epfl.dedis.lib.proto.DarcProto.SignerProxy.Builder, ch.epfl.dedis.lib.proto.DarcProto.SignerProxyOrBuilder> proxyBuilder_;
       /**
        * <code>optional .darc.SignerProxy proxy = 3;</code>
        */
       public boolean hasProxy() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>optional .darc.SignerProxy proxy = 3;</code>
@@ -7926,7 +7917,7 @@ public final class DarcProto {
        */
       public Builder mergeProxy(ch.epfl.dedis.lib.proto.DarcProto.SignerProxy value) {
         if (proxyBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004) &&
+          if (((bitField0_ & 0x00000004) != 0) &&
               proxy_ != null &&
               proxy_ != ch.epfl.dedis.lib.proto.DarcProto.SignerProxy.getDefaultInstance()) {
             proxy_ =
@@ -8158,7 +8149,7 @@ public final class DarcProto {
      * <code>required bytes point = 1;</code>
      */
     public boolean hasPoint() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes point = 1;</code>
@@ -8173,7 +8164,7 @@ public final class DarcProto {
      * <code>required bytes secret = 2;</code>
      */
     public boolean hasSecret() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes secret = 2;</code>
@@ -8204,10 +8195,10 @@ public final class DarcProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, point_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, secret_);
       }
       unknownFields.writeTo(output);
@@ -8219,11 +8210,11 @@ public final class DarcProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, point_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, secret_);
       }
@@ -8242,19 +8233,18 @@ public final class DarcProto {
       }
       ch.epfl.dedis.lib.proto.DarcProto.SignerEd25519 other = (ch.epfl.dedis.lib.proto.DarcProto.SignerEd25519) obj;
 
-      boolean result = true;
-      result = result && (hasPoint() == other.hasPoint());
+      if (hasPoint() != other.hasPoint()) return false;
       if (hasPoint()) {
-        result = result && getPoint()
-            .equals(other.getPoint());
+        if (!getPoint()
+            .equals(other.getPoint())) return false;
       }
-      result = result && (hasSecret() == other.hasSecret());
+      if (hasSecret() != other.hasSecret()) return false;
       if (hasSecret()) {
-        result = result && getSecret()
-            .equals(other.getSecret());
+        if (!getSecret()
+            .equals(other.getSecret())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -8441,11 +8431,11 @@ public final class DarcProto {
         ch.epfl.dedis.lib.proto.DarcProto.SignerEd25519 result = new ch.epfl.dedis.lib.proto.DarcProto.SignerEd25519(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.point_ = point_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.secret_ = secret_;
@@ -8456,35 +8446,35 @@ public final class DarcProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -8545,7 +8535,7 @@ public final class DarcProto {
        * <code>required bytes point = 1;</code>
        */
       public boolean hasPoint() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes point = 1;</code>
@@ -8580,7 +8570,7 @@ public final class DarcProto {
        * <code>required bytes secret = 2;</code>
        */
       public boolean hasSecret() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes secret = 2;</code>
@@ -8764,7 +8754,7 @@ public final class DarcProto {
      * <code>required bytes point = 1;</code>
      */
     public boolean hasPoint() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes point = 1;</code>
@@ -8791,7 +8781,7 @@ public final class DarcProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, point_);
       }
       unknownFields.writeTo(output);
@@ -8803,7 +8793,7 @@ public final class DarcProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, point_);
       }
@@ -8822,14 +8812,13 @@ public final class DarcProto {
       }
       ch.epfl.dedis.lib.proto.DarcProto.SignerX509EC other = (ch.epfl.dedis.lib.proto.DarcProto.SignerX509EC) obj;
 
-      boolean result = true;
-      result = result && (hasPoint() == other.hasPoint());
+      if (hasPoint() != other.hasPoint()) return false;
       if (hasPoint()) {
-        result = result && getPoint()
-            .equals(other.getPoint());
+        if (!getPoint()
+            .equals(other.getPoint())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -9011,7 +9000,7 @@ public final class DarcProto {
         ch.epfl.dedis.lib.proto.DarcProto.SignerX509EC result = new ch.epfl.dedis.lib.proto.DarcProto.SignerX509EC(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.point_ = point_;
@@ -9022,35 +9011,35 @@ public final class DarcProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -9105,7 +9094,7 @@ public final class DarcProto {
        * <code>required bytes point = 1;</code>
        */
       public boolean hasPoint() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes point = 1;</code>
@@ -9310,7 +9299,7 @@ public final class DarcProto {
      * <code>required string data = 1;</code>
      */
     public boolean hasData() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required string data = 1;</code>
@@ -9352,7 +9341,7 @@ public final class DarcProto {
      * <code>required bytes public = 2;</code>
      */
     public boolean hasPublic() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes public = 2;</code>
@@ -9383,10 +9372,10 @@ public final class DarcProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, data_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, public_);
       }
       unknownFields.writeTo(output);
@@ -9398,10 +9387,10 @@ public final class DarcProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, data_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, public_);
       }
@@ -9420,19 +9409,18 @@ public final class DarcProto {
       }
       ch.epfl.dedis.lib.proto.DarcProto.SignerProxy other = (ch.epfl.dedis.lib.proto.DarcProto.SignerProxy) obj;
 
-      boolean result = true;
-      result = result && (hasData() == other.hasData());
+      if (hasData() != other.hasData()) return false;
       if (hasData()) {
-        result = result && getData()
-            .equals(other.getData());
+        if (!getData()
+            .equals(other.getData())) return false;
       }
-      result = result && (hasPublic() == other.hasPublic());
+      if (hasPublic() != other.hasPublic()) return false;
       if (hasPublic()) {
-        result = result && getPublic()
-            .equals(other.getPublic());
+        if (!getPublic()
+            .equals(other.getPublic())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -9620,11 +9608,11 @@ public final class DarcProto {
         ch.epfl.dedis.lib.proto.DarcProto.SignerProxy result = new ch.epfl.dedis.lib.proto.DarcProto.SignerProxy(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.data_ = data_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.public_ = public_;
@@ -9635,35 +9623,35 @@ public final class DarcProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -9726,7 +9714,7 @@ public final class DarcProto {
        * <code>required string data = 1;</code>
        */
       public boolean hasData() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required string data = 1;</code>
@@ -9802,7 +9790,7 @@ public final class DarcProto {
        * <code>required bytes public = 2;</code>
        */
       public boolean hasPublic() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes public = 2;</code>
@@ -10022,7 +10010,7 @@ public final class DarcProto {
               break;
             }
             case 34: {
-              if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+              if (!((mutable_bitField0_ & 0x00000008) != 0)) {
                 identities_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.DarcProto.Identity>();
                 mutable_bitField0_ |= 0x00000008;
               }
@@ -10031,7 +10019,7 @@ public final class DarcProto {
               break;
             }
             case 42: {
-              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+              if (!((mutable_bitField0_ & 0x00000010) != 0)) {
                 signatures_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
                 mutable_bitField0_ |= 0x00000010;
               }
@@ -10053,11 +10041,11 @@ public final class DarcProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((mutable_bitField0_ & 0x00000008) != 0)) {
           identities_ = java.util.Collections.unmodifiableList(identities_);
         }
-        if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-          signatures_ = java.util.Collections.unmodifiableList(signatures_);
+        if (((mutable_bitField0_ & 0x00000010) != 0)) {
+          signatures_ = java.util.Collections.unmodifiableList(signatures_); // C
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -10083,7 +10071,7 @@ public final class DarcProto {
      * <code>required bytes baseid = 1;</code>
      */
     public boolean hasBaseid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes baseid = 1;</code>
@@ -10098,7 +10086,7 @@ public final class DarcProto {
      * <code>required string action = 2;</code>
      */
     public boolean hasAction() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required string action = 2;</code>
@@ -10140,7 +10128,7 @@ public final class DarcProto {
      * <code>required bytes msg = 3;</code>
      */
     public boolean hasMsg() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required bytes msg = 3;</code>
@@ -10238,13 +10226,13 @@ public final class DarcProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, baseid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, action_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(3, msg_);
       }
       for (int i = 0; i < identities_.size(); i++) {
@@ -10262,14 +10250,14 @@ public final class DarcProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, baseid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, action_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, msg_);
       }
@@ -10301,28 +10289,27 @@ public final class DarcProto {
       }
       ch.epfl.dedis.lib.proto.DarcProto.Request other = (ch.epfl.dedis.lib.proto.DarcProto.Request) obj;
 
-      boolean result = true;
-      result = result && (hasBaseid() == other.hasBaseid());
+      if (hasBaseid() != other.hasBaseid()) return false;
       if (hasBaseid()) {
-        result = result && getBaseid()
-            .equals(other.getBaseid());
+        if (!getBaseid()
+            .equals(other.getBaseid())) return false;
       }
-      result = result && (hasAction() == other.hasAction());
+      if (hasAction() != other.hasAction()) return false;
       if (hasAction()) {
-        result = result && getAction()
-            .equals(other.getAction());
+        if (!getAction()
+            .equals(other.getAction())) return false;
       }
-      result = result && (hasMsg() == other.hasMsg());
+      if (hasMsg() != other.hasMsg()) return false;
       if (hasMsg()) {
-        result = result && getMsg()
-            .equals(other.getMsg());
+        if (!getMsg()
+            .equals(other.getMsg())) return false;
       }
-      result = result && getIdentitiesList()
-          .equals(other.getIdentitiesList());
-      result = result && getSignaturesList()
-          .equals(other.getSignaturesList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getIdentitiesList()
+          .equals(other.getIdentitiesList())) return false;
+      if (!getSignaturesList()
+          .equals(other.getSignaturesList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -10532,20 +10519,20 @@ public final class DarcProto {
         ch.epfl.dedis.lib.proto.DarcProto.Request result = new ch.epfl.dedis.lib.proto.DarcProto.Request(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.baseid_ = baseid_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.action_ = action_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.msg_ = msg_;
         if (identitiesBuilder_ == null) {
-          if (((bitField0_ & 0x00000008) == 0x00000008)) {
+          if (((bitField0_ & 0x00000008) != 0)) {
             identities_ = java.util.Collections.unmodifiableList(identities_);
             bitField0_ = (bitField0_ & ~0x00000008);
           }
@@ -10553,7 +10540,7 @@ public final class DarcProto {
         } else {
           result.identities_ = identitiesBuilder_.build();
         }
-        if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((bitField0_ & 0x00000010) != 0)) {
           signatures_ = java.util.Collections.unmodifiableList(signatures_);
           bitField0_ = (bitField0_ & ~0x00000010);
         }
@@ -10565,35 +10552,35 @@ public final class DarcProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -10703,7 +10690,7 @@ public final class DarcProto {
        * <code>required bytes baseid = 1;</code>
        */
       public boolean hasBaseid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes baseid = 1;</code>
@@ -10738,7 +10725,7 @@ public final class DarcProto {
        * <code>required string action = 2;</code>
        */
       public boolean hasAction() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required string action = 2;</code>
@@ -10814,7 +10801,7 @@ public final class DarcProto {
        * <code>required bytes msg = 3;</code>
        */
       public boolean hasMsg() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required bytes msg = 3;</code>
@@ -10847,7 +10834,7 @@ public final class DarcProto {
       private java.util.List<ch.epfl.dedis.lib.proto.DarcProto.Identity> identities_ =
         java.util.Collections.emptyList();
       private void ensureIdentitiesIsMutable() {
-        if (!((bitField0_ & 0x00000008) == 0x00000008)) {
+        if (!((bitField0_ & 0x00000008) != 0)) {
           identities_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.DarcProto.Identity>(identities_);
           bitField0_ |= 0x00000008;
          }
@@ -11076,7 +11063,7 @@ public final class DarcProto {
           identitiesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.DarcProto.Identity, ch.epfl.dedis.lib.proto.DarcProto.Identity.Builder, ch.epfl.dedis.lib.proto.DarcProto.IdentityOrBuilder>(
                   identities_,
-                  ((bitField0_ & 0x00000008) == 0x00000008),
+                  ((bitField0_ & 0x00000008) != 0),
                   getParentForChildren(),
                   isClean());
           identities_ = null;
@@ -11086,7 +11073,7 @@ public final class DarcProto {
 
       private java.util.List<com.google.protobuf.ByteString> signatures_ = java.util.Collections.emptyList();
       private void ensureSignaturesIsMutable() {
-        if (!((bitField0_ & 0x00000010) == 0x00000010)) {
+        if (!((bitField0_ & 0x00000010) != 0)) {
           signatures_ = new java.util.ArrayList<com.google.protobuf.ByteString>(signatures_);
           bitField0_ |= 0x00000010;
          }
@@ -11096,7 +11083,8 @@ public final class DarcProto {
        */
       public java.util.List<com.google.protobuf.ByteString>
           getSignaturesList() {
-        return java.util.Collections.unmodifiableList(signatures_);
+        return ((bitField0_ & 0x00000010) != 0) ?
+                 java.util.Collections.unmodifiableList(signatures_) : signatures_;
       }
       /**
        * <code>repeated bytes signatures = 5;</code>
@@ -11281,7 +11269,7 @@ public final class DarcProto {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 list_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.DarcProto.Rule>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -11304,7 +11292,7 @@ public final class DarcProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           list_ = java.util.Collections.unmodifiableList(list_);
         }
         this.unknownFields = unknownFields.build();
@@ -11410,11 +11398,10 @@ public final class DarcProto {
       }
       ch.epfl.dedis.lib.proto.DarcProto.Rules other = (ch.epfl.dedis.lib.proto.DarcProto.Rules) obj;
 
-      boolean result = true;
-      result = result && getListList()
-          .equals(other.getListList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getListList()
+          .equals(other.getListList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -11600,7 +11587,7 @@ public final class DarcProto {
         ch.epfl.dedis.lib.proto.DarcProto.Rules result = new ch.epfl.dedis.lib.proto.DarcProto.Rules(this);
         int from_bitField0_ = bitField0_;
         if (listBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             list_ = java.util.Collections.unmodifiableList(list_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -11614,35 +11601,35 @@ public final class DarcProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -11720,7 +11707,7 @@ public final class DarcProto {
       private java.util.List<ch.epfl.dedis.lib.proto.DarcProto.Rule> list_ =
         java.util.Collections.emptyList();
       private void ensureListIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           list_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.DarcProto.Rule>(list_);
           bitField0_ |= 0x00000001;
          }
@@ -11949,7 +11936,7 @@ public final class DarcProto {
           listBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.DarcProto.Rule, ch.epfl.dedis.lib.proto.DarcProto.Rule.Builder, ch.epfl.dedis.lib.proto.DarcProto.RuleOrBuilder>(
                   list_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           list_ = null;
@@ -12131,7 +12118,7 @@ public final class DarcProto {
      * <code>required string action = 1;</code>
      */
     public boolean hasAction() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required string action = 1;</code>
@@ -12173,7 +12160,7 @@ public final class DarcProto {
      * <code>required bytes expr = 2;</code>
      */
     public boolean hasExpr() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes expr = 2;</code>
@@ -12204,10 +12191,10 @@ public final class DarcProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, action_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, expr_);
       }
       unknownFields.writeTo(output);
@@ -12219,10 +12206,10 @@ public final class DarcProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, action_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, expr_);
       }
@@ -12241,19 +12228,18 @@ public final class DarcProto {
       }
       ch.epfl.dedis.lib.proto.DarcProto.Rule other = (ch.epfl.dedis.lib.proto.DarcProto.Rule) obj;
 
-      boolean result = true;
-      result = result && (hasAction() == other.hasAction());
+      if (hasAction() != other.hasAction()) return false;
       if (hasAction()) {
-        result = result && getAction()
-            .equals(other.getAction());
+        if (!getAction()
+            .equals(other.getAction())) return false;
       }
-      result = result && (hasExpr() == other.hasExpr());
+      if (hasExpr() != other.hasExpr()) return false;
       if (hasExpr()) {
-        result = result && getExpr()
-            .equals(other.getExpr());
+        if (!getExpr()
+            .equals(other.getExpr())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -12440,11 +12426,11 @@ public final class DarcProto {
         ch.epfl.dedis.lib.proto.DarcProto.Rule result = new ch.epfl.dedis.lib.proto.DarcProto.Rule(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.action_ = action_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.expr_ = expr_;
@@ -12455,35 +12441,35 @@ public final class DarcProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -12546,7 +12532,7 @@ public final class DarcProto {
        * <code>required string action = 1;</code>
        */
       public boolean hasAction() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required string action = 1;</code>
@@ -12622,7 +12608,7 @@ public final class DarcProto {
        * <code>required bytes expr = 2;</code>
        */
       public boolean hasExpr() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes expr = 2;</code>

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/EventLogProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/EventLogProto.java
@@ -119,8 +119,6 @@ public final class EventLogProto {
       instance_ = com.google.protobuf.ByteString.EMPTY;
       id_ = com.google.protobuf.ByteString.EMPTY;
       topic_ = "";
-      from_ = 0L;
-      to_ = 0L;
     }
 
     @java.lang.Override
@@ -212,7 +210,7 @@ public final class EventLogProto {
      * <code>required bytes instance = 1;</code>
      */
     public boolean hasInstance() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes instance = 1;</code>
@@ -227,7 +225,7 @@ public final class EventLogProto {
      * <code>required bytes id = 2;</code>
      */
     public boolean hasId() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes id = 2;</code>
@@ -246,7 +244,7 @@ public final class EventLogProto {
      * <code>required string topic = 3;</code>
      */
     public boolean hasTopic() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <pre>
@@ -300,7 +298,7 @@ public final class EventLogProto {
      * <code>required sint64 from = 4;</code>
      */
     public boolean hasFrom() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <pre>
@@ -323,7 +321,7 @@ public final class EventLogProto {
      * <code>required sint64 to = 5;</code>
      */
     public boolean hasTo() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000010) != 0);
     }
     /**
      * <pre>
@@ -370,19 +368,19 @@ public final class EventLogProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, instance_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, id_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 3, topic_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeSInt64(4, from_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         output.writeSInt64(5, to_);
       }
       unknownFields.writeTo(output);
@@ -394,22 +392,22 @@ public final class EventLogProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, instance_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, id_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, topic_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt64Size(4, from_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt64Size(5, to_);
       }
@@ -428,34 +426,33 @@ public final class EventLogProto {
       }
       ch.epfl.dedis.lib.proto.EventLogProto.SearchRequest other = (ch.epfl.dedis.lib.proto.EventLogProto.SearchRequest) obj;
 
-      boolean result = true;
-      result = result && (hasInstance() == other.hasInstance());
+      if (hasInstance() != other.hasInstance()) return false;
       if (hasInstance()) {
-        result = result && getInstance()
-            .equals(other.getInstance());
+        if (!getInstance()
+            .equals(other.getInstance())) return false;
       }
-      result = result && (hasId() == other.hasId());
+      if (hasId() != other.hasId()) return false;
       if (hasId()) {
-        result = result && getId()
-            .equals(other.getId());
+        if (!getId()
+            .equals(other.getId())) return false;
       }
-      result = result && (hasTopic() == other.hasTopic());
+      if (hasTopic() != other.hasTopic()) return false;
       if (hasTopic()) {
-        result = result && getTopic()
-            .equals(other.getTopic());
+        if (!getTopic()
+            .equals(other.getTopic())) return false;
       }
-      result = result && (hasFrom() == other.hasFrom());
+      if (hasFrom() != other.hasFrom()) return false;
       if (hasFrom()) {
-        result = result && (getFrom()
-            == other.getFrom());
+        if (getFrom()
+            != other.getFrom()) return false;
       }
-      result = result && (hasTo() == other.hasTo());
+      if (hasTo() != other.hasTo()) return false;
       if (hasTo()) {
-        result = result && (getTo()
-            == other.getTo());
+        if (getTo()
+            != other.getTo()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -665,26 +662,26 @@ public final class EventLogProto {
         ch.epfl.dedis.lib.proto.EventLogProto.SearchRequest result = new ch.epfl.dedis.lib.proto.EventLogProto.SearchRequest(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.instance_ = instance_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.id_ = id_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.topic_ = topic_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          result.from_ = from_;
           to_bitField0_ |= 0x00000008;
         }
-        result.from_ = from_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((from_bitField0_ & 0x00000010) != 0)) {
+          result.to_ = to_;
           to_bitField0_ |= 0x00000010;
         }
-        result.to_ = to_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -692,35 +689,35 @@ public final class EventLogProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -801,7 +798,7 @@ public final class EventLogProto {
        * <code>required bytes instance = 1;</code>
        */
       public boolean hasInstance() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes instance = 1;</code>
@@ -836,7 +833,7 @@ public final class EventLogProto {
        * <code>required bytes id = 2;</code>
        */
       public boolean hasId() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes id = 2;</code>
@@ -875,7 +872,7 @@ public final class EventLogProto {
        * <code>required string topic = 3;</code>
        */
       public boolean hasTopic() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <pre>
@@ -975,7 +972,7 @@ public final class EventLogProto {
        * <code>required sint64 from = 4;</code>
        */
       public boolean hasFrom() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <pre>
@@ -1023,7 +1020,7 @@ public final class EventLogProto {
        * <code>required sint64 to = 5;</code>
        */
       public boolean hasTo() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return ((bitField0_ & 0x00000010) != 0);
       }
       /**
        * <pre>
@@ -1181,7 +1178,6 @@ public final class EventLogProto {
     }
     private SearchResponse() {
       events_ = java.util.Collections.emptyList();
-      truncated_ = false;
     }
 
     @java.lang.Override
@@ -1209,7 +1205,7 @@ public final class EventLogProto {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 events_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.EventLogProto.Event>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -1237,7 +1233,7 @@ public final class EventLogProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           events_ = java.util.Collections.unmodifiableList(events_);
         }
         this.unknownFields = unknownFields.build();
@@ -1305,7 +1301,7 @@ public final class EventLogProto {
      * <code>required bool truncated = 2;</code>
      */
     public boolean hasTruncated() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -1347,7 +1343,7 @@ public final class EventLogProto {
       for (int i = 0; i < events_.size(); i++) {
         output.writeMessage(1, events_.get(i));
       }
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBool(2, truncated_);
       }
       unknownFields.writeTo(output);
@@ -1363,7 +1359,7 @@ public final class EventLogProto {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, events_.get(i));
       }
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(2, truncated_);
       }
@@ -1382,16 +1378,15 @@ public final class EventLogProto {
       }
       ch.epfl.dedis.lib.proto.EventLogProto.SearchResponse other = (ch.epfl.dedis.lib.proto.EventLogProto.SearchResponse) obj;
 
-      boolean result = true;
-      result = result && getEventsList()
-          .equals(other.getEventsList());
-      result = result && (hasTruncated() == other.hasTruncated());
+      if (!getEventsList()
+          .equals(other.getEventsList())) return false;
+      if (hasTruncated() != other.hasTruncated()) return false;
       if (hasTruncated()) {
-        result = result && (getTruncated()
-            == other.getTruncated());
+        if (getTruncated()
+            != other.getTruncated()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -1585,7 +1580,7 @@ public final class EventLogProto {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (eventsBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             events_ = java.util.Collections.unmodifiableList(events_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -1593,10 +1588,10 @@ public final class EventLogProto {
         } else {
           result.events_ = eventsBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.truncated_ = truncated_;
           to_bitField0_ |= 0x00000001;
         }
-        result.truncated_ = truncated_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -1604,35 +1599,35 @@ public final class EventLogProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -1716,7 +1711,7 @@ public final class EventLogProto {
       private java.util.List<ch.epfl.dedis.lib.proto.EventLogProto.Event> events_ =
         java.util.Collections.emptyList();
       private void ensureEventsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           events_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.EventLogProto.Event>(events_);
           bitField0_ |= 0x00000001;
          }
@@ -1945,7 +1940,7 @@ public final class EventLogProto {
           eventsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.EventLogProto.Event, ch.epfl.dedis.lib.proto.EventLogProto.Event.Builder, ch.epfl.dedis.lib.proto.EventLogProto.EventOrBuilder>(
                   events_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           events_ = null;
@@ -1964,7 +1959,7 @@ public final class EventLogProto {
        * <code>required bool truncated = 2;</code>
        */
       public boolean hasTruncated() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -2120,7 +2115,6 @@ public final class EventLogProto {
       super(builder);
     }
     private Event() {
-      when_ = 0L;
       topic_ = "";
       content_ = "";
     }
@@ -2205,7 +2199,7 @@ public final class EventLogProto {
      * <code>required sint64 when = 1;</code>
      */
     public boolean hasWhen() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required sint64 when = 1;</code>
@@ -2220,7 +2214,7 @@ public final class EventLogProto {
      * <code>required string topic = 2;</code>
      */
     public boolean hasTopic() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required string topic = 2;</code>
@@ -2262,7 +2256,7 @@ public final class EventLogProto {
      * <code>required string content = 3;</code>
      */
     public boolean hasContent() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required string content = 3;</code>
@@ -2324,13 +2318,13 @@ public final class EventLogProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeSInt64(1, when_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, topic_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 3, content_);
       }
       unknownFields.writeTo(output);
@@ -2342,14 +2336,14 @@ public final class EventLogProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt64Size(1, when_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, topic_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, content_);
       }
       size += unknownFields.getSerializedSize();
@@ -2367,24 +2361,23 @@ public final class EventLogProto {
       }
       ch.epfl.dedis.lib.proto.EventLogProto.Event other = (ch.epfl.dedis.lib.proto.EventLogProto.Event) obj;
 
-      boolean result = true;
-      result = result && (hasWhen() == other.hasWhen());
+      if (hasWhen() != other.hasWhen()) return false;
       if (hasWhen()) {
-        result = result && (getWhen()
-            == other.getWhen());
+        if (getWhen()
+            != other.getWhen()) return false;
       }
-      result = result && (hasTopic() == other.hasTopic());
+      if (hasTopic() != other.hasTopic()) return false;
       if (hasTopic()) {
-        result = result && getTopic()
-            .equals(other.getTopic());
+        if (!getTopic()
+            .equals(other.getTopic())) return false;
       }
-      result = result && (hasContent() == other.hasContent());
+      if (hasContent() != other.hasContent()) return false;
       if (hasContent()) {
-        result = result && getContent()
-            .equals(other.getContent());
+        if (!getContent()
+            .equals(other.getContent())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -2579,15 +2572,15 @@ public final class EventLogProto {
         ch.epfl.dedis.lib.proto.EventLogProto.Event result = new ch.epfl.dedis.lib.proto.EventLogProto.Event(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.when_ = when_;
           to_bitField0_ |= 0x00000001;
         }
-        result.when_ = when_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.topic_ = topic_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.content_ = content_;
@@ -2598,35 +2591,35 @@ public final class EventLogProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -2697,7 +2690,7 @@ public final class EventLogProto {
        * <code>required sint64 when = 1;</code>
        */
       public boolean hasWhen() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required sint64 when = 1;</code>
@@ -2729,7 +2722,7 @@ public final class EventLogProto {
        * <code>required string topic = 2;</code>
        */
       public boolean hasTopic() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required string topic = 2;</code>
@@ -2805,7 +2798,7 @@ public final class EventLogProto {
        * <code>required string content = 3;</code>
        */
       public boolean hasContent() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required string content = 3;</code>

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/NetworkProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/NetworkProto.java
@@ -153,7 +153,7 @@ public final class NetworkProto {
               break;
             }
             case 18: {
-              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
                 serviceIdentities_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.NetworkProto.ServiceIdentity>();
                 mutable_bitField0_ |= 0x00000002;
               }
@@ -199,7 +199,7 @@ public final class NetworkProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((mutable_bitField0_ & 0x00000002) != 0)) {
           serviceIdentities_ = java.util.Collections.unmodifiableList(serviceIdentities_);
         }
         this.unknownFields = unknownFields.build();
@@ -226,7 +226,7 @@ public final class NetworkProto {
      * <code>required bytes public = 1;</code>
      */
     public boolean hasPublic() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes public = 1;</code>
@@ -276,7 +276,7 @@ public final class NetworkProto {
      * <code>required bytes id = 3;</code>
      */
     public boolean hasId() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes id = 3;</code>
@@ -291,7 +291,7 @@ public final class NetworkProto {
      * <code>required string address = 4;</code>
      */
     public boolean hasAddress() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required string address = 4;</code>
@@ -333,7 +333,7 @@ public final class NetworkProto {
      * <code>required string description = 5;</code>
      */
     public boolean hasDescription() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <code>required string description = 5;</code>
@@ -375,7 +375,7 @@ public final class NetworkProto {
      * <code>optional string url = 6;</code>
      */
     public boolean hasUrl() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000010) != 0);
     }
     /**
      * <code>optional string url = 6;</code>
@@ -447,22 +447,22 @@ public final class NetworkProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, public_);
       }
       for (int i = 0; i < serviceIdentities_.size(); i++) {
         output.writeMessage(2, serviceIdentities_.get(i));
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(3, id_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 4, address_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 5, description_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 6, url_);
       }
       unknownFields.writeTo(output);
@@ -474,7 +474,7 @@ public final class NetworkProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, public_);
       }
@@ -482,17 +482,17 @@ public final class NetworkProto {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, serviceIdentities_.get(i));
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, id_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, address_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, description_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, url_);
       }
       size += unknownFields.getSerializedSize();
@@ -510,36 +510,35 @@ public final class NetworkProto {
       }
       ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity other = (ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity) obj;
 
-      boolean result = true;
-      result = result && (hasPublic() == other.hasPublic());
+      if (hasPublic() != other.hasPublic()) return false;
       if (hasPublic()) {
-        result = result && getPublic()
-            .equals(other.getPublic());
+        if (!getPublic()
+            .equals(other.getPublic())) return false;
       }
-      result = result && getServiceIdentitiesList()
-          .equals(other.getServiceIdentitiesList());
-      result = result && (hasId() == other.hasId());
+      if (!getServiceIdentitiesList()
+          .equals(other.getServiceIdentitiesList())) return false;
+      if (hasId() != other.hasId()) return false;
       if (hasId()) {
-        result = result && getId()
-            .equals(other.getId());
+        if (!getId()
+            .equals(other.getId())) return false;
       }
-      result = result && (hasAddress() == other.hasAddress());
+      if (hasAddress() != other.hasAddress()) return false;
       if (hasAddress()) {
-        result = result && getAddress()
-            .equals(other.getAddress());
+        if (!getAddress()
+            .equals(other.getAddress())) return false;
       }
-      result = result && (hasDescription() == other.hasDescription());
+      if (hasDescription() != other.hasDescription()) return false;
       if (hasDescription()) {
-        result = result && getDescription()
-            .equals(other.getDescription());
+        if (!getDescription()
+            .equals(other.getDescription())) return false;
       }
-      result = result && (hasUrl() == other.hasUrl());
+      if (hasUrl() != other.hasUrl()) return false;
       if (hasUrl()) {
-        result = result && getUrl()
-            .equals(other.getUrl());
+        if (!getUrl()
+            .equals(other.getUrl())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -751,12 +750,12 @@ public final class NetworkProto {
         ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity result = new ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.public_ = public_;
         if (serviceIdentitiesBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          if (((bitField0_ & 0x00000002) != 0)) {
             serviceIdentities_ = java.util.Collections.unmodifiableList(serviceIdentities_);
             bitField0_ = (bitField0_ & ~0x00000002);
           }
@@ -764,19 +763,19 @@ public final class NetworkProto {
         } else {
           result.serviceIdentities_ = serviceIdentitiesBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.id_ = id_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.address_ = address_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((from_bitField0_ & 0x00000010) != 0)) {
           to_bitField0_ |= 0x00000008;
         }
         result.description_ = description_;
-        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+        if (((from_bitField0_ & 0x00000020) != 0)) {
           to_bitField0_ |= 0x00000010;
         }
         result.url_ = url_;
@@ -787,35 +786,35 @@ public final class NetworkProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -928,7 +927,7 @@ public final class NetworkProto {
        * <code>required bytes public = 1;</code>
        */
       public boolean hasPublic() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes public = 1;</code>
@@ -961,7 +960,7 @@ public final class NetworkProto {
       private java.util.List<ch.epfl.dedis.lib.proto.NetworkProto.ServiceIdentity> serviceIdentities_ =
         java.util.Collections.emptyList();
       private void ensureServiceIdentitiesIsMutable() {
-        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+        if (!((bitField0_ & 0x00000002) != 0)) {
           serviceIdentities_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.NetworkProto.ServiceIdentity>(serviceIdentities_);
           bitField0_ |= 0x00000002;
          }
@@ -1190,7 +1189,7 @@ public final class NetworkProto {
           serviceIdentitiesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.NetworkProto.ServiceIdentity, ch.epfl.dedis.lib.proto.NetworkProto.ServiceIdentity.Builder, ch.epfl.dedis.lib.proto.NetworkProto.ServiceIdentityOrBuilder>(
                   serviceIdentities_,
-                  ((bitField0_ & 0x00000002) == 0x00000002),
+                  ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
                   isClean());
           serviceIdentities_ = null;
@@ -1203,7 +1202,7 @@ public final class NetworkProto {
        * <code>required bytes id = 3;</code>
        */
       public boolean hasId() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required bytes id = 3;</code>
@@ -1238,7 +1237,7 @@ public final class NetworkProto {
        * <code>required string address = 4;</code>
        */
       public boolean hasAddress() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <code>required string address = 4;</code>
@@ -1314,7 +1313,7 @@ public final class NetworkProto {
        * <code>required string description = 5;</code>
        */
       public boolean hasDescription() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return ((bitField0_ & 0x00000010) != 0);
       }
       /**
        * <code>required string description = 5;</code>
@@ -1390,7 +1389,7 @@ public final class NetworkProto {
        * <code>optional string url = 6;</code>
        */
       public boolean hasUrl() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
+        return ((bitField0_ & 0x00000020) != 0);
       }
       /**
        * <code>optional string url = 6;</code>
@@ -1652,7 +1651,7 @@ public final class NetworkProto {
      * <code>required string name = 1;</code>
      */
     public boolean hasName() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required string name = 1;</code>
@@ -1694,7 +1693,7 @@ public final class NetworkProto {
      * <code>required string suite = 2;</code>
      */
     public boolean hasSuite() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required string suite = 2;</code>
@@ -1736,7 +1735,7 @@ public final class NetworkProto {
      * <code>required bytes public = 3;</code>
      */
     public boolean hasPublic() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required bytes public = 3;</code>
@@ -1771,13 +1770,13 @@ public final class NetworkProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, suite_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(3, public_);
       }
       unknownFields.writeTo(output);
@@ -1789,13 +1788,13 @@ public final class NetworkProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, suite_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, public_);
       }
@@ -1814,24 +1813,23 @@ public final class NetworkProto {
       }
       ch.epfl.dedis.lib.proto.NetworkProto.ServiceIdentity other = (ch.epfl.dedis.lib.proto.NetworkProto.ServiceIdentity) obj;
 
-      boolean result = true;
-      result = result && (hasName() == other.hasName());
+      if (hasName() != other.hasName()) return false;
       if (hasName()) {
-        result = result && getName()
-            .equals(other.getName());
+        if (!getName()
+            .equals(other.getName())) return false;
       }
-      result = result && (hasSuite() == other.hasSuite());
+      if (hasSuite() != other.hasSuite()) return false;
       if (hasSuite()) {
-        result = result && getSuite()
-            .equals(other.getSuite());
+        if (!getSuite()
+            .equals(other.getSuite())) return false;
       }
-      result = result && (hasPublic() == other.hasPublic());
+      if (hasPublic() != other.hasPublic()) return false;
       if (hasPublic()) {
-        result = result && getPublic()
-            .equals(other.getPublic());
+        if (!getPublic()
+            .equals(other.getPublic())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -2020,15 +2018,15 @@ public final class NetworkProto {
         ch.epfl.dedis.lib.proto.NetworkProto.ServiceIdentity result = new ch.epfl.dedis.lib.proto.NetworkProto.ServiceIdentity(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.name_ = name_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.suite_ = suite_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.public_ = public_;
@@ -2039,35 +2037,35 @@ public final class NetworkProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -2138,7 +2136,7 @@ public final class NetworkProto {
        * <code>required string name = 1;</code>
        */
       public boolean hasName() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required string name = 1;</code>
@@ -2214,7 +2212,7 @@ public final class NetworkProto {
        * <code>required string suite = 2;</code>
        */
       public boolean hasSuite() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required string suite = 2;</code>
@@ -2290,7 +2288,7 @@ public final class NetworkProto {
        * <code>required bytes public = 3;</code>
        */
       public boolean hasPublic() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required bytes public = 3;</code>

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/OnetProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/OnetProto.java
@@ -108,7 +108,7 @@ public final class OnetProto {
               break;
             }
             case 18: {
-              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
                 list_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity>();
                 mutable_bitField0_ |= 0x00000002;
               }
@@ -136,7 +136,7 @@ public final class OnetProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((mutable_bitField0_ & 0x00000002) != 0)) {
           list_ = java.util.Collections.unmodifiableList(list_);
         }
         this.unknownFields = unknownFields.build();
@@ -163,7 +163,7 @@ public final class OnetProto {
      * <code>optional bytes id = 1;</code>
      */
     public boolean hasId() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>optional bytes id = 1;</code>
@@ -213,7 +213,7 @@ public final class OnetProto {
      * <code>required bytes aggregate = 3;</code>
      */
     public boolean hasAggregate() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes aggregate = 3;</code>
@@ -246,13 +246,13 @@ public final class OnetProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, id_);
       }
       for (int i = 0; i < list_.size(); i++) {
         output.writeMessage(2, list_.get(i));
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(3, aggregate_);
       }
       unknownFields.writeTo(output);
@@ -264,7 +264,7 @@ public final class OnetProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, id_);
       }
@@ -272,7 +272,7 @@ public final class OnetProto {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, list_.get(i));
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, aggregate_);
       }
@@ -291,21 +291,20 @@ public final class OnetProto {
       }
       ch.epfl.dedis.lib.proto.OnetProto.Roster other = (ch.epfl.dedis.lib.proto.OnetProto.Roster) obj;
 
-      boolean result = true;
-      result = result && (hasId() == other.hasId());
+      if (hasId() != other.hasId()) return false;
       if (hasId()) {
-        result = result && getId()
-            .equals(other.getId());
+        if (!getId()
+            .equals(other.getId())) return false;
       }
-      result = result && getListList()
-          .equals(other.getListList());
-      result = result && (hasAggregate() == other.hasAggregate());
+      if (!getListList()
+          .equals(other.getListList())) return false;
+      if (hasAggregate() != other.hasAggregate()) return false;
       if (hasAggregate()) {
-        result = result && getAggregate()
-            .equals(other.getAggregate());
+        if (!getAggregate()
+            .equals(other.getAggregate())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -499,12 +498,12 @@ public final class OnetProto {
         ch.epfl.dedis.lib.proto.OnetProto.Roster result = new ch.epfl.dedis.lib.proto.OnetProto.Roster(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.id_ = id_;
         if (listBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          if (((bitField0_ & 0x00000002) != 0)) {
             list_ = java.util.Collections.unmodifiableList(list_);
             bitField0_ = (bitField0_ & ~0x00000002);
           }
@@ -512,7 +511,7 @@ public final class OnetProto {
         } else {
           result.list_ = listBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.aggregate_ = aggregate_;
@@ -523,35 +522,35 @@ public final class OnetProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -640,7 +639,7 @@ public final class OnetProto {
        * <code>optional bytes id = 1;</code>
        */
       public boolean hasId() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>optional bytes id = 1;</code>
@@ -673,7 +672,7 @@ public final class OnetProto {
       private java.util.List<ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity> list_ =
         java.util.Collections.emptyList();
       private void ensureListIsMutable() {
-        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+        if (!((bitField0_ & 0x00000002) != 0)) {
           list_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity>(list_);
           bitField0_ |= 0x00000002;
          }
@@ -902,7 +901,7 @@ public final class OnetProto {
           listBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity, ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity.Builder, ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentityOrBuilder>(
                   list_,
-                  ((bitField0_ & 0x00000002) == 0x00000002),
+                  ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
                   isClean());
           list_ = null;
@@ -915,7 +914,7 @@ public final class OnetProto {
        * <code>required bytes aggregate = 3;</code>
        */
       public boolean hasAggregate() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required bytes aggregate = 3;</code>
@@ -1075,7 +1074,7 @@ public final class OnetProto {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 field_ = com.google.protobuf.MapField.newMapField(
                     FieldDefaultEntryHolder.defaultEntry);
                 mutable_bitField0_ |= 0x00000001;
@@ -1261,11 +1260,10 @@ public final class OnetProto {
       }
       ch.epfl.dedis.lib.proto.OnetProto.Status other = (ch.epfl.dedis.lib.proto.OnetProto.Status) obj;
 
-      boolean result = true;
-      result = result && internalGetField().equals(
-          other.internalGetField());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!internalGetField().equals(
+          other.internalGetField())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -1470,35 +1468,35 @@ public final class OnetProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/Personhood.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/Personhood.java
@@ -58,7 +58,6 @@ public final class Personhood {
       super(builder);
     }
     private PartyList() {
-      wipeparties_ = false;
     }
 
     @java.lang.Override
@@ -87,7 +86,7 @@ public final class Personhood {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.Personhood.Party.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = newparty_.toBuilder();
               }
               newparty_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.Party.parser(), extensionRegistry);
@@ -142,7 +141,7 @@ public final class Personhood {
      * <code>optional .personhood.Party newparty = 1;</code>
      */
     public boolean hasNewparty() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>optional .personhood.Party newparty = 1;</code>
@@ -163,7 +162,7 @@ public final class Personhood {
      * <code>optional bool wipeparties = 2;</code>
      */
     public boolean hasWipeparties() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>optional bool wipeparties = 2;</code>
@@ -192,10 +191,10 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getNewparty());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBool(2, wipeparties_);
       }
       unknownFields.writeTo(output);
@@ -207,11 +206,11 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getNewparty());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(2, wipeparties_);
       }
@@ -230,19 +229,18 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.PartyList other = (ch.epfl.dedis.lib.proto.Personhood.PartyList) obj;
 
-      boolean result = true;
-      result = result && (hasNewparty() == other.hasNewparty());
+      if (hasNewparty() != other.hasNewparty()) return false;
       if (hasNewparty()) {
-        result = result && getNewparty()
-            .equals(other.getNewparty());
+        if (!getNewparty()
+            .equals(other.getNewparty())) return false;
       }
-      result = result && (hasWipeparties() == other.hasWipeparties());
+      if (hasWipeparties() != other.hasWipeparties()) return false;
       if (hasWipeparties()) {
-        result = result && (getWipeparties()
-            == other.getWipeparties());
+        if (getWipeparties()
+            != other.getWipeparties()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -436,18 +434,18 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.PartyList result = new ch.epfl.dedis.lib.proto.Personhood.PartyList(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (newpartyBuilder_ == null) {
+            result.newparty_ = newparty_;
+          } else {
+            result.newparty_ = newpartyBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
         }
-        if (newpartyBuilder_ == null) {
-          result.newparty_ = newparty_;
-        } else {
-          result.newparty_ = newpartyBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.wipeparties_ = wipeparties_;
           to_bitField0_ |= 0x00000002;
         }
-        result.wipeparties_ = wipeparties_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -455,35 +453,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -538,14 +536,14 @@ public final class Personhood {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.Personhood.Party newparty_ = null;
+      private ch.epfl.dedis.lib.proto.Personhood.Party newparty_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.Personhood.Party, ch.epfl.dedis.lib.proto.Personhood.Party.Builder, ch.epfl.dedis.lib.proto.Personhood.PartyOrBuilder> newpartyBuilder_;
       /**
        * <code>optional .personhood.Party newparty = 1;</code>
        */
       public boolean hasNewparty() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>optional .personhood.Party newparty = 1;</code>
@@ -592,7 +590,7 @@ public final class Personhood {
        */
       public Builder mergeNewparty(ch.epfl.dedis.lib.proto.Personhood.Party value) {
         if (newpartyBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               newparty_ != null &&
               newparty_ != ch.epfl.dedis.lib.proto.Personhood.Party.getDefaultInstance()) {
             newparty_ =
@@ -661,7 +659,7 @@ public final class Personhood {
        * <code>optional bool wipeparties = 2;</code>
        */
       public boolean hasWipeparties() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>optional bool wipeparties = 2;</code>
@@ -814,7 +812,7 @@ public final class Personhood {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 parties_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.Party>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -837,7 +835,7 @@ public final class Personhood {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           parties_ = java.util.Collections.unmodifiableList(parties_);
         }
         this.unknownFields = unknownFields.build();
@@ -943,11 +941,10 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.PartyListResponse other = (ch.epfl.dedis.lib.proto.Personhood.PartyListResponse) obj;
 
-      boolean result = true;
-      result = result && getPartiesList()
-          .equals(other.getPartiesList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getPartiesList()
+          .equals(other.getPartiesList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -1134,7 +1131,7 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.PartyListResponse result = new ch.epfl.dedis.lib.proto.Personhood.PartyListResponse(this);
         int from_bitField0_ = bitField0_;
         if (partiesBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             parties_ = java.util.Collections.unmodifiableList(parties_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -1148,35 +1145,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -1254,7 +1251,7 @@ public final class Personhood {
       private java.util.List<ch.epfl.dedis.lib.proto.Personhood.Party> parties_ =
         java.util.Collections.emptyList();
       private void ensurePartiesIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           parties_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.Party>(parties_);
           bitField0_ |= 0x00000001;
          }
@@ -1483,7 +1480,7 @@ public final class Personhood {
           partiesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.Personhood.Party, ch.epfl.dedis.lib.proto.Personhood.Party.Builder, ch.epfl.dedis.lib.proto.Personhood.PartyOrBuilder>(
                   parties_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           parties_ = null;
@@ -1653,7 +1650,7 @@ public final class Personhood {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.OnetProto.Roster.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = roster_.toBuilder();
               }
               roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.parser(), extensionRegistry);
@@ -1717,7 +1714,7 @@ public final class Personhood {
      * <code>required .onet.Roster roster = 1;</code>
      */
     public boolean hasRoster() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -1750,7 +1747,7 @@ public final class Personhood {
      * <code>required bytes byzcoinid = 2;</code>
      */
     public boolean hasByzcoinid() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -1773,7 +1770,7 @@ public final class Personhood {
      * <code>required bytes instanceid = 3;</code>
      */
     public boolean hasInstanceid() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <pre>
@@ -1816,13 +1813,13 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getRoster());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, byzcoinid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(3, instanceid_);
       }
       unknownFields.writeTo(output);
@@ -1834,15 +1831,15 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getRoster());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, byzcoinid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, instanceid_);
       }
@@ -1861,24 +1858,23 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.Party other = (ch.epfl.dedis.lib.proto.Personhood.Party) obj;
 
-      boolean result = true;
-      result = result && (hasRoster() == other.hasRoster());
+      if (hasRoster() != other.hasRoster()) return false;
       if (hasRoster()) {
-        result = result && getRoster()
-            .equals(other.getRoster());
+        if (!getRoster()
+            .equals(other.getRoster())) return false;
       }
-      result = result && (hasByzcoinid() == other.hasByzcoinid());
+      if (hasByzcoinid() != other.hasByzcoinid()) return false;
       if (hasByzcoinid()) {
-        result = result && getByzcoinid()
-            .equals(other.getByzcoinid());
+        if (!getByzcoinid()
+            .equals(other.getByzcoinid())) return false;
       }
-      result = result && (hasInstanceid() == other.hasInstanceid());
+      if (hasInstanceid() != other.hasInstanceid()) return false;
       if (hasInstanceid()) {
-        result = result && getInstanceid()
-            .equals(other.getInstanceid());
+        if (!getInstanceid()
+            .equals(other.getInstanceid())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -2076,19 +2072,19 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.Party result = new ch.epfl.dedis.lib.proto.Personhood.Party(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (rosterBuilder_ == null) {
+            result.roster_ = roster_;
+          } else {
+            result.roster_ = rosterBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
         }
-        if (rosterBuilder_ == null) {
-          result.roster_ = roster_;
-        } else {
-          result.roster_ = rosterBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.byzcoinid_ = byzcoinid_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.instanceid_ = instanceid_;
@@ -2099,35 +2095,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -2192,7 +2188,7 @@ public final class Personhood {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.OnetProto.Roster roster_ = null;
+      private ch.epfl.dedis.lib.proto.OnetProto.Roster roster_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.OnetProto.Roster, ch.epfl.dedis.lib.proto.OnetProto.Roster.Builder, ch.epfl.dedis.lib.proto.OnetProto.RosterOrBuilder> rosterBuilder_;
       /**
@@ -2203,7 +2199,7 @@ public final class Personhood {
        * <code>required .onet.Roster roster = 1;</code>
        */
       public boolean hasRoster() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -2266,7 +2262,7 @@ public final class Personhood {
        */
       public Builder mergeRoster(ch.epfl.dedis.lib.proto.OnetProto.Roster value) {
         if (rosterBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               roster_ != null &&
               roster_ != ch.epfl.dedis.lib.proto.OnetProto.Roster.getDefaultInstance()) {
             roster_ =
@@ -2355,7 +2351,7 @@ public final class Personhood {
        * <code>required bytes byzcoinid = 2;</code>
        */
       public boolean hasByzcoinid() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -2406,7 +2402,7 @@ public final class Personhood {
        * <code>required bytes instanceid = 3;</code>
        */
       public boolean hasInstanceid() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <pre>
@@ -2544,7 +2540,6 @@ public final class Personhood {
       super(builder);
     }
     private RoPaSciList() {
-      wipe_ = false;
     }
 
     @java.lang.Override
@@ -2573,7 +2568,7 @@ public final class Personhood {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.Personhood.RoPaSci.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = newropasci_.toBuilder();
               }
               newropasci_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.RoPaSci.parser(), extensionRegistry);
@@ -2628,7 +2623,7 @@ public final class Personhood {
      * <code>optional .personhood.RoPaSci newropasci = 1;</code>
      */
     public boolean hasNewropasci() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>optional .personhood.RoPaSci newropasci = 1;</code>
@@ -2649,7 +2644,7 @@ public final class Personhood {
      * <code>optional bool wipe = 2;</code>
      */
     public boolean hasWipe() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>optional bool wipe = 2;</code>
@@ -2678,10 +2673,10 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getNewropasci());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBool(2, wipe_);
       }
       unknownFields.writeTo(output);
@@ -2693,11 +2688,11 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getNewropasci());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(2, wipe_);
       }
@@ -2716,19 +2711,18 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.RoPaSciList other = (ch.epfl.dedis.lib.proto.Personhood.RoPaSciList) obj;
 
-      boolean result = true;
-      result = result && (hasNewropasci() == other.hasNewropasci());
+      if (hasNewropasci() != other.hasNewropasci()) return false;
       if (hasNewropasci()) {
-        result = result && getNewropasci()
-            .equals(other.getNewropasci());
+        if (!getNewropasci()
+            .equals(other.getNewropasci())) return false;
       }
-      result = result && (hasWipe() == other.hasWipe());
+      if (hasWipe() != other.hasWipe()) return false;
       if (hasWipe()) {
-        result = result && (getWipe()
-            == other.getWipe());
+        if (getWipe()
+            != other.getWipe()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -2922,18 +2916,18 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.RoPaSciList result = new ch.epfl.dedis.lib.proto.Personhood.RoPaSciList(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (newropasciBuilder_ == null) {
+            result.newropasci_ = newropasci_;
+          } else {
+            result.newropasci_ = newropasciBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
         }
-        if (newropasciBuilder_ == null) {
-          result.newropasci_ = newropasci_;
-        } else {
-          result.newropasci_ = newropasciBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.wipe_ = wipe_;
           to_bitField0_ |= 0x00000002;
         }
-        result.wipe_ = wipe_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -2941,35 +2935,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -3024,14 +3018,14 @@ public final class Personhood {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.Personhood.RoPaSci newropasci_ = null;
+      private ch.epfl.dedis.lib.proto.Personhood.RoPaSci newropasci_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.Personhood.RoPaSci, ch.epfl.dedis.lib.proto.Personhood.RoPaSci.Builder, ch.epfl.dedis.lib.proto.Personhood.RoPaSciOrBuilder> newropasciBuilder_;
       /**
        * <code>optional .personhood.RoPaSci newropasci = 1;</code>
        */
       public boolean hasNewropasci() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>optional .personhood.RoPaSci newropasci = 1;</code>
@@ -3078,7 +3072,7 @@ public final class Personhood {
        */
       public Builder mergeNewropasci(ch.epfl.dedis.lib.proto.Personhood.RoPaSci value) {
         if (newropasciBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               newropasci_ != null &&
               newropasci_ != ch.epfl.dedis.lib.proto.Personhood.RoPaSci.getDefaultInstance()) {
             newropasci_ =
@@ -3147,7 +3141,7 @@ public final class Personhood {
        * <code>optional bool wipe = 2;</code>
        */
       public boolean hasWipe() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>optional bool wipe = 2;</code>
@@ -3300,7 +3294,7 @@ public final class Personhood {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 ropascis_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.RoPaSci>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -3323,7 +3317,7 @@ public final class Personhood {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           ropascis_ = java.util.Collections.unmodifiableList(ropascis_);
         }
         this.unknownFields = unknownFields.build();
@@ -3429,11 +3423,10 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.RoPaSciListResponse other = (ch.epfl.dedis.lib.proto.Personhood.RoPaSciListResponse) obj;
 
-      boolean result = true;
-      result = result && getRopascisList()
-          .equals(other.getRopascisList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getRopascisList()
+          .equals(other.getRopascisList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -3620,7 +3613,7 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.RoPaSciListResponse result = new ch.epfl.dedis.lib.proto.Personhood.RoPaSciListResponse(this);
         int from_bitField0_ = bitField0_;
         if (ropascisBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             ropascis_ = java.util.Collections.unmodifiableList(ropascis_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -3634,35 +3627,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -3740,7 +3733,7 @@ public final class Personhood {
       private java.util.List<ch.epfl.dedis.lib.proto.Personhood.RoPaSci> ropascis_ =
         java.util.Collections.emptyList();
       private void ensureRopascisIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           ropascis_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.RoPaSci>(ropascis_);
           bitField0_ |= 0x00000001;
          }
@@ -3969,7 +3962,7 @@ public final class Personhood {
           ropascisBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.Personhood.RoPaSci, ch.epfl.dedis.lib.proto.Personhood.RoPaSci.Builder, ch.epfl.dedis.lib.proto.Personhood.RoPaSciOrBuilder>(
                   ropascis_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           ropascis_ = null;
@@ -4145,7 +4138,7 @@ public final class Personhood {
      * <code>required bytes byzcoinid = 1;</code>
      */
     public boolean hasByzcoinid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes byzcoinid = 1;</code>
@@ -4160,7 +4153,7 @@ public final class Personhood {
      * <code>required bytes ropasciid = 2;</code>
      */
     public boolean hasRopasciid() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes ropasciid = 2;</code>
@@ -4191,10 +4184,10 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, byzcoinid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, ropasciid_);
       }
       unknownFields.writeTo(output);
@@ -4206,11 +4199,11 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, byzcoinid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, ropasciid_);
       }
@@ -4229,19 +4222,18 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.RoPaSci other = (ch.epfl.dedis.lib.proto.Personhood.RoPaSci) obj;
 
-      boolean result = true;
-      result = result && (hasByzcoinid() == other.hasByzcoinid());
+      if (hasByzcoinid() != other.hasByzcoinid()) return false;
       if (hasByzcoinid()) {
-        result = result && getByzcoinid()
-            .equals(other.getByzcoinid());
+        if (!getByzcoinid()
+            .equals(other.getByzcoinid())) return false;
       }
-      result = result && (hasRopasciid() == other.hasRopasciid());
+      if (hasRopasciid() != other.hasRopasciid()) return false;
       if (hasRopasciid()) {
-        result = result && getRopasciid()
-            .equals(other.getRopasciid());
+        if (!getRopasciid()
+            .equals(other.getRopasciid())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -4428,11 +4420,11 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.RoPaSci result = new ch.epfl.dedis.lib.proto.Personhood.RoPaSci(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.byzcoinid_ = byzcoinid_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.ropasciid_ = ropasciid_;
@@ -4443,35 +4435,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -4532,7 +4524,7 @@ public final class Personhood {
        * <code>required bytes byzcoinid = 1;</code>
        */
       public boolean hasByzcoinid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes byzcoinid = 1;</code>
@@ -4567,7 +4559,7 @@ public final class Personhood {
        * <code>required bytes ropasciid = 2;</code>
        */
       public boolean hasRopasciid() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes ropasciid = 2;</code>
@@ -4757,7 +4749,7 @@ public final class Personhood {
      * <code>required string reply = 1;</code>
      */
     public boolean hasReply() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required string reply = 1;</code>
@@ -4811,7 +4803,7 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, reply_);
       }
       unknownFields.writeTo(output);
@@ -4823,7 +4815,7 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, reply_);
       }
       size += unknownFields.getSerializedSize();
@@ -4841,14 +4833,13 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.StringReply other = (ch.epfl.dedis.lib.proto.Personhood.StringReply) obj;
 
-      boolean result = true;
-      result = result && (hasReply() == other.hasReply());
+      if (hasReply() != other.hasReply()) return false;
       if (hasReply()) {
-        result = result && getReply()
-            .equals(other.getReply());
+        if (!getReply()
+            .equals(other.getReply())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -5030,7 +5021,7 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.StringReply result = new ch.epfl.dedis.lib.proto.Personhood.StringReply(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.reply_ = reply_;
@@ -5041,35 +5032,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -5126,7 +5117,7 @@ public final class Personhood {
        * <code>required string reply = 1;</code>
        */
       public boolean hasReply() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required string reply = 1;</code>
@@ -5335,8 +5326,6 @@ public final class Personhood {
     private RoPaSciStruct() {
       description_ = "";
       firstplayerhash_ = com.google.protobuf.ByteString.EMPTY;
-      firstplayer_ = 0;
-      secondplayer_ = 0;
       secondplayeraccount_ = com.google.protobuf.ByteString.EMPTY;
     }
 
@@ -5372,7 +5361,7 @@ public final class Personhood {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = stake_.toBuilder();
               }
               stake_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.parser(), extensionRegistry);
@@ -5442,7 +5431,7 @@ public final class Personhood {
      * <code>required string description = 1;</code>
      */
     public boolean hasDescription() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required string description = 1;</code>
@@ -5484,7 +5473,7 @@ public final class Personhood {
      * <code>required .byzcoin.Coin stake = 2;</code>
      */
     public boolean hasStake() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required .byzcoin.Coin stake = 2;</code>
@@ -5505,7 +5494,7 @@ public final class Personhood {
      * <code>required bytes firstplayerhash = 3;</code>
      */
     public boolean hasFirstplayerhash() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required bytes firstplayerhash = 3;</code>
@@ -5520,7 +5509,7 @@ public final class Personhood {
      * <code>optional sint32 firstplayer = 4;</code>
      */
     public boolean hasFirstplayer() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <code>optional sint32 firstplayer = 4;</code>
@@ -5535,7 +5524,7 @@ public final class Personhood {
      * <code>optional sint32 secondplayer = 5;</code>
      */
     public boolean hasSecondplayer() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000010) != 0);
     }
     /**
      * <code>optional sint32 secondplayer = 5;</code>
@@ -5550,7 +5539,7 @@ public final class Personhood {
      * <code>optional bytes secondplayeraccount = 6;</code>
      */
     public boolean hasSecondplayeraccount() {
-      return ((bitField0_ & 0x00000020) == 0x00000020);
+      return ((bitField0_ & 0x00000020) != 0);
     }
     /**
      * <code>optional bytes secondplayeraccount = 6;</code>
@@ -5589,22 +5578,22 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, description_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getStake());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(3, firstplayerhash_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeSInt32(4, firstplayer_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         output.writeSInt32(5, secondplayer_);
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if (((bitField0_ & 0x00000020) != 0)) {
         output.writeBytes(6, secondplayeraccount_);
       }
       unknownFields.writeTo(output);
@@ -5616,26 +5605,26 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, description_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getStake());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, firstplayerhash_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(4, firstplayer_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(5, secondplayer_);
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if (((bitField0_ & 0x00000020) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(6, secondplayeraccount_);
       }
@@ -5654,39 +5643,38 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.RoPaSciStruct other = (ch.epfl.dedis.lib.proto.Personhood.RoPaSciStruct) obj;
 
-      boolean result = true;
-      result = result && (hasDescription() == other.hasDescription());
+      if (hasDescription() != other.hasDescription()) return false;
       if (hasDescription()) {
-        result = result && getDescription()
-            .equals(other.getDescription());
+        if (!getDescription()
+            .equals(other.getDescription())) return false;
       }
-      result = result && (hasStake() == other.hasStake());
+      if (hasStake() != other.hasStake()) return false;
       if (hasStake()) {
-        result = result && getStake()
-            .equals(other.getStake());
+        if (!getStake()
+            .equals(other.getStake())) return false;
       }
-      result = result && (hasFirstplayerhash() == other.hasFirstplayerhash());
+      if (hasFirstplayerhash() != other.hasFirstplayerhash()) return false;
       if (hasFirstplayerhash()) {
-        result = result && getFirstplayerhash()
-            .equals(other.getFirstplayerhash());
+        if (!getFirstplayerhash()
+            .equals(other.getFirstplayerhash())) return false;
       }
-      result = result && (hasFirstplayer() == other.hasFirstplayer());
+      if (hasFirstplayer() != other.hasFirstplayer()) return false;
       if (hasFirstplayer()) {
-        result = result && (getFirstplayer()
-            == other.getFirstplayer());
+        if (getFirstplayer()
+            != other.getFirstplayer()) return false;
       }
-      result = result && (hasSecondplayer() == other.hasSecondplayer());
+      if (hasSecondplayer() != other.hasSecondplayer()) return false;
       if (hasSecondplayer()) {
-        result = result && (getSecondplayer()
-            == other.getSecondplayer());
+        if (getSecondplayer()
+            != other.getSecondplayer()) return false;
       }
-      result = result && (hasSecondplayeraccount() == other.hasSecondplayeraccount());
+      if (hasSecondplayeraccount() != other.hasSecondplayeraccount()) return false;
       if (hasSecondplayeraccount()) {
-        result = result && getSecondplayeraccount()
-            .equals(other.getSecondplayeraccount());
+        if (!getSecondplayeraccount()
+            .equals(other.getSecondplayeraccount())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -5902,31 +5890,31 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.RoPaSciStruct result = new ch.epfl.dedis.lib.proto.Personhood.RoPaSciStruct(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.description_ = description_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (stakeBuilder_ == null) {
+            result.stake_ = stake_;
+          } else {
+            result.stake_ = stakeBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
         }
-        if (stakeBuilder_ == null) {
-          result.stake_ = stake_;
-        } else {
-          result.stake_ = stakeBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.firstplayerhash_ = firstplayerhash_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          result.firstplayer_ = firstplayer_;
           to_bitField0_ |= 0x00000008;
         }
-        result.firstplayer_ = firstplayer_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((from_bitField0_ & 0x00000010) != 0)) {
+          result.secondplayer_ = secondplayer_;
           to_bitField0_ |= 0x00000010;
         }
-        result.secondplayer_ = secondplayer_;
-        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+        if (((from_bitField0_ & 0x00000020) != 0)) {
           to_bitField0_ |= 0x00000020;
         }
         result.secondplayeraccount_ = secondplayeraccount_;
@@ -5937,35 +5925,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -6046,7 +6034,7 @@ public final class Personhood {
        * <code>required string description = 1;</code>
        */
       public boolean hasDescription() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required string description = 1;</code>
@@ -6117,14 +6105,14 @@ public final class Personhood {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.Coin stake_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.Coin stake_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.Coin, ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.CoinOrBuilder> stakeBuilder_;
       /**
        * <code>required .byzcoin.Coin stake = 2;</code>
        */
       public boolean hasStake() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required .byzcoin.Coin stake = 2;</code>
@@ -6171,7 +6159,7 @@ public final class Personhood {
        */
       public Builder mergeStake(ch.epfl.dedis.lib.proto.ByzCoinProto.Coin value) {
         if (stakeBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               stake_ != null &&
               stake_ != ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.getDefaultInstance()) {
             stake_ =
@@ -6240,7 +6228,7 @@ public final class Personhood {
        * <code>required bytes firstplayerhash = 3;</code>
        */
       public boolean hasFirstplayerhash() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required bytes firstplayerhash = 3;</code>
@@ -6275,7 +6263,7 @@ public final class Personhood {
        * <code>optional sint32 firstplayer = 4;</code>
        */
       public boolean hasFirstplayer() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <code>optional sint32 firstplayer = 4;</code>
@@ -6307,7 +6295,7 @@ public final class Personhood {
        * <code>optional sint32 secondplayer = 5;</code>
        */
       public boolean hasSecondplayer() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return ((bitField0_ & 0x00000010) != 0);
       }
       /**
        * <code>optional sint32 secondplayer = 5;</code>
@@ -6339,7 +6327,7 @@ public final class Personhood {
        * <code>optional bytes secondplayeraccount = 6;</code>
        */
       public boolean hasSecondplayeraccount() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
+        return ((bitField0_ & 0x00000020) != 0);
       }
       /**
        * <code>optional bytes secondplayeraccount = 6;</code>
@@ -6494,7 +6482,7 @@ public final class Personhood {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 credentials_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.Credential>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -6517,7 +6505,7 @@ public final class Personhood {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           credentials_ = java.util.Collections.unmodifiableList(credentials_);
         }
         this.unknownFields = unknownFields.build();
@@ -6623,11 +6611,10 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.CredentialStruct other = (ch.epfl.dedis.lib.proto.Personhood.CredentialStruct) obj;
 
-      boolean result = true;
-      result = result && getCredentialsList()
-          .equals(other.getCredentialsList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getCredentialsList()
+          .equals(other.getCredentialsList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -6813,7 +6800,7 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.CredentialStruct result = new ch.epfl.dedis.lib.proto.Personhood.CredentialStruct(this);
         int from_bitField0_ = bitField0_;
         if (credentialsBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             credentials_ = java.util.Collections.unmodifiableList(credentials_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -6827,35 +6814,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -6933,7 +6920,7 @@ public final class Personhood {
       private java.util.List<ch.epfl.dedis.lib.proto.Personhood.Credential> credentials_ =
         java.util.Collections.emptyList();
       private void ensureCredentialsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           credentials_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.Credential>(credentials_);
           bitField0_ |= 0x00000001;
          }
@@ -7162,7 +7149,7 @@ public final class Personhood {
           credentialsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.Personhood.Credential, ch.epfl.dedis.lib.proto.Personhood.Credential.Builder, ch.epfl.dedis.lib.proto.Personhood.CredentialOrBuilder>(
                   credentials_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           credentials_ = null;
@@ -7316,7 +7303,7 @@ public final class Personhood {
               break;
             }
             case 18: {
-              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
                 attributes_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.Attribute>();
                 mutable_bitField0_ |= 0x00000002;
               }
@@ -7339,7 +7326,7 @@ public final class Personhood {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((mutable_bitField0_ & 0x00000002) != 0)) {
           attributes_ = java.util.Collections.unmodifiableList(attributes_);
         }
         this.unknownFields = unknownFields.build();
@@ -7366,7 +7353,7 @@ public final class Personhood {
      * <code>required string name = 1;</code>
      */
     public boolean hasName() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required string name = 1;</code>
@@ -7461,7 +7448,7 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
       }
       for (int i = 0; i < attributes_.size(); i++) {
@@ -7476,7 +7463,7 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
       }
       for (int i = 0; i < attributes_.size(); i++) {
@@ -7498,16 +7485,15 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.Credential other = (ch.epfl.dedis.lib.proto.Personhood.Credential) obj;
 
-      boolean result = true;
-      result = result && (hasName() == other.hasName());
+      if (hasName() != other.hasName()) return false;
       if (hasName()) {
-        result = result && getName()
-            .equals(other.getName());
+        if (!getName()
+            .equals(other.getName())) return false;
       }
-      result = result && getAttributesList()
-          .equals(other.getAttributesList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getAttributesList()
+          .equals(other.getAttributesList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -7699,12 +7685,12 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.Credential result = new ch.epfl.dedis.lib.proto.Personhood.Credential(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.name_ = name_;
         if (attributesBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          if (((bitField0_ & 0x00000002) != 0)) {
             attributes_ = java.util.Collections.unmodifiableList(attributes_);
             bitField0_ = (bitField0_ & ~0x00000002);
           }
@@ -7719,35 +7705,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -7835,7 +7821,7 @@ public final class Personhood {
        * <code>required string name = 1;</code>
        */
       public boolean hasName() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required string name = 1;</code>
@@ -7909,7 +7895,7 @@ public final class Personhood {
       private java.util.List<ch.epfl.dedis.lib.proto.Personhood.Attribute> attributes_ =
         java.util.Collections.emptyList();
       private void ensureAttributesIsMutable() {
-        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+        if (!((bitField0_ & 0x00000002) != 0)) {
           attributes_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.Attribute>(attributes_);
           bitField0_ |= 0x00000002;
          }
@@ -8138,7 +8124,7 @@ public final class Personhood {
           attributesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.Personhood.Attribute, ch.epfl.dedis.lib.proto.Personhood.Attribute.Builder, ch.epfl.dedis.lib.proto.Personhood.AttributeOrBuilder>(
                   attributes_,
-                  ((bitField0_ & 0x00000002) == 0x00000002),
+                  ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
                   isClean());
           attributes_ = null;
@@ -8320,7 +8306,7 @@ public final class Personhood {
      * <code>required string name = 1;</code>
      */
     public boolean hasName() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required string name = 1;</code>
@@ -8362,7 +8348,7 @@ public final class Personhood {
      * <code>required bytes value = 2;</code>
      */
     public boolean hasValue() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes value = 2;</code>
@@ -8393,10 +8379,10 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, value_);
       }
       unknownFields.writeTo(output);
@@ -8408,10 +8394,10 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, value_);
       }
@@ -8430,19 +8416,18 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.Attribute other = (ch.epfl.dedis.lib.proto.Personhood.Attribute) obj;
 
-      boolean result = true;
-      result = result && (hasName() == other.hasName());
+      if (hasName() != other.hasName()) return false;
       if (hasName()) {
-        result = result && getName()
-            .equals(other.getName());
+        if (!getName()
+            .equals(other.getName())) return false;
       }
-      result = result && (hasValue() == other.hasValue());
+      if (hasValue() != other.hasValue()) return false;
       if (hasValue()) {
-        result = result && getValue()
-            .equals(other.getValue());
+        if (!getValue()
+            .equals(other.getValue())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -8629,11 +8614,11 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.Attribute result = new ch.epfl.dedis.lib.proto.Personhood.Attribute(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.name_ = name_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.value_ = value_;
@@ -8644,35 +8629,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -8735,7 +8720,7 @@ public final class Personhood {
        * <code>required string name = 1;</code>
        */
       public boolean hasName() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required string name = 1;</code>
@@ -8811,7 +8796,7 @@ public final class Personhood {
        * <code>required bytes value = 2;</code>
        */
       public boolean hasValue() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes value = 2;</code>
@@ -9018,7 +9003,7 @@ public final class Personhood {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = costdarc_.toBuilder();
               }
               costdarc_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.parser(), extensionRegistry);
@@ -9031,7 +9016,7 @@ public final class Personhood {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = costcoin_.toBuilder();
               }
               costcoin_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.parser(), extensionRegistry);
@@ -9044,7 +9029,7 @@ public final class Personhood {
             }
             case 26: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+              if (((bitField0_ & 0x00000004) != 0)) {
                 subBuilder = costcredential_.toBuilder();
               }
               costcredential_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.parser(), extensionRegistry);
@@ -9057,7 +9042,7 @@ public final class Personhood {
             }
             case 34: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000008) == 0x00000008)) {
+              if (((bitField0_ & 0x00000008) != 0)) {
                 subBuilder = costparty_.toBuilder();
               }
               costparty_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.parser(), extensionRegistry);
@@ -9075,7 +9060,7 @@ public final class Personhood {
             }
             case 50: {
               ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000020) == 0x00000020)) {
+              if (((bitField0_ & 0x00000020) != 0)) {
                 subBuilder = costropasci_.toBuilder();
               }
               costropasci_ = input.readMessage(ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.parser(), extensionRegistry);
@@ -9125,7 +9110,7 @@ public final class Personhood {
      * <code>required .byzcoin.Coin costdarc = 1;</code>
      */
     public boolean hasCostdarc() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required .byzcoin.Coin costdarc = 1;</code>
@@ -9146,7 +9131,7 @@ public final class Personhood {
      * <code>required .byzcoin.Coin costcoin = 2;</code>
      */
     public boolean hasCostcoin() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required .byzcoin.Coin costcoin = 2;</code>
@@ -9167,7 +9152,7 @@ public final class Personhood {
      * <code>required .byzcoin.Coin costcredential = 3;</code>
      */
     public boolean hasCostcredential() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required .byzcoin.Coin costcredential = 3;</code>
@@ -9188,7 +9173,7 @@ public final class Personhood {
      * <code>required .byzcoin.Coin costparty = 4;</code>
      */
     public boolean hasCostparty() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <code>required .byzcoin.Coin costparty = 4;</code>
@@ -9209,7 +9194,7 @@ public final class Personhood {
      * <code>required bytes beneficiary = 5;</code>
      */
     public boolean hasBeneficiary() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000010) != 0);
     }
     /**
      * <code>required bytes beneficiary = 5;</code>
@@ -9224,7 +9209,7 @@ public final class Personhood {
      * <code>optional .byzcoin.Coin costropasci = 6;</code>
      */
     public boolean hasCostropasci() {
-      return ((bitField0_ & 0x00000020) == 0x00000020);
+      return ((bitField0_ & 0x00000020) != 0);
     }
     /**
      * <code>optional .byzcoin.Coin costropasci = 6;</code>
@@ -9295,22 +9280,22 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getCostdarc());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getCostcoin());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeMessage(3, getCostcredential());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeMessage(4, getCostparty());
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         output.writeBytes(5, beneficiary_);
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if (((bitField0_ & 0x00000020) != 0)) {
         output.writeMessage(6, getCostropasci());
       }
       unknownFields.writeTo(output);
@@ -9322,27 +9307,27 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getCostdarc());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getCostcoin());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, getCostcredential());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(4, getCostparty());
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(5, beneficiary_);
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if (((bitField0_ & 0x00000020) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(6, getCostropasci());
       }
@@ -9361,39 +9346,38 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.SpawnerStruct other = (ch.epfl.dedis.lib.proto.Personhood.SpawnerStruct) obj;
 
-      boolean result = true;
-      result = result && (hasCostdarc() == other.hasCostdarc());
+      if (hasCostdarc() != other.hasCostdarc()) return false;
       if (hasCostdarc()) {
-        result = result && getCostdarc()
-            .equals(other.getCostdarc());
+        if (!getCostdarc()
+            .equals(other.getCostdarc())) return false;
       }
-      result = result && (hasCostcoin() == other.hasCostcoin());
+      if (hasCostcoin() != other.hasCostcoin()) return false;
       if (hasCostcoin()) {
-        result = result && getCostcoin()
-            .equals(other.getCostcoin());
+        if (!getCostcoin()
+            .equals(other.getCostcoin())) return false;
       }
-      result = result && (hasCostcredential() == other.hasCostcredential());
+      if (hasCostcredential() != other.hasCostcredential()) return false;
       if (hasCostcredential()) {
-        result = result && getCostcredential()
-            .equals(other.getCostcredential());
+        if (!getCostcredential()
+            .equals(other.getCostcredential())) return false;
       }
-      result = result && (hasCostparty() == other.hasCostparty());
+      if (hasCostparty() != other.hasCostparty()) return false;
       if (hasCostparty()) {
-        result = result && getCostparty()
-            .equals(other.getCostparty());
+        if (!getCostparty()
+            .equals(other.getCostparty())) return false;
       }
-      result = result && (hasBeneficiary() == other.hasBeneficiary());
+      if (hasBeneficiary() != other.hasBeneficiary()) return false;
       if (hasBeneficiary()) {
-        result = result && getBeneficiary()
-            .equals(other.getBeneficiary());
+        if (!getBeneficiary()
+            .equals(other.getBeneficiary())) return false;
       }
-      result = result && (hasCostropasci() == other.hasCostropasci());
+      if (hasCostropasci() != other.hasCostropasci()) return false;
       if (hasCostropasci()) {
-        result = result && getCostropasci()
-            .equals(other.getCostropasci());
+        if (!getCostropasci()
+            .equals(other.getCostropasci())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -9630,49 +9614,49 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.SpawnerStruct result = new ch.epfl.dedis.lib.proto.Personhood.SpawnerStruct(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (costdarcBuilder_ == null) {
+            result.costdarc_ = costdarc_;
+          } else {
+            result.costdarc_ = costdarcBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
         }
-        if (costdarcBuilder_ == null) {
-          result.costdarc_ = costdarc_;
-        } else {
-          result.costdarc_ = costdarcBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (costcoinBuilder_ == null) {
+            result.costcoin_ = costcoin_;
+          } else {
+            result.costcoin_ = costcoinBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
         }
-        if (costcoinBuilder_ == null) {
-          result.costcoin_ = costcoin_;
-        } else {
-          result.costcoin_ = costcoinBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          if (costcredentialBuilder_ == null) {
+            result.costcredential_ = costcredential_;
+          } else {
+            result.costcredential_ = costcredentialBuilder_.build();
+          }
           to_bitField0_ |= 0x00000004;
         }
-        if (costcredentialBuilder_ == null) {
-          result.costcredential_ = costcredential_;
-        } else {
-          result.costcredential_ = costcredentialBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          if (costpartyBuilder_ == null) {
+            result.costparty_ = costparty_;
+          } else {
+            result.costparty_ = costpartyBuilder_.build();
+          }
           to_bitField0_ |= 0x00000008;
         }
-        if (costpartyBuilder_ == null) {
-          result.costparty_ = costparty_;
-        } else {
-          result.costparty_ = costpartyBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((from_bitField0_ & 0x00000010) != 0)) {
           to_bitField0_ |= 0x00000010;
         }
         result.beneficiary_ = beneficiary_;
-        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+        if (((from_bitField0_ & 0x00000020) != 0)) {
+          if (costropasciBuilder_ == null) {
+            result.costropasci_ = costropasci_;
+          } else {
+            result.costropasci_ = costropasciBuilder_.build();
+          }
           to_bitField0_ |= 0x00000020;
-        }
-        if (costropasciBuilder_ == null) {
-          result.costropasci_ = costropasci_;
-        } else {
-          result.costropasci_ = costropasciBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -9681,35 +9665,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -9803,14 +9787,14 @@ public final class Personhood {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.Coin costdarc_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.Coin costdarc_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.Coin, ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.CoinOrBuilder> costdarcBuilder_;
       /**
        * <code>required .byzcoin.Coin costdarc = 1;</code>
        */
       public boolean hasCostdarc() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required .byzcoin.Coin costdarc = 1;</code>
@@ -9857,7 +9841,7 @@ public final class Personhood {
        */
       public Builder mergeCostdarc(ch.epfl.dedis.lib.proto.ByzCoinProto.Coin value) {
         if (costdarcBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               costdarc_ != null &&
               costdarc_ != ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.getDefaultInstance()) {
             costdarc_ =
@@ -9921,14 +9905,14 @@ public final class Personhood {
         return costdarcBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.Coin costcoin_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.Coin costcoin_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.Coin, ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.CoinOrBuilder> costcoinBuilder_;
       /**
        * <code>required .byzcoin.Coin costcoin = 2;</code>
        */
       public boolean hasCostcoin() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required .byzcoin.Coin costcoin = 2;</code>
@@ -9975,7 +9959,7 @@ public final class Personhood {
        */
       public Builder mergeCostcoin(ch.epfl.dedis.lib.proto.ByzCoinProto.Coin value) {
         if (costcoinBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               costcoin_ != null &&
               costcoin_ != ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.getDefaultInstance()) {
             costcoin_ =
@@ -10039,14 +10023,14 @@ public final class Personhood {
         return costcoinBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.Coin costcredential_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.Coin costcredential_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.Coin, ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.CoinOrBuilder> costcredentialBuilder_;
       /**
        * <code>required .byzcoin.Coin costcredential = 3;</code>
        */
       public boolean hasCostcredential() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required .byzcoin.Coin costcredential = 3;</code>
@@ -10093,7 +10077,7 @@ public final class Personhood {
        */
       public Builder mergeCostcredential(ch.epfl.dedis.lib.proto.ByzCoinProto.Coin value) {
         if (costcredentialBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004) &&
+          if (((bitField0_ & 0x00000004) != 0) &&
               costcredential_ != null &&
               costcredential_ != ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.getDefaultInstance()) {
             costcredential_ =
@@ -10157,14 +10141,14 @@ public final class Personhood {
         return costcredentialBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.Coin costparty_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.Coin costparty_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.Coin, ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.CoinOrBuilder> costpartyBuilder_;
       /**
        * <code>required .byzcoin.Coin costparty = 4;</code>
        */
       public boolean hasCostparty() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <code>required .byzcoin.Coin costparty = 4;</code>
@@ -10211,7 +10195,7 @@ public final class Personhood {
        */
       public Builder mergeCostparty(ch.epfl.dedis.lib.proto.ByzCoinProto.Coin value) {
         if (costpartyBuilder_ == null) {
-          if (((bitField0_ & 0x00000008) == 0x00000008) &&
+          if (((bitField0_ & 0x00000008) != 0) &&
               costparty_ != null &&
               costparty_ != ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.getDefaultInstance()) {
             costparty_ =
@@ -10280,7 +10264,7 @@ public final class Personhood {
        * <code>required bytes beneficiary = 5;</code>
        */
       public boolean hasBeneficiary() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return ((bitField0_ & 0x00000010) != 0);
       }
       /**
        * <code>required bytes beneficiary = 5;</code>
@@ -10310,14 +10294,14 @@ public final class Personhood {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.ByzCoinProto.Coin costropasci_ = null;
+      private ch.epfl.dedis.lib.proto.ByzCoinProto.Coin costropasci_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.ByzCoinProto.Coin, ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.Builder, ch.epfl.dedis.lib.proto.ByzCoinProto.CoinOrBuilder> costropasciBuilder_;
       /**
        * <code>optional .byzcoin.Coin costropasci = 6;</code>
        */
       public boolean hasCostropasci() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
+        return ((bitField0_ & 0x00000020) != 0);
       }
       /**
        * <code>optional .byzcoin.Coin costropasci = 6;</code>
@@ -10364,7 +10348,7 @@ public final class Personhood {
        */
       public Builder mergeCostropasci(ch.epfl.dedis.lib.proto.ByzCoinProto.Coin value) {
         if (costropasciBuilder_ == null) {
-          if (((bitField0_ & 0x00000020) == 0x00000020) &&
+          if (((bitField0_ & 0x00000020) != 0) &&
               costropasci_ != null &&
               costropasci_ != ch.epfl.dedis.lib.proto.ByzCoinProto.Coin.getDefaultInstance()) {
             costropasci_ =
@@ -10737,11 +10721,8 @@ public final class Personhood {
       super(builder);
     }
     private PopPartyStruct() {
-      state_ = 0;
-      organizers_ = 0;
       finalizations_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       miners_ = java.util.Collections.emptyList();
-      miningreward_ = 0L;
       previous_ = com.google.protobuf.ByteString.EMPTY;
       next_ = com.google.protobuf.ByteString.EMPTY;
     }
@@ -10782,7 +10763,7 @@ public final class Personhood {
             }
             case 26: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              if (!((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+              if (!((mutable_bitField0_ & 0x00000004) != 0)) {
                 finalizations_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000004;
               }
@@ -10791,7 +10772,7 @@ public final class Personhood {
             }
             case 34: {
               ch.epfl.dedis.lib.proto.Personhood.PopDesc.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+              if (((bitField0_ & 0x00000004) != 0)) {
                 subBuilder = description_.toBuilder();
               }
               description_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.PopDesc.parser(), extensionRegistry);
@@ -10804,7 +10785,7 @@ public final class Personhood {
             }
             case 42: {
               ch.epfl.dedis.lib.proto.Personhood.Attendees.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000008) == 0x00000008)) {
+              if (((bitField0_ & 0x00000008) != 0)) {
                 subBuilder = attendees_.toBuilder();
               }
               attendees_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.Attendees.parser(), extensionRegistry);
@@ -10816,7 +10797,7 @@ public final class Personhood {
               break;
             }
             case 50: {
-              if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+              if (!((mutable_bitField0_ & 0x00000020) != 0)) {
                 miners_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.LRSTag>();
                 mutable_bitField0_ |= 0x00000020;
               }
@@ -10854,10 +10835,10 @@ public final class Personhood {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((mutable_bitField0_ & 0x00000004) != 0)) {
           finalizations_ = finalizations_.getUnmodifiableView();
         }
-        if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+        if (((mutable_bitField0_ & 0x00000020) != 0)) {
           miners_ = java.util.Collections.unmodifiableList(miners_);
         }
         this.unknownFields = unknownFields.build();
@@ -10891,7 +10872,7 @@ public final class Personhood {
      * <code>required sint32 state = 1;</code>
      */
     public boolean hasState() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -10917,7 +10898,7 @@ public final class Personhood {
      * <code>required sint32 organizers = 2;</code>
      */
     public boolean hasOrganizers() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -10990,7 +10971,7 @@ public final class Personhood {
      * <code>required .personhood.PopDesc description = 4;</code>
      */
     public boolean hasDescription() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <pre>
@@ -11025,7 +11006,7 @@ public final class Personhood {
      * <code>required .personhood.Attendees attendees = 5;</code>
      */
     public boolean hasAttendees() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <pre>
@@ -11118,7 +11099,7 @@ public final class Personhood {
      * <code>required uint64 miningreward = 7;</code>
      */
     public boolean hasMiningreward() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000010) != 0);
     }
     /**
      * <pre>
@@ -11142,7 +11123,7 @@ public final class Personhood {
      * <code>optional bytes previous = 8;</code>
      */
     public boolean hasPrevious() {
-      return ((bitField0_ & 0x00000020) == 0x00000020);
+      return ((bitField0_ & 0x00000020) != 0);
     }
     /**
      * <pre>
@@ -11167,7 +11148,7 @@ public final class Personhood {
      * <code>optional bytes next = 9;</code>
      */
     public boolean hasNext() {
-      return ((bitField0_ & 0x00000040) == 0x00000040);
+      return ((bitField0_ & 0x00000040) != 0);
     }
     /**
      * <pre>
@@ -11225,31 +11206,31 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeSInt32(1, state_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeSInt32(2, organizers_);
       }
       for (int i = 0; i < finalizations_.size(); i++) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 3, finalizations_.getRaw(i));
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeMessage(4, getDescription());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeMessage(5, getAttendees());
       }
       for (int i = 0; i < miners_.size(); i++) {
         output.writeMessage(6, miners_.get(i));
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         output.writeUInt64(7, miningreward_);
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if (((bitField0_ & 0x00000020) != 0)) {
         output.writeBytes(8, previous_);
       }
-      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+      if (((bitField0_ & 0x00000040) != 0)) {
         output.writeBytes(9, next_);
       }
       unknownFields.writeTo(output);
@@ -11261,11 +11242,11 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(1, state_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(2, organizers_);
       }
@@ -11277,11 +11258,11 @@ public final class Personhood {
         size += dataSize;
         size += 1 * getFinalizationsList().size();
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(4, getDescription());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(5, getAttendees());
       }
@@ -11289,15 +11270,15 @@ public final class Personhood {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(6, miners_.get(i));
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(7, miningreward_);
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if (((bitField0_ & 0x00000020) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(8, previous_);
       }
-      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+      if (((bitField0_ & 0x00000040) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(9, next_);
       }
@@ -11316,48 +11297,47 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.PopPartyStruct other = (ch.epfl.dedis.lib.proto.Personhood.PopPartyStruct) obj;
 
-      boolean result = true;
-      result = result && (hasState() == other.hasState());
+      if (hasState() != other.hasState()) return false;
       if (hasState()) {
-        result = result && (getState()
-            == other.getState());
+        if (getState()
+            != other.getState()) return false;
       }
-      result = result && (hasOrganizers() == other.hasOrganizers());
+      if (hasOrganizers() != other.hasOrganizers()) return false;
       if (hasOrganizers()) {
-        result = result && (getOrganizers()
-            == other.getOrganizers());
+        if (getOrganizers()
+            != other.getOrganizers()) return false;
       }
-      result = result && getFinalizationsList()
-          .equals(other.getFinalizationsList());
-      result = result && (hasDescription() == other.hasDescription());
+      if (!getFinalizationsList()
+          .equals(other.getFinalizationsList())) return false;
+      if (hasDescription() != other.hasDescription()) return false;
       if (hasDescription()) {
-        result = result && getDescription()
-            .equals(other.getDescription());
+        if (!getDescription()
+            .equals(other.getDescription())) return false;
       }
-      result = result && (hasAttendees() == other.hasAttendees());
+      if (hasAttendees() != other.hasAttendees()) return false;
       if (hasAttendees()) {
-        result = result && getAttendees()
-            .equals(other.getAttendees());
+        if (!getAttendees()
+            .equals(other.getAttendees())) return false;
       }
-      result = result && getMinersList()
-          .equals(other.getMinersList());
-      result = result && (hasMiningreward() == other.hasMiningreward());
+      if (!getMinersList()
+          .equals(other.getMinersList())) return false;
+      if (hasMiningreward() != other.hasMiningreward()) return false;
       if (hasMiningreward()) {
-        result = result && (getMiningreward()
-            == other.getMiningreward());
+        if (getMiningreward()
+            != other.getMiningreward()) return false;
       }
-      result = result && (hasPrevious() == other.hasPrevious());
+      if (hasPrevious() != other.hasPrevious()) return false;
       if (hasPrevious()) {
-        result = result && getPrevious()
-            .equals(other.getPrevious());
+        if (!getPrevious()
+            .equals(other.getPrevious())) return false;
       }
-      result = result && (hasNext() == other.hasNext());
+      if (hasNext() != other.hasNext()) return false;
       if (hasNext()) {
-        result = result && getNext()
-            .equals(other.getNext());
+        if (!getNext()
+            .equals(other.getNext())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -11602,37 +11582,37 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.PopPartyStruct result = new ch.epfl.dedis.lib.proto.Personhood.PopPartyStruct(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.state_ = state_;
           to_bitField0_ |= 0x00000001;
         }
-        result.state_ = state_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.organizers_ = organizers_;
           to_bitField0_ |= 0x00000002;
         }
-        result.organizers_ = organizers_;
-        if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((bitField0_ & 0x00000004) != 0)) {
           finalizations_ = finalizations_.getUnmodifiableView();
           bitField0_ = (bitField0_ & ~0x00000004);
         }
         result.finalizations_ = finalizations_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          if (descriptionBuilder_ == null) {
+            result.description_ = description_;
+          } else {
+            result.description_ = descriptionBuilder_.build();
+          }
           to_bitField0_ |= 0x00000004;
         }
-        if (descriptionBuilder_ == null) {
-          result.description_ = description_;
-        } else {
-          result.description_ = descriptionBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((from_bitField0_ & 0x00000010) != 0)) {
+          if (attendeesBuilder_ == null) {
+            result.attendees_ = attendees_;
+          } else {
+            result.attendees_ = attendeesBuilder_.build();
+          }
           to_bitField0_ |= 0x00000008;
         }
-        if (attendeesBuilder_ == null) {
-          result.attendees_ = attendees_;
-        } else {
-          result.attendees_ = attendeesBuilder_.build();
-        }
         if (minersBuilder_ == null) {
-          if (((bitField0_ & 0x00000020) == 0x00000020)) {
+          if (((bitField0_ & 0x00000020) != 0)) {
             miners_ = java.util.Collections.unmodifiableList(miners_);
             bitField0_ = (bitField0_ & ~0x00000020);
           }
@@ -11640,15 +11620,15 @@ public final class Personhood {
         } else {
           result.miners_ = minersBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+        if (((from_bitField0_ & 0x00000040) != 0)) {
+          result.miningreward_ = miningreward_;
           to_bitField0_ |= 0x00000010;
         }
-        result.miningreward_ = miningreward_;
-        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
+        if (((from_bitField0_ & 0x00000080) != 0)) {
           to_bitField0_ |= 0x00000020;
         }
         result.previous_ = previous_;
-        if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
+        if (((from_bitField0_ & 0x00000100) != 0)) {
           to_bitField0_ |= 0x00000040;
         }
         result.next_ = next_;
@@ -11659,35 +11639,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -11823,7 +11803,7 @@ public final class Personhood {
        * <code>required sint32 state = 1;</code>
        */
       public boolean hasState() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -11880,7 +11860,7 @@ public final class Personhood {
        * <code>required sint32 organizers = 2;</code>
        */
       public boolean hasOrganizers() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -11921,7 +11901,7 @@ public final class Personhood {
 
       private com.google.protobuf.LazyStringList finalizations_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureFinalizationsIsMutable() {
-        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
+        if (!((bitField0_ & 0x00000004) != 0)) {
           finalizations_ = new com.google.protobuf.LazyStringArrayList(finalizations_);
           bitField0_ |= 0x00000004;
          }
@@ -12057,7 +12037,7 @@ public final class Personhood {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.Personhood.PopDesc description_ = null;
+      private ch.epfl.dedis.lib.proto.Personhood.PopDesc description_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.Personhood.PopDesc, ch.epfl.dedis.lib.proto.Personhood.PopDesc.Builder, ch.epfl.dedis.lib.proto.Personhood.PopDescOrBuilder> descriptionBuilder_;
       /**
@@ -12069,7 +12049,7 @@ public final class Personhood {
        * <code>required .personhood.PopDesc description = 4;</code>
        */
       public boolean hasDescription() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <pre>
@@ -12136,7 +12116,7 @@ public final class Personhood {
        */
       public Builder mergeDescription(ch.epfl.dedis.lib.proto.Personhood.PopDesc value) {
         if (descriptionBuilder_ == null) {
-          if (((bitField0_ & 0x00000008) == 0x00000008) &&
+          if (((bitField0_ & 0x00000008) != 0) &&
               description_ != null &&
               description_ != ch.epfl.dedis.lib.proto.Personhood.PopDesc.getDefaultInstance()) {
             description_ =
@@ -12220,7 +12200,7 @@ public final class Personhood {
         return descriptionBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.Personhood.Attendees attendees_ = null;
+      private ch.epfl.dedis.lib.proto.Personhood.Attendees attendees_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.Personhood.Attendees, ch.epfl.dedis.lib.proto.Personhood.Attendees.Builder, ch.epfl.dedis.lib.proto.Personhood.AttendeesOrBuilder> attendeesBuilder_;
       /**
@@ -12231,7 +12211,7 @@ public final class Personhood {
        * <code>required .personhood.Attendees attendees = 5;</code>
        */
       public boolean hasAttendees() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return ((bitField0_ & 0x00000010) != 0);
       }
       /**
        * <pre>
@@ -12294,7 +12274,7 @@ public final class Personhood {
        */
       public Builder mergeAttendees(ch.epfl.dedis.lib.proto.Personhood.Attendees value) {
         if (attendeesBuilder_ == null) {
-          if (((bitField0_ & 0x00000010) == 0x00000010) &&
+          if (((bitField0_ & 0x00000010) != 0) &&
               attendees_ != null &&
               attendees_ != ch.epfl.dedis.lib.proto.Personhood.Attendees.getDefaultInstance()) {
             attendees_ =
@@ -12377,7 +12357,7 @@ public final class Personhood {
       private java.util.List<ch.epfl.dedis.lib.proto.Personhood.LRSTag> miners_ =
         java.util.Collections.emptyList();
       private void ensureMinersIsMutable() {
-        if (!((bitField0_ & 0x00000020) == 0x00000020)) {
+        if (!((bitField0_ & 0x00000020) != 0)) {
           miners_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.LRSTag>(miners_);
           bitField0_ |= 0x00000020;
          }
@@ -12696,7 +12676,7 @@ public final class Personhood {
           minersBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.Personhood.LRSTag, ch.epfl.dedis.lib.proto.Personhood.LRSTag.Builder, ch.epfl.dedis.lib.proto.Personhood.LRSTagOrBuilder>(
                   miners_,
-                  ((bitField0_ & 0x00000020) == 0x00000020),
+                  ((bitField0_ & 0x00000020) != 0),
                   getParentForChildren(),
                   isClean());
           miners_ = null;
@@ -12713,7 +12693,7 @@ public final class Personhood {
        * <code>required uint64 miningreward = 7;</code>
        */
       public boolean hasMiningreward() {
-        return ((bitField0_ & 0x00000040) == 0x00000040);
+        return ((bitField0_ & 0x00000040) != 0);
       }
       /**
        * <pre>
@@ -12762,7 +12742,7 @@ public final class Personhood {
        * <code>optional bytes previous = 8;</code>
        */
       public boolean hasPrevious() {
-        return ((bitField0_ & 0x00000080) == 0x00000080);
+        return ((bitField0_ & 0x00000080) != 0);
       }
       /**
        * <pre>
@@ -12817,7 +12797,7 @@ public final class Personhood {
        * <code>optional bytes next = 9;</code>
        */
       public boolean hasNext() {
-        return ((bitField0_ & 0x00000100) == 0x00000100);
+        return ((bitField0_ & 0x00000100) != 0);
       }
       /**
        * <pre>
@@ -13032,7 +13012,6 @@ public final class Personhood {
     private PopDesc() {
       name_ = "";
       purpose_ = "";
-      datetime_ = 0L;
       location_ = "";
     }
 
@@ -13126,7 +13105,7 @@ public final class Personhood {
      * <code>required string name = 1;</code>
      */
     public boolean hasName() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -13180,7 +13159,7 @@ public final class Personhood {
      * <code>required string purpose = 2;</code>
      */
     public boolean hasPurpose() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -13234,7 +13213,7 @@ public final class Personhood {
      * <code>required uint64 datetime = 3;</code>
      */
     public boolean hasDatetime() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <pre>
@@ -13257,7 +13236,7 @@ public final class Personhood {
      * <code>required string location = 4;</code>
      */
     public boolean hasLocation() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <pre>
@@ -13331,16 +13310,16 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, purpose_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeUInt64(3, datetime_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 4, location_);
       }
       unknownFields.writeTo(output);
@@ -13352,17 +13331,17 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, purpose_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeUInt64Size(3, datetime_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, location_);
       }
       size += unknownFields.getSerializedSize();
@@ -13380,29 +13359,28 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.PopDesc other = (ch.epfl.dedis.lib.proto.Personhood.PopDesc) obj;
 
-      boolean result = true;
-      result = result && (hasName() == other.hasName());
+      if (hasName() != other.hasName()) return false;
       if (hasName()) {
-        result = result && getName()
-            .equals(other.getName());
+        if (!getName()
+            .equals(other.getName())) return false;
       }
-      result = result && (hasPurpose() == other.hasPurpose());
+      if (hasPurpose() != other.hasPurpose()) return false;
       if (hasPurpose()) {
-        result = result && getPurpose()
-            .equals(other.getPurpose());
+        if (!getPurpose()
+            .equals(other.getPurpose())) return false;
       }
-      result = result && (hasDatetime() == other.hasDatetime());
+      if (hasDatetime() != other.hasDatetime()) return false;
       if (hasDatetime()) {
-        result = result && (getDatetime()
-            == other.getDatetime());
+        if (getDatetime()
+            != other.getDatetime()) return false;
       }
-      result = result && (hasLocation() == other.hasLocation());
+      if (hasLocation() != other.hasLocation()) return false;
       if (hasLocation()) {
-        result = result && getLocation()
-            .equals(other.getLocation());
+        if (!getLocation()
+            .equals(other.getLocation())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -13602,19 +13580,19 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.PopDesc result = new ch.epfl.dedis.lib.proto.Personhood.PopDesc(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.name_ = name_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.purpose_ = purpose_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.datetime_ = datetime_;
           to_bitField0_ |= 0x00000004;
         }
-        result.datetime_ = datetime_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
           to_bitField0_ |= 0x00000008;
         }
         result.location_ = location_;
@@ -13625,35 +13603,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -13736,7 +13714,7 @@ public final class Personhood {
        * <code>required string name = 1;</code>
        */
       public boolean hasName() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -13836,7 +13814,7 @@ public final class Personhood {
        * <code>required string purpose = 2;</code>
        */
       public boolean hasPurpose() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -13936,7 +13914,7 @@ public final class Personhood {
        * <code>required uint64 datetime = 3;</code>
        */
       public boolean hasDatetime() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <pre>
@@ -13984,7 +13962,7 @@ public final class Personhood {
        * <code>required string location = 4;</code>
        */
       public boolean hasLocation() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <pre>
@@ -14227,7 +14205,7 @@ public final class Personhood {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.Personhood.PopDesc.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = desc_.toBuilder();
               }
               desc_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.PopDesc.parser(), extensionRegistry);
@@ -14240,7 +14218,7 @@ public final class Personhood {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.Personhood.Attendees.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = attendees_.toBuilder();
               }
               attendees_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.Attendees.parser(), extensionRegistry);
@@ -14294,7 +14272,7 @@ public final class Personhood {
      * <code>optional .personhood.PopDesc desc = 1;</code>
      */
     public boolean hasDesc() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -14327,7 +14305,7 @@ public final class Personhood {
      * <code>required .personhood.Attendees attendees = 2;</code>
      */
     public boolean hasAttendees() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <pre>
@@ -14374,10 +14352,10 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getDesc());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getAttendees());
       }
       unknownFields.writeTo(output);
@@ -14389,11 +14367,11 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getDesc());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getAttendees());
       }
@@ -14412,19 +14390,18 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.FinalStatement other = (ch.epfl.dedis.lib.proto.Personhood.FinalStatement) obj;
 
-      boolean result = true;
-      result = result && (hasDesc() == other.hasDesc());
+      if (hasDesc() != other.hasDesc()) return false;
       if (hasDesc()) {
-        result = result && getDesc()
-            .equals(other.getDesc());
+        if (!getDesc()
+            .equals(other.getDesc())) return false;
       }
-      result = result && (hasAttendees() == other.hasAttendees());
+      if (hasAttendees() != other.hasAttendees()) return false;
       if (hasAttendees()) {
-        result = result && getAttendees()
-            .equals(other.getAttendees());
+        if (!getAttendees()
+            .equals(other.getAttendees())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -14622,21 +14599,21 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.FinalStatement result = new ch.epfl.dedis.lib.proto.Personhood.FinalStatement(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (descBuilder_ == null) {
+            result.desc_ = desc_;
+          } else {
+            result.desc_ = descBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
         }
-        if (descBuilder_ == null) {
-          result.desc_ = desc_;
-        } else {
-          result.desc_ = descBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (attendeesBuilder_ == null) {
+            result.attendees_ = attendees_;
+          } else {
+            result.attendees_ = attendeesBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
-        }
-        if (attendeesBuilder_ == null) {
-          result.attendees_ = attendees_;
-        } else {
-          result.attendees_ = attendeesBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -14645,35 +14622,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -14731,7 +14708,7 @@ public final class Personhood {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.Personhood.PopDesc desc_ = null;
+      private ch.epfl.dedis.lib.proto.Personhood.PopDesc desc_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.Personhood.PopDesc, ch.epfl.dedis.lib.proto.Personhood.PopDesc.Builder, ch.epfl.dedis.lib.proto.Personhood.PopDescOrBuilder> descBuilder_;
       /**
@@ -14742,7 +14719,7 @@ public final class Personhood {
        * <code>optional .personhood.PopDesc desc = 1;</code>
        */
       public boolean hasDesc() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -14805,7 +14782,7 @@ public final class Personhood {
        */
       public Builder mergeDesc(ch.epfl.dedis.lib.proto.Personhood.PopDesc value) {
         if (descBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               desc_ != null &&
               desc_ != ch.epfl.dedis.lib.proto.Personhood.PopDesc.getDefaultInstance()) {
             desc_ =
@@ -14885,7 +14862,7 @@ public final class Personhood {
         return descBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.Personhood.Attendees attendees_ = null;
+      private ch.epfl.dedis.lib.proto.Personhood.Attendees attendees_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.Personhood.Attendees, ch.epfl.dedis.lib.proto.Personhood.Attendees.Builder, ch.epfl.dedis.lib.proto.Personhood.AttendeesOrBuilder> attendeesBuilder_;
       /**
@@ -14896,7 +14873,7 @@ public final class Personhood {
        * <code>required .personhood.Attendees attendees = 2;</code>
        */
       public boolean hasAttendees() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <pre>
@@ -14959,7 +14936,7 @@ public final class Personhood {
        */
       public Builder mergeAttendees(ch.epfl.dedis.lib.proto.Personhood.Attendees value) {
         if (attendeesBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               attendees_ != null &&
               attendees_ != ch.epfl.dedis.lib.proto.Personhood.Attendees.getDefaultInstance()) {
             attendees_ =
@@ -15153,7 +15130,7 @@ public final class Personhood {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 keys_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -15175,8 +15152,8 @@ public final class Personhood {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          keys_ = java.util.Collections.unmodifiableList(keys_);
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
+          keys_ = java.util.Collections.unmodifiableList(keys_); // C
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -15267,11 +15244,10 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.Attendees other = (ch.epfl.dedis.lib.proto.Personhood.Attendees) obj;
 
-      boolean result = true;
-      result = result && getKeysList()
-          .equals(other.getKeysList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getKeysList()
+          .equals(other.getKeysList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -15451,7 +15427,7 @@ public final class Personhood {
       public ch.epfl.dedis.lib.proto.Personhood.Attendees buildPartial() {
         ch.epfl.dedis.lib.proto.Personhood.Attendees result = new ch.epfl.dedis.lib.proto.Personhood.Attendees(this);
         int from_bitField0_ = bitField0_;
-        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((bitField0_ & 0x00000001) != 0)) {
           keys_ = java.util.Collections.unmodifiableList(keys_);
           bitField0_ = (bitField0_ & ~0x00000001);
         }
@@ -15462,35 +15438,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -15546,7 +15522,7 @@ public final class Personhood {
 
       private java.util.List<com.google.protobuf.ByteString> keys_ = java.util.Collections.emptyList();
       private void ensureKeysIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           keys_ = new java.util.ArrayList<com.google.protobuf.ByteString>(keys_);
           bitField0_ |= 0x00000001;
          }
@@ -15556,7 +15532,8 @@ public final class Personhood {
        */
       public java.util.List<com.google.protobuf.ByteString>
           getKeysList() {
-        return java.util.Collections.unmodifiableList(keys_);
+        return ((bitField0_ & 0x00000001) != 0) ?
+                 java.util.Collections.unmodifiableList(keys_) : keys_;
       }
       /**
        * <code>repeated bytes keys = 1;</code>
@@ -15769,7 +15746,7 @@ public final class Personhood {
      * <code>required bytes tag = 1;</code>
      */
     public boolean hasTag() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes tag = 1;</code>
@@ -15796,7 +15773,7 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, tag_);
       }
       unknownFields.writeTo(output);
@@ -15808,7 +15785,7 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, tag_);
       }
@@ -15827,14 +15804,13 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.LRSTag other = (ch.epfl.dedis.lib.proto.Personhood.LRSTag) obj;
 
-      boolean result = true;
-      result = result && (hasTag() == other.hasTag());
+      if (hasTag() != other.hasTag()) return false;
       if (hasTag()) {
-        result = result && getTag()
-            .equals(other.getTag());
+        if (!getTag()
+            .equals(other.getTag())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -16015,7 +15991,7 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.LRSTag result = new ch.epfl.dedis.lib.proto.Personhood.LRSTag(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.tag_ = tag_;
@@ -16026,35 +16002,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -16109,7 +16085,7 @@ public final class Personhood {
        * <code>required bytes tag = 1;</code>
        */
       public boolean hasTag() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes tag = 1;</code>
@@ -16294,7 +16270,7 @@ public final class Personhood {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.Personhood.PollStruct.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = newpoll_.toBuilder();
               }
               newpoll_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.PollStruct.parser(), extensionRegistry);
@@ -16307,7 +16283,7 @@ public final class Personhood {
             }
             case 26: {
               ch.epfl.dedis.lib.proto.Personhood.PollList.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+              if (((bitField0_ & 0x00000004) != 0)) {
                 subBuilder = list_.toBuilder();
               }
               list_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.PollList.parser(), extensionRegistry);
@@ -16320,7 +16296,7 @@ public final class Personhood {
             }
             case 34: {
               ch.epfl.dedis.lib.proto.Personhood.PollAnswer.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000008) == 0x00000008)) {
+              if (((bitField0_ & 0x00000008) != 0)) {
                 subBuilder = answer_.toBuilder();
               }
               answer_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.PollAnswer.parser(), extensionRegistry);
@@ -16370,7 +16346,7 @@ public final class Personhood {
      * <code>required bytes byzcoinid = 1;</code>
      */
     public boolean hasByzcoinid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes byzcoinid = 1;</code>
@@ -16385,7 +16361,7 @@ public final class Personhood {
      * <code>optional .personhood.PollStruct newpoll = 2;</code>
      */
     public boolean hasNewpoll() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>optional .personhood.PollStruct newpoll = 2;</code>
@@ -16406,7 +16382,7 @@ public final class Personhood {
      * <code>optional .personhood.PollList list = 3;</code>
      */
     public boolean hasList() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>optional .personhood.PollList list = 3;</code>
@@ -16427,7 +16403,7 @@ public final class Personhood {
      * <code>optional .personhood.PollAnswer answer = 4;</code>
      */
     public boolean hasAnswer() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <code>optional .personhood.PollAnswer answer = 4;</code>
@@ -16472,16 +16448,16 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, byzcoinid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getNewpoll());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeMessage(3, getList());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeMessage(4, getAnswer());
       }
       unknownFields.writeTo(output);
@@ -16493,19 +16469,19 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, byzcoinid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getNewpoll());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, getList());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(4, getAnswer());
       }
@@ -16524,29 +16500,28 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.Poll other = (ch.epfl.dedis.lib.proto.Personhood.Poll) obj;
 
-      boolean result = true;
-      result = result && (hasByzcoinid() == other.hasByzcoinid());
+      if (hasByzcoinid() != other.hasByzcoinid()) return false;
       if (hasByzcoinid()) {
-        result = result && getByzcoinid()
-            .equals(other.getByzcoinid());
+        if (!getByzcoinid()
+            .equals(other.getByzcoinid())) return false;
       }
-      result = result && (hasNewpoll() == other.hasNewpoll());
+      if (hasNewpoll() != other.hasNewpoll()) return false;
       if (hasNewpoll()) {
-        result = result && getNewpoll()
-            .equals(other.getNewpoll());
+        if (!getNewpoll()
+            .equals(other.getNewpoll())) return false;
       }
-      result = result && (hasList() == other.hasList());
+      if (hasList() != other.hasList()) return false;
       if (hasList()) {
-        result = result && getList()
-            .equals(other.getList());
+        if (!getList()
+            .equals(other.getList())) return false;
       }
-      result = result && (hasAnswer() == other.hasAnswer());
+      if (hasAnswer() != other.hasAnswer()) return false;
       if (hasAnswer()) {
-        result = result && getAnswer()
-            .equals(other.getAnswer());
+        if (!getAnswer()
+            .equals(other.getAnswer())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -16760,33 +16735,33 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.Poll result = new ch.epfl.dedis.lib.proto.Personhood.Poll(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.byzcoinid_ = byzcoinid_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (newpollBuilder_ == null) {
+            result.newpoll_ = newpoll_;
+          } else {
+            result.newpoll_ = newpollBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
         }
-        if (newpollBuilder_ == null) {
-          result.newpoll_ = newpoll_;
-        } else {
-          result.newpoll_ = newpollBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          if (listBuilder_ == null) {
+            result.list_ = list_;
+          } else {
+            result.list_ = listBuilder_.build();
+          }
           to_bitField0_ |= 0x00000004;
         }
-        if (listBuilder_ == null) {
-          result.list_ = list_;
-        } else {
-          result.list_ = listBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          if (answerBuilder_ == null) {
+            result.answer_ = answer_;
+          } else {
+            result.answer_ = answerBuilder_.build();
+          }
           to_bitField0_ |= 0x00000008;
-        }
-        if (answerBuilder_ == null) {
-          result.answer_ = answer_;
-        } else {
-          result.answer_ = answerBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -16795,35 +16770,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -16897,7 +16872,7 @@ public final class Personhood {
        * <code>required bytes byzcoinid = 1;</code>
        */
       public boolean hasByzcoinid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes byzcoinid = 1;</code>
@@ -16927,14 +16902,14 @@ public final class Personhood {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.Personhood.PollStruct newpoll_ = null;
+      private ch.epfl.dedis.lib.proto.Personhood.PollStruct newpoll_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.Personhood.PollStruct, ch.epfl.dedis.lib.proto.Personhood.PollStruct.Builder, ch.epfl.dedis.lib.proto.Personhood.PollStructOrBuilder> newpollBuilder_;
       /**
        * <code>optional .personhood.PollStruct newpoll = 2;</code>
        */
       public boolean hasNewpoll() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>optional .personhood.PollStruct newpoll = 2;</code>
@@ -16981,7 +16956,7 @@ public final class Personhood {
        */
       public Builder mergeNewpoll(ch.epfl.dedis.lib.proto.Personhood.PollStruct value) {
         if (newpollBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               newpoll_ != null &&
               newpoll_ != ch.epfl.dedis.lib.proto.Personhood.PollStruct.getDefaultInstance()) {
             newpoll_ =
@@ -17045,14 +17020,14 @@ public final class Personhood {
         return newpollBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.Personhood.PollList list_ = null;
+      private ch.epfl.dedis.lib.proto.Personhood.PollList list_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.Personhood.PollList, ch.epfl.dedis.lib.proto.Personhood.PollList.Builder, ch.epfl.dedis.lib.proto.Personhood.PollListOrBuilder> listBuilder_;
       /**
        * <code>optional .personhood.PollList list = 3;</code>
        */
       public boolean hasList() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>optional .personhood.PollList list = 3;</code>
@@ -17099,7 +17074,7 @@ public final class Personhood {
        */
       public Builder mergeList(ch.epfl.dedis.lib.proto.Personhood.PollList value) {
         if (listBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004) &&
+          if (((bitField0_ & 0x00000004) != 0) &&
               list_ != null &&
               list_ != ch.epfl.dedis.lib.proto.Personhood.PollList.getDefaultInstance()) {
             list_ =
@@ -17163,14 +17138,14 @@ public final class Personhood {
         return listBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.Personhood.PollAnswer answer_ = null;
+      private ch.epfl.dedis.lib.proto.Personhood.PollAnswer answer_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.Personhood.PollAnswer, ch.epfl.dedis.lib.proto.Personhood.PollAnswer.Builder, ch.epfl.dedis.lib.proto.Personhood.PollAnswerOrBuilder> answerBuilder_;
       /**
        * <code>optional .personhood.PollAnswer answer = 4;</code>
        */
       public boolean hasAnswer() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <code>optional .personhood.PollAnswer answer = 4;</code>
@@ -17217,7 +17192,7 @@ public final class Personhood {
        */
       public Builder mergeAnswer(ch.epfl.dedis.lib.proto.Personhood.PollAnswer value) {
         if (answerBuilder_ == null) {
-          if (((bitField0_ & 0x00000008) == 0x00000008) &&
+          if (((bitField0_ & 0x00000008) != 0) &&
               answer_ != null &&
               answer_ != ch.epfl.dedis.lib.proto.Personhood.PollAnswer.getDefaultInstance()) {
             answer_ =
@@ -17395,7 +17370,7 @@ public final class Personhood {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 partyids_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -17417,8 +17392,8 @@ public final class Personhood {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          partyids_ = java.util.Collections.unmodifiableList(partyids_);
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
+          partyids_ = java.util.Collections.unmodifiableList(partyids_); // C
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -17509,11 +17484,10 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.PollList other = (ch.epfl.dedis.lib.proto.Personhood.PollList) obj;
 
-      boolean result = true;
-      result = result && getPartyidsList()
-          .equals(other.getPartyidsList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getPartyidsList()
+          .equals(other.getPartyidsList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -17693,7 +17667,7 @@ public final class Personhood {
       public ch.epfl.dedis.lib.proto.Personhood.PollList buildPartial() {
         ch.epfl.dedis.lib.proto.Personhood.PollList result = new ch.epfl.dedis.lib.proto.Personhood.PollList(this);
         int from_bitField0_ = bitField0_;
-        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((bitField0_ & 0x00000001) != 0)) {
           partyids_ = java.util.Collections.unmodifiableList(partyids_);
           bitField0_ = (bitField0_ & ~0x00000001);
         }
@@ -17704,35 +17678,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -17788,7 +17762,7 @@ public final class Personhood {
 
       private java.util.List<com.google.protobuf.ByteString> partyids_ = java.util.Collections.emptyList();
       private void ensurePartyidsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           partyids_ = new java.util.ArrayList<com.google.protobuf.ByteString>(partyids_);
           bitField0_ |= 0x00000001;
          }
@@ -17798,7 +17772,8 @@ public final class Personhood {
        */
       public java.util.List<com.google.protobuf.ByteString>
           getPartyidsList() {
-        return java.util.Collections.unmodifiableList(partyids_);
+        return ((bitField0_ & 0x00000001) != 0) ?
+                 java.util.Collections.unmodifiableList(partyids_) : partyids_;
       }
       /**
        * <code>repeated bytes partyids = 1;</code>
@@ -17963,7 +17938,6 @@ public final class Personhood {
     }
     private PollAnswer() {
       pollid_ = com.google.protobuf.ByteString.EMPTY;
-      choice_ = 0;
       lrs_ = com.google.protobuf.ByteString.EMPTY;
     }
 
@@ -18045,7 +18019,7 @@ public final class Personhood {
      * <code>required bytes pollid = 1;</code>
      */
     public boolean hasPollid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes pollid = 1;</code>
@@ -18060,7 +18034,7 @@ public final class Personhood {
      * <code>required sint32 choice = 2;</code>
      */
     public boolean hasChoice() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required sint32 choice = 2;</code>
@@ -18075,7 +18049,7 @@ public final class Personhood {
      * <code>required bytes lrs = 3;</code>
      */
     public boolean hasLrs() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required bytes lrs = 3;</code>
@@ -18110,13 +18084,13 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, pollid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeSInt32(2, choice_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(3, lrs_);
       }
       unknownFields.writeTo(output);
@@ -18128,15 +18102,15 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, pollid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(2, choice_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, lrs_);
       }
@@ -18155,24 +18129,23 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.PollAnswer other = (ch.epfl.dedis.lib.proto.Personhood.PollAnswer) obj;
 
-      boolean result = true;
-      result = result && (hasPollid() == other.hasPollid());
+      if (hasPollid() != other.hasPollid()) return false;
       if (hasPollid()) {
-        result = result && getPollid()
-            .equals(other.getPollid());
+        if (!getPollid()
+            .equals(other.getPollid())) return false;
       }
-      result = result && (hasChoice() == other.hasChoice());
+      if (hasChoice() != other.hasChoice()) return false;
       if (hasChoice()) {
-        result = result && (getChoice()
-            == other.getChoice());
+        if (getChoice()
+            != other.getChoice()) return false;
       }
-      result = result && (hasLrs() == other.hasLrs());
+      if (hasLrs() != other.hasLrs()) return false;
       if (hasLrs()) {
-        result = result && getLrs()
-            .equals(other.getLrs());
+        if (!getLrs()
+            .equals(other.getLrs())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -18369,15 +18342,15 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.PollAnswer result = new ch.epfl.dedis.lib.proto.Personhood.PollAnswer(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.pollid_ = pollid_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.choice_ = choice_;
           to_bitField0_ |= 0x00000002;
         }
-        result.choice_ = choice_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.lrs_ = lrs_;
@@ -18388,35 +18361,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -18483,7 +18456,7 @@ public final class Personhood {
        * <code>required bytes pollid = 1;</code>
        */
       public boolean hasPollid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes pollid = 1;</code>
@@ -18518,7 +18491,7 @@ public final class Personhood {
        * <code>required sint32 choice = 2;</code>
        */
       public boolean hasChoice() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required sint32 choice = 2;</code>
@@ -18550,7 +18523,7 @@ public final class Personhood {
        * <code>required bytes lrs = 3;</code>
        */
       public boolean hasLrs() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required bytes lrs = 3;</code>
@@ -18798,7 +18771,7 @@ public final class Personhood {
             }
             case 42: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+              if (!((mutable_bitField0_ & 0x00000010) != 0)) {
                 choices_ = new com.google.protobuf.LazyStringArrayList();
                 mutable_bitField0_ |= 0x00000010;
               }
@@ -18806,7 +18779,7 @@ public final class Personhood {
               break;
             }
             case 50: {
-              if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+              if (!((mutable_bitField0_ & 0x00000020) != 0)) {
                 chosen_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.PollChoice>();
                 mutable_bitField0_ |= 0x00000020;
               }
@@ -18829,10 +18802,10 @@ public final class Personhood {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((mutable_bitField0_ & 0x00000010) != 0)) {
           choices_ = choices_.getUnmodifiableView();
         }
-        if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+        if (((mutable_bitField0_ & 0x00000020) != 0)) {
           chosen_ = java.util.Collections.unmodifiableList(chosen_);
         }
         this.unknownFields = unknownFields.build();
@@ -18859,7 +18832,7 @@ public final class Personhood {
      * <code>required bytes personhood = 1;</code>
      */
     public boolean hasPersonhood() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes personhood = 1;</code>
@@ -18874,7 +18847,7 @@ public final class Personhood {
      * <code>optional bytes pollid = 2;</code>
      */
     public boolean hasPollid() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>optional bytes pollid = 2;</code>
@@ -18889,7 +18862,7 @@ public final class Personhood {
      * <code>required string title = 3;</code>
      */
     public boolean hasTitle() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required string title = 3;</code>
@@ -18931,7 +18904,7 @@ public final class Personhood {
      * <code>required string description = 4;</code>
      */
     public boolean hasDescription() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <code>required string description = 4;</code>
@@ -19063,16 +19036,16 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, personhood_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, pollid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 3, title_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 4, description_);
       }
       for (int i = 0; i < choices_.size(); i++) {
@@ -19090,18 +19063,18 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, personhood_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, pollid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, title_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, description_);
       }
       {
@@ -19131,33 +19104,32 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.PollStruct other = (ch.epfl.dedis.lib.proto.Personhood.PollStruct) obj;
 
-      boolean result = true;
-      result = result && (hasPersonhood() == other.hasPersonhood());
+      if (hasPersonhood() != other.hasPersonhood()) return false;
       if (hasPersonhood()) {
-        result = result && getPersonhood()
-            .equals(other.getPersonhood());
+        if (!getPersonhood()
+            .equals(other.getPersonhood())) return false;
       }
-      result = result && (hasPollid() == other.hasPollid());
+      if (hasPollid() != other.hasPollid()) return false;
       if (hasPollid()) {
-        result = result && getPollid()
-            .equals(other.getPollid());
+        if (!getPollid()
+            .equals(other.getPollid())) return false;
       }
-      result = result && (hasTitle() == other.hasTitle());
+      if (hasTitle() != other.hasTitle()) return false;
       if (hasTitle()) {
-        result = result && getTitle()
-            .equals(other.getTitle());
+        if (!getTitle()
+            .equals(other.getTitle())) return false;
       }
-      result = result && (hasDescription() == other.hasDescription());
+      if (hasDescription() != other.hasDescription()) return false;
       if (hasDescription()) {
-        result = result && getDescription()
-            .equals(other.getDescription());
+        if (!getDescription()
+            .equals(other.getDescription())) return false;
       }
-      result = result && getChoicesList()
-          .equals(other.getChoicesList());
-      result = result && getChosenList()
-          .equals(other.getChosenList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getChoicesList()
+          .equals(other.getChoicesList())) return false;
+      if (!getChosenList()
+          .equals(other.getChosenList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -19373,29 +19345,29 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.PollStruct result = new ch.epfl.dedis.lib.proto.Personhood.PollStruct(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.personhood_ = personhood_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.pollid_ = pollid_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.title_ = title_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
           to_bitField0_ |= 0x00000008;
         }
         result.description_ = description_;
-        if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((bitField0_ & 0x00000010) != 0)) {
           choices_ = choices_.getUnmodifiableView();
           bitField0_ = (bitField0_ & ~0x00000010);
         }
         result.choices_ = choices_;
         if (chosenBuilder_ == null) {
-          if (((bitField0_ & 0x00000020) == 0x00000020)) {
+          if (((bitField0_ & 0x00000020) != 0)) {
             chosen_ = java.util.Collections.unmodifiableList(chosen_);
             bitField0_ = (bitField0_ & ~0x00000020);
           }
@@ -19410,35 +19382,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -19553,7 +19525,7 @@ public final class Personhood {
        * <code>required bytes personhood = 1;</code>
        */
       public boolean hasPersonhood() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes personhood = 1;</code>
@@ -19588,7 +19560,7 @@ public final class Personhood {
        * <code>optional bytes pollid = 2;</code>
        */
       public boolean hasPollid() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>optional bytes pollid = 2;</code>
@@ -19623,7 +19595,7 @@ public final class Personhood {
        * <code>required string title = 3;</code>
        */
       public boolean hasTitle() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required string title = 3;</code>
@@ -19699,7 +19671,7 @@ public final class Personhood {
        * <code>required string description = 4;</code>
        */
       public boolean hasDescription() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <code>required string description = 4;</code>
@@ -19772,7 +19744,7 @@ public final class Personhood {
 
       private com.google.protobuf.LazyStringList choices_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       private void ensureChoicesIsMutable() {
-        if (!((bitField0_ & 0x00000010) == 0x00000010)) {
+        if (!((bitField0_ & 0x00000010) != 0)) {
           choices_ = new com.google.protobuf.LazyStringArrayList(choices_);
           bitField0_ |= 0x00000010;
          }
@@ -19866,7 +19838,7 @@ public final class Personhood {
       private java.util.List<ch.epfl.dedis.lib.proto.Personhood.PollChoice> chosen_ =
         java.util.Collections.emptyList();
       private void ensureChosenIsMutable() {
-        if (!((bitField0_ & 0x00000020) == 0x00000020)) {
+        if (!((bitField0_ & 0x00000020) != 0)) {
           chosen_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.PollChoice>(chosen_);
           bitField0_ |= 0x00000020;
          }
@@ -20095,7 +20067,7 @@ public final class Personhood {
           chosenBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.Personhood.PollChoice, ch.epfl.dedis.lib.proto.Personhood.PollChoice.Builder, ch.epfl.dedis.lib.proto.Personhood.PollChoiceOrBuilder>(
                   chosen_,
-                  ((bitField0_ & 0x00000020) == 0x00000020),
+                  ((bitField0_ & 0x00000020) != 0),
                   getParentForChildren(),
                   isClean());
           chosen_ = null;
@@ -20194,7 +20166,6 @@ public final class Personhood {
       super(builder);
     }
     private PollChoice() {
-      choice_ = 0;
       lrstag_ = com.google.protobuf.ByteString.EMPTY;
     }
 
@@ -20271,7 +20242,7 @@ public final class Personhood {
      * <code>required sint32 choice = 1;</code>
      */
     public boolean hasChoice() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required sint32 choice = 1;</code>
@@ -20286,7 +20257,7 @@ public final class Personhood {
      * <code>required bytes lrstag = 2;</code>
      */
     public boolean hasLrstag() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes lrstag = 2;</code>
@@ -20317,10 +20288,10 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeSInt32(1, choice_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, lrstag_);
       }
       unknownFields.writeTo(output);
@@ -20332,11 +20303,11 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(1, choice_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, lrstag_);
       }
@@ -20355,19 +20326,18 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.PollChoice other = (ch.epfl.dedis.lib.proto.Personhood.PollChoice) obj;
 
-      boolean result = true;
-      result = result && (hasChoice() == other.hasChoice());
+      if (hasChoice() != other.hasChoice()) return false;
       if (hasChoice()) {
-        result = result && (getChoice()
-            == other.getChoice());
+        if (getChoice()
+            != other.getChoice()) return false;
       }
-      result = result && (hasLrstag() == other.hasLrstag());
+      if (hasLrstag() != other.hasLrstag()) return false;
       if (hasLrstag()) {
-        result = result && getLrstag()
-            .equals(other.getLrstag());
+        if (!getLrstag()
+            .equals(other.getLrstag())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -20554,11 +20524,11 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.PollChoice result = new ch.epfl.dedis.lib.proto.Personhood.PollChoice(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.choice_ = choice_;
           to_bitField0_ |= 0x00000001;
         }
-        result.choice_ = choice_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.lrstag_ = lrstag_;
@@ -20569,35 +20539,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -20658,7 +20628,7 @@ public final class Personhood {
        * <code>required sint32 choice = 1;</code>
        */
       public boolean hasChoice() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required sint32 choice = 1;</code>
@@ -20690,7 +20660,7 @@ public final class Personhood {
        * <code>required bytes lrstag = 2;</code>
        */
       public boolean hasLrstag() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes lrstag = 2;</code>
@@ -20847,7 +20817,7 @@ public final class Personhood {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 polls_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.PollStruct>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -20870,7 +20840,7 @@ public final class Personhood {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           polls_ = java.util.Collections.unmodifiableList(polls_);
         }
         this.unknownFields = unknownFields.build();
@@ -20976,11 +20946,10 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.PollResponse other = (ch.epfl.dedis.lib.proto.Personhood.PollResponse) obj;
 
-      boolean result = true;
-      result = result && getPollsList()
-          .equals(other.getPollsList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getPollsList()
+          .equals(other.getPollsList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -21168,7 +21137,7 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.PollResponse result = new ch.epfl.dedis.lib.proto.Personhood.PollResponse(this);
         int from_bitField0_ = bitField0_;
         if (pollsBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             polls_ = java.util.Collections.unmodifiableList(polls_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -21182,35 +21151,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -21288,7 +21257,7 @@ public final class Personhood {
       private java.util.List<ch.epfl.dedis.lib.proto.Personhood.PollStruct> polls_ =
         java.util.Collections.emptyList();
       private void ensurePollsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           polls_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.PollStruct>(polls_);
           bitField0_ |= 0x00000001;
          }
@@ -21517,7 +21486,7 @@ public final class Personhood {
           pollsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.Personhood.PollStruct, ch.epfl.dedis.lib.proto.Personhood.PollStruct.Builder, ch.epfl.dedis.lib.proto.Personhood.PollStructOrBuilder>(
                   polls_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           polls_ = null;
@@ -21693,9 +21662,8 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.Capabilities other = (ch.epfl.dedis.lib.proto.Personhood.Capabilities) obj;
 
-      boolean result = true;
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -21874,35 +21842,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -22077,7 +22045,7 @@ public final class Personhood {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 capabilities_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.Capability>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -22100,7 +22068,7 @@ public final class Personhood {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           capabilities_ = java.util.Collections.unmodifiableList(capabilities_);
         }
         this.unknownFields = unknownFields.build();
@@ -22206,11 +22174,10 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.CapabilitiesResponse other = (ch.epfl.dedis.lib.proto.Personhood.CapabilitiesResponse) obj;
 
-      boolean result = true;
-      result = result && getCapabilitiesList()
-          .equals(other.getCapabilitiesList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getCapabilitiesList()
+          .equals(other.getCapabilitiesList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -22403,7 +22370,7 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.CapabilitiesResponse result = new ch.epfl.dedis.lib.proto.Personhood.CapabilitiesResponse(this);
         int from_bitField0_ = bitField0_;
         if (capabilitiesBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             capabilities_ = java.util.Collections.unmodifiableList(capabilities_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -22417,35 +22384,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -22523,7 +22490,7 @@ public final class Personhood {
       private java.util.List<ch.epfl.dedis.lib.proto.Personhood.Capability> capabilities_ =
         java.util.Collections.emptyList();
       private void ensureCapabilitiesIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           capabilities_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.Capability>(capabilities_);
           bitField0_ |= 0x00000001;
          }
@@ -22752,7 +22719,7 @@ public final class Personhood {
           capabilitiesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.Personhood.Capability, ch.epfl.dedis.lib.proto.Personhood.Capability.Builder, ch.epfl.dedis.lib.proto.Personhood.CapabilityOrBuilder>(
                   capabilities_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           capabilities_ = null;
@@ -22934,7 +22901,7 @@ public final class Personhood {
      * <code>required string endpoint = 1;</code>
      */
     public boolean hasEndpoint() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required string endpoint = 1;</code>
@@ -22976,7 +22943,7 @@ public final class Personhood {
      * <code>required bytes version = 2;</code>
      */
     public boolean hasVersion() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes version = 2;</code>
@@ -23007,10 +22974,10 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, endpoint_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, version_);
       }
       unknownFields.writeTo(output);
@@ -23022,10 +22989,10 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, endpoint_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, version_);
       }
@@ -23044,19 +23011,18 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.Capability other = (ch.epfl.dedis.lib.proto.Personhood.Capability) obj;
 
-      boolean result = true;
-      result = result && (hasEndpoint() == other.hasEndpoint());
+      if (hasEndpoint() != other.hasEndpoint()) return false;
       if (hasEndpoint()) {
-        result = result && getEndpoint()
-            .equals(other.getEndpoint());
+        if (!getEndpoint()
+            .equals(other.getEndpoint())) return false;
       }
-      result = result && (hasVersion() == other.hasVersion());
+      if (hasVersion() != other.hasVersion()) return false;
       if (hasVersion()) {
-        result = result && getVersion()
-            .equals(other.getVersion());
+        if (!getVersion()
+            .equals(other.getVersion())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -23243,11 +23209,11 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.Capability result = new ch.epfl.dedis.lib.proto.Personhood.Capability(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.endpoint_ = endpoint_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.version_ = version_;
@@ -23258,35 +23224,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -23349,7 +23315,7 @@ public final class Personhood {
        * <code>required string endpoint = 1;</code>
        */
       public boolean hasEndpoint() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required string endpoint = 1;</code>
@@ -23425,7 +23391,7 @@ public final class Personhood {
        * <code>required bytes version = 2;</code>
        */
       public boolean hasVersion() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes version = 2;</code>
@@ -23585,7 +23551,6 @@ public final class Personhood {
       publickey_ = com.google.protobuf.ByteString.EMPTY;
       credentialiid_ = com.google.protobuf.ByteString.EMPTY;
       location_ = "";
-      time_ = 0L;
     }
 
     @java.lang.Override
@@ -23624,7 +23589,7 @@ public final class Personhood {
             }
             case 26: {
               ch.epfl.dedis.lib.proto.Personhood.CredentialStruct.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+              if (((bitField0_ & 0x00000004) != 0)) {
                 subBuilder = credential_.toBuilder();
               }
               credential_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.CredentialStruct.parser(), extensionRegistry);
@@ -23685,7 +23650,7 @@ public final class Personhood {
      * <code>required bytes publickey = 1;</code>
      */
     public boolean hasPublickey() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes publickey = 1;</code>
@@ -23700,7 +23665,7 @@ public final class Personhood {
      * <code>optional bytes credentialiid = 2;</code>
      */
     public boolean hasCredentialiid() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>optional bytes credentialiid = 2;</code>
@@ -23715,7 +23680,7 @@ public final class Personhood {
      * <code>optional .personhood.CredentialStruct credential = 3;</code>
      */
     public boolean hasCredential() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>optional .personhood.CredentialStruct credential = 3;</code>
@@ -23736,7 +23701,7 @@ public final class Personhood {
      * <code>optional string location = 4;</code>
      */
     public boolean hasLocation() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <code>optional string location = 4;</code>
@@ -23778,7 +23743,7 @@ public final class Personhood {
      * <code>required sint64 time = 5;</code>
      */
     public boolean hasTime() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000010) != 0);
     }
     /**
      * <code>required sint64 time = 5;</code>
@@ -23815,19 +23780,19 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, publickey_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, credentialiid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeMessage(3, getCredential());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 4, location_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         output.writeSInt64(5, time_);
       }
       unknownFields.writeTo(output);
@@ -23839,22 +23804,22 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, publickey_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, credentialiid_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, getCredential());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, location_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt64Size(5, time_);
       }
@@ -23873,34 +23838,33 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.UserLocation other = (ch.epfl.dedis.lib.proto.Personhood.UserLocation) obj;
 
-      boolean result = true;
-      result = result && (hasPublickey() == other.hasPublickey());
+      if (hasPublickey() != other.hasPublickey()) return false;
       if (hasPublickey()) {
-        result = result && getPublickey()
-            .equals(other.getPublickey());
+        if (!getPublickey()
+            .equals(other.getPublickey())) return false;
       }
-      result = result && (hasCredentialiid() == other.hasCredentialiid());
+      if (hasCredentialiid() != other.hasCredentialiid()) return false;
       if (hasCredentialiid()) {
-        result = result && getCredentialiid()
-            .equals(other.getCredentialiid());
+        if (!getCredentialiid()
+            .equals(other.getCredentialiid())) return false;
       }
-      result = result && (hasCredential() == other.hasCredential());
+      if (hasCredential() != other.hasCredential()) return false;
       if (hasCredential()) {
-        result = result && getCredential()
-            .equals(other.getCredential());
+        if (!getCredential()
+            .equals(other.getCredential())) return false;
       }
-      result = result && (hasLocation() == other.hasLocation());
+      if (hasLocation() != other.hasLocation()) return false;
       if (hasLocation()) {
-        result = result && getLocation()
-            .equals(other.getLocation());
+        if (!getLocation()
+            .equals(other.getLocation())) return false;
       }
-      result = result && (hasTime() == other.hasTime());
+      if (hasTime() != other.hasTime()) return false;
       if (hasTime()) {
-        result = result && (getTime()
-            == other.getTime());
+        if (getTime()
+            != other.getTime()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -24111,30 +24075,30 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.UserLocation result = new ch.epfl.dedis.lib.proto.Personhood.UserLocation(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.publickey_ = publickey_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.credentialiid_ = credentialiid_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          if (credentialBuilder_ == null) {
+            result.credential_ = credential_;
+          } else {
+            result.credential_ = credentialBuilder_.build();
+          }
           to_bitField0_ |= 0x00000004;
         }
-        if (credentialBuilder_ == null) {
-          result.credential_ = credential_;
-        } else {
-          result.credential_ = credentialBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
           to_bitField0_ |= 0x00000008;
         }
         result.location_ = location_;
-        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((from_bitField0_ & 0x00000010) != 0)) {
+          result.time_ = time_;
           to_bitField0_ |= 0x00000010;
         }
-        result.time_ = time_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -24142,35 +24106,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -24247,7 +24211,7 @@ public final class Personhood {
        * <code>required bytes publickey = 1;</code>
        */
       public boolean hasPublickey() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes publickey = 1;</code>
@@ -24282,7 +24246,7 @@ public final class Personhood {
        * <code>optional bytes credentialiid = 2;</code>
        */
       public boolean hasCredentialiid() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>optional bytes credentialiid = 2;</code>
@@ -24312,14 +24276,14 @@ public final class Personhood {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.Personhood.CredentialStruct credential_ = null;
+      private ch.epfl.dedis.lib.proto.Personhood.CredentialStruct credential_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.Personhood.CredentialStruct, ch.epfl.dedis.lib.proto.Personhood.CredentialStruct.Builder, ch.epfl.dedis.lib.proto.Personhood.CredentialStructOrBuilder> credentialBuilder_;
       /**
        * <code>optional .personhood.CredentialStruct credential = 3;</code>
        */
       public boolean hasCredential() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>optional .personhood.CredentialStruct credential = 3;</code>
@@ -24366,7 +24330,7 @@ public final class Personhood {
        */
       public Builder mergeCredential(ch.epfl.dedis.lib.proto.Personhood.CredentialStruct value) {
         if (credentialBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004) &&
+          if (((bitField0_ & 0x00000004) != 0) &&
               credential_ != null &&
               credential_ != ch.epfl.dedis.lib.proto.Personhood.CredentialStruct.getDefaultInstance()) {
             credential_ =
@@ -24435,7 +24399,7 @@ public final class Personhood {
        * <code>optional string location = 4;</code>
        */
       public boolean hasLocation() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <code>optional string location = 4;</code>
@@ -24511,7 +24475,7 @@ public final class Personhood {
        * <code>required sint64 time = 5;</code>
        */
       public boolean hasTime() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return ((bitField0_ & 0x00000010) != 0);
       }
       /**
        * <code>required sint64 time = 5;</code>
@@ -24633,7 +24597,6 @@ public final class Personhood {
       super(builder);
     }
     private Meetup() {
-      wipe_ = false;
     }
 
     @java.lang.Override
@@ -24662,7 +24625,7 @@ public final class Personhood {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.Personhood.UserLocation.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = userlocation_.toBuilder();
               }
               userlocation_ = input.readMessage(ch.epfl.dedis.lib.proto.Personhood.UserLocation.parser(), extensionRegistry);
@@ -24717,7 +24680,7 @@ public final class Personhood {
      * <code>optional .personhood.UserLocation userlocation = 1;</code>
      */
     public boolean hasUserlocation() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>optional .personhood.UserLocation userlocation = 1;</code>
@@ -24738,7 +24701,7 @@ public final class Personhood {
      * <code>optional bool wipe = 2;</code>
      */
     public boolean hasWipe() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>optional bool wipe = 2;</code>
@@ -24767,10 +24730,10 @@ public final class Personhood {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getUserlocation());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBool(2, wipe_);
       }
       unknownFields.writeTo(output);
@@ -24782,11 +24745,11 @@ public final class Personhood {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getUserlocation());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(2, wipe_);
       }
@@ -24805,19 +24768,18 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.Meetup other = (ch.epfl.dedis.lib.proto.Personhood.Meetup) obj;
 
-      boolean result = true;
-      result = result && (hasUserlocation() == other.hasUserlocation());
+      if (hasUserlocation() != other.hasUserlocation()) return false;
       if (hasUserlocation()) {
-        result = result && getUserlocation()
-            .equals(other.getUserlocation());
+        if (!getUserlocation()
+            .equals(other.getUserlocation())) return false;
       }
-      result = result && (hasWipe() == other.hasWipe());
+      if (hasWipe() != other.hasWipe()) return false;
       if (hasWipe()) {
-        result = result && (getWipe()
-            == other.getWipe());
+        if (getWipe()
+            != other.getWipe()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -25010,18 +24972,18 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.Meetup result = new ch.epfl.dedis.lib.proto.Personhood.Meetup(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (userlocationBuilder_ == null) {
+            result.userlocation_ = userlocation_;
+          } else {
+            result.userlocation_ = userlocationBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
         }
-        if (userlocationBuilder_ == null) {
-          result.userlocation_ = userlocation_;
-        } else {
-          result.userlocation_ = userlocationBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.wipe_ = wipe_;
           to_bitField0_ |= 0x00000002;
         }
-        result.wipe_ = wipe_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -25029,35 +24991,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -25112,14 +25074,14 @@ public final class Personhood {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.Personhood.UserLocation userlocation_ = null;
+      private ch.epfl.dedis.lib.proto.Personhood.UserLocation userlocation_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.Personhood.UserLocation, ch.epfl.dedis.lib.proto.Personhood.UserLocation.Builder, ch.epfl.dedis.lib.proto.Personhood.UserLocationOrBuilder> userlocationBuilder_;
       /**
        * <code>optional .personhood.UserLocation userlocation = 1;</code>
        */
       public boolean hasUserlocation() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>optional .personhood.UserLocation userlocation = 1;</code>
@@ -25166,7 +25128,7 @@ public final class Personhood {
        */
       public Builder mergeUserlocation(ch.epfl.dedis.lib.proto.Personhood.UserLocation value) {
         if (userlocationBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               userlocation_ != null &&
               userlocation_ != ch.epfl.dedis.lib.proto.Personhood.UserLocation.getDefaultInstance()) {
             userlocation_ =
@@ -25235,7 +25197,7 @@ public final class Personhood {
        * <code>optional bool wipe = 2;</code>
        */
       public boolean hasWipe() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>optional bool wipe = 2;</code>
@@ -25387,7 +25349,7 @@ public final class Personhood {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 users_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.UserLocation>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -25410,7 +25372,7 @@ public final class Personhood {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           users_ = java.util.Collections.unmodifiableList(users_);
         }
         this.unknownFields = unknownFields.build();
@@ -25516,11 +25478,10 @@ public final class Personhood {
       }
       ch.epfl.dedis.lib.proto.Personhood.MeetupResponse other = (ch.epfl.dedis.lib.proto.Personhood.MeetupResponse) obj;
 
-      boolean result = true;
-      result = result && getUsersList()
-          .equals(other.getUsersList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getUsersList()
+          .equals(other.getUsersList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -25706,7 +25667,7 @@ public final class Personhood {
         ch.epfl.dedis.lib.proto.Personhood.MeetupResponse result = new ch.epfl.dedis.lib.proto.Personhood.MeetupResponse(this);
         int from_bitField0_ = bitField0_;
         if (usersBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             users_ = java.util.Collections.unmodifiableList(users_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -25720,35 +25681,35 @@ public final class Personhood {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -25826,7 +25787,7 @@ public final class Personhood {
       private java.util.List<ch.epfl.dedis.lib.proto.Personhood.UserLocation> users_ =
         java.util.Collections.emptyList();
       private void ensureUsersIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           users_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.Personhood.UserLocation>(users_);
           bitField0_ |= 0x00000001;
          }
@@ -26055,7 +26016,7 @@ public final class Personhood {
           usersBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.Personhood.UserLocation, ch.epfl.dedis.lib.proto.Personhood.UserLocation.Builder, ch.epfl.dedis.lib.proto.Personhood.UserLocationOrBuilder>(
                   users_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           users_ = null;

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/SkipchainProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/SkipchainProto.java
@@ -104,7 +104,7 @@ public final class SkipchainProto {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = newBlock_.toBuilder();
               }
               newBlock_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.parser(), extensionRegistry);
@@ -159,7 +159,7 @@ public final class SkipchainProto {
      * <code>required bytes targetSkipChainID = 1;</code>
      */
     public boolean hasTargetSkipChainID() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes targetSkipChainID = 1;</code>
@@ -174,7 +174,7 @@ public final class SkipchainProto {
      * <code>required .skipchain.SkipBlock newBlock = 2;</code>
      */
     public boolean hasNewBlock() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required .skipchain.SkipBlock newBlock = 2;</code>
@@ -195,7 +195,7 @@ public final class SkipchainProto {
      * <code>optional bytes signature = 3;</code>
      */
     public boolean hasSignature() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>optional bytes signature = 3;</code>
@@ -230,13 +230,13 @@ public final class SkipchainProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, targetSkipChainID_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getNewBlock());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(3, signature_);
       }
       unknownFields.writeTo(output);
@@ -248,15 +248,15 @@ public final class SkipchainProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, targetSkipChainID_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getNewBlock());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, signature_);
       }
@@ -275,24 +275,23 @@ public final class SkipchainProto {
       }
       ch.epfl.dedis.lib.proto.SkipchainProto.StoreSkipBlock other = (ch.epfl.dedis.lib.proto.SkipchainProto.StoreSkipBlock) obj;
 
-      boolean result = true;
-      result = result && (hasTargetSkipChainID() == other.hasTargetSkipChainID());
+      if (hasTargetSkipChainID() != other.hasTargetSkipChainID()) return false;
       if (hasTargetSkipChainID()) {
-        result = result && getTargetSkipChainID()
-            .equals(other.getTargetSkipChainID());
+        if (!getTargetSkipChainID()
+            .equals(other.getTargetSkipChainID())) return false;
       }
-      result = result && (hasNewBlock() == other.hasNewBlock());
+      if (hasNewBlock() != other.hasNewBlock()) return false;
       if (hasNewBlock()) {
-        result = result && getNewBlock()
-            .equals(other.getNewBlock());
+        if (!getNewBlock()
+            .equals(other.getNewBlock())) return false;
       }
-      result = result && (hasSignature() == other.hasSignature());
+      if (hasSignature() != other.hasSignature()) return false;
       if (hasSignature()) {
-        result = result && getSignature()
-            .equals(other.getSignature());
+        if (!getSignature()
+            .equals(other.getSignature())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -493,19 +492,19 @@ public final class SkipchainProto {
         ch.epfl.dedis.lib.proto.SkipchainProto.StoreSkipBlock result = new ch.epfl.dedis.lib.proto.SkipchainProto.StoreSkipBlock(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.targetSkipChainID_ = targetSkipChainID_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (newBlockBuilder_ == null) {
+            result.newBlock_ = newBlock_;
+          } else {
+            result.newBlock_ = newBlockBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
         }
-        if (newBlockBuilder_ == null) {
-          result.newBlock_ = newBlock_;
-        } else {
-          result.newBlock_ = newBlockBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.signature_ = signature_;
@@ -516,35 +515,35 @@ public final class SkipchainProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -611,7 +610,7 @@ public final class SkipchainProto {
        * <code>required bytes targetSkipChainID = 1;</code>
        */
       public boolean hasTargetSkipChainID() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes targetSkipChainID = 1;</code>
@@ -641,14 +640,14 @@ public final class SkipchainProto {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock newBlock_ = null;
+      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock newBlock_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlockOrBuilder> newBlockBuilder_;
       /**
        * <code>required .skipchain.SkipBlock newBlock = 2;</code>
        */
       public boolean hasNewBlock() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required .skipchain.SkipBlock newBlock = 2;</code>
@@ -695,7 +694,7 @@ public final class SkipchainProto {
        */
       public Builder mergeNewBlock(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock value) {
         if (newBlockBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               newBlock_ != null &&
               newBlock_ != ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.getDefaultInstance()) {
             newBlock_ =
@@ -764,7 +763,7 @@ public final class SkipchainProto {
        * <code>optional bytes signature = 3;</code>
        */
       public boolean hasSignature() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>optional bytes signature = 3;</code>
@@ -922,7 +921,7 @@ public final class SkipchainProto {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = previous_.toBuilder();
               }
               previous_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.parser(), extensionRegistry);
@@ -935,7 +934,7 @@ public final class SkipchainProto {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = latest_.toBuilder();
               }
               latest_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.parser(), extensionRegistry);
@@ -985,7 +984,7 @@ public final class SkipchainProto {
      * <code>optional .skipchain.SkipBlock previous = 1;</code>
      */
     public boolean hasPrevious() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>optional .skipchain.SkipBlock previous = 1;</code>
@@ -1006,7 +1005,7 @@ public final class SkipchainProto {
      * <code>required .skipchain.SkipBlock latest = 2;</code>
      */
     public boolean hasLatest() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required .skipchain.SkipBlock latest = 2;</code>
@@ -1049,10 +1048,10 @@ public final class SkipchainProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getPrevious());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(2, getLatest());
       }
       unknownFields.writeTo(output);
@@ -1064,11 +1063,11 @@ public final class SkipchainProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getPrevious());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getLatest());
       }
@@ -1087,19 +1086,18 @@ public final class SkipchainProto {
       }
       ch.epfl.dedis.lib.proto.SkipchainProto.StoreSkipBlockReply other = (ch.epfl.dedis.lib.proto.SkipchainProto.StoreSkipBlockReply) obj;
 
-      boolean result = true;
-      result = result && (hasPrevious() == other.hasPrevious());
+      if (hasPrevious() != other.hasPrevious()) return false;
       if (hasPrevious()) {
-        result = result && getPrevious()
-            .equals(other.getPrevious());
+        if (!getPrevious()
+            .equals(other.getPrevious())) return false;
       }
-      result = result && (hasLatest() == other.hasLatest());
+      if (hasLatest() != other.hasLatest()) return false;
       if (hasLatest()) {
-        result = result && getLatest()
-            .equals(other.getLatest());
+        if (!getLatest()
+            .equals(other.getLatest())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -1297,21 +1295,21 @@ public final class SkipchainProto {
         ch.epfl.dedis.lib.proto.SkipchainProto.StoreSkipBlockReply result = new ch.epfl.dedis.lib.proto.SkipchainProto.StoreSkipBlockReply(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (previousBuilder_ == null) {
+            result.previous_ = previous_;
+          } else {
+            result.previous_ = previousBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
         }
-        if (previousBuilder_ == null) {
-          result.previous_ = previous_;
-        } else {
-          result.previous_ = previousBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (latestBuilder_ == null) {
+            result.latest_ = latest_;
+          } else {
+            result.latest_ = latestBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
-        }
-        if (latestBuilder_ == null) {
-          result.latest_ = latest_;
-        } else {
-          result.latest_ = latestBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -1320,35 +1318,35 @@ public final class SkipchainProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -1409,14 +1407,14 @@ public final class SkipchainProto {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock previous_ = null;
+      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock previous_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlockOrBuilder> previousBuilder_;
       /**
        * <code>optional .skipchain.SkipBlock previous = 1;</code>
        */
       public boolean hasPrevious() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>optional .skipchain.SkipBlock previous = 1;</code>
@@ -1463,7 +1461,7 @@ public final class SkipchainProto {
        */
       public Builder mergePrevious(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock value) {
         if (previousBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               previous_ != null &&
               previous_ != ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.getDefaultInstance()) {
             previous_ =
@@ -1527,14 +1525,14 @@ public final class SkipchainProto {
         return previousBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock latest_ = null;
+      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock latest_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlockOrBuilder> latestBuilder_;
       /**
        * <code>required .skipchain.SkipBlock latest = 2;</code>
        */
       public boolean hasLatest() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required .skipchain.SkipBlock latest = 2;</code>
@@ -1581,7 +1579,7 @@ public final class SkipchainProto {
        */
       public Builder mergeLatest(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock value) {
         if (latestBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               latest_ != null &&
               latest_ != ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.getDefaultInstance()) {
             latest_ =
@@ -1814,9 +1812,8 @@ public final class SkipchainProto {
       }
       ch.epfl.dedis.lib.proto.SkipchainProto.GetAllSkipChainIDs other = (ch.epfl.dedis.lib.proto.SkipchainProto.GetAllSkipChainIDs) obj;
 
-      boolean result = true;
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -1996,35 +1993,35 @@ public final class SkipchainProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -2181,7 +2178,7 @@ public final class SkipchainProto {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 skipChainIDs_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -2203,8 +2200,8 @@ public final class SkipchainProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          skipChainIDs_ = java.util.Collections.unmodifiableList(skipChainIDs_);
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
+          skipChainIDs_ = java.util.Collections.unmodifiableList(skipChainIDs_); // C
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -2295,11 +2292,10 @@ public final class SkipchainProto {
       }
       ch.epfl.dedis.lib.proto.SkipchainProto.GetAllSkipChainIDsReply other = (ch.epfl.dedis.lib.proto.SkipchainProto.GetAllSkipChainIDsReply) obj;
 
-      boolean result = true;
-      result = result && getSkipChainIDsList()
-          .equals(other.getSkipChainIDsList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getSkipChainIDsList()
+          .equals(other.getSkipChainIDsList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -2479,7 +2475,7 @@ public final class SkipchainProto {
       public ch.epfl.dedis.lib.proto.SkipchainProto.GetAllSkipChainIDsReply buildPartial() {
         ch.epfl.dedis.lib.proto.SkipchainProto.GetAllSkipChainIDsReply result = new ch.epfl.dedis.lib.proto.SkipchainProto.GetAllSkipChainIDsReply(this);
         int from_bitField0_ = bitField0_;
-        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((bitField0_ & 0x00000001) != 0)) {
           skipChainIDs_ = java.util.Collections.unmodifiableList(skipChainIDs_);
           bitField0_ = (bitField0_ & ~0x00000001);
         }
@@ -2490,35 +2486,35 @@ public final class SkipchainProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -2574,7 +2570,7 @@ public final class SkipchainProto {
 
       private java.util.List<com.google.protobuf.ByteString> skipChainIDs_ = java.util.Collections.emptyList();
       private void ensureSkipChainIDsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           skipChainIDs_ = new java.util.ArrayList<com.google.protobuf.ByteString>(skipChainIDs_);
           bitField0_ |= 0x00000001;
          }
@@ -2584,7 +2580,8 @@ public final class SkipchainProto {
        */
       public java.util.List<com.google.protobuf.ByteString>
           getSkipChainIDsList() {
-        return java.util.Collections.unmodifiableList(skipChainIDs_);
+        return ((bitField0_ & 0x00000001) != 0) ?
+                 java.util.Collections.unmodifiableList(skipChainIDs_) : skipChainIDs_;
       }
       /**
        * <code>repeated bytes skipChainIDs = 1;</code>
@@ -2797,7 +2794,7 @@ public final class SkipchainProto {
      * <code>required bytes id = 1;</code>
      */
     public boolean hasId() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes id = 1;</code>
@@ -2824,7 +2821,7 @@ public final class SkipchainProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, id_);
       }
       unknownFields.writeTo(output);
@@ -2836,7 +2833,7 @@ public final class SkipchainProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, id_);
       }
@@ -2855,14 +2852,13 @@ public final class SkipchainProto {
       }
       ch.epfl.dedis.lib.proto.SkipchainProto.GetSingleBlock other = (ch.epfl.dedis.lib.proto.SkipchainProto.GetSingleBlock) obj;
 
-      boolean result = true;
-      result = result && (hasId() == other.hasId());
+      if (hasId() != other.hasId()) return false;
       if (hasId()) {
-        result = result && getId()
-            .equals(other.getId());
+        if (!getId()
+            .equals(other.getId())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -3043,7 +3039,7 @@ public final class SkipchainProto {
         ch.epfl.dedis.lib.proto.SkipchainProto.GetSingleBlock result = new ch.epfl.dedis.lib.proto.SkipchainProto.GetSingleBlock(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.id_ = id_;
@@ -3054,35 +3050,35 @@ public final class SkipchainProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -3137,7 +3133,7 @@ public final class SkipchainProto {
        * <code>required bytes id = 1;</code>
        */
       public boolean hasId() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes id = 1;</code>
@@ -3260,7 +3256,6 @@ public final class SkipchainProto {
     }
     private GetSingleBlockByIndex() {
       genesis_ = com.google.protobuf.ByteString.EMPTY;
-      index_ = 0;
     }
 
     @java.lang.Override
@@ -3336,7 +3331,7 @@ public final class SkipchainProto {
      * <code>required bytes genesis = 1;</code>
      */
     public boolean hasGenesis() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes genesis = 1;</code>
@@ -3351,7 +3346,7 @@ public final class SkipchainProto {
      * <code>required sint32 index = 2;</code>
      */
     public boolean hasIndex() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required sint32 index = 2;</code>
@@ -3382,10 +3377,10 @@ public final class SkipchainProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, genesis_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeSInt32(2, index_);
       }
       unknownFields.writeTo(output);
@@ -3397,11 +3392,11 @@ public final class SkipchainProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, genesis_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(2, index_);
       }
@@ -3420,19 +3415,18 @@ public final class SkipchainProto {
       }
       ch.epfl.dedis.lib.proto.SkipchainProto.GetSingleBlockByIndex other = (ch.epfl.dedis.lib.proto.SkipchainProto.GetSingleBlockByIndex) obj;
 
-      boolean result = true;
-      result = result && (hasGenesis() == other.hasGenesis());
+      if (hasGenesis() != other.hasGenesis()) return false;
       if (hasGenesis()) {
-        result = result && getGenesis()
-            .equals(other.getGenesis());
+        if (!getGenesis()
+            .equals(other.getGenesis())) return false;
       }
-      result = result && (hasIndex() == other.hasIndex());
+      if (hasIndex() != other.hasIndex()) return false;
       if (hasIndex()) {
-        result = result && (getIndex()
-            == other.getIndex());
+        if (getIndex()
+            != other.getIndex()) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -3620,14 +3614,14 @@ public final class SkipchainProto {
         ch.epfl.dedis.lib.proto.SkipchainProto.GetSingleBlockByIndex result = new ch.epfl.dedis.lib.proto.SkipchainProto.GetSingleBlockByIndex(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.genesis_ = genesis_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.index_ = index_;
           to_bitField0_ |= 0x00000002;
         }
-        result.index_ = index_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -3635,35 +3629,35 @@ public final class SkipchainProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -3724,7 +3718,7 @@ public final class SkipchainProto {
        * <code>required bytes genesis = 1;</code>
        */
       public boolean hasGenesis() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes genesis = 1;</code>
@@ -3759,7 +3753,7 @@ public final class SkipchainProto {
        * <code>required sint32 index = 2;</code>
        */
       public boolean hasIndex() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required sint32 index = 2;</code>
@@ -3926,7 +3920,7 @@ public final class SkipchainProto {
               break;
             case 10: {
               ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = skipblock_.toBuilder();
               }
               skipblock_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.parser(), extensionRegistry);
@@ -3938,7 +3932,7 @@ public final class SkipchainProto {
               break;
             }
             case 18: {
-              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
                 links_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink>();
                 mutable_bitField0_ |= 0x00000002;
               }
@@ -3961,7 +3955,7 @@ public final class SkipchainProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((mutable_bitField0_ & 0x00000002) != 0)) {
           links_ = java.util.Collections.unmodifiableList(links_);
         }
         this.unknownFields = unknownFields.build();
@@ -3988,7 +3982,7 @@ public final class SkipchainProto {
      * <code>required .skipchain.SkipBlock skipblock = 1;</code>
      */
     public boolean hasSkipblock() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required .skipchain.SkipBlock skipblock = 1;</code>
@@ -4066,7 +4060,7 @@ public final class SkipchainProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getSkipblock());
       }
       for (int i = 0; i < links_.size(); i++) {
@@ -4081,7 +4075,7 @@ public final class SkipchainProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getSkipblock());
       }
@@ -4104,16 +4098,15 @@ public final class SkipchainProto {
       }
       ch.epfl.dedis.lib.proto.SkipchainProto.GetSingleBlockByIndexReply other = (ch.epfl.dedis.lib.proto.SkipchainProto.GetSingleBlockByIndexReply) obj;
 
-      boolean result = true;
-      result = result && (hasSkipblock() == other.hasSkipblock());
+      if (hasSkipblock() != other.hasSkipblock()) return false;
       if (hasSkipblock()) {
-        result = result && getSkipblock()
-            .equals(other.getSkipblock());
+        if (!getSkipblock()
+            .equals(other.getSkipblock())) return false;
       }
-      result = result && getLinksList()
-          .equals(other.getLinksList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getLinksList()
+          .equals(other.getLinksList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -4311,16 +4304,16 @@ public final class SkipchainProto {
         ch.epfl.dedis.lib.proto.SkipchainProto.GetSingleBlockByIndexReply result = new ch.epfl.dedis.lib.proto.SkipchainProto.GetSingleBlockByIndexReply(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          if (skipblockBuilder_ == null) {
+            result.skipblock_ = skipblock_;
+          } else {
+            result.skipblock_ = skipblockBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
         }
-        if (skipblockBuilder_ == null) {
-          result.skipblock_ = skipblock_;
-        } else {
-          result.skipblock_ = skipblockBuilder_.build();
-        }
         if (linksBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          if (((bitField0_ & 0x00000002) != 0)) {
             links_ = java.util.Collections.unmodifiableList(links_);
             bitField0_ = (bitField0_ & ~0x00000002);
           }
@@ -4335,35 +4328,35 @@ public final class SkipchainProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -4447,14 +4440,14 @@ public final class SkipchainProto {
       }
       private int bitField0_;
 
-      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock skipblock_ = null;
+      private ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock skipblock_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlockOrBuilder> skipblockBuilder_;
       /**
        * <code>required .skipchain.SkipBlock skipblock = 1;</code>
        */
       public boolean hasSkipblock() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required .skipchain.SkipBlock skipblock = 1;</code>
@@ -4501,7 +4494,7 @@ public final class SkipchainProto {
        */
       public Builder mergeSkipblock(ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock value) {
         if (skipblockBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001) &&
+          if (((bitField0_ & 0x00000001) != 0) &&
               skipblock_ != null &&
               skipblock_ != ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.getDefaultInstance()) {
             skipblock_ =
@@ -4568,7 +4561,7 @@ public final class SkipchainProto {
       private java.util.List<ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink> links_ =
         java.util.Collections.emptyList();
       private void ensureLinksIsMutable() {
-        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+        if (!((bitField0_ & 0x00000002) != 0)) {
           links_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink>(links_);
           bitField0_ |= 0x00000002;
          }
@@ -4797,7 +4790,7 @@ public final class SkipchainProto {
           linksBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink, ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink.Builder, ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLinkOrBuilder>(
                   links_,
-                  ((bitField0_ & 0x00000002) == 0x00000002),
+                  ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
                   isClean());
           links_ = null;
@@ -4972,7 +4965,7 @@ public final class SkipchainProto {
      * <code>required bytes latestID = 1;</code>
      */
     public boolean hasLatestID() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <pre>
@@ -5003,7 +4996,7 @@ public final class SkipchainProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, latestID_);
       }
       unknownFields.writeTo(output);
@@ -5015,7 +5008,7 @@ public final class SkipchainProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, latestID_);
       }
@@ -5034,14 +5027,13 @@ public final class SkipchainProto {
       }
       ch.epfl.dedis.lib.proto.SkipchainProto.GetUpdateChain other = (ch.epfl.dedis.lib.proto.SkipchainProto.GetUpdateChain) obj;
 
-      boolean result = true;
-      result = result && (hasLatestID() == other.hasLatestID());
+      if (hasLatestID() != other.hasLatestID()) return false;
       if (hasLatestID()) {
-        result = result && getLatestID()
-            .equals(other.getLatestID());
+        if (!getLatestID()
+            .equals(other.getLatestID())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -5224,7 +5216,7 @@ public final class SkipchainProto {
         ch.epfl.dedis.lib.proto.SkipchainProto.GetUpdateChain result = new ch.epfl.dedis.lib.proto.SkipchainProto.GetUpdateChain(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.latestID_ = latestID_;
@@ -5235,35 +5227,35 @@ public final class SkipchainProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -5322,7 +5314,7 @@ public final class SkipchainProto {
        * <code>required bytes latestID = 1;</code>
        */
       public boolean hasLatestID() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <pre>
@@ -5515,7 +5507,7 @@ public final class SkipchainProto {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 update_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -5538,7 +5530,7 @@ public final class SkipchainProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           update_ = java.util.Collections.unmodifiableList(update_);
         }
         this.unknownFields = unknownFields.build();
@@ -5669,11 +5661,10 @@ public final class SkipchainProto {
       }
       ch.epfl.dedis.lib.proto.SkipchainProto.GetUpdateChainReply other = (ch.epfl.dedis.lib.proto.SkipchainProto.GetUpdateChainReply) obj;
 
-      boolean result = true;
-      result = result && getUpdateList()
-          .equals(other.getUpdateList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getUpdateList()
+          .equals(other.getUpdateList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -5860,7 +5851,7 @@ public final class SkipchainProto {
         ch.epfl.dedis.lib.proto.SkipchainProto.GetUpdateChainReply result = new ch.epfl.dedis.lib.proto.SkipchainProto.GetUpdateChainReply(this);
         int from_bitField0_ = bitField0_;
         if (updateBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             update_ = java.util.Collections.unmodifiableList(update_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -5874,35 +5865,35 @@ public final class SkipchainProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -5980,7 +5971,7 @@ public final class SkipchainProto {
       private java.util.List<ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock> update_ =
         java.util.Collections.emptyList();
       private void ensureUpdateIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           update_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock>(update_);
           bitField0_ |= 0x00000001;
          }
@@ -6299,7 +6290,7 @@ public final class SkipchainProto {
           updateBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock.Builder, ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlockOrBuilder>(
                   update_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           update_ = null;
@@ -6511,10 +6502,6 @@ public final class SkipchainProto {
       super(builder);
     }
     private SkipBlock() {
-      index_ = 0;
-      height_ = 0;
-      maxHeight_ = 0;
-      baseHeight_ = 0;
       backlinks_ = java.util.Collections.emptyList();
       verifiers_ = java.util.Collections.emptyList();
       genesis_ = com.google.protobuf.ByteString.EMPTY;
@@ -6569,7 +6556,7 @@ public final class SkipchainProto {
               break;
             }
             case 42: {
-              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+              if (!((mutable_bitField0_ & 0x00000010) != 0)) {
                 backlinks_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
                 mutable_bitField0_ |= 0x00000010;
               }
@@ -6577,7 +6564,7 @@ public final class SkipchainProto {
               break;
             }
             case 50: {
-              if (!((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
+              if (!((mutable_bitField0_ & 0x00000020) != 0)) {
                 verifiers_ = new java.util.ArrayList<com.google.protobuf.ByteString>();
                 mutable_bitField0_ |= 0x00000020;
               }
@@ -6596,7 +6583,7 @@ public final class SkipchainProto {
             }
             case 74: {
               ch.epfl.dedis.lib.proto.OnetProto.Roster.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000040) == 0x00000040)) {
+              if (((bitField0_ & 0x00000040) != 0)) {
                 subBuilder = roster_.toBuilder();
               }
               roster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.parser(), extensionRegistry);
@@ -6613,7 +6600,7 @@ public final class SkipchainProto {
               break;
             }
             case 90: {
-              if (!((mutable_bitField0_ & 0x00000400) == 0x00000400)) {
+              if (!((mutable_bitField0_ & 0x00000400) != 0)) {
                 forward_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink>();
                 mutable_bitField0_ |= 0x00000400;
               }
@@ -6641,13 +6628,13 @@ public final class SkipchainProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
-          backlinks_ = java.util.Collections.unmodifiableList(backlinks_);
+        if (((mutable_bitField0_ & 0x00000010) != 0)) {
+          backlinks_ = java.util.Collections.unmodifiableList(backlinks_); // C
         }
-        if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
-          verifiers_ = java.util.Collections.unmodifiableList(verifiers_);
+        if (((mutable_bitField0_ & 0x00000020) != 0)) {
+          verifiers_ = java.util.Collections.unmodifiableList(verifiers_); // C
         }
-        if (((mutable_bitField0_ & 0x00000400) == 0x00000400)) {
+        if (((mutable_bitField0_ & 0x00000400) != 0)) {
           forward_ = java.util.Collections.unmodifiableList(forward_);
         }
         this.unknownFields = unknownFields.build();
@@ -6674,7 +6661,7 @@ public final class SkipchainProto {
      * <code>required sint32 index = 1;</code>
      */
     public boolean hasIndex() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required sint32 index = 1;</code>
@@ -6689,7 +6676,7 @@ public final class SkipchainProto {
      * <code>required sint32 height = 2;</code>
      */
     public boolean hasHeight() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required sint32 height = 2;</code>
@@ -6704,7 +6691,7 @@ public final class SkipchainProto {
      * <code>required sint32 max_height = 3;</code>
      */
     public boolean hasMaxHeight() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required sint32 max_height = 3;</code>
@@ -6719,7 +6706,7 @@ public final class SkipchainProto {
      * <code>required sint32 base_height = 4;</code>
      */
     public boolean hasBaseHeight() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <code>required sint32 base_height = 4;</code>
@@ -6778,7 +6765,7 @@ public final class SkipchainProto {
      * <code>required bytes genesis = 7;</code>
      */
     public boolean hasGenesis() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000010) != 0);
     }
     /**
      * <code>required bytes genesis = 7;</code>
@@ -6793,7 +6780,7 @@ public final class SkipchainProto {
      * <code>required bytes data = 8;</code>
      */
     public boolean hasData() {
-      return ((bitField0_ & 0x00000020) == 0x00000020);
+      return ((bitField0_ & 0x00000020) != 0);
     }
     /**
      * <code>required bytes data = 8;</code>
@@ -6808,7 +6795,7 @@ public final class SkipchainProto {
      * <code>required .onet.Roster roster = 9;</code>
      */
     public boolean hasRoster() {
-      return ((bitField0_ & 0x00000040) == 0x00000040);
+      return ((bitField0_ & 0x00000040) != 0);
     }
     /**
      * <code>required .onet.Roster roster = 9;</code>
@@ -6829,7 +6816,7 @@ public final class SkipchainProto {
      * <code>required bytes hash = 10;</code>
      */
     public boolean hasHash() {
-      return ((bitField0_ & 0x00000080) == 0x00000080);
+      return ((bitField0_ & 0x00000080) != 0);
     }
     /**
      * <code>required bytes hash = 10;</code>
@@ -6879,7 +6866,7 @@ public final class SkipchainProto {
      * <code>optional bytes payload = 12;</code>
      */
     public boolean hasPayload() {
-      return ((bitField0_ & 0x00000100) == 0x00000100);
+      return ((bitField0_ & 0x00000100) != 0);
     }
     /**
      * <code>optional bytes payload = 12;</code>
@@ -6944,16 +6931,16 @@ public final class SkipchainProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeSInt32(1, index_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeSInt32(2, height_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeSInt32(3, maxHeight_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeSInt32(4, baseHeight_);
       }
       for (int i = 0; i < backlinks_.size(); i++) {
@@ -6962,22 +6949,22 @@ public final class SkipchainProto {
       for (int i = 0; i < verifiers_.size(); i++) {
         output.writeBytes(6, verifiers_.get(i));
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         output.writeBytes(7, genesis_);
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if (((bitField0_ & 0x00000020) != 0)) {
         output.writeBytes(8, data_);
       }
-      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+      if (((bitField0_ & 0x00000040) != 0)) {
         output.writeMessage(9, getRoster());
       }
-      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+      if (((bitField0_ & 0x00000080) != 0)) {
         output.writeBytes(10, hash_);
       }
       for (int i = 0; i < forward_.size(); i++) {
         output.writeMessage(11, forward_.get(i));
       }
-      if (((bitField0_ & 0x00000100) == 0x00000100)) {
+      if (((bitField0_ & 0x00000100) != 0)) {
         output.writeBytes(12, payload_);
       }
       unknownFields.writeTo(output);
@@ -6989,19 +6976,19 @@ public final class SkipchainProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(1, index_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(2, height_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(3, maxHeight_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(4, baseHeight_);
       }
@@ -7023,19 +7010,19 @@ public final class SkipchainProto {
         size += dataSize;
         size += 1 * getVerifiersList().size();
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000010) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(7, genesis_);
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if (((bitField0_ & 0x00000020) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(8, data_);
       }
-      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+      if (((bitField0_ & 0x00000040) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(9, getRoster());
       }
-      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+      if (((bitField0_ & 0x00000080) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(10, hash_);
       }
@@ -7043,7 +7030,7 @@ public final class SkipchainProto {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(11, forward_.get(i));
       }
-      if (((bitField0_ & 0x00000100) == 0x00000100)) {
+      if (((bitField0_ & 0x00000100) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(12, payload_);
       }
@@ -7062,60 +7049,59 @@ public final class SkipchainProto {
       }
       ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock other = (ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock) obj;
 
-      boolean result = true;
-      result = result && (hasIndex() == other.hasIndex());
+      if (hasIndex() != other.hasIndex()) return false;
       if (hasIndex()) {
-        result = result && (getIndex()
-            == other.getIndex());
+        if (getIndex()
+            != other.getIndex()) return false;
       }
-      result = result && (hasHeight() == other.hasHeight());
+      if (hasHeight() != other.hasHeight()) return false;
       if (hasHeight()) {
-        result = result && (getHeight()
-            == other.getHeight());
+        if (getHeight()
+            != other.getHeight()) return false;
       }
-      result = result && (hasMaxHeight() == other.hasMaxHeight());
+      if (hasMaxHeight() != other.hasMaxHeight()) return false;
       if (hasMaxHeight()) {
-        result = result && (getMaxHeight()
-            == other.getMaxHeight());
+        if (getMaxHeight()
+            != other.getMaxHeight()) return false;
       }
-      result = result && (hasBaseHeight() == other.hasBaseHeight());
+      if (hasBaseHeight() != other.hasBaseHeight()) return false;
       if (hasBaseHeight()) {
-        result = result && (getBaseHeight()
-            == other.getBaseHeight());
+        if (getBaseHeight()
+            != other.getBaseHeight()) return false;
       }
-      result = result && getBacklinksList()
-          .equals(other.getBacklinksList());
-      result = result && getVerifiersList()
-          .equals(other.getVerifiersList());
-      result = result && (hasGenesis() == other.hasGenesis());
+      if (!getBacklinksList()
+          .equals(other.getBacklinksList())) return false;
+      if (!getVerifiersList()
+          .equals(other.getVerifiersList())) return false;
+      if (hasGenesis() != other.hasGenesis()) return false;
       if (hasGenesis()) {
-        result = result && getGenesis()
-            .equals(other.getGenesis());
+        if (!getGenesis()
+            .equals(other.getGenesis())) return false;
       }
-      result = result && (hasData() == other.hasData());
+      if (hasData() != other.hasData()) return false;
       if (hasData()) {
-        result = result && getData()
-            .equals(other.getData());
+        if (!getData()
+            .equals(other.getData())) return false;
       }
-      result = result && (hasRoster() == other.hasRoster());
+      if (hasRoster() != other.hasRoster()) return false;
       if (hasRoster()) {
-        result = result && getRoster()
-            .equals(other.getRoster());
+        if (!getRoster()
+            .equals(other.getRoster())) return false;
       }
-      result = result && (hasHash() == other.hasHash());
+      if (hasHash() != other.hasHash()) return false;
       if (hasHash()) {
-        result = result && getHash()
-            .equals(other.getHash());
+        if (!getHash()
+            .equals(other.getHash())) return false;
       }
-      result = result && getForwardList()
-          .equals(other.getForwardList());
-      result = result && (hasPayload() == other.hasPayload());
+      if (!getForwardList()
+          .equals(other.getForwardList())) return false;
+      if (hasPayload() != other.hasPayload()) return false;
       if (hasPayload()) {
-        result = result && getPayload()
-            .equals(other.getPayload());
+        if (!getPayload()
+            .equals(other.getPayload())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -7368,54 +7354,54 @@ public final class SkipchainProto {
         ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock result = new ch.epfl.dedis.lib.proto.SkipchainProto.SkipBlock(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.index_ = index_;
           to_bitField0_ |= 0x00000001;
         }
-        result.index_ = index_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.height_ = height_;
           to_bitField0_ |= 0x00000002;
         }
-        result.height_ = height_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.maxHeight_ = maxHeight_;
           to_bitField0_ |= 0x00000004;
         }
-        result.maxHeight_ = maxHeight_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          result.baseHeight_ = baseHeight_;
           to_bitField0_ |= 0x00000008;
         }
-        result.baseHeight_ = baseHeight_;
-        if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((bitField0_ & 0x00000010) != 0)) {
           backlinks_ = java.util.Collections.unmodifiableList(backlinks_);
           bitField0_ = (bitField0_ & ~0x00000010);
         }
         result.backlinks_ = backlinks_;
-        if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        if (((bitField0_ & 0x00000020) != 0)) {
           verifiers_ = java.util.Collections.unmodifiableList(verifiers_);
           bitField0_ = (bitField0_ & ~0x00000020);
         }
         result.verifiers_ = verifiers_;
-        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+        if (((from_bitField0_ & 0x00000040) != 0)) {
           to_bitField0_ |= 0x00000010;
         }
         result.genesis_ = genesis_;
-        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
+        if (((from_bitField0_ & 0x00000080) != 0)) {
           to_bitField0_ |= 0x00000020;
         }
         result.data_ = data_;
-        if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
+        if (((from_bitField0_ & 0x00000100) != 0)) {
+          if (rosterBuilder_ == null) {
+            result.roster_ = roster_;
+          } else {
+            result.roster_ = rosterBuilder_.build();
+          }
           to_bitField0_ |= 0x00000040;
         }
-        if (rosterBuilder_ == null) {
-          result.roster_ = roster_;
-        } else {
-          result.roster_ = rosterBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
+        if (((from_bitField0_ & 0x00000200) != 0)) {
           to_bitField0_ |= 0x00000080;
         }
         result.hash_ = hash_;
         if (forwardBuilder_ == null) {
-          if (((bitField0_ & 0x00000400) == 0x00000400)) {
+          if (((bitField0_ & 0x00000400) != 0)) {
             forward_ = java.util.Collections.unmodifiableList(forward_);
             bitField0_ = (bitField0_ & ~0x00000400);
           }
@@ -7423,7 +7409,7 @@ public final class SkipchainProto {
         } else {
           result.forward_ = forwardBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00000800) == 0x00000800)) {
+        if (((from_bitField0_ & 0x00000800) != 0)) {
           to_bitField0_ |= 0x00000100;
         }
         result.payload_ = payload_;
@@ -7434,35 +7420,35 @@ public final class SkipchainProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -7616,7 +7602,7 @@ public final class SkipchainProto {
        * <code>required sint32 index = 1;</code>
        */
       public boolean hasIndex() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required sint32 index = 1;</code>
@@ -7648,7 +7634,7 @@ public final class SkipchainProto {
        * <code>required sint32 height = 2;</code>
        */
       public boolean hasHeight() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required sint32 height = 2;</code>
@@ -7680,7 +7666,7 @@ public final class SkipchainProto {
        * <code>required sint32 max_height = 3;</code>
        */
       public boolean hasMaxHeight() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required sint32 max_height = 3;</code>
@@ -7712,7 +7698,7 @@ public final class SkipchainProto {
        * <code>required sint32 base_height = 4;</code>
        */
       public boolean hasBaseHeight() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <code>required sint32 base_height = 4;</code>
@@ -7741,7 +7727,7 @@ public final class SkipchainProto {
 
       private java.util.List<com.google.protobuf.ByteString> backlinks_ = java.util.Collections.emptyList();
       private void ensureBacklinksIsMutable() {
-        if (!((bitField0_ & 0x00000010) == 0x00000010)) {
+        if (!((bitField0_ & 0x00000010) != 0)) {
           backlinks_ = new java.util.ArrayList<com.google.protobuf.ByteString>(backlinks_);
           bitField0_ |= 0x00000010;
          }
@@ -7751,7 +7737,8 @@ public final class SkipchainProto {
        */
       public java.util.List<com.google.protobuf.ByteString>
           getBacklinksList() {
-        return java.util.Collections.unmodifiableList(backlinks_);
+        return ((bitField0_ & 0x00000010) != 0) ?
+                 java.util.Collections.unmodifiableList(backlinks_) : backlinks_;
       }
       /**
        * <code>repeated bytes backlinks = 5;</code>
@@ -7813,7 +7800,7 @@ public final class SkipchainProto {
 
       private java.util.List<com.google.protobuf.ByteString> verifiers_ = java.util.Collections.emptyList();
       private void ensureVerifiersIsMutable() {
-        if (!((bitField0_ & 0x00000020) == 0x00000020)) {
+        if (!((bitField0_ & 0x00000020) != 0)) {
           verifiers_ = new java.util.ArrayList<com.google.protobuf.ByteString>(verifiers_);
           bitField0_ |= 0x00000020;
          }
@@ -7823,7 +7810,8 @@ public final class SkipchainProto {
        */
       public java.util.List<com.google.protobuf.ByteString>
           getVerifiersList() {
-        return java.util.Collections.unmodifiableList(verifiers_);
+        return ((bitField0_ & 0x00000020) != 0) ?
+                 java.util.Collections.unmodifiableList(verifiers_) : verifiers_;
       }
       /**
        * <code>repeated bytes verifiers = 6;</code>
@@ -7888,7 +7876,7 @@ public final class SkipchainProto {
        * <code>required bytes genesis = 7;</code>
        */
       public boolean hasGenesis() {
-        return ((bitField0_ & 0x00000040) == 0x00000040);
+        return ((bitField0_ & 0x00000040) != 0);
       }
       /**
        * <code>required bytes genesis = 7;</code>
@@ -7923,7 +7911,7 @@ public final class SkipchainProto {
        * <code>required bytes data = 8;</code>
        */
       public boolean hasData() {
-        return ((bitField0_ & 0x00000080) == 0x00000080);
+        return ((bitField0_ & 0x00000080) != 0);
       }
       /**
        * <code>required bytes data = 8;</code>
@@ -7953,14 +7941,14 @@ public final class SkipchainProto {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.OnetProto.Roster roster_ = null;
+      private ch.epfl.dedis.lib.proto.OnetProto.Roster roster_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.OnetProto.Roster, ch.epfl.dedis.lib.proto.OnetProto.Roster.Builder, ch.epfl.dedis.lib.proto.OnetProto.RosterOrBuilder> rosterBuilder_;
       /**
        * <code>required .onet.Roster roster = 9;</code>
        */
       public boolean hasRoster() {
-        return ((bitField0_ & 0x00000100) == 0x00000100);
+        return ((bitField0_ & 0x00000100) != 0);
       }
       /**
        * <code>required .onet.Roster roster = 9;</code>
@@ -8007,7 +7995,7 @@ public final class SkipchainProto {
        */
       public Builder mergeRoster(ch.epfl.dedis.lib.proto.OnetProto.Roster value) {
         if (rosterBuilder_ == null) {
-          if (((bitField0_ & 0x00000100) == 0x00000100) &&
+          if (((bitField0_ & 0x00000100) != 0) &&
               roster_ != null &&
               roster_ != ch.epfl.dedis.lib.proto.OnetProto.Roster.getDefaultInstance()) {
             roster_ =
@@ -8076,7 +8064,7 @@ public final class SkipchainProto {
        * <code>required bytes hash = 10;</code>
        */
       public boolean hasHash() {
-        return ((bitField0_ & 0x00000200) == 0x00000200);
+        return ((bitField0_ & 0x00000200) != 0);
       }
       /**
        * <code>required bytes hash = 10;</code>
@@ -8109,7 +8097,7 @@ public final class SkipchainProto {
       private java.util.List<ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink> forward_ =
         java.util.Collections.emptyList();
       private void ensureForwardIsMutable() {
-        if (!((bitField0_ & 0x00000400) == 0x00000400)) {
+        if (!((bitField0_ & 0x00000400) != 0)) {
           forward_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink>(forward_);
           bitField0_ |= 0x00000400;
          }
@@ -8338,7 +8326,7 @@ public final class SkipchainProto {
           forwardBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink, ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink.Builder, ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLinkOrBuilder>(
                   forward_,
-                  ((bitField0_ & 0x00000400) == 0x00000400),
+                  ((bitField0_ & 0x00000400) != 0),
                   getParentForChildren(),
                   isClean());
           forward_ = null;
@@ -8351,7 +8339,7 @@ public final class SkipchainProto {
        * <code>optional bytes payload = 12;</code>
        */
       public boolean hasPayload() {
-        return ((bitField0_ & 0x00000800) == 0x00000800);
+        return ((bitField0_ & 0x00000800) != 0);
       }
       /**
        * <code>optional bytes payload = 12;</code>
@@ -8534,7 +8522,7 @@ public final class SkipchainProto {
             }
             case 26: {
               ch.epfl.dedis.lib.proto.OnetProto.Roster.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000004) == 0x00000004)) {
+              if (((bitField0_ & 0x00000004) != 0)) {
                 subBuilder = newRoster_.toBuilder();
               }
               newRoster_ = input.readMessage(ch.epfl.dedis.lib.proto.OnetProto.Roster.parser(), extensionRegistry);
@@ -8547,7 +8535,7 @@ public final class SkipchainProto {
             }
             case 34: {
               ch.epfl.dedis.lib.proto.SkipchainProto.ByzcoinSig.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000008) == 0x00000008)) {
+              if (((bitField0_ & 0x00000008) != 0)) {
                 subBuilder = signature_.toBuilder();
               }
               signature_ = input.readMessage(ch.epfl.dedis.lib.proto.SkipchainProto.ByzcoinSig.parser(), extensionRegistry);
@@ -8597,7 +8585,7 @@ public final class SkipchainProto {
      * <code>required bytes from = 1;</code>
      */
     public boolean hasFrom() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes from = 1;</code>
@@ -8612,7 +8600,7 @@ public final class SkipchainProto {
      * <code>required bytes to = 2;</code>
      */
     public boolean hasTo() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes to = 2;</code>
@@ -8627,7 +8615,7 @@ public final class SkipchainProto {
      * <code>optional .onet.Roster newRoster = 3;</code>
      */
     public boolean hasNewRoster() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>optional .onet.Roster newRoster = 3;</code>
@@ -8648,7 +8636,7 @@ public final class SkipchainProto {
      * <code>required .skipchain.ByzcoinSig signature = 4;</code>
      */
     public boolean hasSignature() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /**
      * <code>required .skipchain.ByzcoinSig signature = 4;</code>
@@ -8699,16 +8687,16 @@ public final class SkipchainProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, from_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, to_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeMessage(3, getNewRoster());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeMessage(4, getSignature());
       }
       unknownFields.writeTo(output);
@@ -8720,19 +8708,19 @@ public final class SkipchainProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, from_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, to_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, getNewRoster());
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(4, getSignature());
       }
@@ -8751,29 +8739,28 @@ public final class SkipchainProto {
       }
       ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink other = (ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink) obj;
 
-      boolean result = true;
-      result = result && (hasFrom() == other.hasFrom());
+      if (hasFrom() != other.hasFrom()) return false;
       if (hasFrom()) {
-        result = result && getFrom()
-            .equals(other.getFrom());
+        if (!getFrom()
+            .equals(other.getFrom())) return false;
       }
-      result = result && (hasTo() == other.hasTo());
+      if (hasTo() != other.hasTo()) return false;
       if (hasTo()) {
-        result = result && getTo()
-            .equals(other.getTo());
+        if (!getTo()
+            .equals(other.getTo())) return false;
       }
-      result = result && (hasNewRoster() == other.hasNewRoster());
+      if (hasNewRoster() != other.hasNewRoster()) return false;
       if (hasNewRoster()) {
-        result = result && getNewRoster()
-            .equals(other.getNewRoster());
+        if (!getNewRoster()
+            .equals(other.getNewRoster())) return false;
       }
-      result = result && (hasSignature() == other.hasSignature());
+      if (hasSignature() != other.hasSignature()) return false;
       if (hasSignature()) {
-        result = result && getSignature()
-            .equals(other.getSignature());
+        if (!getSignature()
+            .equals(other.getSignature())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -8978,29 +8965,29 @@ public final class SkipchainProto {
         ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink result = new ch.epfl.dedis.lib.proto.SkipchainProto.ForwardLink(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.from_ = from_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.to_ = to_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          if (newRosterBuilder_ == null) {
+            result.newRoster_ = newRoster_;
+          } else {
+            result.newRoster_ = newRosterBuilder_.build();
+          }
           to_bitField0_ |= 0x00000004;
         }
-        if (newRosterBuilder_ == null) {
-          result.newRoster_ = newRoster_;
-        } else {
-          result.newRoster_ = newRosterBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          if (signatureBuilder_ == null) {
+            result.signature_ = signature_;
+          } else {
+            result.signature_ = signatureBuilder_.build();
+          }
           to_bitField0_ |= 0x00000008;
-        }
-        if (signatureBuilder_ == null) {
-          result.signature_ = signature_;
-        } else {
-          result.signature_ = signatureBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -9009,35 +8996,35 @@ public final class SkipchainProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -9115,7 +9102,7 @@ public final class SkipchainProto {
        * <code>required bytes from = 1;</code>
        */
       public boolean hasFrom() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes from = 1;</code>
@@ -9150,7 +9137,7 @@ public final class SkipchainProto {
        * <code>required bytes to = 2;</code>
        */
       public boolean hasTo() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes to = 2;</code>
@@ -9180,14 +9167,14 @@ public final class SkipchainProto {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.OnetProto.Roster newRoster_ = null;
+      private ch.epfl.dedis.lib.proto.OnetProto.Roster newRoster_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.OnetProto.Roster, ch.epfl.dedis.lib.proto.OnetProto.Roster.Builder, ch.epfl.dedis.lib.proto.OnetProto.RosterOrBuilder> newRosterBuilder_;
       /**
        * <code>optional .onet.Roster newRoster = 3;</code>
        */
       public boolean hasNewRoster() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>optional .onet.Roster newRoster = 3;</code>
@@ -9234,7 +9221,7 @@ public final class SkipchainProto {
        */
       public Builder mergeNewRoster(ch.epfl.dedis.lib.proto.OnetProto.Roster value) {
         if (newRosterBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004) &&
+          if (((bitField0_ & 0x00000004) != 0) &&
               newRoster_ != null &&
               newRoster_ != ch.epfl.dedis.lib.proto.OnetProto.Roster.getDefaultInstance()) {
             newRoster_ =
@@ -9298,14 +9285,14 @@ public final class SkipchainProto {
         return newRosterBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.SkipchainProto.ByzcoinSig signature_ = null;
+      private ch.epfl.dedis.lib.proto.SkipchainProto.ByzcoinSig signature_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.SkipchainProto.ByzcoinSig, ch.epfl.dedis.lib.proto.SkipchainProto.ByzcoinSig.Builder, ch.epfl.dedis.lib.proto.SkipchainProto.ByzcoinSigOrBuilder> signatureBuilder_;
       /**
        * <code>required .skipchain.ByzcoinSig signature = 4;</code>
        */
       public boolean hasSignature() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <code>required .skipchain.ByzcoinSig signature = 4;</code>
@@ -9352,7 +9339,7 @@ public final class SkipchainProto {
        */
       public Builder mergeSignature(ch.epfl.dedis.lib.proto.SkipchainProto.ByzcoinSig value) {
         if (signatureBuilder_ == null) {
-          if (((bitField0_ & 0x00000008) == 0x00000008) &&
+          if (((bitField0_ & 0x00000008) != 0) &&
               signature_ != null &&
               signature_ != ch.epfl.dedis.lib.proto.SkipchainProto.ByzcoinSig.getDefaultInstance()) {
             signature_ =
@@ -9580,7 +9567,7 @@ public final class SkipchainProto {
      * <code>required bytes msg = 1;</code>
      */
     public boolean hasMsg() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes msg = 1;</code>
@@ -9595,7 +9582,7 @@ public final class SkipchainProto {
      * <code>required bytes sig = 2;</code>
      */
     public boolean hasSig() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes sig = 2;</code>
@@ -9626,10 +9613,10 @@ public final class SkipchainProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, msg_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, sig_);
       }
       unknownFields.writeTo(output);
@@ -9641,11 +9628,11 @@ public final class SkipchainProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, msg_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, sig_);
       }
@@ -9664,19 +9651,18 @@ public final class SkipchainProto {
       }
       ch.epfl.dedis.lib.proto.SkipchainProto.ByzcoinSig other = (ch.epfl.dedis.lib.proto.SkipchainProto.ByzcoinSig) obj;
 
-      boolean result = true;
-      result = result && (hasMsg() == other.hasMsg());
+      if (hasMsg() != other.hasMsg()) return false;
       if (hasMsg()) {
-        result = result && getMsg()
-            .equals(other.getMsg());
+        if (!getMsg()
+            .equals(other.getMsg())) return false;
       }
-      result = result && (hasSig() == other.hasSig());
+      if (hasSig() != other.hasSig()) return false;
       if (hasSig()) {
-        result = result && getSig()
-            .equals(other.getSig());
+        if (!getSig()
+            .equals(other.getSig())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -9859,11 +9845,11 @@ public final class SkipchainProto {
         ch.epfl.dedis.lib.proto.SkipchainProto.ByzcoinSig result = new ch.epfl.dedis.lib.proto.SkipchainProto.ByzcoinSig(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.msg_ = msg_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.sig_ = sig_;
@@ -9874,35 +9860,35 @@ public final class SkipchainProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -9963,7 +9949,7 @@ public final class SkipchainProto {
        * <code>required bytes msg = 1;</code>
        */
       public boolean hasMsg() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes msg = 1;</code>
@@ -9998,7 +9984,7 @@ public final class SkipchainProto {
        * <code>required bytes sig = 2;</code>
        */
       public boolean hasSig() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes sig = 2;</code>
@@ -10192,7 +10178,7 @@ public final class SkipchainProto {
      * <code>required bytes challenge = 1;</code>
      */
     public boolean hasChallenge() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes challenge = 1;</code>
@@ -10207,7 +10193,7 @@ public final class SkipchainProto {
      * <code>required bytes response = 2;</code>
      */
     public boolean hasResponse() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes response = 2;</code>
@@ -10238,10 +10224,10 @@ public final class SkipchainProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, challenge_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, response_);
       }
       unknownFields.writeTo(output);
@@ -10253,11 +10239,11 @@ public final class SkipchainProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, challenge_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, response_);
       }
@@ -10276,19 +10262,18 @@ public final class SkipchainProto {
       }
       ch.epfl.dedis.lib.proto.SkipchainProto.SchnorrSig other = (ch.epfl.dedis.lib.proto.SkipchainProto.SchnorrSig) obj;
 
-      boolean result = true;
-      result = result && (hasChallenge() == other.hasChallenge());
+      if (hasChallenge() != other.hasChallenge()) return false;
       if (hasChallenge()) {
-        result = result && getChallenge()
-            .equals(other.getChallenge());
+        if (!getChallenge()
+            .equals(other.getChallenge())) return false;
       }
-      result = result && (hasResponse() == other.hasResponse());
+      if (hasResponse() != other.hasResponse()) return false;
       if (hasResponse()) {
-        result = result && getResponse()
-            .equals(other.getResponse());
+        if (!getResponse()
+            .equals(other.getResponse())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -10471,11 +10456,11 @@ public final class SkipchainProto {
         ch.epfl.dedis.lib.proto.SkipchainProto.SchnorrSig result = new ch.epfl.dedis.lib.proto.SkipchainProto.SchnorrSig(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.challenge_ = challenge_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.response_ = response_;
@@ -10486,35 +10471,35 @@ public final class SkipchainProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -10575,7 +10560,7 @@ public final class SkipchainProto {
        * <code>required bytes challenge = 1;</code>
        */
       public boolean hasChallenge() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes challenge = 1;</code>
@@ -10610,7 +10595,7 @@ public final class SkipchainProto {
        * <code>required bytes response = 2;</code>
        */
       public boolean hasResponse() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes response = 2;</code>
@@ -10727,7 +10712,6 @@ public final class SkipchainProto {
       super(builder);
     }
     private Exception() {
-      index_ = 0;
       commitment_ = com.google.protobuf.ByteString.EMPTY;
     }
 
@@ -10804,7 +10788,7 @@ public final class SkipchainProto {
      * <code>required sint32 index = 1;</code>
      */
     public boolean hasIndex() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required sint32 index = 1;</code>
@@ -10819,7 +10803,7 @@ public final class SkipchainProto {
      * <code>required bytes commitment = 2;</code>
      */
     public boolean hasCommitment() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes commitment = 2;</code>
@@ -10850,10 +10834,10 @@ public final class SkipchainProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeSInt32(1, index_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, commitment_);
       }
       unknownFields.writeTo(output);
@@ -10865,11 +10849,11 @@ public final class SkipchainProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeSInt32Size(1, index_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, commitment_);
       }
@@ -10888,19 +10872,18 @@ public final class SkipchainProto {
       }
       ch.epfl.dedis.lib.proto.SkipchainProto.Exception other = (ch.epfl.dedis.lib.proto.SkipchainProto.Exception) obj;
 
-      boolean result = true;
-      result = result && (hasIndex() == other.hasIndex());
+      if (hasIndex() != other.hasIndex()) return false;
       if (hasIndex()) {
-        result = result && (getIndex()
-            == other.getIndex());
+        if (getIndex()
+            != other.getIndex()) return false;
       }
-      result = result && (hasCommitment() == other.hasCommitment());
+      if (hasCommitment() != other.hasCommitment()) return false;
       if (hasCommitment()) {
-        result = result && getCommitment()
-            .equals(other.getCommitment());
+        if (!getCommitment()
+            .equals(other.getCommitment())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -11083,11 +11066,11 @@ public final class SkipchainProto {
         ch.epfl.dedis.lib.proto.SkipchainProto.Exception result = new ch.epfl.dedis.lib.proto.SkipchainProto.Exception(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.index_ = index_;
           to_bitField0_ |= 0x00000001;
         }
-        result.index_ = index_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.commitment_ = commitment_;
@@ -11098,35 +11081,35 @@ public final class SkipchainProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -11187,7 +11170,7 @@ public final class SkipchainProto {
        * <code>required sint32 index = 1;</code>
        */
       public boolean hasIndex() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required sint32 index = 1;</code>
@@ -11219,7 +11202,7 @@ public final class SkipchainProto {
        * <code>required bytes commitment = 2;</code>
        */
       public boolean hasCommitment() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes commitment = 2;</code>

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/StatusProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/StatusProto.java
@@ -130,9 +130,8 @@ public final class StatusProto {
       }
       ch.epfl.dedis.lib.proto.StatusProto.Request other = (ch.epfl.dedis.lib.proto.StatusProto.Request) obj;
 
-      boolean result = true;
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -311,35 +310,35 @@ public final class StatusProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -529,7 +528,7 @@ public final class StatusProto {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 status_ = com.google.protobuf.MapField.newMapField(
                     StatusDefaultEntryHolder.defaultEntry);
                 mutable_bitField0_ |= 0x00000001;
@@ -543,7 +542,7 @@ public final class StatusProto {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = serveridentity_.toBuilder();
               }
               serveridentity_ = input.readMessage(ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity.parser(), extensionRegistry);
@@ -681,7 +680,7 @@ public final class StatusProto {
      * <code>optional .network.ServerIdentity serveridentity = 2;</code>
      */
     public boolean hasServeridentity() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>optional .network.ServerIdentity serveridentity = 2;</code>
@@ -722,7 +721,7 @@ public final class StatusProto {
           internalGetStatus(),
           StatusDefaultEntryHolder.defaultEntry,
           1);
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(2, getServeridentity());
       }
       unknownFields.writeTo(output);
@@ -744,7 +743,7 @@ public final class StatusProto {
         size += com.google.protobuf.CodedOutputStream
             .computeMessageSize(1, status__);
       }
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getServeridentity());
       }
@@ -763,16 +762,15 @@ public final class StatusProto {
       }
       ch.epfl.dedis.lib.proto.StatusProto.Response other = (ch.epfl.dedis.lib.proto.StatusProto.Response) obj;
 
-      boolean result = true;
-      result = result && internalGetStatus().equals(
-          other.internalGetStatus());
-      result = result && (hasServeridentity() == other.hasServeridentity());
+      if (!internalGetStatus().equals(
+          other.internalGetStatus())) return false;
+      if (hasServeridentity() != other.hasServeridentity()) return false;
       if (hasServeridentity()) {
-        result = result && getServeridentity()
-            .equals(other.getServeridentity());
+        if (!getServeridentity()
+            .equals(other.getServeridentity())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -987,13 +985,13 @@ public final class StatusProto {
         int to_bitField0_ = 0;
         result.status_ = internalGetStatus();
         result.status_.makeImmutable();
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (serveridentityBuilder_ == null) {
+            result.serveridentity_ = serveridentity_;
+          } else {
+            result.serveridentity_ = serveridentityBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
-        }
-        if (serveridentityBuilder_ == null) {
-          result.serveridentity_ = serveridentity_;
-        } else {
-          result.serveridentity_ = serveridentityBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -1002,35 +1000,35 @@ public final class StatusProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -1207,14 +1205,14 @@ public final class StatusProto {
         return this;
       }
 
-      private ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity serveridentity_ = null;
+      private ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity serveridentity_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity, ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity.Builder, ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentityOrBuilder> serveridentityBuilder_;
       /**
        * <code>optional .network.ServerIdentity serveridentity = 2;</code>
        */
       public boolean hasServeridentity() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>optional .network.ServerIdentity serveridentity = 2;</code>
@@ -1261,7 +1259,7 @@ public final class StatusProto {
        */
       public Builder mergeServeridentity(ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity value) {
         if (serveridentityBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               serveridentity_ != null &&
               serveridentity_ != ch.epfl.dedis.lib.proto.NetworkProto.ServerIdentity.getDefaultInstance()) {
             serveridentity_ =

--- a/external/java/src/main/java/ch/epfl/dedis/lib/proto/TrieProto.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/proto/TrieProto.java
@@ -126,7 +126,7 @@ public final class TrieProto {
      * <code>required bytes left = 1;</code>
      */
     public boolean hasLeft() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes left = 1;</code>
@@ -141,7 +141,7 @@ public final class TrieProto {
      * <code>required bytes right = 2;</code>
      */
     public boolean hasRight() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes right = 2;</code>
@@ -172,10 +172,10 @@ public final class TrieProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(1, left_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, right_);
       }
       unknownFields.writeTo(output);
@@ -187,11 +187,11 @@ public final class TrieProto {
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(1, left_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, right_);
       }
@@ -210,19 +210,18 @@ public final class TrieProto {
       }
       ch.epfl.dedis.lib.proto.TrieProto.InteriorNode other = (ch.epfl.dedis.lib.proto.TrieProto.InteriorNode) obj;
 
-      boolean result = true;
-      result = result && (hasLeft() == other.hasLeft());
+      if (hasLeft() != other.hasLeft()) return false;
       if (hasLeft()) {
-        result = result && getLeft()
-            .equals(other.getLeft());
+        if (!getLeft()
+            .equals(other.getLeft())) return false;
       }
-      result = result && (hasRight() == other.hasRight());
+      if (hasRight() != other.hasRight()) return false;
       if (hasRight()) {
-        result = result && getRight()
-            .equals(other.getRight());
+        if (!getRight()
+            .equals(other.getRight())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -405,11 +404,11 @@ public final class TrieProto {
         ch.epfl.dedis.lib.proto.TrieProto.InteriorNode result = new ch.epfl.dedis.lib.proto.TrieProto.InteriorNode(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.left_ = left_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.right_ = right_;
@@ -420,35 +419,35 @@ public final class TrieProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -509,7 +508,7 @@ public final class TrieProto {
        * <code>required bytes left = 1;</code>
        */
       public boolean hasLeft() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required bytes left = 1;</code>
@@ -544,7 +543,7 @@ public final class TrieProto {
        * <code>required bytes right = 2;</code>
        */
       public boolean hasRight() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes right = 2;</code>
@@ -656,7 +655,7 @@ public final class TrieProto {
       super(builder);
     }
     private EmptyNode() {
-      prefix_ = java.util.Collections.emptyList();
+      prefix_ = emptyBooleanList();
     }
 
     @java.lang.Override
@@ -684,22 +683,22 @@ public final class TrieProto {
               done = true;
               break;
             case 8: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                prefix_ = new java.util.ArrayList<java.lang.Boolean>();
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                prefix_ = newBooleanList();
                 mutable_bitField0_ |= 0x00000001;
               }
-              prefix_.add(input.readBool());
+              prefix_.addBoolean(input.readBool());
               break;
             }
             case 10: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001) && input.getBytesUntilLimit() > 0) {
-                prefix_ = new java.util.ArrayList<java.lang.Boolean>();
+              if (!((mutable_bitField0_ & 0x00000001) != 0) && input.getBytesUntilLimit() > 0) {
+                prefix_ = newBooleanList();
                 mutable_bitField0_ |= 0x00000001;
               }
               while (input.getBytesUntilLimit() > 0) {
-                prefix_.add(input.readBool());
+                prefix_.addBoolean(input.readBool());
               }
               input.popLimit(limit);
               break;
@@ -719,8 +718,8 @@ public final class TrieProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          prefix_ = java.util.Collections.unmodifiableList(prefix_);
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
+          prefix_.makeImmutable(); // C
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -740,7 +739,7 @@ public final class TrieProto {
     }
 
     public static final int PREFIX_FIELD_NUMBER = 1;
-    private java.util.List<java.lang.Boolean> prefix_;
+    private com.google.protobuf.Internal.BooleanList prefix_;
     /**
      * <code>repeated bool prefix = 1 [packed = true];</code>
      */
@@ -758,7 +757,7 @@ public final class TrieProto {
      * <code>repeated bool prefix = 1 [packed = true];</code>
      */
     public boolean getPrefix(int index) {
-      return prefix_.get(index);
+      return prefix_.getBoolean(index);
     }
     private int prefixMemoizedSerializedSize = -1;
 
@@ -782,7 +781,7 @@ public final class TrieProto {
         output.writeUInt32NoTag(prefixMemoizedSerializedSize);
       }
       for (int i = 0; i < prefix_.size(); i++) {
-        output.writeBoolNoTag(prefix_.get(i));
+        output.writeBoolNoTag(prefix_.getBoolean(i));
       }
       unknownFields.writeTo(output);
     }
@@ -819,11 +818,10 @@ public final class TrieProto {
       }
       ch.epfl.dedis.lib.proto.TrieProto.EmptyNode other = (ch.epfl.dedis.lib.proto.TrieProto.EmptyNode) obj;
 
-      boolean result = true;
-      result = result && getPrefixList()
-          .equals(other.getPrefixList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!getPrefixList()
+          .equals(other.getPrefixList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -970,7 +968,7 @@ public final class TrieProto {
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        prefix_ = java.util.Collections.emptyList();
+        prefix_ = emptyBooleanList();
         bitField0_ = (bitField0_ & ~0x00000001);
         return this;
       }
@@ -999,8 +997,8 @@ public final class TrieProto {
       public ch.epfl.dedis.lib.proto.TrieProto.EmptyNode buildPartial() {
         ch.epfl.dedis.lib.proto.TrieProto.EmptyNode result = new ch.epfl.dedis.lib.proto.TrieProto.EmptyNode(this);
         int from_bitField0_ = bitField0_;
-        if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          prefix_ = java.util.Collections.unmodifiableList(prefix_);
+        if (((bitField0_ & 0x00000001) != 0)) {
+          prefix_.makeImmutable();
           bitField0_ = (bitField0_ & ~0x00000001);
         }
         result.prefix_ = prefix_;
@@ -1010,35 +1008,35 @@ public final class TrieProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -1092,10 +1090,10 @@ public final class TrieProto {
       }
       private int bitField0_;
 
-      private java.util.List<java.lang.Boolean> prefix_ = java.util.Collections.emptyList();
+      private com.google.protobuf.Internal.BooleanList prefix_ = emptyBooleanList();
       private void ensurePrefixIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          prefix_ = new java.util.ArrayList<java.lang.Boolean>(prefix_);
+        if (!((bitField0_ & 0x00000001) != 0)) {
+          prefix_ = mutableCopy(prefix_);
           bitField0_ |= 0x00000001;
          }
       }
@@ -1104,7 +1102,8 @@ public final class TrieProto {
        */
       public java.util.List<java.lang.Boolean>
           getPrefixList() {
-        return java.util.Collections.unmodifiableList(prefix_);
+        return ((bitField0_ & 0x00000001) != 0) ?
+                 java.util.Collections.unmodifiableList(prefix_) : prefix_;
       }
       /**
        * <code>repeated bool prefix = 1 [packed = true];</code>
@@ -1116,7 +1115,7 @@ public final class TrieProto {
        * <code>repeated bool prefix = 1 [packed = true];</code>
        */
       public boolean getPrefix(int index) {
-        return prefix_.get(index);
+        return prefix_.getBoolean(index);
       }
       /**
        * <code>repeated bool prefix = 1 [packed = true];</code>
@@ -1124,7 +1123,7 @@ public final class TrieProto {
       public Builder setPrefix(
           int index, boolean value) {
         ensurePrefixIsMutable();
-        prefix_.set(index, value);
+        prefix_.setBoolean(index, value);
         onChanged();
         return this;
       }
@@ -1133,7 +1132,7 @@ public final class TrieProto {
        */
       public Builder addPrefix(boolean value) {
         ensurePrefixIsMutable();
-        prefix_.add(value);
+        prefix_.addBoolean(value);
         onChanged();
         return this;
       }
@@ -1152,7 +1151,7 @@ public final class TrieProto {
        * <code>repeated bool prefix = 1 [packed = true];</code>
        */
       public Builder clearPrefix() {
-        prefix_ = java.util.Collections.emptyList();
+        prefix_ = emptyBooleanList();
         bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
@@ -1258,7 +1257,7 @@ public final class TrieProto {
       super(builder);
     }
     private LeafNode() {
-      prefix_ = java.util.Collections.emptyList();
+      prefix_ = emptyBooleanList();
       key_ = com.google.protobuf.ByteString.EMPTY;
       value_ = com.google.protobuf.ByteString.EMPTY;
     }
@@ -1288,22 +1287,22 @@ public final class TrieProto {
               done = true;
               break;
             case 8: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                prefix_ = new java.util.ArrayList<java.lang.Boolean>();
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                prefix_ = newBooleanList();
                 mutable_bitField0_ |= 0x00000001;
               }
-              prefix_.add(input.readBool());
+              prefix_.addBoolean(input.readBool());
               break;
             }
             case 10: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001) && input.getBytesUntilLimit() > 0) {
-                prefix_ = new java.util.ArrayList<java.lang.Boolean>();
+              if (!((mutable_bitField0_ & 0x00000001) != 0) && input.getBytesUntilLimit() > 0) {
+                prefix_ = newBooleanList();
                 mutable_bitField0_ |= 0x00000001;
               }
               while (input.getBytesUntilLimit() > 0) {
-                prefix_.add(input.readBool());
+                prefix_.addBoolean(input.readBool());
               }
               input.popLimit(limit);
               break;
@@ -1333,8 +1332,8 @@ public final class TrieProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          prefix_ = java.util.Collections.unmodifiableList(prefix_);
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
+          prefix_.makeImmutable(); // C
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -1355,7 +1354,7 @@ public final class TrieProto {
 
     private int bitField0_;
     public static final int PREFIX_FIELD_NUMBER = 1;
-    private java.util.List<java.lang.Boolean> prefix_;
+    private com.google.protobuf.Internal.BooleanList prefix_;
     /**
      * <code>repeated bool prefix = 1 [packed = true];</code>
      */
@@ -1373,7 +1372,7 @@ public final class TrieProto {
      * <code>repeated bool prefix = 1 [packed = true];</code>
      */
     public boolean getPrefix(int index) {
-      return prefix_.get(index);
+      return prefix_.getBoolean(index);
     }
     private int prefixMemoizedSerializedSize = -1;
 
@@ -1383,7 +1382,7 @@ public final class TrieProto {
      * <code>required bytes key = 2;</code>
      */
     public boolean hasKey() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required bytes key = 2;</code>
@@ -1398,7 +1397,7 @@ public final class TrieProto {
      * <code>required bytes value = 3;</code>
      */
     public boolean hasValue() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required bytes value = 3;</code>
@@ -1435,12 +1434,12 @@ public final class TrieProto {
         output.writeUInt32NoTag(prefixMemoizedSerializedSize);
       }
       for (int i = 0; i < prefix_.size(); i++) {
-        output.writeBoolNoTag(prefix_.get(i));
+        output.writeBoolNoTag(prefix_.getBoolean(i));
       }
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeBytes(2, key_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(3, value_);
       }
       unknownFields.writeTo(output);
@@ -1463,11 +1462,11 @@ public final class TrieProto {
         }
         prefixMemoizedSerializedSize = dataSize;
       }
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, key_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, value_);
       }
@@ -1486,21 +1485,20 @@ public final class TrieProto {
       }
       ch.epfl.dedis.lib.proto.TrieProto.LeafNode other = (ch.epfl.dedis.lib.proto.TrieProto.LeafNode) obj;
 
-      boolean result = true;
-      result = result && getPrefixList()
-          .equals(other.getPrefixList());
-      result = result && (hasKey() == other.hasKey());
+      if (!getPrefixList()
+          .equals(other.getPrefixList())) return false;
+      if (hasKey() != other.hasKey()) return false;
       if (hasKey()) {
-        result = result && getKey()
-            .equals(other.getKey());
+        if (!getKey()
+            .equals(other.getKey())) return false;
       }
-      result = result && (hasValue() == other.hasValue());
+      if (hasValue() != other.hasValue()) return false;
       if (hasValue()) {
-        result = result && getValue()
-            .equals(other.getValue());
+        if (!getValue()
+            .equals(other.getValue())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -1655,7 +1653,7 @@ public final class TrieProto {
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        prefix_ = java.util.Collections.emptyList();
+        prefix_ = emptyBooleanList();
         bitField0_ = (bitField0_ & ~0x00000001);
         key_ = com.google.protobuf.ByteString.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000002);
@@ -1689,16 +1687,16 @@ public final class TrieProto {
         ch.epfl.dedis.lib.proto.TrieProto.LeafNode result = new ch.epfl.dedis.lib.proto.TrieProto.LeafNode(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          prefix_ = java.util.Collections.unmodifiableList(prefix_);
+        if (((bitField0_ & 0x00000001) != 0)) {
+          prefix_.makeImmutable();
           bitField0_ = (bitField0_ & ~0x00000001);
         }
         result.prefix_ = prefix_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.key_ = key_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.value_ = value_;
@@ -1709,35 +1707,35 @@ public final class TrieProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -1803,10 +1801,10 @@ public final class TrieProto {
       }
       private int bitField0_;
 
-      private java.util.List<java.lang.Boolean> prefix_ = java.util.Collections.emptyList();
+      private com.google.protobuf.Internal.BooleanList prefix_ = emptyBooleanList();
       private void ensurePrefixIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          prefix_ = new java.util.ArrayList<java.lang.Boolean>(prefix_);
+        if (!((bitField0_ & 0x00000001) != 0)) {
+          prefix_ = mutableCopy(prefix_);
           bitField0_ |= 0x00000001;
          }
       }
@@ -1815,7 +1813,8 @@ public final class TrieProto {
        */
       public java.util.List<java.lang.Boolean>
           getPrefixList() {
-        return java.util.Collections.unmodifiableList(prefix_);
+        return ((bitField0_ & 0x00000001) != 0) ?
+                 java.util.Collections.unmodifiableList(prefix_) : prefix_;
       }
       /**
        * <code>repeated bool prefix = 1 [packed = true];</code>
@@ -1827,7 +1826,7 @@ public final class TrieProto {
        * <code>repeated bool prefix = 1 [packed = true];</code>
        */
       public boolean getPrefix(int index) {
-        return prefix_.get(index);
+        return prefix_.getBoolean(index);
       }
       /**
        * <code>repeated bool prefix = 1 [packed = true];</code>
@@ -1835,7 +1834,7 @@ public final class TrieProto {
       public Builder setPrefix(
           int index, boolean value) {
         ensurePrefixIsMutable();
-        prefix_.set(index, value);
+        prefix_.setBoolean(index, value);
         onChanged();
         return this;
       }
@@ -1844,7 +1843,7 @@ public final class TrieProto {
        */
       public Builder addPrefix(boolean value) {
         ensurePrefixIsMutable();
-        prefix_.add(value);
+        prefix_.addBoolean(value);
         onChanged();
         return this;
       }
@@ -1863,7 +1862,7 @@ public final class TrieProto {
        * <code>repeated bool prefix = 1 [packed = true];</code>
        */
       public Builder clearPrefix() {
-        prefix_ = java.util.Collections.emptyList();
+        prefix_ = emptyBooleanList();
         bitField0_ = (bitField0_ & ~0x00000001);
         onChanged();
         return this;
@@ -1874,7 +1873,7 @@ public final class TrieProto {
        * <code>required bytes key = 2;</code>
        */
       public boolean hasKey() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required bytes key = 2;</code>
@@ -1909,7 +1908,7 @@ public final class TrieProto {
        * <code>required bytes value = 3;</code>
        */
       public boolean hasValue() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required bytes value = 3;</code>
@@ -2100,7 +2099,7 @@ public final class TrieProto {
               done = true;
               break;
             case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                 interiors_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.TrieProto.InteriorNode>();
                 mutable_bitField0_ |= 0x00000001;
               }
@@ -2110,7 +2109,7 @@ public final class TrieProto {
             }
             case 18: {
               ch.epfl.dedis.lib.proto.TrieProto.LeafNode.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000001) == 0x00000001)) {
+              if (((bitField0_ & 0x00000001) != 0)) {
                 subBuilder = leaf_.toBuilder();
               }
               leaf_ = input.readMessage(ch.epfl.dedis.lib.proto.TrieProto.LeafNode.parser(), extensionRegistry);
@@ -2123,7 +2122,7 @@ public final class TrieProto {
             }
             case 26: {
               ch.epfl.dedis.lib.proto.TrieProto.EmptyNode.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000002) == 0x00000002)) {
+              if (((bitField0_ & 0x00000002) != 0)) {
                 subBuilder = empty_.toBuilder();
               }
               empty_ = input.readMessage(ch.epfl.dedis.lib.proto.TrieProto.EmptyNode.parser(), extensionRegistry);
@@ -2154,7 +2153,7 @@ public final class TrieProto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           interiors_ = java.util.Collections.unmodifiableList(interiors_);
         }
         this.unknownFields = unknownFields.build();
@@ -2216,7 +2215,7 @@ public final class TrieProto {
      * <code>required .trie.LeafNode leaf = 2;</code>
      */
     public boolean hasLeaf() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required .trie.LeafNode leaf = 2;</code>
@@ -2237,7 +2236,7 @@ public final class TrieProto {
      * <code>required .trie.EmptyNode empty = 3;</code>
      */
     public boolean hasEmpty() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required .trie.EmptyNode empty = 3;</code>
@@ -2258,7 +2257,7 @@ public final class TrieProto {
      * <code>required bytes nonce = 4;</code>
      */
     public boolean hasNonce() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required bytes nonce = 4;</code>
@@ -2306,13 +2305,13 @@ public final class TrieProto {
       for (int i = 0; i < interiors_.size(); i++) {
         output.writeMessage(1, interiors_.get(i));
       }
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(2, getLeaf());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(3, getEmpty());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeBytes(4, nonce_);
       }
       unknownFields.writeTo(output);
@@ -2328,15 +2327,15 @@ public final class TrieProto {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, interiors_.get(i));
       }
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getLeaf());
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(3, getEmpty());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(4, nonce_);
       }
@@ -2355,26 +2354,25 @@ public final class TrieProto {
       }
       ch.epfl.dedis.lib.proto.TrieProto.Proof other = (ch.epfl.dedis.lib.proto.TrieProto.Proof) obj;
 
-      boolean result = true;
-      result = result && getInteriorsList()
-          .equals(other.getInteriorsList());
-      result = result && (hasLeaf() == other.hasLeaf());
+      if (!getInteriorsList()
+          .equals(other.getInteriorsList())) return false;
+      if (hasLeaf() != other.hasLeaf()) return false;
       if (hasLeaf()) {
-        result = result && getLeaf()
-            .equals(other.getLeaf());
+        if (!getLeaf()
+            .equals(other.getLeaf())) return false;
       }
-      result = result && (hasEmpty() == other.hasEmpty());
+      if (hasEmpty() != other.hasEmpty()) return false;
       if (hasEmpty()) {
-        result = result && getEmpty()
-            .equals(other.getEmpty());
+        if (!getEmpty()
+            .equals(other.getEmpty())) return false;
       }
-      result = result && (hasNonce() == other.hasNonce());
+      if (hasNonce() != other.hasNonce()) return false;
       if (hasNonce()) {
-        result = result && getNonce()
-            .equals(other.getNonce());
+        if (!getNonce()
+            .equals(other.getNonce())) return false;
       }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
     }
 
     @java.lang.Override
@@ -2589,7 +2587,7 @@ public final class TrieProto {
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
         if (interiorsBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             interiors_ = java.util.Collections.unmodifiableList(interiors_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -2597,23 +2595,23 @@ public final class TrieProto {
         } else {
           result.interiors_ = interiorsBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (leafBuilder_ == null) {
+            result.leaf_ = leaf_;
+          } else {
+            result.leaf_ = leafBuilder_.build();
+          }
           to_bitField0_ |= 0x00000001;
         }
-        if (leafBuilder_ == null) {
-          result.leaf_ = leaf_;
-        } else {
-          result.leaf_ = leafBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          if (emptyBuilder_ == null) {
+            result.empty_ = empty_;
+          } else {
+            result.empty_ = emptyBuilder_.build();
+          }
           to_bitField0_ |= 0x00000002;
         }
-        if (emptyBuilder_ == null) {
-          result.empty_ = empty_;
-        } else {
-          result.empty_ = emptyBuilder_.build();
-        }
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.nonce_ = nonce_;
@@ -2624,35 +2622,35 @@ public final class TrieProto {
 
       @java.lang.Override
       public Builder clone() {
-        return (Builder) super.clone();
+        return super.clone();
       }
       @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.setField(field, value);
+        return super.setField(field, value);
       }
       @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
+        return super.clearField(field);
       }
       @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
+        return super.clearOneof(oneof);
       }
       @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
+        return super.setRepeatedField(field, index, value);
       }
       @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
           java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
+        return super.addRepeatedField(field, value);
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
@@ -2751,7 +2749,7 @@ public final class TrieProto {
       private java.util.List<ch.epfl.dedis.lib.proto.TrieProto.InteriorNode> interiors_ =
         java.util.Collections.emptyList();
       private void ensureInteriorsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           interiors_ = new java.util.ArrayList<ch.epfl.dedis.lib.proto.TrieProto.InteriorNode>(interiors_);
           bitField0_ |= 0x00000001;
          }
@@ -2980,7 +2978,7 @@ public final class TrieProto {
           interiorsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
               ch.epfl.dedis.lib.proto.TrieProto.InteriorNode, ch.epfl.dedis.lib.proto.TrieProto.InteriorNode.Builder, ch.epfl.dedis.lib.proto.TrieProto.InteriorNodeOrBuilder>(
                   interiors_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           interiors_ = null;
@@ -2988,14 +2986,14 @@ public final class TrieProto {
         return interiorsBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.TrieProto.LeafNode leaf_ = null;
+      private ch.epfl.dedis.lib.proto.TrieProto.LeafNode leaf_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.TrieProto.LeafNode, ch.epfl.dedis.lib.proto.TrieProto.LeafNode.Builder, ch.epfl.dedis.lib.proto.TrieProto.LeafNodeOrBuilder> leafBuilder_;
       /**
        * <code>required .trie.LeafNode leaf = 2;</code>
        */
       public boolean hasLeaf() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required .trie.LeafNode leaf = 2;</code>
@@ -3042,7 +3040,7 @@ public final class TrieProto {
        */
       public Builder mergeLeaf(ch.epfl.dedis.lib.proto.TrieProto.LeafNode value) {
         if (leafBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002) &&
+          if (((bitField0_ & 0x00000002) != 0) &&
               leaf_ != null &&
               leaf_ != ch.epfl.dedis.lib.proto.TrieProto.LeafNode.getDefaultInstance()) {
             leaf_ =
@@ -3106,14 +3104,14 @@ public final class TrieProto {
         return leafBuilder_;
       }
 
-      private ch.epfl.dedis.lib.proto.TrieProto.EmptyNode empty_ = null;
+      private ch.epfl.dedis.lib.proto.TrieProto.EmptyNode empty_;
       private com.google.protobuf.SingleFieldBuilderV3<
           ch.epfl.dedis.lib.proto.TrieProto.EmptyNode, ch.epfl.dedis.lib.proto.TrieProto.EmptyNode.Builder, ch.epfl.dedis.lib.proto.TrieProto.EmptyNodeOrBuilder> emptyBuilder_;
       /**
        * <code>required .trie.EmptyNode empty = 3;</code>
        */
       public boolean hasEmpty() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required .trie.EmptyNode empty = 3;</code>
@@ -3160,7 +3158,7 @@ public final class TrieProto {
        */
       public Builder mergeEmpty(ch.epfl.dedis.lib.proto.TrieProto.EmptyNode value) {
         if (emptyBuilder_ == null) {
-          if (((bitField0_ & 0x00000004) == 0x00000004) &&
+          if (((bitField0_ & 0x00000004) != 0) &&
               empty_ != null &&
               empty_ != ch.epfl.dedis.lib.proto.TrieProto.EmptyNode.getDefaultInstance()) {
             empty_ =
@@ -3229,7 +3227,7 @@ public final class TrieProto {
        * <code>required bytes nonce = 4;</code>
        */
       public boolean hasNonce() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /**
        * <code>required bytes nonce = 4;</code>

--- a/external/proto/calypso.proto
+++ b/external/proto/calypso.proto
@@ -116,3 +116,64 @@ message GetLTSReply {
 message LtsInstanceInfo {
   required onet.Roster roster = 1;
 }
+
+//
+// V4 proposed extensions
+//
+
+// Auth holds all possible authentication structures. When using it to call
+// Authorise, only one of the fields must be non-nil.
+message Auth {
+  optional AuthByzCoin byzcoin = 1;
+  optional AuthX509Cert authx509cert = 2;
+}
+
+// AuthByzCoin holds the information necessary to authenticate a byzcoin request.
+// In the ByzCoin model, all requests are valid as long as they are stored in the
+// blockchain with the given ID.
+// The TTL is to avoid that too old requests are re-used. If it is 0, it is disabled.
+message AuthByzCoin {
+  required bytes byzcoinid = 1;
+  required uint64 ttl = 2;
+}
+
+// AuthX509Cert holds the information necessary to authenticate a HyperLedger/Fabric
+// request. In its simplest form, it is simply the CA that will have to sign the
+// certificates of the requesters.
+// The Threshold indicates how many clients must have signed the request before it
+// is accepted.
+message AuthX509Cert {
+  // Slice of ASN.1 encoded X509 certificates.
+  repeated bytes ca = 1;
+  required sint32 threshold = 2;
+}
+
+// Grant holds one of the possible grant proofs for a reencryption request. Each
+// grant proof must hold the secret to be reencrypted, the ephemeral key, as well
+// as the proof itself that the request is valid. For each of the authentication
+// schemes, this proof will be different.
+message Grant {
+  optional GrantByzCoin byzcoin = 1;
+  optional GrantX509Cert x509cert = 2;
+}
+
+// GrantByzCoin holds the proof of the write instance, holding the secret itself.
+// The proof of the read instance holds the ephemeral key. Both proofs can be
+// verified using one of the stored ByzCoinIDs.
+message GrantByzCoin {
+  // Write is the proof containing the write request.
+  required byzcoin.Proof write = 1;
+  // Read is the proof that he has been accepted to read the secret.
+  required byzcoin.Proof read = 2;
+}
+
+// GrantX509Cert holds the proof that at least a threshold number of clients
+// accepted the reencryption.
+// For each client, there must exist a certificate that can be verified by the
+// CA certificate from AuthX509Cert. Additionally, each client must sign the
+// following message:
+//   sha256( Secret | Ephemeral | Time )
+message GrantX509Cert {
+  required bytes secret = 1;
+  repeated bytes certificates = 2;
+}

--- a/proto.sh
+++ b/proto.sh
@@ -6,8 +6,8 @@ set -u
 struct_files=(`find . -name proto.go | sort`)
 
 pv=`protoc --version`
-if [ "$pv" != "libprotoc 3.6.1" ]; then
-	echo "Protoc version $pv is not supported."
+if [ "$pv" != "libprotoc 3.6.1" and "$pv" != "libprotoc 3.7.1"]; then
+	echo "Protoc version $pv is not supported. Please install 3.6.1 or 3.7.1"
 	exit 1
 fi
 


### PR DESCRIPTION
This is a proposed API to support non-byzcoin verified calypso deployments. The first use-case is ByzGen's need to have a HyperLedger/Fabric backend for the authorization, but Calypso for the re-encryption.