### PR TITLE
Add error handling to Calypso, export contracts, and add random-source

### DIFF
--- a/calypso/proto.go
+++ b/calypso/proto.go
@@ -45,6 +45,8 @@ type Write struct {
 	ExtraData []byte `protobuf:"opt"`
 	// LTSID points to the identity of the lts group
 	LTSID byzcoin.InstanceID
+	// Cost reflects how many coins you'll have to pay for a read-request
+	Cost byzcoin.Coin `protobuf:"opt"`
 }
 
 // Read is the data stored in a read instance. It has a pointer to the write

--- a/calypso/struct.go
+++ b/calypso/struct.go
@@ -68,13 +68,6 @@ func NewWrite(suite suites.Suite, ltsid byzcoin.InstanceID, writeDarc darc.ID, X
 	return wr
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // CheckProof verifies that the write-request has actually been created with
 // somebody having access to the secret key.
 func (wr *Write) CheckProof(suite suite, writeID darc.ID) error {


### PR DESCRIPTION
Added error handling to the calypso-service to better debug eventual errors.
Export calypso-read and calypso-write contracts for future changes in personhood-spawner.
Added a cost-field to Calypso.ContractWrite, to have paying read-requests.