### PR TITLE
Disable AddTransaction_WithFailure_OnFollower

### DIFF
--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -118,6 +118,9 @@ func TestService_AddTransaction_WithFailure(t *testing.T) {
 }
 
 func TestService_AddTransaction_WithFailure_OnFollower(t *testing.T) {
+	if testing.Short() {
+		t.Skip("this test fails because of #1795")
+	}
 	testAddTransaction(t, 2*time.Second, 1, true)
 }
 


### PR DESCRIPTION
The test fails due to  #1795. We should enable it when the issue is
fixed.