### PR TITLE
Prevent catch up to trigger when one block away

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -2003,13 +2003,16 @@ func (s *Service) getTxs(leader *network.ServerIdentity, roster *onet.Roster, sc
 	defer s.working.Done()
 
 	// First we check if we are up-to-date with this chain (and that we know it)
-	latestSB := s.db().GetByID(latestID)
+	latestSB, doCatchUp := s.skService().WaitBlock(scID, latestID)
 	if latestSB == nil {
-		// The function will prevent multiple request to catch up so we can securely call it here
-		err := s.catchupFromID(roster, scID, latestID)
-		if err != nil {
-			log.Error(s.ServerIdentity(), err)
+		if doCatchUp {
+			// The function will prevent multiple request to catch up so we can securely call it here
+			err := s.catchupFromID(roster, scID, latestID)
+			if err != nil {
+				log.Error(s.ServerIdentity(), err)
+			}
 		}
+
 		// Give up the current request and wait for the next one, and keep skipping requests
 		// until the catching up is done
 		return []ClientTransaction{}

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -729,10 +729,14 @@ func TestService_FloodLedger(t *testing.T) {
 	log.Lvl1("Create 10 transactions and don't wait")
 	n := 10
 	for i := 0; i < n; i++ {
-		sendTransactionWithCounter(t, s, 0, slowContract, 0, uint64(i)+2)
+		_, _, err, err2 := sendTransactionWithCounter(t, s, 0, slowContract, 0, uint64(i)+2)
+		require.NoError(t, err)
+		require.NoError(t, err2)
 	}
 	// Send a last transaction and wait for it to be included
-	sendTransactionWithCounter(t, s, 0, dummyContract, 100, uint64(n)+2)
+	_, _, err, err2 := sendTransactionWithCounter(t, s, 0, dummyContract, 10, uint64(n)+2)
+	require.NoError(t, err)
+	require.NoError(t, err2)
 
 	// Suppose we need at least 2 blocks (slowContract waits 1/5 interval
 	// for each execution)

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -748,7 +748,7 @@ func TestService_BigTx(t *testing.T) {
 	// blocks gets to be too close to the edge with the normal short
 	// testing interval, and starts generating
 	// errors-that-might-not-be-errors.
-	s := newSer(t, 1, testInterval)
+	s := newSer(t, 1, 1*time.Second)
 	defer s.local.CloseAll()
 
 	// Check block number before.
@@ -812,7 +812,7 @@ func sendTransactionWithCounter(t *testing.T, s *ser, client int, kind string, w
 		InclusionWait: wait,
 	})
 
-	for doCatchUp := false; !doCatchUp; _, doCatchUp = s.services[client].skService().WaitBlock(s.genesis.SkipChainID(), nil) {
+	for doCatchUp := false; !doCatchUp && wait != 0; _, doCatchUp = s.services[client].skService().WaitBlock(s.genesis.SkipChainID(), nil) {
 		time.Sleep(s.interval)
 	}
 

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -624,7 +624,9 @@ func TestService_WaitInclusion(t *testing.T) {
 }
 
 func waitInclusion(t *testing.T, client int) {
-	s := newSer(t, 2, testInterval)
+	// use a bigger block interval to allow txs to be included
+	// in the same block
+	s := newSer(t, 2, 2*time.Second)
 	defer s.local.CloseAll()
 
 	// Get counter
@@ -663,7 +665,7 @@ func waitInclusion(t *testing.T, client int) {
 	// We expect to see both transactions in the block in pr.
 	txr, err := txResultsFromBlock(&pr.Latest)
 	require.NoError(t, err)
-	require.Equal(t, len(txr), 2)
+	require.Equal(t, 2, len(txr))
 
 	log.Lvl1("Create wrong transaction and wait")
 	counter++
@@ -2020,7 +2022,7 @@ func TestService_StateChangeStorage(t *testing.T) {
 		// Queue all transactions, except for the last one
 		wait := 0
 		if i == n-1 {
-			wait = n
+			wait = 10
 		}
 		_, err = s.service().AddTransaction(&AddTxRequest{
 			Version:       CurrentVersion,

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -103,25 +103,25 @@ func TestService_CreateGenesisBlock(t *testing.T) {
 }
 
 func TestService_AddTransaction(t *testing.T) {
-	testAddTransaction(t, time.Second, 0, false)
+	testAddTransaction(t, testInterval, 0, false)
 }
 
 func TestService_AddTransaction_ToFollower(t *testing.T) {
-	testAddTransaction(t, time.Second, 1, false)
+	testAddTransaction(t, testInterval, 1, false)
 }
 
 func TestService_AddTransaction_WithFailure(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Keep edge cases for Jenkins")
 	}
-	testAddTransaction(t, 2*time.Second, 0, true)
+	testAddTransaction(t, testInterval, 0, true)
 }
 
 func TestService_AddTransaction_WithFailure_OnFollower(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Keep edge cases for Jenkins")
 	}
-	testAddTransaction(t, 2*time.Second, 1, true)
+	testAddTransaction(t, testInterval, 1, true)
 }
 
 func testAddTransaction(t *testing.T, blockInterval time.Duration, sendToIdx int, failure bool) {
@@ -129,7 +129,7 @@ func testAddTransaction(t *testing.T, blockInterval time.Duration, sendToIdx int
 	if failure {
 		s = newSerN(t, 1, blockInterval, 4, false)
 		for _, service := range s.services {
-			service.SetPropagationTimeout(blockInterval / 2)
+			service.SetPropagationTimeout(blockInterval * 2)
 		}
 	} else {
 		s = newSer(t, 1, testInterval)
@@ -253,7 +253,7 @@ func testAddTransaction(t *testing.T, blockInterval time.Duration, sendToIdx int
 func TestService_AddTransaction_WrongNode(t *testing.T) {
 	defer log.SetShowTime(log.ShowTime())
 	log.SetShowTime(true)
-	s := newSerN(t, 1, time.Second, 4, false)
+	s := newSerN(t, 1, testInterval, 4, false)
 	defer s.local.CloseAll()
 
 	outsideServer := s.local.GenServers(1)[0]
@@ -299,7 +299,7 @@ func TestService_AddTransaction_WrongNode(t *testing.T) {
 func TestService_AddTransaction_ValidInvalid(t *testing.T) {
 	defer log.SetShowTime(log.ShowTime())
 	log.SetShowTime(true)
-	s := newSerN(t, 1, time.Second, 4, false)
+	s := newSerN(t, 1, testInterval, 4, false)
 	defer s.local.CloseAll()
 
 	// add the first tx to create the instance
@@ -624,7 +624,7 @@ func TestService_WaitInclusion(t *testing.T) {
 }
 
 func waitInclusion(t *testing.T, client int) {
-	s := newSer(t, 2, 2*time.Second)
+	s := newSer(t, 2, testInterval)
 	defer s.local.CloseAll()
 
 	// Get counter
@@ -717,13 +717,12 @@ func waitInclusion(t *testing.T, client int) {
 // Sends too many transactions to the ledger and waits for all blocks to be
 // done.
 func TestService_FloodLedger(t *testing.T) {
-	s := newSer(t, 2, 2*time.Second)
+	s := newSer(t, 2, testInterval)
 	defer s.local.CloseAll()
 
-	// Fetch the latest block
-	reply, err := skipchain.NewClient().GetUpdateChain(s.genesis.Roster, s.genesis.SkipChainID())
-	require.Nil(t, err)
-	before := reply.Update[len(reply.Update)-1]
+	// ask to the root service because of propagation delay
+	before, err := s.service().db().GetLatestByID(s.genesis.Hash)
+	require.NoError(t, err)
 
 	log.Lvl1("Create 10 transactions and don't wait")
 	n := 10
@@ -735,9 +734,8 @@ func TestService_FloodLedger(t *testing.T) {
 
 	// Suppose we need at least 2 blocks (slowContract waits 1/5 interval
 	// for each execution)
-	reply, err = skipchain.NewClient().GetUpdateChain(s.genesis.Roster, s.genesis.SkipChainID())
-	require.Nil(t, err)
-	latest := reply.Update[len(reply.Update)-1]
+	latest, err := s.service().db().GetLatestByID(s.genesis.Hash)
+	require.NoError(t, err)
 	if latest.Index-before.Index < 2 {
 		t.Fatalf("didn't get at least 2 blocks: index before %d, index after %v", before.Index, latest.Index)
 	}
@@ -748,7 +746,7 @@ func TestService_BigTx(t *testing.T) {
 	// blocks gets to be too close to the edge with the normal short
 	// testing interval, and starts generating
 	// errors-that-might-not-be-errors.
-	s := newSer(t, 1, 1*time.Second)
+	s := newSer(t, 1, testInterval)
 	defer s.local.CloseAll()
 
 	// Check block number before.
@@ -811,6 +809,11 @@ func sendTransactionWithCounter(t *testing.T, s *ser, client int, kind string, w
 		Transaction:   tx,
 		InclusionWait: wait,
 	})
+
+	for doCatchUp := false; !doCatchUp; _, doCatchUp = s.services[client].skService().WaitBlock(s.genesis.SkipChainID(), nil) {
+		time.Sleep(s.interval)
+	}
+
 	rep, err2 := ser.GetProof(&GetProof{
 		Version: CurrentVersion,
 		ID:      s.genesis.SkipChainID(),
@@ -1681,7 +1684,7 @@ func addDummyTxs(t *testing.T, s *ser, nbr int, perCTx int, count int) int {
 }
 
 func TestService_SetConfigRosterDownload(t *testing.T) {
-	s := newSer(t, 1, 2*time.Second)
+	s := newSer(t, 1, testInterval)
 	defer s.local.CloseAll()
 
 	ids := []darc.Identity{s.signer.Identity()}

--- a/byzcoin/tx_pipeline.go
+++ b/byzcoin/tx_pipeline.go
@@ -95,6 +95,12 @@ func (s *defaultTxProcessor) CollectTx() ([]ClientTransaction, error) {
 		return nil, err
 	}
 
+	sb, doCatchUp := s.skService().WaitBlock(s.scID, nil)
+	if sb == nil && !doCatchUp {
+		// block is still processing but the skipchain is known
+		return nil, nil
+	}
+
 	latest, err := s.db().GetLatestByID(s.scID)
 	if err != nil {
 		log.Errorf("Error while searching for %x", s.scID[:])

--- a/byzcoin/viewchange_test.go
+++ b/byzcoin/viewchange_test.go
@@ -19,14 +19,14 @@ import (
 // followers. Finally, we bring the failed nodes back up and they should
 // contain the transactions that they missed.
 func TestViewChange_Basic(t *testing.T) {
-	testViewChange(t, 4, 1, 4*time.Second)
+	testViewChange(t, 4, 1, testInterval)
 }
 
 func TestViewChange_Basic2(t *testing.T) {
 	if testing.Short() {
 		t.Skip("doesn't work on travis correctly due to byzcoinx timeout issue, see #1428")
 	}
-	testViewChange(t, 7, 2, 4*time.Second)
+	testViewChange(t, 7, 2, testInterval)
 }
 
 func testViewChange(t *testing.T, nHosts, nFailures int, interval time.Duration) {
@@ -39,7 +39,7 @@ func testViewChange(t *testing.T, nHosts, nFailures int, interval time.Duration)
 	defer s.local.CloseAll()
 
 	for _, service := range s.services {
-		service.SetPropagationTimeout(2 * interval)
+		service.SetPropagationTimeout(interval)
 	}
 
 	// Wait for all the genesis config to be written on all nodes.
@@ -60,9 +60,11 @@ func testViewChange(t *testing.T, nHosts, nFailures int, interval time.Duration)
 	// will wait before starting a view-change. Then, we sleep a little
 	// longer for the view-change transaction to be stored in the block.
 	for i := 0; i < nFailures; i++ {
-		time.Sleep(time.Duration(math.Pow(2, float64(i))) * s.interval * rotationWindow)
+		time.Sleep(time.Duration(math.Pow(2, float64(i+1))) * s.interval * rotationWindow)
 	}
-	time.Sleep(2 * s.interval)
+	for doCatchUp := false; !doCatchUp; _, doCatchUp = s.services[nFailures].skService().WaitBlock(s.genesis.SkipChainID(), nil) {
+		time.Sleep(interval)
+	}
 	config, err := s.services[nFailures].LoadConfig(s.genesis.SkipChainID())
 	require.NoError(t, err)
 	log.Lvl2("Verifying roster", config.Roster.List)
@@ -105,13 +107,16 @@ func testViewChange(t *testing.T, nHosts, nFailures int, interval time.Duration)
 		pr = s.waitProofWithIdx(t, tx1.Instructions[0].InstanceID.Slice(), i)
 		require.True(t, pr.InclusionProof.Match(tx1.Instructions[0].InstanceID.Slice()))
 	}
+	for doCatchUp := false; !doCatchUp; _, doCatchUp = s.services[nFailures].skService().WaitBlock(s.genesis.SkipChainID(), nil) {
+		time.Sleep(s.interval)
+	}
 
 	log.Lvl1("Sending 1st tx")
-	tx1, err = createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, s.value, s.signer, 1)
+	tx1, err = createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, s.value, s.signer, 2)
 	require.NoError(t, err)
 	s.sendTxToAndWait(t, tx1, nFailures, 10)
 	log.Lvl1("Sending 2nd tx")
-	tx1, err = createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, s.value, s.signer, 2)
+	tx1, err = createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, s.value, s.signer, 3)
 	require.NoError(t, err)
 	s.sendTxToAndWait(t, tx1, nFailures, 10)
 	log.Lvl1("Sent two tx")

--- a/byzcoin/viewchange_test.go
+++ b/byzcoin/viewchange_test.go
@@ -39,7 +39,7 @@ func testViewChange(t *testing.T, nHosts, nFailures int, interval time.Duration)
 	defer s.local.CloseAll()
 
 	for _, service := range s.services {
-		service.SetPropagationTimeout(interval)
+		service.SetPropagationTimeout(2 * interval)
 	}
 
 	// Wait for all the genesis config to be written on all nodes.
@@ -72,6 +72,10 @@ func testViewChange(t *testing.T, nHosts, nFailures int, interval time.Duration)
 
 	// check that the leader is updated for all nodes
 	for _, service := range s.services[nFailures:] {
+		for doCatchUp := false; !doCatchUp; _, doCatchUp = service.skService().WaitBlock(s.genesis.SkipChainID(), nil) {
+			time.Sleep(interval)
+		}
+
 		// everyone should have the same leader after the genesis block is stored
 		leader, err := service.getLeader(s.genesis.SkipChainID())
 		require.NoError(t, err)

--- a/calypso/api.go
+++ b/calypso/api.go
@@ -68,7 +68,7 @@ func (c *Client) CreateLTS(ltsRoster *onet.Roster, darcID darc.ID, signers []dar
 	if err := tx.FillSignersAndSignWith(signers...); err != nil {
 		return nil, err
 	}
-	if _, err := c.bcClient.AddTransactionAndWait(tx, 4); err != nil {
+	if _, err := c.bcClient.AddTransactionAndWait(tx, 10); err != nil {
 		return nil, err
 	}
 	resp, err := c.bcClient.GetProof(tx.Instructions[0].DeriveID("").Slice())

--- a/calypso/api_test.go
+++ b/calypso/api_test.go
@@ -23,7 +23,7 @@ func TestClient_CreateLTS(t *testing.T) {
 	msg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:dummy", "spawn:" + ContractLongTermSecretID},
 		signer.Identity())
-	msg.BlockInterval = 100 * time.Millisecond
+	msg.BlockInterval = 500 * time.Millisecond
 	require.Nil(t, err)
 	d := msg.GenesisDarc
 	require.Nil(t, d.Verify(true))

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -832,6 +832,23 @@ func (s *Service) ListFollow(list *ListFollow) (*ListFollowReply, error) {
 	return reply, nil
 }
 
+// WaitBlock returns a block by its ID instantly if already stored in the DB
+// or check if the block is inside the buffer. If the block is known, false will
+// be returned because a catch up is not necessary, true otherwise.
+func (s *Service) WaitBlock(sid SkipBlockID, id SkipBlockID) (*SkipBlock, bool) {
+	sb := s.db.GetByID(id)
+	if sb != nil {
+		return sb, false
+	}
+
+	ok := s.blockBuffer.has(sid)
+	if ok {
+		return nil, false
+	}
+
+	return nil, true
+}
+
 // GetDB returns a pointer to the internal database.
 func (s *Service) GetDB() *SkipBlockDB {
 	return s.db

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -1175,6 +1175,15 @@ func (sbb *skipBlockBuffer) get(sid SkipBlockID, id SkipBlockID) *SkipBlock {
 	return block
 }
 
+// has returns true when the skipchain has a block in the buffer
+func (sbb *skipBlockBuffer) has(sid SkipBlockID) bool {
+	sbb.Lock()
+	defer sbb.Unlock()
+
+	_, ok := sbb.buffer[string(sid)]
+	return ok
+}
+
 // clear deletes the current block of the given skipchain
 func (sbb *skipBlockBuffer) clear(sid SkipBlockID) {
 	sbb.Lock()

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -325,6 +325,8 @@ func TestBlockBuffer(t *testing.T) {
 
 	sb = bb.get(sid, bid)
 	require.NotNil(t, sb)
+	require.True(t, bb.has(sid))
+	require.False(t, bb.has(bid))
 
 	// wrong key
 	sb = bb.get(bid, bid)


### PR DESCRIPTION
The collectTx callback can trigger a catch up when necessary but it
could happen that it triggers because of a new block in processing.
This fixes the situation by checking the block buffer before using
the catch up.

Fixes #1813