### PR TITLE
Fixes #1756 (store new skipblocks when skipchain service is linked)

### DIFF
--- a/byzcoin/bcadmin/test.sh
+++ b/byzcoin/bcadmin/test.sh
@@ -97,13 +97,15 @@ testRoster(){
   testGrep "Roster: tls://localhost:2006" runBA latest -server 2 $bc
 }
 
-# When a conode is linked to a client (`scmgr link add ...`), it removes the possibility
-# for 3rd parties to create a new skipchain on that conode. In the case a Bizcoin service
-# hosted on a linked conode wants to adds a new skipchain, we have to bypass this 
-# authorization process and allow a local service be able to send requests on the same
-# local linked conode. This process is handled with the `StoreSkipBlockInternal` method,
-# and this is what this method checks.
-# Note: this methods relies on the `scmgr` and the ability to create/update Byzcoin.
+# When a conode is linked to a client (`scmgr link add ...`), it removes the
+# possibility for 3rd parties to create a new skipchain on that conode. In the
+# case a Bizcoin service hosted on a linked conode wants to adds a new
+# skipchain, we have to bypass this authorization process and allow a local
+# service be able to send requests on the same local linked conode. This process
+# is handled with the `StoreSkipBlockInternal` method, and this is what this
+# method checks. 
+# Note: this methods relies on the `scmgr` and the ability to create/update 
+#       Byzcoin.
 testLinkPermission() {
   rm -f config/*
   runCoBG 1 2 3
@@ -113,14 +115,15 @@ testLinkPermission() {
   bc=config/bc*cfg
   key=config/key*cfg
   testOK runBA latest $bc
-  if [ ! -x ../../../scmgr/scmgr ]; then
-    echo "Didn't find \"cothority/scmgr/smgr\" executable"
-    echo "You may want to run \"go build\" in that directory"
+  build $APPDIR/../../scmgr
+  SCMGR_APP="$APPDIR/../../scmgr/scmgr"
+  if [ ! -x $SCMGR_APP ]; then
+    echo "Didn't find the \"scmgr\" executable at $SCMGR_APP"
     exit 1
   fi
-  scmgr link add co1/private.toml
-  scmgr link add co2/private.toml
-  scmgr link add co3/private.toml
+  $SCMGR_APP link add co1/private.toml
+  $SCMGR_APP link add co2/private.toml
+  $SCMGR_APP link add co3/private.toml
   testOK runBA create --roster public.toml --interval .5s
   testOK runBA darc rule -rule spawn:xxx -identity ed25519:foo 
 }

--- a/byzcoin/bcadmin/test.sh
+++ b/byzcoin/bcadmin/test.sh
@@ -91,11 +91,10 @@ testRoster(){
   testFail runBA roster leader $bc $key co2/public.toml
   # Setting a conode that is a leader as a leader raises an error
   testFail runBA roster leader $bc $key co1/public.toml
-  # This one fails, because only a leader is allowed to add new blocks
-  testFail runBA roster leader $bc $key co3/public.toml
+  testOK runBA roster leader $bc $key co3/public.toml
   # Change the block size to create a new block before verifying the roster
   testOK runBA config --blockSize 1000000 $bc $key
-  testGrep "Roster: tls://localhost:2002, tls://localhost:2006, tls://localhost:2008" runBA latest -server 2 $bc
+  testGrep "Roster: tls://localhost:2006" runBA latest -server 2 $bc
 }
 
 # When a conode is linked to a client (`scmgr link add ...`), it removes the possibility

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -879,27 +879,15 @@ func (s *Service) createNewBlock(scID skipchain.SkipBlockID, r *onet.Roster, tx 
 		NewBlock:          sb,
 		TargetSkipChainID: scID,
 	}
+
 	log.Lvlf3("Storing skipblock with %d transactions.", len(txRes))
 	var ssbReply *skipchain.StoreSkipBlockReply
-	if sb.Roster.List[0].Equal(s.ServerIdentity()) {
-		ssbReply, err = s.skService().StoreSkipBlock(&ssb)
-	} else {
-		log.Lvl2("Sending new block to other node", sb.Roster.List[0])
-		ssbReply = &skipchain.StoreSkipBlockReply{}
-		err = skipchain.NewClient().SendProtobuf(sb.Roster.List[0], &ssb, ssbReply)
-		if err != nil {
-			return nil, err
-		}
 
-		if ssbReply.Latest == nil {
-			return nil, errors.New("got an empty reply")
-		}
+	// Since only a leader can add new blocks, we safely assume that
+	// we are in a "local" context, ie. the bzcoin service is hosted
+	// with the skipchain one (on the same host). See PR of #1756
+	ssbReply, err = s.skService().StoreSkipBlockInternal(&ssb)
 
-		// we're not doing more verification because the block should not be used
-		// as is. It's up to the client to fetch the forward link of the previous
-		// block to insure the new one has been validated but at this moment we
-		// can't do it because it might not be propagated to this node yet
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/conode/CLI.md
+++ b/conode/CLI.md
@@ -90,7 +90,7 @@ COMMANDS:
 
 GLOBAL OPTIONS:
    --debug value, -d value   debug-level: 1 for terse, 5 for maximal (default: 0)
-   --config value, -c value  Configuration file of the server (default: os-specific)
+   --config value, -c value  Configuration file (private.toml) of the server (default: os-specific)
    --help, -h                show help
    --version, -v             print the version
 ```

--- a/libtest.sh
+++ b/libtest.sh
@@ -353,6 +353,7 @@ setupConode(){
   DBG_TEST=$DBG_OLD
 }
 
+# A few words about what this function does wouldn't hurt
 runCoBG(){
   for nb in "$@"; do
     dbgOut "starting conode-server #$nb"

--- a/libtest.sh
+++ b/libtest.sh
@@ -353,7 +353,10 @@ setupConode(){
   DBG_TEST=$DBG_OLD
 }
 
-# A few words about what this function does wouldn't hurt
+# runCoBG: Run a conode in the background. It runs a conode under a subshell so
+# that when it exits, it can make the .dead file once the conode dies. It then
+# checks that they started listening on the expected port, and finally reports
+# if one did not start as expected.
 runCoBG(){
   for nb in "$@"; do
     dbgOut "starting conode-server #$nb"

--- a/skipchain/README.md
+++ b/skipchain/README.md
@@ -30,7 +30,7 @@ lists are stored on the skipchain.
 
 The skipchain itself is held by one or more conodes. Clients can connect to the
 leader and propose new blocks. Every time a new block is received, the leader
-runs a BFT-protocol with the other nodes. All nodes keep a copy of the
+runs a BFT-protocol with the other conodes. All conodes keep a copy of the
 skipchain-blocks.
 
 ## Usage
@@ -43,7 +43,7 @@ Another usage example is in [CISC](../cisc/README.md).
 # Catch-up Behavior
 
 If the conode is a follower for a given skipchain, then when it is asked to add
-a block onto that skipchain by the leader, it will contact other nodes in the
+a block onto that skipchain by the leader, it will contact other conodes in the
 last known roster for that skipchain in order to get copies of blocks that it is
 missing. Once it has followed the skipchain to the latest block mentioned in the
 proposed update, it will add the proposed block.


### PR DESCRIPTION
This PR implements a new function `StoreSkipBlockInternal` which is meant to be used in the case a service is used on the same host as the Skipchain service.~~I also removed a condition in `skipchain/skipchain.go` as discussed.~~

~~Note: I had to update 2 tests in `byzcoin/bcadmin/test.sh` line 95 and 98 that were supposed to pass. This is due to the removal of the condition. I am not 100% confident about the expected behavior now that I removed the condition, so please double check.~~ (Reverted it)

Fixes #1756