### PR TITLE
fixes coin-contract and Dockerfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
       go_import_path: go.dedis.ch/cothority/v3
  
       go:
-        - "1.11.x"
+        - "1.12.x"
 
       install:
         - go get github.com/dedis/Coding || true
@@ -37,8 +37,8 @@ matrix:
       # defaults to Go 1.8 and does not respect the go version
       # specifier.
       install:
-        - gimme 1.11.6
-        - . $HOME/.gimme/envs/go1.11.6.env
+        - gimme 1.12.4
+        - . $HOME/.gimme/envs/go1.12.4.env
         - env GO111MODULE=off go get github.com/dedis/Coding || true
 
       script:
@@ -65,8 +65,8 @@ matrix:
 
       before_install: dpkg --compare-versions `npm -v` ge 6.7 || npm i -g npm@^6.7.0
       install:
-        - gimme 1.11.6
-        - . $HOME/.gimme/envs/go1.11.6.env
+        - gimme 1.12.4
+        - . $HOME/.gimme/envs/go1.12.4.env
         - env GO111MODULE=off go get github.com/dedis/Coding || true
 
       script:

--- a/byzcoin/contracts/coins.go
+++ b/byzcoin/contracts/coins.go
@@ -58,7 +58,14 @@ func (c *contractCoin) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instruc
 
 	// Spawn creates a new coin account as a separate instance.
 	ca := inst.DeriveID("")
-	if coinID := inst.Spawn.Args.Search("coinID"); coinID != nil {
+	// Previous versions had the 'public' argument to define which coinID to create. Later versions
+	// use a more meaningful name of "coinID". For backwards-compatibility, we need both here, letting
+	// the previous "public" have precedence over an eventual later "coinID".
+	coinID := inst.Spawn.Args.Search("public")
+	if coinID == nil {
+		coinID = inst.Spawn.Args.Search("coinID")
+	}
+	if coinID != nil {
 		h := sha256.New()
 		h.Write([]byte(ContractCoinID))
 		h.Write(coinID)

--- a/conode/CLI.md
+++ b/conode/CLI.md
@@ -9,7 +9,7 @@ This document describes how to run a conode from the command line. This is usefu
 if you have ssh access to a server or a virtual server. To use the code of this
 package you need to:
 
-- Install [Golang](https://golang.org/doc/install) - version 1.11 or later
+- Install [Golang](https://golang.org/doc/install) - version 1.12 or later
 - Optional: Set [`$GOPATH`](https://golang.org/doc/code.html#GOPATH) to point to your workspace directory
 - Put $GOPATH/bin in your PATH: `export PATH=$PATH:$(go env GOPATH)/bin`
 

--- a/conode/Dockerfile
+++ b/conode/Dockerfile
@@ -1,17 +1,18 @@
-FROM golang:1.11 as builder
+FROM golang:1.12 as builder
 ARG BUILD_TAG=none
 ARG ldflags="-s -w -X main.gitTag=unknown"
 RUN go get go.dedis.ch/cothority
 RUN cd /go/src/go.dedis.ch/cothority && git checkout $BUILD_TAG && GO111MODULE=on go install -ldflags="$ldflags" ./conode ./byzcoin/bcadmin ./eventlog/el ./scmgr 
 
 FROM debian:stretch-slim
+RUN apt update; apt install -y procps ca-certificates; apt clean
 WORKDIR /root/
-COPY --from=builder /go/bin/conode .
-COPY --from=builder /go/bin/bcadmin /go/bin/el /go/bin/scmgr /usr/local/bin/
 RUN mkdir /conode_data
 RUN mkdir -p .local/share .config
 RUN ln -s /conode_data .local/share/conode
 RUN ln -s /conode_data .config/conode
+COPY --from=builder /go/bin/conode .
+COPY --from=builder /go/bin/bcadmin /go/bin/el /go/bin/scmgr /usr/local/bin/
 
 EXPOSE 7770 7771
 

--- a/conode/Dockerfile-dev
+++ b/conode/Dockerfile-dev
@@ -4,10 +4,10 @@ RUN mkdir /conode_data
 RUN mkdir -p .local/share .config
 RUN ln -s /conode_data .local/share/conode
 RUN ln -s /conode_data .config/conode
-RUN apt update; apt install -y procps; apt clean
+RUN apt update; apt install -y procps ca-certificates; apt clean
 COPY run_nodes.sh .
 COPY exe/conode.Linux.x86_64 ./conode
 
 EXPOSE 7770 7771
 
-CMD "./run_nodes.sh -n 1"
+CMD [ "./run_nodes.sh", "-n 1" ]

--- a/conode/README.md
+++ b/conode/README.md
@@ -25,7 +25,7 @@ Conode is the program that allows you to be part of a cothority. For the server 
 - 24/7 availability
 - 512MB of RAM and 1GB of disk-space
 - a public IP-address and two consecutive, open ports
-- Go 1.11 installed and set up according to https://golang.org/doc/install
+- Go 1.12.x installed and set up according to https://golang.org/doc/install
 
 You find further information about what is important when you operate a conode
 in the following document: [Operating a Conode](Operating.md).

--- a/conode/run_nodes.sh
+++ b/conode/run_nodes.sh
@@ -60,7 +60,8 @@ shift $((OPTIND-1))
 
 [ "${1:-}" = "--" ] && shift
 
-if [ ! -x ./conode ]; then
+CONODE_BIN="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/conode
+if [ ! -x $CONODE_BIN ]; then
 	echo "No conode executable found. Use \"go build\" to make it."
 	exit 1
 fi
@@ -80,7 +81,7 @@ for n in $( seq $nbr_nodes -1 1 ); do
   co=co$n
   PORT=$(($base_port + 2 * n - 2))
   if [ ! -d $co ]; then
-    echo -e "$base_ip:$PORT\nConode_$n\n$co" | ./conode setup
+    echo -e "$base_ip:$PORT\nConode_$n\n$co" | $CONODE_BIN setup
   fi
   (
     LOG=log/conode_${co}_$PORT
@@ -89,9 +90,9 @@ for n in $( seq $nbr_nodes -1 1 ); do
     while [[ -f running ]]; do
       echo "Starting conode $LOG"
       if [[ "$SHOW" ]]; then
-        ./conode -d $verbose -c $co/private.toml server 2>&1 | tee $LOG-$(date +%y%m%d-%H%M).log
+        $CONODE_BIN -d $verbose -c $co/private.toml server 2>&1 | tee $LOG-$(date +%y%m%d-%H%M).log
       else
-        ./conode -d $verbose -c $co/private.toml server > $LOG-$(date +%y%m%d-%H%M).log 2>&1
+        $CONODE_BIN -d $verbose -c $co/private.toml server > $LOG-$(date +%y%m%d-%H%M).log 2>&1
       fi
       if [[ "$single" ]]; then
         echo "Will not restart conode in single mode."

--- a/external/docker/Dockerfile-int
+++ b/external/docker/Dockerfile-int
@@ -6,7 +6,7 @@
 #   commit=`git rev-parse --short HEAD`
 #   docker build -f Dockerfile-int -t dedis/cothority-integration-tester:$commit .
 
-FROM golang:1.11
+FROM golang:1.12
 RUN apt update && apt install pcregrep && apt clean
 
 WORKDIR /cothority

--- a/external/docker/Dockerfile-unit
+++ b/external/docker/Dockerfile-unit
@@ -8,7 +8,7 @@
 #
 # As you can see, you can run the long tests using the tag build argument.
 
-FROM golang:1.11
+FROM golang:1.12
 
 ARG test_tag
 ENV TEST_TAG=$test_tag


### PR DESCRIPTION
Reverts the change of the coin-contract to be backward-compatible with previous coin-contract.
Fixes Dockerfile(-dev) to use go1.12 (for tls in old linux boxes) and to run ./run_nodes.sh correctly

Closes #1836 