### PR TITLE
adds marshalSize() to the scalar-interface

### DIFF
--- a/external/js/kyber/src/index.ts
+++ b/external/js/kyber/src/index.ts
@@ -165,6 +165,12 @@ export interface Scalar {
   unmarshalBinary(bytes: Buffer): void;
 
   /**
+   * Get the length of the buffer after marshaling the scalar
+   * @returns the length as a number
+   */
+  marshalSize(): number;
+
+  /**
    * Sets the receiver equal to another Scalar a
    * @param a the new scalar
    * @return the current scalar set to the new value

--- a/external/js/kyber/src/pairing/scalar.ts
+++ b/external/js/kyber/src/pairing/scalar.ts
@@ -104,6 +104,11 @@ export default class BN256Scalar implements Scalar {
     }
 
     /** @inheritdoc */
+    marshalSize(): number{
+        return 32;
+    }
+
+    /** @inheritdoc */
     clone(): BN256Scalar {
         const s = new BN256Scalar(new BN(this.v));
         return s;


### PR DESCRIPTION
The scalar interface also should have `marshalSize`, as it's used in some methods, and it's provided at least by the `Ed25519` group.