### PR TITLE
Implementation of a Deferred Contract

### DIFF
--- a/byzcoin/contracts.go
+++ b/byzcoin/contracts.go
@@ -24,6 +24,8 @@ import (
 type Contract interface {
 	// Verify returns nil if the instruction is valid with regard to the signature.
 	VerifyInstruction(ReadOnlyStateTrie, Instruction, []byte) error
+	// Verify returns nil if the instruction is valid with regard to the signature.
+	VerifyDeferedInstruction(ReadOnlyStateTrie, Instruction, []byte) error
 	// Spawn is used to spawn new instances
 	Spawn(ReadOnlyStateTrie, Instruction, []Coin) ([]StateChange, []Coin, error)
 	// Invoke only modifies existing instances
@@ -60,6 +62,13 @@ func (b BasicContract) VerifyInstruction(rst ReadOnlyStateTrie, inst Instruction
 		return err
 	}
 	return nil
+}
+
+// VerifyDeferedInstruction is not implemented in a BasicContract. Types which
+// embed BasicContract must override this method if they want to support
+// deferred executions (using the Deferred contract).
+func (b BasicContract) VerifyDeferedInstruction(rst ReadOnlyStateTrie, inst Instruction, ctxHash []byte) error {
+	return notImpl("VerifyDeferedInstruction")
 }
 
 // Spawn is not implmented in a BasicContract. Types which embed BasicContract

--- a/byzcoin/contracts/deferred.go
+++ b/byzcoin/contracts/deferred.go
@@ -1,0 +1,239 @@
+package contracts
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"go.dedis.ch/cothority/v3/byzcoin"
+	"go.dedis.ch/cothority/v3/darc"
+	"go.dedis.ch/protobuf"
+)
+
+// The deferred contract allows a group of signers to agree on and sign a
+// proposed transaction, the "proposed transaction".
+
+// ContractDeferredID denotes a contract that can aggregate signatures for a
+// "proposed" instruction
+var ContractDeferredID = "deferred"
+
+// DeferredData contains the specific data of a deferred contract
+type DeferredData struct {
+	ProposedTransaction byzcoin.ClientTransaction
+	Timestamp           uint64
+	ExpireSec           uint64
+	Hash                []byte
+}
+
+type contractDeferred struct {
+	byzcoin.BasicContract
+	DeferredData
+	s *byzcoin.Service
+}
+
+func (s *Service) contractDeferredFromBytes(in []byte) (byzcoin.Contract, error) {
+	c := &contractDeferred{s: s.byzService()}
+
+	err := protobuf.Decode(in, &c.DeferredData)
+	if err != nil {
+		return nil, errors.New("couldn't unmarshal instance data: " + err.Error())
+	}
+	return c, nil
+}
+
+func (c *contractDeferred) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instruction, coins []byzcoin.Coin) (sc []byzcoin.StateChange, cout []byzcoin.Coin, err error) {
+	// This method should do the following:
+	//   1. Parse the input buffer
+	//   2. Compute and store the transaction hash
+	//   3. Save the data
+	//
+	// Spawn should have those input arguments:
+	//   - proposedTransaction ClientTransaction
+	//   - expireSec uint64
+	cout = coins
+
+	// Find the darcID for this instance.
+	var darcID darc.ID
+	_, _, _, darcID, err = rst.GetValues(inst.InstanceID.Slice())
+	if err != nil {
+		return
+	}
+
+	// 1. Reads and parses the input
+	proposedTransaction := byzcoin.ClientTransaction{}
+	err = protobuf.Decode(inst.Spawn.Args.Search("proposedTransaction"), &proposedTransaction)
+	timestamp := uint64(time.Now().Unix())
+	expireSec, err := strconv.ParseUint(string(inst.Spawn.Args.Search("expireSec")), 10, 64)
+	if err != nil {
+		return nil, nil, errors.New("couldn't convert expireSec: " + err.Error())
+	}
+
+	// 2. Computes the hash
+	hash := hashDeferred(proposedTransaction.Instructions[0], timestamp)
+
+	// 3. Saves the data
+	data := DeferredData{
+		proposedTransaction,
+		timestamp,
+		expireSec,
+		hash,
+	}
+	var dataBuf []byte
+	dataBuf, err = protobuf.Encode(&data)
+	if err != nil {
+		return nil, nil, errors.New("couldn't encode DeferredData: " + err.Error())
+	}
+
+	sc = append(sc, byzcoin.NewStateChange(byzcoin.Create, inst.DeriveID(""),
+		ContractDeferredID, dataBuf, darcID))
+	return
+}
+
+func (c *contractDeferred) Invoke(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instruction, coins []byzcoin.Coin) (sc []byzcoin.StateChange, cout []byzcoin.Coin, err error) {
+	// This method should do the following:
+	//   - Handle the "addProof" invocation
+	//   - Handle the "execProposedTx" invocation
+	//
+	// Invoke:addProof should have the following input argument:
+	//   - identity darc.Identity
+	//   - signature string
+	cout = coins
+
+	// Find the darcID for this instance.
+	var darcID darc.ID
+
+	_, _, _, darcID, err = rst.GetValues(inst.InstanceID.Slice())
+	if err != nil {
+		return
+	}
+
+	switch inst.Invoke.Command {
+	case "addProof":
+		// This invocation appends the identity and the corresponding signature,
+		// which is based on the stored hash of a client. Returns the contract's
+		// data.
+
+		// Get the given Identity
+		identityBuf := inst.Invoke.Args.Search("identity")
+		if identityBuf == nil {
+			return nil, nil, errors.New("Identity args is nil")
+		}
+		identity := darc.Identity{}
+		err = protobuf.Decode(identityBuf, &identity)
+		if err != nil {
+			return nil, nil, errors.New("Couldn't decode Identity")
+		}
+		// Get the given signature
+		signature := inst.Invoke.Args.Search("signature")
+		if signature == nil {
+			return nil, nil, errors.New("Signature args is nil")
+		}
+		// Update the contract's data with the given signature and identity
+		c.DeferredData.ProposedTransaction.Instructions[0].SignerIdentities = append(c.DeferredData.ProposedTransaction.Instructions[0].SignerIdentities, identity)
+		c.DeferredData.ProposedTransaction.Instructions[0].Signatures = append(c.DeferredData.ProposedTransaction.Instructions[0].Signatures, signature)
+		// Save and send the modifications
+		cosiDataBuf, err2 := protobuf.Encode(&c.DeferredData)
+		if err2 != nil {
+			return nil, nil, errors.New("Couldn't encode DeferredData")
+		}
+		sc = append(sc, byzcoin.NewStateChange(byzcoin.Update, inst.InstanceID,
+			ContractDeferredID, cosiDataBuf, darcID))
+		return
+	case "execProposedTx":
+		// This invocation tries to execute the transaction stored with the
+		// "Spawn" invocation. If it is successful, this invocation returns
+		// the InstanceID of the executed proposed transaction.
+
+		instruction := c.DeferredData.ProposedTransaction.Instructions[0]
+
+		// In case it goes well, we want to return the proposed Tx InstanceID
+		rootInstructionID := instruction.DeriveID("").Slice()
+		sc = append(sc, byzcoin.NewStateChange(byzcoin.Update, inst.InstanceID,
+			ContractDeferredID, rootInstructionID, darcID))
+
+		instructionType := instruction.GetType()
+		if instructionType == byzcoin.SpawnType {
+			fn, exists := c.s.GetContractConstructor(instruction.Spawn.ContractID)
+			if !exists {
+				return nil, nil, errors.New("Couldn't get the root function")
+			}
+			rootInstructionBuff, err := protobuf.Encode(&c.DeferredData.ProposedTransaction.Instructions[0])
+			if err != nil {
+				return nil, nil, errors.New("Couldn't encode the root instruction buffer")
+			}
+			contract, err := fn(rootInstructionBuff)
+			if err != nil {
+				return nil, nil, errors.New("Couldn't get the root contract")
+			}
+
+			err = contract.VerifyDeferedInstruction(rst, instruction, c.DeferredData.Hash)
+			if err != nil {
+				return nil, nil, fmt.Errorf("Verifying the root instruction failed: %s", err)
+			}
+
+			rootSc, _, err := contract.Spawn(rst, c.DeferredData.ProposedTransaction.Instructions[0], coins)
+			sc = append(sc, rootSc...)
+		}
+		return
+	default:
+		return nil, nil, errors.New("Cosi contract can only addProof and execRoot")
+	}
+}
+
+func (c *contractDeferred) Delete(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instruction, coins []byzcoin.Coin) (sc []byzcoin.StateChange, cout []byzcoin.Coin, err error) {
+	cout = coins
+
+	// Find the darcID for this instance.
+	var darcID darc.ID
+	_, _, _, darcID, err = rst.GetValues(inst.InstanceID.Slice())
+	if err != nil {
+		return
+	}
+
+	sc = byzcoin.StateChanges{
+		byzcoin.NewStateChange(byzcoin.Remove, inst.InstanceID, ContractDeferredID, nil, darcID),
+	}
+	return
+}
+
+// This is a modified version of computing the hash of a transaction. In this
+// version, we do not take into account the signers nor the signers counters. We
+// also add to the hash a timestamp.
+func hashDeferred(instr byzcoin.Instruction, timestamp uint64) []byte {
+	h := sha256.New()
+	h.Write(instr.InstanceID[:])
+	var args []byzcoin.Argument
+	switch instr.GetType() {
+	case byzcoin.SpawnType:
+		h.Write([]byte{0})
+		h.Write([]byte(instr.Spawn.ContractID))
+		args = instr.Spawn.Args
+	case byzcoin.InvokeType:
+		h.Write([]byte{1})
+		h.Write([]byte(instr.Invoke.ContractID))
+		args = instr.Invoke.Args
+	case byzcoin.DeleteType:
+		h.Write([]byte{2})
+		h.Write([]byte(instr.Delete.ContractID))
+	}
+	for _, a := range args {
+		nameBuf := []byte(a.Name)
+		nameLenBuf := make([]byte, 8)
+		binary.LittleEndian.PutUint64(nameLenBuf, uint64(len(nameBuf)))
+		h.Write(nameLenBuf)
+		h.Write(nameBuf)
+
+		valueLenBuf := make([]byte, 8)
+		binary.LittleEndian.PutUint64(valueLenBuf, uint64(len(a.Value)))
+		h.Write(valueLenBuf)
+		h.Write(a.Value)
+	}
+	timestampBuf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(timestampBuf, timestamp)
+	h.Write(timestampBuf)
+
+	return h.Sum(nil)
+}

--- a/byzcoin/contracts/deferred.go
+++ b/byzcoin/contracts/deferred.go
@@ -26,13 +26,15 @@ type DeferredData struct {
 	// The transaction that signers must sign and can be executed with an
 	// "executeProposedTx".
 	ProposedTransaction byzcoin.ClientTransaction
-	// The maximum current block index before any new Invoke command is rejected.
+	// If the current block index is greater than this value, any Invoke on the
+	// deferred contract is rejected. This provides an expiration mechanism.
 	ExpireBlockIndex uint64
 	// Hashes of each instruction of the proposed transaction. Those hashes are
 	// computed using the special "hashDeferred" method.
 	InstructionHashes [][]byte
 	// The number of time the proposed transaction can be executed. This number
-	// decreases for each successful invocation of "executeProposedTx"
+	// decreases for each successful invocation of "executeProposedTx" and its
+	// default value is set to 1.
 	NumExecution uint64
 	// This array is filled with the instruction IDs of each executed
 	// instruction when a successful "executeProposedTx" happens.

--- a/byzcoin/contracts/deferred.go
+++ b/byzcoin/contracts/deferred.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"time"
 
 	"go.dedis.ch/cothority/v3/byzcoin"
 	"go.dedis.ch/cothority/v3/darc"
@@ -17,15 +16,27 @@ import (
 // proposed transaction, the "proposed transaction".
 
 // ContractDeferredID denotes a contract that can aggregate signatures for a
-// "proposed" instruction
+// "proposed" transaction
 var ContractDeferredID = "deferred"
+
+const defaultNumExecution uint64 = 1
 
 // DeferredData contains the specific data of a deferred contract
 type DeferredData struct {
+	// The transaction that signers must sign and can be executed with an
+	// "executeProposedTx".
 	ProposedTransaction byzcoin.ClientTransaction
-	Timestamp           uint64
-	ExpireSec           uint64
-	Hash                []byte
+	// The maximum current block index before any new Invoke command is rejected.
+	ExpireBlockIndex uint64
+	// Hashes of each instruction of the proposed transaction. Those hashes are
+	// computed using the special "hashDeferred" method.
+	InstructionHashes [][]byte
+	// The number of time the proposed transaction can be executed. This number
+	// decreases for each successful invocation of "executeProposedTx"
+	NumExecution uint64
+	// This array is filled with the instruction IDs of each executed
+	// instruction when a successful "executeProposedTx" happens.
+	ExecResult [][]byte
 }
 
 type contractDeferred struct {
@@ -47,12 +58,13 @@ func (s *Service) contractDeferredFromBytes(in []byte) (byzcoin.Contract, error)
 func (c *contractDeferred) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instruction, coins []byzcoin.Coin) (sc []byzcoin.StateChange, cout []byzcoin.Coin, err error) {
 	// This method should do the following:
 	//   1. Parse the input buffer
-	//   2. Compute and store the transaction hash
+	//   2. Compute and store the instruction hashes
 	//   3. Save the data
 	//
 	// Spawn should have those input arguments:
 	//   - proposedTransaction ClientTransaction
-	//   - expireSec uint64
+	//   - expireBlockIndex uint64
+	//   - numExecution uint64 (default: 1)
 	cout = coins
 
 	// Find the darcID for this instance.
@@ -65,21 +77,31 @@ func (c *contractDeferred) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Ins
 	// 1. Reads and parses the input
 	proposedTransaction := byzcoin.ClientTransaction{}
 	err = protobuf.Decode(inst.Spawn.Args.Search("proposedTransaction"), &proposedTransaction)
-	timestamp := uint64(time.Now().Unix())
-	expireSec, err := strconv.ParseUint(string(inst.Spawn.Args.Search("expireSec")), 10, 64)
+	expireBlockIndex, err := strconv.ParseUint(string(inst.Spawn.Args.Search("expireBlockIndex")), 10, 64)
 	if err != nil {
-		return nil, nil, errors.New("couldn't convert expireSec: " + err.Error())
+		return nil, nil, errors.New("couldn't convert expireBlockIndex: " + err.Error())
+	}
+	NumExecutionBuff := inst.Spawn.Args.Search("NumExecution")
+	NumExecution := defaultNumExecution
+	if len(NumExecutionBuff) > 0 {
+		NumExecution, err = strconv.ParseUint(string(NumExecutionBuff), 10, 64)
+		if err != nil {
+			return nil, nil, errors.New("couldn't parse NumExecution: " + err.Error())
+		}
 	}
 
-	// 2. Computes the hash
-	hash := hashDeferred(proposedTransaction.Instructions[0], timestamp)
+	// 2. Computes the hashes of each instruction and store it
+	hash := make([][]byte, len(proposedTransaction.Instructions))
+	for i, proposedInstruction := range proposedTransaction.Instructions {
+		hash[i] = hashDeferred(proposedInstruction, inst.InstanceID.Slice())
+	}
 
 	// 3. Saves the data
 	data := DeferredData{
-		proposedTransaction,
-		timestamp,
-		expireSec,
-		hash,
+		ProposedTransaction: proposedTransaction,
+		ExpireBlockIndex:    expireBlockIndex,
+		InstructionHashes:   hash,
+		NumExecution:        NumExecution,
 	}
 	var dataBuf []byte
 	dataBuf, err = protobuf.Encode(&data)
@@ -99,7 +121,8 @@ func (c *contractDeferred) Invoke(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.In
 	//
 	// Invoke:addProof should have the following input argument:
 	//   - identity darc.Identity
-	//   - signature string
+	//   - signature []byte
+	//	 - index uint32 (index of the instruction wrt the transaction)
 	cout = coins
 
 	// Find the darcID for this instance.
@@ -113,8 +136,14 @@ func (c *contractDeferred) Invoke(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.In
 	switch inst.Invoke.Command {
 	case "addProof":
 		// This invocation appends the identity and the corresponding signature,
-		// which is based on the stored hash of a client. Returns the contract's
-		// data.
+		// which is based on the stored instruction hash (in instructionHashes)
+
+		// Get the given index
+		indexBuf := inst.Invoke.Args.Search("index")
+		if indexBuf == nil {
+			return nil, nil, errors.New("Index args is nil")
+		}
+		index := binary.LittleEndian.Uint32(indexBuf)
 
 		// Get the given Identity
 		identityBuf := inst.Invoke.Args.Search("identity")
@@ -126,14 +155,15 @@ func (c *contractDeferred) Invoke(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.In
 		if err != nil {
 			return nil, nil, errors.New("Couldn't decode Identity")
 		}
+
 		// Get the given signature
 		signature := inst.Invoke.Args.Search("signature")
 		if signature == nil {
 			return nil, nil, errors.New("Signature args is nil")
 		}
 		// Update the contract's data with the given signature and identity
-		c.DeferredData.ProposedTransaction.Instructions[0].SignerIdentities = append(c.DeferredData.ProposedTransaction.Instructions[0].SignerIdentities, identity)
-		c.DeferredData.ProposedTransaction.Instructions[0].Signatures = append(c.DeferredData.ProposedTransaction.Instructions[0].Signatures, signature)
+		c.DeferredData.ProposedTransaction.Instructions[index].SignerIdentities = append(c.DeferredData.ProposedTransaction.Instructions[index].SignerIdentities, identity)
+		c.DeferredData.ProposedTransaction.Instructions[index].Signatures = append(c.DeferredData.ProposedTransaction.Instructions[index].Signatures, signature)
 		// Save and send the modifications
 		cosiDataBuf, err2 := protobuf.Encode(&c.DeferredData)
 		if err2 != nil {
@@ -144,23 +174,33 @@ func (c *contractDeferred) Invoke(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.In
 		return
 	case "execProposedTx":
 		// This invocation tries to execute the transaction stored with the
-		// "Spawn" invocation. If it is successful, this invocation returns
-		// the InstanceID of the executed proposed transaction.
+		// "Spawn" invocation. If it is successful, this invocation fills the
+		// "ExecResult" field of the "DeferredData" struct.
 
-		instruction := c.DeferredData.ProposedTransaction.Instructions[0]
+		instructionIDs := make([][]byte, len(c.DeferredData.ProposedTransaction.Instructions))
 
-		// In case it goes well, we want to return the proposed Tx InstanceID
-		rootInstructionID := instruction.DeriveID("").Slice()
-		sc = append(sc, byzcoin.NewStateChange(byzcoin.Update, inst.InstanceID,
-			ContractDeferredID, rootInstructionID, darcID))
+		for i, proposedInstr := range c.DeferredData.ProposedTransaction.Instructions {
 
-		instructionType := instruction.GetType()
-		if instructionType == byzcoin.SpawnType {
-			fn, exists := c.s.GetContractConstructor(instruction.Spawn.ContractID)
+			// In case it goes well, we want to return the proposed Tx InstanceID
+			instructionIDs[i] = proposedInstr.DeriveID("").Slice()
+
+			instructionType := proposedInstr.GetType()
+
+			var contractID string
+			switch instructionType {
+			case byzcoin.SpawnType:
+				contractID = proposedInstr.Spawn.ContractID
+			case byzcoin.InvokeType:
+				contractID = proposedInstr.Invoke.ContractID
+			case byzcoin.DeleteType:
+				contractID = proposedInstr.Delete.ContractID
+			}
+
+			fn, exists := c.s.GetContractConstructor(contractID)
 			if !exists {
 				return nil, nil, errors.New("Couldn't get the root function")
 			}
-			rootInstructionBuff, err := protobuf.Encode(&c.DeferredData.ProposedTransaction.Instructions[0])
+			rootInstructionBuff, err := protobuf.Encode(&proposedInstr)
 			if err != nil {
 				return nil, nil, errors.New("Couldn't encode the root instruction buffer")
 			}
@@ -168,18 +208,39 @@ func (c *contractDeferred) Invoke(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.In
 			if err != nil {
 				return nil, nil, errors.New("Couldn't get the root contract")
 			}
-
-			err = contract.VerifyDeferedInstruction(rst, instruction, c.DeferredData.Hash)
+			err = contract.VerifyDeferedInstruction(rst, proposedInstr, c.DeferredData.InstructionHashes[i])
 			if err != nil {
-				return nil, nil, fmt.Errorf("Verifying the root instruction failed: %s", err)
+				return nil, nil, fmt.Errorf("Verifying the instruction failed: %s", err)
 			}
 
-			rootSc, _, err := contract.Spawn(rst, c.DeferredData.ProposedTransaction.Instructions[0], coins)
-			sc = append(sc, rootSc...)
+			var stateChanges []byzcoin.StateChange
+			switch instructionType {
+			case byzcoin.SpawnType:
+				stateChanges, _, err = contract.Spawn(rst, proposedInstr, coins)
+			case byzcoin.InvokeType:
+				stateChanges, _, err = contract.Invoke(rst, proposedInstr, coins)
+			case byzcoin.DeleteType:
+				stateChanges, _, err = contract.Delete(rst, proposedInstr, coins)
+
+			}
+
+			if err != nil {
+				return nil, nil, fmt.Errorf("Error while executing an instruction: %s", err)
+			}
+			sc = append(sc, stateChanges...)
+
 		}
+
+		c.DeferredData.ExecResult = instructionIDs
+		resultBuf, err2 := protobuf.Encode(&c.DeferredData)
+		if err2 != nil {
+			return nil, nil, errors.New("Couldn't encode the result")
+		}
+		sc = append(sc, byzcoin.NewStateChange(byzcoin.Update, inst.InstanceID,
+			ContractDeferredID, resultBuf, darcID))
 		return
 	default:
-		return nil, nil, errors.New("Cosi contract can only addProof and execRoot")
+		return nil, nil, errors.New("Deferred contract can only addProof and execProposedTx")
 	}
 }
 
@@ -199,10 +260,89 @@ func (c *contractDeferred) Delete(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.In
 	return
 }
 
+// VerifyInstruction overrides the basic VerifyInstruction
+func (c *contractDeferred) VerifyInstruction(rst byzcoin.ReadOnlyStateTrie, instr byzcoin.Instruction, ctxHash []byte) error {
+
+	// Basic check: can the client actually invoke?
+	err := c.BasicContract.VerifyInstruction(rst, instr, ctxHash)
+	if err != nil {
+		return err
+	}
+
+	if instr.GetType() == byzcoin.InvokeType {
+		// Global check on the invoke method:
+		//   1. The NumExecution should be greater than 0
+		//   2. the current skipblock index should be lower than the provided
+		//      "expireBlockIndex" argument.
+
+		// 1.
+		if c.DeferredData.NumExecution < uint64(1) {
+			return errors.New("Maximum number of executions reached")
+		}
+
+		// 2.
+		expireBlockIndex := c.DeferredData.ExpireBlockIndex
+		currentIndex := uint64(rst.GetIndex())
+		if currentIndex > expireBlockIndex {
+			return fmt.Errorf("Current block index is too high (%d > %d)", currentIndex, expireBlockIndex)
+		}
+	}
+
+	if instr.GetType() == byzcoin.InvokeType && instr.Invoke.Command == "addProof" {
+		// We will go through 2 checks:
+		//   1. Check if the identity is already stored
+		//   2. Check if the signature is valid
+
+		// 1:
+		// Get the given Identity
+		identityBuf := instr.Invoke.Args.Search("identity")
+		if identityBuf == nil {
+			return errors.New("Identity args is nil")
+		}
+		identity := darc.Identity{}
+		err = protobuf.Decode(identityBuf, &identity)
+		if err != nil {
+			return errors.New("Couldn't decode Identity")
+		}
+		// Get the instruction index
+		indexBuf := instr.Invoke.Args.Search("index")
+		if indexBuf == nil {
+			return errors.New("Index args is nil")
+		}
+		index := binary.LittleEndian.Uint32(indexBuf)
+
+		for _, storedIdentity := range c.DeferredData.ProposedTransaction.Instructions[index].SignerIdentities {
+			if identity.Equal(&storedIdentity) {
+				return errors.New("Identity already stored")
+			}
+		}
+		// 2:
+		// Get the given signature
+		signature := instr.Invoke.Args.Search("signature")
+		if signature == nil {
+			return errors.New("Signature args is nil")
+		}
+		err = identity.Verify(c.InstructionHashes[index], signature)
+		if err != nil {
+			return errors.New("Bad signature")
+		}
+
+		return nil
+	}
+
+	// In the case all the verifications passed for an "ExecProposedTx", we need
+	// to decrease the NumExecution counter
+	if instr.GetType() == byzcoin.InvokeType && instr.Invoke.Command == "execProposedTx" {
+		c.DeferredData.NumExecution = c.DeferredData.NumExecution - 1
+	}
+
+	return nil
+}
+
 // This is a modified version of computing the hash of a transaction. In this
 // version, we do not take into account the signers nor the signers counters. We
-// also add to the hash a timestamp.
-func hashDeferred(instr byzcoin.Instruction, timestamp uint64) []byte {
+// also add to the hash the instanceID.
+func hashDeferred(instr byzcoin.Instruction, instanceID []byte) []byte {
 	h := sha256.New()
 	h.Write(instr.InstanceID[:])
 	var args []byzcoin.Argument
@@ -231,9 +371,7 @@ func hashDeferred(instr byzcoin.Instruction, timestamp uint64) []byte {
 		h.Write(valueLenBuf)
 		h.Write(a.Value)
 	}
-	timestampBuf := make([]byte, 8)
-	binary.LittleEndian.PutUint64(timestampBuf, timestamp)
-	h.Write(timestampBuf)
+	h.Write(instanceID)
 
 	return h.Sum(nil)
 }

--- a/byzcoin/contracts/deferred_test.go
+++ b/byzcoin/contracts/deferred_test.go
@@ -1,6 +1,7 @@
 package contracts
 
 import (
+	"encoding/binary"
 	"strconv"
 	"testing"
 	"time"
@@ -16,89 +17,7 @@ import (
 	"go.dedis.ch/onet/v3"
 )
 
-func TestDeferred_Spawn(t *testing.T) {
-	// In this test I am just trying to see if a spawn successfully stores
-	// the given argument and if I am able to retrieve them after. It was
-	// interesting to play with the encode/decode protobuf.
-	local := onet.NewTCPTest(cothority.Suite)
-	defer local.CloseAll()
-
-	signer := darc.NewSignerEd25519(nil, nil)
-	_, roster, _ := local.GenTree(3, true)
-
-	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
-		[]string{"spawn:deferred"}, signer.Identity())
-	require.Nil(t, err)
-	gDarc := &genesisMsg.GenesisDarc
-
-	genesisMsg.BlockInterval = time.Second
-
-	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
-	require.Nil(t, err)
-
-	proposedTransaction := byzcoin.ClientTransaction{
-		Instructions: []byzcoin.Instruction{
-			byzcoin.Instruction{
-				InstanceID: byzcoin.InstanceID{0x10, 0x11, 0x12},
-				Spawn: &byzcoin.Spawn{
-					ContractID: "value",
-					Args: byzcoin.Arguments{
-						byzcoin.Argument{
-							Name:  "test",
-							Value: []byte("1234"),
-						},
-					},
-				},
-			},
-		},
-	}
-	expireSec := []byte("6000")
-	expireSecInt, _ := strconv.ParseUint(string(expireSec), 10, 64)
-	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
-	require.Nil(t, err)
-
-	ctx := byzcoin.ClientTransaction{
-		Instructions: []byzcoin.Instruction{{
-			InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
-			Spawn: &byzcoin.Spawn{
-				ContractID: ContractDeferredID,
-				Args: []byzcoin.Argument{
-					{
-						Name:  "proposedTransaction",
-						Value: proposedTransactionBuf,
-					},
-					{
-						Name:  "expireSec",
-						Value: expireSec,
-					},
-				},
-			},
-			SignerCounter: []uint64{1},
-		}},
-	}
-	require.Nil(t, ctx.FillSignersAndSignWith(signer))
-
-	_, err = cl.AddTransaction(ctx)
-	require.Nil(t, err)
-
-	pr, err := cl.WaitProof(byzcoin.NewInstanceID(ctx.Instructions[0].DeriveID("").Slice()), 2*genesisMsg.BlockInterval, nil)
-	require.Nil(t, err)
-	require.True(t, pr.InclusionProof.Match(ctx.Instructions[0].DeriveID("").Slice()))
-
-	dataBuf, _, _, err := pr.Get(ctx.Instructions[0].DeriveID("").Slice())
-	require.Nil(t, err)
-	result := DeferredData{}
-	err = protobuf.Decode(dataBuf, &result)
-	require.Nil(t, err)
-
-	require.Equal(t, result.ProposedTransaction, proposedTransaction)
-	require.Equal(t, result.ExpireSec, expireSecInt)
-	require.NotEmpty(t, result.Timestamp)
-
-	local.WaitDone(genesisMsg.BlockInterval)
-}
-
-func TestDeferred_Scenario(t *testing.T) {
+func TestDeferred_ScenarioSingleInstruction(t *testing.T) {
 	// Since every method relies on the execution of a previous ones, I am not
 	// unit test but rather creating a scenario:
 	//
@@ -107,7 +26,7 @@ func TestDeferred_Scenario(t *testing.T) {
 	// 3. Invoke an "execRoot"
 
 	// ------------------------------------------------------------------------
-	// 1. Spawn
+	// 0. Set up
 	// ------------------------------------------------------------------------
 	local := onet.NewTCPTest(cothority.Suite)
 	defer local.CloseAll()
@@ -126,6 +45,9 @@ func TestDeferred_Scenario(t *testing.T) {
 	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
 	require.Nil(t, err)
 
+	// ------------------------------------------------------------------------
+	// 1. Spawn
+	// ------------------------------------------------------------------------
 	rootInstructionValue := []byte("aef123456789fab")
 
 	proposedTransaction := byzcoin.ClientTransaction{
@@ -145,8 +67,8 @@ func TestDeferred_Scenario(t *testing.T) {
 		},
 	}
 
-	expireSec := []byte("6000")
-	expireSecInt, _ := strconv.ParseUint(string(expireSec), 10, 64)
+	expireBlockIndex := []byte("6000")
+	expireBlockIndexInt, _ := strconv.ParseUint(string(expireBlockIndex), 10, 64)
 	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
 	require.Nil(t, err)
 
@@ -161,8 +83,8 @@ func TestDeferred_Scenario(t *testing.T) {
 						Value: proposedTransactionBuf,
 					},
 					{
-						Name:  "expireSec",
-						Value: expireSec,
+						Name:  "expireBlockIndex",
+						Value: expireBlockIndex,
 					},
 				},
 			},
@@ -187,15 +109,13 @@ func TestDeferred_Scenario(t *testing.T) {
 
 	require.Equal(t, result.ProposedTransaction, proposedTransaction)
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
-	// require.Equal(t, result.ProposedTransaction.Instructions[0].Spawn.Args.Search("value"), 1)
-	require.Equal(t, result.ExpireSec, expireSecInt)
-	require.NotEmpty(t, result.Timestamp)
+	require.Equal(t, result.ExpireBlockIndex, expireBlockIndexInt)
 	require.Empty(t, result.ProposedTransaction.Instructions[0].SignerIdentities)
 	require.Empty(t, result.ProposedTransaction.Instructions[0].Signatures)
 
 	local.WaitDone(genesisMsg.BlockInterval)
 
-	rootHash := result.Hash
+	rootHash := result.InstructionHashes
 
 	// ------------------------------------------------------------------------
 	// 2.1 Invoke a first "addProof"
@@ -205,9 +125,13 @@ func TestDeferred_Scenario(t *testing.T) {
 	identityBuf, err := protobuf.Encode(&identity)
 	require.Nil(t, err)
 
-	signature, err := signer.Sign(rootHash)
+	signature, err := signer.Sign(rootHash[0]) // == index
 	require.Nil(t, err)
 	// signature[1] = 0xf
+
+	index := uint32(0)
+	indexBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(indexBuf, uint32(index))
 
 	ctx = byzcoin.ClientTransaction{
 		Instructions: []byzcoin.Instruction{{
@@ -223,6 +147,10 @@ func TestDeferred_Scenario(t *testing.T) {
 					{
 						Name:  "signature",
 						Value: signature,
+					},
+					{
+						Name:  "index",
+						Value: indexBuf,
 					},
 				},
 			},
@@ -255,24 +183,25 @@ func TestDeferred_Scenario(t *testing.T) {
 	// the Equal() method.
 	//require.Equal(t, result.ProposedTransaction, proposedTransaction)
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
-	require.Equal(t, result.ExpireSec, expireSecInt)
-	require.NotEmpty(t, result.Timestamp)
+	require.Equal(t, result.ExpireBlockIndex, expireBlockIndexInt)
 	require.NotEmpty(t, result.ProposedTransaction.Instructions[0].SignerIdentities)
 	require.Equal(t, len(result.ProposedTransaction.Instructions[0].SignerIdentities), 1)
-	// Surprisingly this test won't work. But by using Equal() will.
+	// This test won't work. But by using Equal() will.
 	// require.Equal(t, result.ProposedTransaction.Instructions[0].SignerIdentities[0], identity)
 	require.True(t, identity.Equal(&result.ProposedTransaction.Instructions[0].SignerIdentities[0]))
 
 	require.NotEmpty(t, result.ProposedTransaction.Instructions[0].Signatures)
 	require.Equal(t, len(result.ProposedTransaction.Instructions[0].Signatures), 1)
 	require.Equal(t, result.ProposedTransaction.Instructions[0].Signatures[0], signature)
+	// Default NumExecution should be 1
+	require.Equal(t, result.NumExecution, uint64(1))
 
-	require.NotEmpty(t, result.Hash)
+	require.NotEmpty(t, result.InstructionHashes)
 
 	local.WaitDone(genesisMsg.BlockInterval)
 
 	// ------------------------------------------------------------------------
-	// 2.1 Invoke a second "addProof"
+	// 2.2 Invoke a second "addProof"
 	// ------------------------------------------------------------------------
 	//
 	// Lets try to add another signer. Here I am still using the previous signer
@@ -286,9 +215,9 @@ func TestDeferred_Scenario(t *testing.T) {
 	identityBuf, err = protobuf.Encode(&identity)
 	require.Nil(t, err)
 
-	signature, err = signer2.Sign(rootHash)
+	signature, err = signer2.Sign(rootHash[0]) // == index
 	require.Nil(t, err)
-	signature[1] = 0xf // Simulates a wrong signature
+	// signature[1] = 0xf // Simulates a wrong signature
 
 	ctx = byzcoin.ClientTransaction{
 		Instructions: []byzcoin.Instruction{{
@@ -304,6 +233,10 @@ func TestDeferred_Scenario(t *testing.T) {
 					{
 						Name:  "signature",
 						Value: signature,
+					},
+					{
+						Name:  "index",
+						Value: indexBuf,
 					},
 				},
 			},
@@ -336,11 +269,10 @@ func TestDeferred_Scenario(t *testing.T) {
 	// the Equal() method.
 	//require.Equal(t, result.ProposedTransaction, proposedTransaction)
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
-	require.Equal(t, result.ExpireSec, expireSecInt)
-	require.NotEmpty(t, result.Timestamp)
+	require.Equal(t, result.ExpireBlockIndex, expireBlockIndexInt)
 	require.NotEmpty(t, result.ProposedTransaction.Instructions[0].SignerIdentities)
 	require.Equal(t, len(result.ProposedTransaction.Instructions[0].SignerIdentities), 2)
-	// Surprisingly this test won't work. But by using Equal() will.
+	// This test won't work. But by using Equal() will.
 	// require.Equal(t, result.ProposedTransaction.Instructions[0].SignerIdentities[0], identity)
 	require.True(t, identity.Equal(&result.ProposedTransaction.Instructions[0].SignerIdentities[1]))
 
@@ -348,7 +280,7 @@ func TestDeferred_Scenario(t *testing.T) {
 	require.Equal(t, len(result.ProposedTransaction.Instructions[0].Signatures), 2)
 	require.Equal(t, result.ProposedTransaction.Instructions[0].Signatures[1], signature)
 
-	require.NotEmpty(t, result.Hash)
+	require.NotEmpty(t, result.InstructionHashes)
 
 	local.WaitDone(genesisMsg.BlockInterval)
 
@@ -379,18 +311,1631 @@ func TestDeferred_Scenario(t *testing.T) {
 	dataBuf, _, _, err = pr.Get(myID.Slice())
 	require.Nil(t, err)
 
-	local.WaitDone(genesisMsg.BlockInterval)
+	result = DeferredData{}
+	protobuf.Decode(dataBuf, &result)
+	require.Equal(t, 1, len(result.ExecResult))
 
 	time.Sleep(2 * genesisMsg.BlockInterval)
-	pr, err = cl.WaitProof(byzcoin.NewInstanceID(dataBuf), 2*genesisMsg.BlockInterval, nil)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(result.ExecResult[0]), 2*genesisMsg.BlockInterval, nil)
 	require.Nil(t, err)
-	require.True(t, pr.InclusionProof.Match(dataBuf))
+	require.True(t, pr.InclusionProof.Match(result.ExecResult[0]))
 
-	valueRes, _, _, err := pr.Get(dataBuf)
+	valueRes, _, _, err := pr.Get(result.ExecResult[0])
 	require.Nil(t, err)
 
 	// Such a miracle to retrieve this value that was set at the begining
 	require.Equal(t, valueRes, rootInstructionValue)
 
 	local.WaitDone(genesisMsg.BlockInterval)
+
+	// ------------------------------------------------------------------------
+	// 4. Invoke an "execRoot" command a second time. Since NumExecution should
+	//    be at 0, we expect it to fail.
+	//    NOTE: We are trying to spawn two times a contract with the sane id,
+	//          which is not likely to create two instances. Here we are only
+	//          testing if the check of the NumExecution works.
+	// ------------------------------------------------------------------------
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "execProposedTx",
+			},
+			SignerCounter: []uint64{5},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	myID = ctx.Instructions[0].DeriveID("")
+
+	// Need to sleep because we can't predict the output (hence the 'nil')
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Error(t, err)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+}
+
+func TestDeferred_ScenarioMultiInstructions(t *testing.T) {
+	// Since every method relies on the execution of a previous ones, I am not
+	// unit test but rather creating a scenario:
+	//
+	// 1. Spawn a new contract with two instruction
+	// 2. Invoke two "addProff"
+	// 3. Invoke an "execRoot"
+
+	// ------------------------------------------------------------------------
+	// 0. Set up
+	// ------------------------------------------------------------------------
+	local := onet.NewTCPTest(cothority.Suite)
+	defer local.CloseAll()
+
+	signer := darc.NewSignerEd25519(nil, nil)
+	_, roster, _ := local.GenTree(3, true)
+
+	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
+		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.addProof",
+			"invoke:deferred.execProposedTx"}, signer.Identity())
+	require.Nil(t, err)
+	gDarc := &genesisMsg.GenesisDarc
+
+	genesisMsg.BlockInterval = time.Second
+
+	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
+	require.Nil(t, err)
+
+	// ------------------------------------------------------------------------
+	// 1. Spawn
+	// ------------------------------------------------------------------------
+	rootInstructionValue1 := []byte("aef123456789fab")
+	rootInstructionValue2 := []byte("1234aef")
+
+	// We spawn two value contracts
+	proposedTransaction := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{
+			byzcoin.Instruction{
+				InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+				Spawn: &byzcoin.Spawn{
+					ContractID: "value",
+					Args: byzcoin.Arguments{
+						byzcoin.Argument{
+							Name:  "value",
+							Value: rootInstructionValue1,
+						},
+					},
+				},
+			},
+			byzcoin.Instruction{
+				InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+				Spawn: &byzcoin.Spawn{
+					ContractID: "value",
+					Args: byzcoin.Arguments{
+						byzcoin.Argument{
+							Name:  "value",
+							Value: rootInstructionValue2,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expireBlockIndex := []byte("6000")
+	expireBlockIndexInt, _ := strconv.ParseUint(string(expireBlockIndex), 10, 64)
+	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
+	require.Nil(t, err)
+
+	ctx := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+			Spawn: &byzcoin.Spawn{
+				ContractID: ContractDeferredID,
+				Args: []byzcoin.Argument{
+					{
+						Name:  "proposedTransaction",
+						Value: proposedTransactionBuf,
+					},
+					{
+						Name:  "expireBlockIndex",
+						Value: expireBlockIndex,
+					},
+				},
+			},
+			SignerCounter: []uint64{1},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	myID := ctx.Instructions[0].DeriveID("")
+	pr, err := cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+
+	dataBuf, _, _, err := pr.Get(myID.Slice())
+	require.Nil(t, err)
+	result := DeferredData{}
+	err = protobuf.Decode(dataBuf, &result)
+	require.Nil(t, err)
+
+	require.Equal(t, result.ProposedTransaction, proposedTransaction)
+	require.Equal(t, len(result.ProposedTransaction.Instructions), 2)
+	require.Equal(t, result.ExpireBlockIndex, expireBlockIndexInt)
+	require.Empty(t, result.ProposedTransaction.Instructions[0].SignerIdentities)
+	require.Empty(t, result.ProposedTransaction.Instructions[0].Signatures)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	rootHash := result.InstructionHashes
+
+	// ------------------------------------------------------------------------
+	// 2.1 Invoke a first "addProof" on the first instruction
+	// ------------------------------------------------------------------------
+
+	identity := signer.Identity()
+	identityBuf, err := protobuf.Encode(&identity)
+	require.Nil(t, err)
+
+	signature, err := signer.Sign(rootHash[0]) // == index
+	require.Nil(t, err)
+	// signature[1] = 0xf
+
+	index := uint32(0)
+	indexBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(indexBuf, uint32(index))
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "addProof",
+				Args: []byzcoin.Argument{
+					{
+						Name:  "identity",
+						Value: identityBuf,
+					},
+					{
+						Name:  "signature",
+						Value: signature,
+					},
+					{
+						Name:  "index",
+						Value: indexBuf,
+					},
+				},
+			},
+			SignerCounter: []uint64{2},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	proposedTransaction.Instructions[0].SignerIdentities = append(proposedTransaction.Instructions[0].SignerIdentities, identity)
+	proposedTransaction.Instructions[0].Signatures = append(proposedTransaction.Instructions[0].Signatures, signature)
+	result.ProposedTransaction = proposedTransaction
+	resultBuf, err := protobuf.Encode(&result)
+	require.Nil(t, err)
+
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, resultBuf)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+
+	dataBuf, _, _, err = pr.Get(myID.Slice())
+	require.Nil(t, err)
+
+	result = DeferredData{}
+	err = protobuf.Decode(dataBuf, &result)
+	require.Nil(t, err)
+
+	// We can not do this test because the identities have to be compared using
+	// the Equal() method.
+	//require.Equal(t, result.ProposedTransaction, proposedTransaction)
+	require.Equal(t, len(result.ProposedTransaction.Instructions), 2)
+	require.Equal(t, result.ExpireBlockIndex, expireBlockIndexInt)
+	require.NotEmpty(t, result.ProposedTransaction.Instructions[0].SignerIdentities)
+	require.Equal(t, len(result.ProposedTransaction.Instructions[0].SignerIdentities), 1)
+	// This test won't work. But by using Equal() will.
+	// require.Equal(t, result.ProposedTransaction.Instructions[0].SignerIdentities[0], identity)
+	require.True(t, identity.Equal(&result.ProposedTransaction.Instructions[0].SignerIdentities[0]))
+
+	require.NotEmpty(t, result.ProposedTransaction.Instructions[0].Signatures)
+	require.Equal(t, len(result.ProposedTransaction.Instructions[0].Signatures), 1)
+	require.Equal(t, result.ProposedTransaction.Instructions[0].Signatures[0], signature)
+	// Default NumExecution should be 1
+	require.Equal(t, result.NumExecution, uint64(1))
+
+	require.NotEmpty(t, result.InstructionHashes)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	// ------------------------------------------------------------------------
+	// 2.2 Invoke a second "addProof" on the second instruction
+	// ------------------------------------------------------------------------
+
+	signature, err = signer.Sign(rootHash[1]) // == index
+	require.Nil(t, err)
+
+	index = uint32(1)
+	indexBuf = make([]byte, 4)
+	binary.LittleEndian.PutUint32(indexBuf, uint32(index))
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "addProof",
+				Args: []byzcoin.Argument{
+					{
+						Name:  "identity",
+						Value: identityBuf,
+					},
+					{
+						Name:  "signature",
+						Value: signature,
+					},
+					{
+						Name:  "index",
+						Value: indexBuf,
+					},
+				},
+			},
+			SignerCounter: []uint64{3},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+
+	dataBuf, _, _, err = pr.Get(myID.Slice())
+	require.Nil(t, err)
+
+	result = DeferredData{}
+	err = protobuf.Decode(dataBuf, &result)
+	require.Nil(t, err)
+
+	// We can not do this test because the identities have to be compared using
+	// the Equal() method.
+	//require.Equal(t, result.ProposedTransaction, proposedTransaction)
+	require.Equal(t, len(result.ProposedTransaction.Instructions), 2)
+	require.Equal(t, result.ExpireBlockIndex, expireBlockIndexInt)
+	require.NotEmpty(t, result.ProposedTransaction.Instructions[1].SignerIdentities)
+	require.Equal(t, len(result.ProposedTransaction.Instructions[1].SignerIdentities), 1)
+	// This test won't work. But by using Equal() will.
+	// require.Equal(t, result.ProposedTransaction.Instructions[0].SignerIdentities[0], identity)
+	require.True(t, identity.Equal(&result.ProposedTransaction.Instructions[1].SignerIdentities[0]))
+
+	require.NotEmpty(t, result.ProposedTransaction.Instructions[1].Signatures)
+	require.Equal(t, len(result.ProposedTransaction.Instructions[1].Signatures), 1)
+	require.Equal(t, result.ProposedTransaction.Instructions[1].Signatures[0], signature)
+
+	require.NotEmpty(t, result.InstructionHashes)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	// ------------------------------------------------------------------------
+	// 3. Invoke an "execRoot" command
+	// ------------------------------------------------------------------------
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "execProposedTx",
+			},
+			SignerCounter: []uint64{4},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	// Need to sleep because we can't predict the output (hence the 'nil')
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+	dataBuf, _, _, err = pr.Get(myID.Slice())
+	require.Nil(t, err)
+
+	result = DeferredData{}
+	protobuf.Decode(dataBuf, &result)
+
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(result.ExecResult[0]), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(result.ExecResult[0]))
+
+	valueRes, _, _, err := pr.Get(result.ExecResult[0])
+	require.Nil(t, err)
+
+	// Such a miracle to retrieve this value that was set at the begining
+	require.Equal(t, valueRes, rootInstructionValue1)
+
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(result.ExecResult[1]), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(result.ExecResult[1]))
+
+	valueRes, _, _, err = pr.Get(result.ExecResult[1])
+	require.Nil(t, err)
+
+	// Such a miracle to retrieve this value that was set at the begining
+	require.Equal(t, valueRes, rootInstructionValue2)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+}
+
+func TestDeferred_ScenarioMultiInstructionsDifferentSigners(t *testing.T) {
+	// I commit two instructions that are siged by two different signers. The
+	// second signer has no right to sign the instruction, so we expect the transaction to fail.
+
+	// ------------------------------------------------------------------------
+	// 0. Set up
+	// ------------------------------------------------------------------------
+	local := onet.NewTCPTest(cothority.Suite)
+	defer local.CloseAll()
+
+	signer := darc.NewSignerEd25519(nil, nil)
+	_, roster, _ := local.GenTree(3, true)
+
+	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
+		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.addProof",
+			"invoke:deferred.execProposedTx"}, signer.Identity())
+	require.Nil(t, err)
+	gDarc := &genesisMsg.GenesisDarc
+
+	genesisMsg.BlockInterval = time.Second
+
+	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
+	require.Nil(t, err)
+
+	// ------------------------------------------------------------------------
+	// 1. Spawn
+	// ------------------------------------------------------------------------
+	rootInstructionValue1 := []byte("aef123456789fab")
+	rootInstructionValue2 := []byte("1234aef")
+
+	// We spawn two value contracts
+	proposedTransaction := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{
+			byzcoin.Instruction{
+				InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+				Spawn: &byzcoin.Spawn{
+					ContractID: "value",
+					Args: byzcoin.Arguments{
+						byzcoin.Argument{
+							Name:  "value",
+							Value: rootInstructionValue1,
+						},
+					},
+				},
+			},
+			byzcoin.Instruction{
+				InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+				Spawn: &byzcoin.Spawn{
+					ContractID: "value",
+					Args: byzcoin.Arguments{
+						byzcoin.Argument{
+							Name:  "value",
+							Value: rootInstructionValue2,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expireBlockIndex := []byte("6000")
+	expireBlockIndexInt, _ := strconv.ParseUint(string(expireBlockIndex), 10, 64)
+	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
+	require.Nil(t, err)
+
+	ctx := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+			Spawn: &byzcoin.Spawn{
+				ContractID: ContractDeferredID,
+				Args: []byzcoin.Argument{
+					{
+						Name:  "proposedTransaction",
+						Value: proposedTransactionBuf,
+					},
+					{
+						Name:  "expireBlockIndex",
+						Value: expireBlockIndex,
+					},
+				},
+			},
+			SignerCounter: []uint64{1},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	myID := ctx.Instructions[0].DeriveID("")
+	pr, err := cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+
+	dataBuf, _, _, err := pr.Get(myID.Slice())
+	require.Nil(t, err)
+	result := DeferredData{}
+	err = protobuf.Decode(dataBuf, &result)
+	require.Nil(t, err)
+
+	require.Equal(t, result.ProposedTransaction, proposedTransaction)
+	require.Equal(t, len(result.ProposedTransaction.Instructions), 2)
+	require.Equal(t, result.ExpireBlockIndex, expireBlockIndexInt)
+	require.Empty(t, result.ProposedTransaction.Instructions[0].SignerIdentities)
+	require.Empty(t, result.ProposedTransaction.Instructions[0].Signatures)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	rootHash := result.InstructionHashes
+
+	// ------------------------------------------------------------------------
+	// 2.1 Invoke a first "addProof" on the first instruction
+	// ------------------------------------------------------------------------
+
+	identity := signer.Identity()
+	identityBuf, err := protobuf.Encode(&identity)
+	require.Nil(t, err)
+
+	signature, err := signer.Sign(rootHash[0]) // == index
+	require.Nil(t, err)
+	// signature[1] = 0xf
+
+	index := uint32(0)
+	indexBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(indexBuf, uint32(index))
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "addProof",
+				Args: []byzcoin.Argument{
+					{
+						Name:  "identity",
+						Value: identityBuf,
+					},
+					{
+						Name:  "signature",
+						Value: signature,
+					},
+					{
+						Name:  "index",
+						Value: indexBuf,
+					},
+				},
+			},
+			SignerCounter: []uint64{2},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	proposedTransaction.Instructions[0].SignerIdentities = append(proposedTransaction.Instructions[0].SignerIdentities, identity)
+	proposedTransaction.Instructions[0].Signatures = append(proposedTransaction.Instructions[0].Signatures, signature)
+	result.ProposedTransaction = proposedTransaction
+	resultBuf, err := protobuf.Encode(&result)
+	require.Nil(t, err)
+
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, resultBuf)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+
+	dataBuf, _, _, err = pr.Get(myID.Slice())
+	require.Nil(t, err)
+
+	result = DeferredData{}
+	err = protobuf.Decode(dataBuf, &result)
+	require.Nil(t, err)
+
+	// We can not do this test because the identities have to be compared using
+	// the Equal() method.
+	//require.Equal(t, result.ProposedTransaction, proposedTransaction)
+	require.Equal(t, len(result.ProposedTransaction.Instructions), 2)
+	require.Equal(t, result.ExpireBlockIndex, expireBlockIndexInt)
+	require.NotEmpty(t, result.ProposedTransaction.Instructions[0].SignerIdentities)
+	require.Equal(t, len(result.ProposedTransaction.Instructions[0].SignerIdentities), 1)
+	// This test won't work. But by using Equal() will.
+	// require.Equal(t, result.ProposedTransaction.Instructions[0].SignerIdentities[0], identity)
+	require.True(t, identity.Equal(&result.ProposedTransaction.Instructions[0].SignerIdentities[0]))
+
+	require.NotEmpty(t, result.ProposedTransaction.Instructions[0].Signatures)
+	require.Equal(t, len(result.ProposedTransaction.Instructions[0].Signatures), 1)
+	require.Equal(t, result.ProposedTransaction.Instructions[0].Signatures[0], signature)
+	// Default NumExecution should be 1
+	require.Equal(t, result.NumExecution, uint64(1))
+
+	require.NotEmpty(t, result.InstructionHashes)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	// ------------------------------------------------------------------------
+	// 2.2 Invoke a second "addProof" on the second instruction, but with a
+	//     different signer
+	// ------------------------------------------------------------------------
+
+	signer2 := darc.NewSignerEd25519(nil, nil)
+
+	identity = signer2.Identity()
+	identityBuf, err = protobuf.Encode(&identity)
+	require.Nil(t, err)
+
+	signature, err = signer2.Sign(rootHash[1]) // == index
+	require.Nil(t, err)
+
+	index = uint32(1)
+	indexBuf = make([]byte, 4)
+	binary.LittleEndian.PutUint32(indexBuf, uint32(index))
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "addProof",
+				Args: []byzcoin.Argument{
+					{
+						Name:  "identity",
+						Value: identityBuf,
+					},
+					{
+						Name:  "signature",
+						Value: signature,
+					},
+					{
+						Name:  "index",
+						Value: indexBuf,
+					},
+				},
+			},
+			SignerCounter: []uint64{3},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+
+	dataBuf, _, _, err = pr.Get(myID.Slice())
+	require.Nil(t, err)
+
+	result = DeferredData{}
+	err = protobuf.Decode(dataBuf, &result)
+	require.Nil(t, err)
+
+	// We can not do this test because the identities have to be compared using
+	// the Equal() method.
+	//require.Equal(t, result.ProposedTransaction, proposedTransaction)
+	require.Equal(t, len(result.ProposedTransaction.Instructions), 2)
+	require.Equal(t, result.ExpireBlockIndex, expireBlockIndexInt)
+	require.NotEmpty(t, result.ProposedTransaction.Instructions[1].SignerIdentities)
+	require.Equal(t, len(result.ProposedTransaction.Instructions[1].SignerIdentities), 1)
+	// This test won't work. But by using Equal() will.
+	// require.Equal(t, result.ProposedTransaction.Instructions[0].SignerIdentities[0], identity)
+	require.True(t, identity.Equal(&result.ProposedTransaction.Instructions[1].SignerIdentities[0]))
+
+	require.NotEmpty(t, result.ProposedTransaction.Instructions[1].Signatures)
+	require.Equal(t, len(result.ProposedTransaction.Instructions[1].Signatures), 1)
+	require.Equal(t, result.ProposedTransaction.Instructions[1].Signatures[0], signature)
+
+	require.NotEmpty(t, result.InstructionHashes)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	// ------------------------------------------------------------------------
+	// 3. Invoke an "execRoot" command. This one will fail since one of the
+	//    instruction is signed by an unauthorized signer.
+	// ------------------------------------------------------------------------
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "execProposedTx",
+			},
+			SignerCounter: []uint64{4},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	myID = ctx.Instructions[0].DeriveID("")
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	// Need to sleep because we can't predict the output (hence the 'nil')
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Error(t, err)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+}
+
+func TestDeferred_WrongSignature(t *testing.T) {
+	// If a client performs an "addProof" with a wrong signature, then it should
+	// produce an error and reject the transaction
+
+	// ------------------------------------------------------------------------
+	// 0. Set up
+	// ------------------------------------------------------------------------
+	local := onet.NewTCPTest(cothority.Suite)
+	defer local.CloseAll()
+
+	signer := darc.NewSignerEd25519(nil, nil)
+	_, roster, _ := local.GenTree(3, true)
+
+	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
+		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.addProof",
+			"invoke:deferred.execProposedTx"}, signer.Identity())
+	require.Nil(t, err)
+	gDarc := &genesisMsg.GenesisDarc
+
+	genesisMsg.BlockInterval = time.Second
+
+	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
+	require.Nil(t, err)
+
+	// ------------------------------------------------------------------------
+	// 1. Spawn
+	// ------------------------------------------------------------------------
+	rootInstructionValue := []byte("aef123456789fab")
+
+	proposedTransaction := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{
+			byzcoin.Instruction{
+				InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+				Spawn: &byzcoin.Spawn{
+					ContractID: "value",
+					Args: byzcoin.Arguments{
+						byzcoin.Argument{
+							Name:  "value",
+							Value: rootInstructionValue,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expireBlockIndex := []byte("6000")
+	expireBlockIndexInt, _ := strconv.ParseUint(string(expireBlockIndex), 10, 64)
+	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
+	require.Nil(t, err)
+
+	ctx := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+			Spawn: &byzcoin.Spawn{
+				ContractID: ContractDeferredID,
+				Args: []byzcoin.Argument{
+					{
+						Name:  "proposedTransaction",
+						Value: proposedTransactionBuf,
+					},
+					{
+						Name:  "expireBlockIndex",
+						Value: expireBlockIndex,
+					},
+				},
+			},
+			SignerCounter: []uint64{1},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	myID := ctx.Instructions[0].DeriveID("")
+	pr, err := cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+
+	dataBuf, _, _, err := pr.Get(myID.Slice())
+	require.Nil(t, err)
+	result := DeferredData{}
+	err = protobuf.Decode(dataBuf, &result)
+	require.Nil(t, err)
+
+	require.Equal(t, result.ProposedTransaction, proposedTransaction)
+	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
+	require.Equal(t, result.ExpireBlockIndex, expireBlockIndexInt)
+	require.Empty(t, result.ProposedTransaction.Instructions[0].SignerIdentities)
+	require.Empty(t, result.ProposedTransaction.Instructions[0].Signatures)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	rootHash := result.InstructionHashes
+
+	// ------------------------------------------------------------------------
+	// 2 Invoke an "addProof" with a wrong signature
+	// ------------------------------------------------------------------------
+
+	identity := signer.Identity()
+	identityBuf, err := protobuf.Encode(&identity)
+	require.Nil(t, err)
+
+	signature, err := signer.Sign(rootHash[0]) // == index
+	require.Nil(t, err)
+	signature[1] = 0xf
+
+	index := uint32(0)
+	indexBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(indexBuf, uint32(index))
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "addProof",
+				Args: []byzcoin.Argument{
+					{
+						Name:  "identity",
+						Value: identityBuf,
+					},
+					{
+						Name:  "signature",
+						Value: signature,
+					},
+					{
+						Name:  "index",
+						Value: indexBuf,
+					},
+				},
+			},
+			SignerCounter: []uint64{2},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+	myID = ctx.Instructions[0].DeriveID("")
+
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Error(t, err)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+}
+
+func TestDeferred_DuplicateIdentity(t *testing.T) {
+	// We do not store duplicates of identities. If someone tries to add an
+	// identity that is already added, it returns an error.
+
+	// ------------------------------------------------------------------------
+	// 0. Set up
+	// ------------------------------------------------------------------------
+	local := onet.NewTCPTest(cothority.Suite)
+	defer local.CloseAll()
+
+	signer := darc.NewSignerEd25519(nil, nil)
+	_, roster, _ := local.GenTree(3, true)
+
+	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
+		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.addProof",
+			"invoke:deferred.execProposedTx"}, signer.Identity())
+	require.Nil(t, err)
+	gDarc := &genesisMsg.GenesisDarc
+
+	genesisMsg.BlockInterval = time.Second
+
+	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
+	require.Nil(t, err)
+
+	// ------------------------------------------------------------------------
+	// 1. Spawn
+	// ------------------------------------------------------------------------
+	rootInstructionValue := []byte("aef123456789fab")
+
+	proposedTransaction := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{
+			byzcoin.Instruction{
+				InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+				Spawn: &byzcoin.Spawn{
+					ContractID: "value",
+					Args: byzcoin.Arguments{
+						byzcoin.Argument{
+							Name:  "value",
+							Value: rootInstructionValue,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expireBlockIndex := []byte("6000")
+	expireBlockIndexInt, _ := strconv.ParseUint(string(expireBlockIndex), 10, 64)
+	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
+	require.Nil(t, err)
+
+	ctx := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+			Spawn: &byzcoin.Spawn{
+				ContractID: ContractDeferredID,
+				Args: []byzcoin.Argument{
+					{
+						Name:  "proposedTransaction",
+						Value: proposedTransactionBuf,
+					},
+					{
+						Name:  "expireBlockIndex",
+						Value: expireBlockIndex,
+					},
+				},
+			},
+			SignerCounter: []uint64{1},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	myID := ctx.Instructions[0].DeriveID("")
+	pr, err := cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+
+	dataBuf, _, _, err := pr.Get(myID.Slice())
+	require.Nil(t, err)
+	result := DeferredData{}
+	err = protobuf.Decode(dataBuf, &result)
+	require.Nil(t, err)
+
+	require.Equal(t, result.ProposedTransaction, proposedTransaction)
+	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
+	require.Equal(t, result.ExpireBlockIndex, expireBlockIndexInt)
+	require.Empty(t, result.ProposedTransaction.Instructions[0].SignerIdentities)
+	require.Empty(t, result.ProposedTransaction.Instructions[0].Signatures)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	rootHash := result.InstructionHashes
+
+	// ------------------------------------------------------------------------
+	// 2 Invoke an "addProof"
+	// ------------------------------------------------------------------------
+
+	identity := signer.Identity()
+	identityBuf, err := protobuf.Encode(&identity)
+	require.Nil(t, err)
+
+	signature, err := signer.Sign(rootHash[0]) // == index
+	require.Nil(t, err)
+
+	index := uint32(0)
+	indexBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(indexBuf, uint32(index))
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "addProof",
+				Args: []byzcoin.Argument{
+					{
+						Name:  "identity",
+						Value: identityBuf,
+					},
+					{
+						Name:  "signature",
+						Value: signature,
+					},
+					{
+						Name:  "index",
+						Value: indexBuf,
+					},
+				},
+			},
+			SignerCounter: []uint64{2},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+
+	// ------------------------------------------------------------------------
+	// 3 Invoke a second time the same "addProof"
+	// ------------------------------------------------------------------------
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "addProof",
+				Args: []byzcoin.Argument{
+					{
+						Name:  "identity",
+						Value: identityBuf,
+					},
+					{
+						Name:  "signature",
+						Value: signature,
+					},
+					{
+						Name:  "index",
+						Value: indexBuf,
+					},
+				},
+			},
+			SignerCounter: []uint64{3},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(ctx.Instructions[0].DeriveID("").Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Error(t, err)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+}
+
+func TestDeferred_ExpireBlockIndex(t *testing.T) {
+	// We set an "expireBlockIndex" to 0, which should prevent any invoke.
+
+	// ------------------------------------------------------------------------
+	// 0. Set up
+	// ------------------------------------------------------------------------
+	local := onet.NewTCPTest(cothority.Suite)
+	defer local.CloseAll()
+
+	signer := darc.NewSignerEd25519(nil, nil)
+	_, roster, _ := local.GenTree(3, true)
+
+	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
+		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.addProof",
+			"invoke:deferred.execProposedTx"}, signer.Identity())
+	require.Nil(t, err)
+	gDarc := &genesisMsg.GenesisDarc
+
+	genesisMsg.BlockInterval = time.Second
+
+	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
+	require.Nil(t, err)
+
+	// ------------------------------------------------------------------------
+	// 1. Spawn
+	// ------------------------------------------------------------------------
+	rootInstructionValue := []byte("aef123456789fab")
+
+	proposedTransaction := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{
+			byzcoin.Instruction{
+				InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+				Spawn: &byzcoin.Spawn{
+					ContractID: "value",
+					Args: byzcoin.Arguments{
+						byzcoin.Argument{
+							Name:  "value",
+							Value: rootInstructionValue,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expireBlockIndex := []byte("0")
+	expireBlockIndexInt, _ := strconv.ParseUint(string(expireBlockIndex), 10, 64)
+	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
+	require.Nil(t, err)
+
+	ctx := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+			Spawn: &byzcoin.Spawn{
+				ContractID: ContractDeferredID,
+				Args: []byzcoin.Argument{
+					{
+						Name:  "proposedTransaction",
+						Value: proposedTransactionBuf,
+					},
+					{
+						Name:  "expireBlockIndex",
+						Value: expireBlockIndex,
+					},
+				},
+			},
+			SignerCounter: []uint64{1},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	myID := ctx.Instructions[0].DeriveID("")
+	pr, err := cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+
+	dataBuf, _, _, err := pr.Get(myID.Slice())
+	require.Nil(t, err)
+	result := DeferredData{}
+	err = protobuf.Decode(dataBuf, &result)
+	require.Nil(t, err)
+
+	require.Equal(t, result.ProposedTransaction, proposedTransaction)
+	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
+	require.Equal(t, result.ExpireBlockIndex, expireBlockIndexInt)
+	require.Empty(t, result.ProposedTransaction.Instructions[0].SignerIdentities)
+	require.Empty(t, result.ProposedTransaction.Instructions[0].Signatures)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	rootHash := result.InstructionHashes
+
+	// ------------------------------------------------------------------------
+	// 2 Invoke an "addProof"
+	// ------------------------------------------------------------------------
+
+	identity := signer.Identity()
+	identityBuf, err := protobuf.Encode(&identity)
+	require.Nil(t, err)
+
+	signature, err := signer.Sign(rootHash[0]) // == index
+	require.Nil(t, err)
+
+	index := uint32(0)
+	indexBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(indexBuf, uint32(index))
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "addProof",
+				Args: []byzcoin.Argument{
+					{
+						Name:  "identity",
+						Value: identityBuf,
+					},
+					{
+						Name:  "signature",
+						Value: signature,
+					},
+					{
+						Name:  "index",
+						Value: indexBuf,
+					},
+				},
+			},
+			SignerCounter: []uint64{2},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(ctx.Instructions[0].DeriveID("").Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Error(t, err)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+}
+
+func TestDeferred_ExecWithNoProof(t *testing.T) {
+	// We will sign the proposed transaction with no proof on it. We expect it
+	// to fail
+
+	// ------------------------------------------------------------------------
+	// 0. Set up
+	// ------------------------------------------------------------------------
+	local := onet.NewTCPTest(cothority.Suite)
+	defer local.CloseAll()
+
+	signer := darc.NewSignerEd25519(nil, nil)
+	_, roster, _ := local.GenTree(3, true)
+
+	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
+		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.addProof",
+			"invoke:deferred.execProposedTx"}, signer.Identity())
+	require.Nil(t, err)
+	gDarc := &genesisMsg.GenesisDarc
+
+	genesisMsg.BlockInterval = time.Second
+
+	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
+	require.Nil(t, err)
+
+	// ------------------------------------------------------------------------
+	// 1. Spawn
+	// ------------------------------------------------------------------------
+	rootInstructionValue := []byte("aef123456789fab")
+
+	proposedTransaction := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{
+			byzcoin.Instruction{
+				InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+				Spawn: &byzcoin.Spawn{
+					ContractID: "value",
+					Args: byzcoin.Arguments{
+						byzcoin.Argument{
+							Name:  "value",
+							Value: rootInstructionValue,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expireBlockIndex := []byte("6000")
+	expireBlockIndexInt, _ := strconv.ParseUint(string(expireBlockIndex), 10, 64)
+	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
+	require.Nil(t, err)
+
+	ctx := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+			Spawn: &byzcoin.Spawn{
+				ContractID: ContractDeferredID,
+				Args: []byzcoin.Argument{
+					{
+						Name:  "proposedTransaction",
+						Value: proposedTransactionBuf,
+					},
+					{
+						Name:  "expireBlockIndex",
+						Value: expireBlockIndex,
+					},
+				},
+			},
+			SignerCounter: []uint64{1},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	myID := ctx.Instructions[0].DeriveID("")
+	pr, err := cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+
+	dataBuf, _, _, err := pr.Get(myID.Slice())
+	require.Nil(t, err)
+	result := DeferredData{}
+	err = protobuf.Decode(dataBuf, &result)
+	require.Nil(t, err)
+
+	require.Equal(t, result.ProposedTransaction, proposedTransaction)
+	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
+	require.Equal(t, result.ExpireBlockIndex, expireBlockIndexInt)
+	require.Empty(t, result.ProposedTransaction.Instructions[0].SignerIdentities)
+	require.Empty(t, result.ProposedTransaction.Instructions[0].Signatures)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	// ------------------------------------------------------------------------
+	// 2. Invoke an "execProposedTx" command
+	// ------------------------------------------------------------------------
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "execProposedTx",
+			},
+			SignerCounter: []uint64{2},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	// Need to sleep because we can't predict the output (hence the 'nil')
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+	dataBuf, _, _, err = pr.Get(myID.Slice())
+	require.Nil(t, err)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(dataBuf), 2*genesisMsg.BlockInterval, nil)
+	require.Error(t, err)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+}
+
+func TestDeferred_SpawnWithMaxecution(t *testing.T) {
+	// Here we specify a "NumExecution" of 2 and exec 3 times the proposed
+	// transaciton. We expect the "MaxExectuion" to be updated and the third
+	// proposed transaction execution to fail.
+	// Since we can not spawn a contract two times with the same ID, we will
+	// frst spawn a contract, then propose to update it.
+	//
+	// 0.1.  Setup
+	// 0.2.  Spawn a vlue contract
+	// 1.    Spawn the deferred contract that updates the value contract
+	// 2.    Invoke an "addProof" to sign the proposed transaction
+	// 3,4,5 Invoke an "execProposedTx"
+
+	// ------------------------------------------------------------------------
+	// 0.1. Set up
+	// ------------------------------------------------------------------------
+	local := onet.NewTCPTest(cothority.Suite)
+	defer local.CloseAll()
+
+	signer := darc.NewSignerEd25519(nil, nil)
+	_, roster, _ := local.GenTree(3, true)
+
+	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
+		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.addProof",
+			"invoke:deferred.execProposedTx", "invoke:value.update"}, signer.Identity())
+	require.Nil(t, err)
+	gDarc := &genesisMsg.GenesisDarc
+
+	genesisMsg.BlockInterval = time.Second
+
+	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
+	require.Nil(t, err)
+
+	// ------------------------------------------------------------------------
+	// 0.2. Spawn a value contract
+	// ------------------------------------------------------------------------
+
+	myvalue := []byte("1234")
+	ctx := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+			Spawn: &byzcoin.Spawn{
+				ContractID: ContractValueID,
+				Args: []byzcoin.Argument{{
+					Name:  "value",
+					Value: myvalue,
+				}},
+			},
+			SignerCounter: []uint64{1},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	valueID := ctx.Instructions[0].DeriveID("")
+	pr, err := cl.WaitProof(byzcoin.NewInstanceID(valueID.Slice()), 2*genesisMsg.BlockInterval, myvalue)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(valueID.Slice()))
+
+	v0, _, _, err := pr.Get(valueID.Slice())
+	require.Nil(t, err)
+	require.Equal(t, myvalue, v0)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	// ------------------------------------------------------------------------
+	// 1. Spawn our deferred contract. We provide the previous ID.
+	// ------------------------------------------------------------------------
+	rootInstructionValue := []byte("aef123456789fab")
+
+	proposedTransaction := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{
+			byzcoin.Instruction{
+				InstanceID: valueID,
+				Invoke: &byzcoin.Invoke{
+					ContractID: "value",
+					Command:    "update",
+					Args: byzcoin.Arguments{
+						byzcoin.Argument{
+							Name:  "value",
+							Value: rootInstructionValue,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expireBlockIndex := []byte("6000")
+	NumExecution := []byte("2")
+	expireBlockIndexInt, _ := strconv.ParseUint(string(expireBlockIndex), 10, 64)
+	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
+	require.Nil(t, err)
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+			Spawn: &byzcoin.Spawn{
+				ContractID: ContractDeferredID,
+				Args: []byzcoin.Argument{
+					{
+						Name:  "proposedTransaction",
+						Value: proposedTransactionBuf,
+					},
+					{
+						Name:  "expireBlockIndex",
+						Value: expireBlockIndex,
+					},
+					{
+						Name:  "NumExecution",
+						Value: NumExecution,
+					},
+				},
+			},
+			SignerCounter: []uint64{2},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	myID := ctx.Instructions[0].DeriveID("")
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+
+	dataBuf, _, _, err := pr.Get(myID.Slice())
+	require.Nil(t, err)
+	result := DeferredData{}
+	err = protobuf.Decode(dataBuf, &result)
+	require.Nil(t, err)
+
+	require.Equal(t, result.ProposedTransaction, proposedTransaction)
+	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
+	require.Equal(t, result.ExpireBlockIndex, expireBlockIndexInt)
+	require.Empty(t, result.ProposedTransaction.Instructions[0].SignerIdentities)
+	require.Empty(t, result.ProposedTransaction.Instructions[0].Signatures)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	rootHash := result.InstructionHashes
+
+	// ------------------------------------------------------------------------
+	// 2 Invoke a first "addProof"
+	// ------------------------------------------------------------------------
+
+	identity := signer.Identity()
+	identityBuf, err := protobuf.Encode(&identity)
+	require.Nil(t, err)
+
+	signature, err := signer.Sign(rootHash[0]) // == index
+	require.Nil(t, err)
+	// signature[1] = 0xf
+
+	index := uint32(0)
+	indexBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(indexBuf, uint32(index))
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "addProof",
+				Args: []byzcoin.Argument{
+					{
+						Name:  "identity",
+						Value: identityBuf,
+					},
+					{
+						Name:  "signature",
+						Value: signature,
+					},
+					{
+						Name:  "index",
+						Value: indexBuf,
+					},
+				},
+			},
+			SignerCounter: []uint64{3},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	proposedTransaction.Instructions[0].SignerIdentities = append(proposedTransaction.Instructions[0].SignerIdentities, identity)
+	proposedTransaction.Instructions[0].Signatures = append(proposedTransaction.Instructions[0].Signatures, signature)
+	result.ProposedTransaction = proposedTransaction
+	resultBuf, err := protobuf.Encode(&result)
+	require.Nil(t, err)
+
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, resultBuf)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+
+	dataBuf, _, _, err = pr.Get(myID.Slice())
+	require.Nil(t, err)
+
+	result = DeferredData{}
+	err = protobuf.Decode(dataBuf, &result)
+	require.Nil(t, err)
+
+	// We can not do this test because the identities have to be compared using
+	// the Equal() method.
+	//require.Equal(t, result.ProposedTransaction, proposedTransaction)
+	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
+	require.Equal(t, result.ExpireBlockIndex, expireBlockIndexInt)
+	require.NotEmpty(t, result.ProposedTransaction.Instructions[0].SignerIdentities)
+	require.Equal(t, len(result.ProposedTransaction.Instructions[0].SignerIdentities), 1)
+	// This test won't work. But by using Equal() will.
+	// require.Equal(t, result.ProposedTransaction.Instructions[0].SignerIdentities[0], identity)
+	require.True(t, identity.Equal(&result.ProposedTransaction.Instructions[0].SignerIdentities[0]))
+
+	require.NotEmpty(t, result.ProposedTransaction.Instructions[0].Signatures)
+	require.Equal(t, len(result.ProposedTransaction.Instructions[0].Signatures), 1)
+	require.Equal(t, result.ProposedTransaction.Instructions[0].Signatures[0], signature)
+	// Default NumExecution should be 1
+	require.Equal(t, result.NumExecution, uint64(2))
+
+	require.NotEmpty(t, result.InstructionHashes)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	// ------------------------------------------------------------------------
+	// 3. Invoke an "execRoot" command
+	// ------------------------------------------------------------------------
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "execProposedTx",
+			},
+			SignerCounter: []uint64{4},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	// Need to sleep because we can't predict the output (hence the 'nil')
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+	dataBuf, _, _, err = pr.Get(myID.Slice())
+	require.Nil(t, err)
+
+	result = DeferredData{}
+	protobuf.Decode(dataBuf, &result)
+	require.Equal(t, 1, len(result.ExecResult))
+	require.Equal(t, uint64(1), result.NumExecution)
+
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(valueID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(valueID.Slice()))
+
+	valueRes, _, _, err := pr.Get(valueID.Slice())
+	require.Nil(t, err)
+
+	// Such a miracle to retrieve this value that was set at the begining
+	require.Equal(t, valueRes, rootInstructionValue)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	// ------------------------------------------------------------------------
+	// 4. Invoke an "execRoot" command a second time.
+	// ------------------------------------------------------------------------
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "execProposedTx",
+			},
+			SignerCounter: []uint64{5},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	// Need to sleep because we can't predict the output (hence the 'nil')
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+	dataBuf, _, _, err = pr.Get(myID.Slice())
+	require.Nil(t, err)
+
+	result = DeferredData{}
+	protobuf.Decode(dataBuf, &result)
+	require.Equal(t, 1, len(result.ExecResult))
+	require.Equal(t, uint64(0), result.NumExecution)
+
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(valueID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(valueID.Slice()))
+
+	valueRes, _, _, err = pr.Get(valueID.Slice())
+	require.Nil(t, err)
+
+	// Such a miracle to retrieve this value that was set at the begining
+	require.Equal(t, valueRes, rootInstructionValue)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	// ------------------------------------------------------------------------
+	// 5. Invoke an "execRoot" command a third time. Since NumExecution should
+	//    be at 0, we expect it to fail.
+	// ------------------------------------------------------------------------
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "execProposedTx",
+			},
+			SignerCounter: []uint64{5},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	// Need to sleep because we can't predict the output (hence the 'nil')
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(ctx.Instructions[0].DeriveID("").Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Error(t, err)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
 }

--- a/byzcoin/contracts/deferred_test.go
+++ b/byzcoin/contracts/deferred_test.go
@@ -1,0 +1,396 @@
+package contracts
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.dedis.ch/cothority/v3/byzcoin"
+	"go.dedis.ch/protobuf"
+
+	"go.dedis.ch/cothority/v3/darc"
+
+	"go.dedis.ch/cothority/v3"
+	"go.dedis.ch/onet/v3"
+)
+
+func TestDeferred_Spawn(t *testing.T) {
+	// In this test I am just trying to see if a spawn successfully stores
+	// the given argument and if I am able to retrieve them after. It was
+	// interesting to play with the encode/decode protobuf.
+	local := onet.NewTCPTest(cothority.Suite)
+	defer local.CloseAll()
+
+	signer := darc.NewSignerEd25519(nil, nil)
+	_, roster, _ := local.GenTree(3, true)
+
+	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
+		[]string{"spawn:deferred"}, signer.Identity())
+	require.Nil(t, err)
+	gDarc := &genesisMsg.GenesisDarc
+
+	genesisMsg.BlockInterval = time.Second
+
+	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
+	require.Nil(t, err)
+
+	proposedTransaction := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{
+			byzcoin.Instruction{
+				InstanceID: byzcoin.InstanceID{0x10, 0x11, 0x12},
+				Spawn: &byzcoin.Spawn{
+					ContractID: "value",
+					Args: byzcoin.Arguments{
+						byzcoin.Argument{
+							Name:  "test",
+							Value: []byte("1234"),
+						},
+					},
+				},
+			},
+		},
+	}
+	expireSec := []byte("6000")
+	expireSecInt, _ := strconv.ParseUint(string(expireSec), 10, 64)
+	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
+	require.Nil(t, err)
+
+	ctx := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+			Spawn: &byzcoin.Spawn{
+				ContractID: ContractDeferredID,
+				Args: []byzcoin.Argument{
+					{
+						Name:  "proposedTransaction",
+						Value: proposedTransactionBuf,
+					},
+					{
+						Name:  "expireSec",
+						Value: expireSec,
+					},
+				},
+			},
+			SignerCounter: []uint64{1},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	pr, err := cl.WaitProof(byzcoin.NewInstanceID(ctx.Instructions[0].DeriveID("").Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(ctx.Instructions[0].DeriveID("").Slice()))
+
+	dataBuf, _, _, err := pr.Get(ctx.Instructions[0].DeriveID("").Slice())
+	require.Nil(t, err)
+	result := DeferredData{}
+	err = protobuf.Decode(dataBuf, &result)
+	require.Nil(t, err)
+
+	require.Equal(t, result.ProposedTransaction, proposedTransaction)
+	require.Equal(t, result.ExpireSec, expireSecInt)
+	require.NotEmpty(t, result.Timestamp)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+}
+
+func TestDeferred_Scenario(t *testing.T) {
+	// Since every method relies on the execution of a previous ones, I am not
+	// unit test but rather creating a scenario:
+	//
+	// 1. Spawn a new contract
+	// 2. Invoke two "addProff"
+	// 3. Invoke an "execRoot"
+
+	// ------------------------------------------------------------------------
+	// 1. Spawn
+	// ------------------------------------------------------------------------
+	local := onet.NewTCPTest(cothority.Suite)
+	defer local.CloseAll()
+
+	signer := darc.NewSignerEd25519(nil, nil)
+	_, roster, _ := local.GenTree(3, true)
+
+	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
+		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.addProof",
+			"invoke:deferred.execProposedTx"}, signer.Identity())
+	require.Nil(t, err)
+	gDarc := &genesisMsg.GenesisDarc
+
+	genesisMsg.BlockInterval = time.Second
+
+	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
+	require.Nil(t, err)
+
+	rootInstructionValue := []byte("aef123456789fab")
+
+	proposedTransaction := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{
+			byzcoin.Instruction{
+				InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+				Spawn: &byzcoin.Spawn{
+					ContractID: "value",
+					Args: byzcoin.Arguments{
+						byzcoin.Argument{
+							Name:  "value",
+							Value: rootInstructionValue,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expireSec := []byte("6000")
+	expireSecInt, _ := strconv.ParseUint(string(expireSec), 10, 64)
+	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
+	require.Nil(t, err)
+
+	ctx := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+			Spawn: &byzcoin.Spawn{
+				ContractID: ContractDeferredID,
+				Args: []byzcoin.Argument{
+					{
+						Name:  "proposedTransaction",
+						Value: proposedTransactionBuf,
+					},
+					{
+						Name:  "expireSec",
+						Value: expireSec,
+					},
+				},
+			},
+			SignerCounter: []uint64{1},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	myID := ctx.Instructions[0].DeriveID("")
+	pr, err := cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+
+	dataBuf, _, _, err := pr.Get(myID.Slice())
+	require.Nil(t, err)
+	result := DeferredData{}
+	err = protobuf.Decode(dataBuf, &result)
+	require.Nil(t, err)
+
+	require.Equal(t, result.ProposedTransaction, proposedTransaction)
+	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
+	// require.Equal(t, result.ProposedTransaction.Instructions[0].Spawn.Args.Search("value"), 1)
+	require.Equal(t, result.ExpireSec, expireSecInt)
+	require.NotEmpty(t, result.Timestamp)
+	require.Empty(t, result.ProposedTransaction.Instructions[0].SignerIdentities)
+	require.Empty(t, result.ProposedTransaction.Instructions[0].Signatures)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	rootHash := result.Hash
+
+	// ------------------------------------------------------------------------
+	// 2.1 Invoke a first "addProof"
+	// ------------------------------------------------------------------------
+
+	identity := signer.Identity()
+	identityBuf, err := protobuf.Encode(&identity)
+	require.Nil(t, err)
+
+	signature, err := signer.Sign(rootHash)
+	require.Nil(t, err)
+	// signature[1] = 0xf
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "addProof",
+				Args: []byzcoin.Argument{
+					{
+						Name:  "identity",
+						Value: identityBuf,
+					},
+					{
+						Name:  "signature",
+						Value: signature,
+					},
+				},
+			},
+			SignerCounter: []uint64{2},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	proposedTransaction.Instructions[0].SignerIdentities = append(proposedTransaction.Instructions[0].SignerIdentities, identity)
+	proposedTransaction.Instructions[0].Signatures = append(proposedTransaction.Instructions[0].Signatures, signature)
+	result.ProposedTransaction = proposedTransaction
+	resultBuf, err := protobuf.Encode(&result)
+	require.Nil(t, err)
+
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, resultBuf)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+
+	dataBuf, _, _, err = pr.Get(myID.Slice())
+	require.Nil(t, err)
+
+	result = DeferredData{}
+	err = protobuf.Decode(dataBuf, &result)
+	require.Nil(t, err)
+
+	// We can not do this test because the identities have to be compared using
+	// the Equal() method.
+	//require.Equal(t, result.ProposedTransaction, proposedTransaction)
+	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
+	require.Equal(t, result.ExpireSec, expireSecInt)
+	require.NotEmpty(t, result.Timestamp)
+	require.NotEmpty(t, result.ProposedTransaction.Instructions[0].SignerIdentities)
+	require.Equal(t, len(result.ProposedTransaction.Instructions[0].SignerIdentities), 1)
+	// Surprisingly this test won't work. But by using Equal() will.
+	// require.Equal(t, result.ProposedTransaction.Instructions[0].SignerIdentities[0], identity)
+	require.True(t, identity.Equal(&result.ProposedTransaction.Instructions[0].SignerIdentities[0]))
+
+	require.NotEmpty(t, result.ProposedTransaction.Instructions[0].Signatures)
+	require.Equal(t, len(result.ProposedTransaction.Instructions[0].Signatures), 1)
+	require.Equal(t, result.ProposedTransaction.Instructions[0].Signatures[0], signature)
+
+	require.NotEmpty(t, result.Hash)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	// ------------------------------------------------------------------------
+	// 2.1 Invoke a second "addProof"
+	// ------------------------------------------------------------------------
+	//
+	// Lets try to add another signer. Here I am still using the previous signer
+	// to send the transaction because he has the right to. I am just trying to
+	// see if adding another new identity and signature will result in having
+	// two identities and two signatures.
+	//
+
+	signer2 := darc.NewSignerEd25519(nil, nil)
+	identity = signer2.Identity()
+	identityBuf, err = protobuf.Encode(&identity)
+	require.Nil(t, err)
+
+	signature, err = signer2.Sign(rootHash)
+	require.Nil(t, err)
+	signature[1] = 0xf // Simulates a wrong signature
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "addProof",
+				Args: []byzcoin.Argument{
+					{
+						Name:  "identity",
+						Value: identityBuf,
+					},
+					{
+						Name:  "signature",
+						Value: signature,
+					},
+				},
+			},
+			SignerCounter: []uint64{3},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	proposedTransaction.Instructions[0].SignerIdentities = append(proposedTransaction.Instructions[0].SignerIdentities, identity)
+	proposedTransaction.Instructions[0].Signatures = append(proposedTransaction.Instructions[0].Signatures, signature)
+	result.ProposedTransaction = proposedTransaction
+	resultBuf, err = protobuf.Encode(&result)
+	require.Nil(t, err)
+
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, resultBuf)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+
+	dataBuf, _, _, err = pr.Get(myID.Slice())
+	require.Nil(t, err)
+
+	result = DeferredData{}
+	err = protobuf.Decode(dataBuf, &result)
+	require.Nil(t, err)
+
+	// We can not do this test because the identities have to be compared using
+	// the Equal() method.
+	//require.Equal(t, result.ProposedTransaction, proposedTransaction)
+	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
+	require.Equal(t, result.ExpireSec, expireSecInt)
+	require.NotEmpty(t, result.Timestamp)
+	require.NotEmpty(t, result.ProposedTransaction.Instructions[0].SignerIdentities)
+	require.Equal(t, len(result.ProposedTransaction.Instructions[0].SignerIdentities), 2)
+	// Surprisingly this test won't work. But by using Equal() will.
+	// require.Equal(t, result.ProposedTransaction.Instructions[0].SignerIdentities[0], identity)
+	require.True(t, identity.Equal(&result.ProposedTransaction.Instructions[0].SignerIdentities[1]))
+
+	require.NotEmpty(t, result.ProposedTransaction.Instructions[0].Signatures)
+	require.Equal(t, len(result.ProposedTransaction.Instructions[0].Signatures), 2)
+	require.Equal(t, result.ProposedTransaction.Instructions[0].Signatures[1], signature)
+
+	require.NotEmpty(t, result.Hash)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	// ------------------------------------------------------------------------
+	// 3. Invoke an "execRoot" command
+	// ------------------------------------------------------------------------
+
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractDeferredID,
+				Command:    "execProposedTx",
+			},
+			SignerCounter: []uint64{4},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	// Need to sleep because we can't predict the output (hence the 'nil')
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+	dataBuf, _, _, err = pr.Get(myID.Slice())
+	require.Nil(t, err)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	time.Sleep(2 * genesisMsg.BlockInterval)
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(dataBuf), 2*genesisMsg.BlockInterval, nil)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(dataBuf))
+
+	valueRes, _, _, err := pr.Get(dataBuf)
+	require.Nil(t, err)
+
+	// Such a miracle to retrieve this value that was set at the begining
+	require.Equal(t, valueRes, rootInstructionValue)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+}

--- a/byzcoin/contracts/service.go
+++ b/byzcoin/contracts/service.go
@@ -34,5 +34,6 @@ func newService(c *onet.Context) (onet.Service, error) {
 	byzcoin.RegisterContract(c, ContractValueID, contractValueFromBytes)
 	byzcoin.RegisterContract(c, ContractCoinID, contractCoinFromBytes)
 	byzcoin.RegisterContract(c, ContractInsecureDarcID, s.contractInsecureDarcFromBytes)
+	byzcoin.RegisterContract(c, ContractDeferredID, s.contractDeferredFromBytes)
 	return s, nil
 }

--- a/byzcoin/contracts/value.go
+++ b/byzcoin/contracts/value.go
@@ -84,3 +84,10 @@ func (c *contractValue) Delete(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instr
 	}
 	return
 }
+
+func (c *contractValue) VerifyDeferedInstruction(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instruction, ctxHash []byte) error {
+	if err := inst.VerifyWithOption(rst, ctxHash, false); err != nil {
+		return err
+	}
+	return nil
+}

--- a/byzcoin/contracts/value_test.go
+++ b/byzcoin/contracts/value_test.go
@@ -55,3 +55,86 @@ func TestValue_Spawn(t *testing.T) {
 
 	local.WaitDone(genesisMsg.BlockInterval)
 }
+
+// This test uses the same code as the Spawn one but then performs an upadte
+// on the value contract.
+func TestValue_Invoke(t *testing.T) {
+	local := onet.NewTCPTest(cothority.Suite)
+	defer local.CloseAll()
+
+	signer := darc.NewSignerEd25519(nil, nil)
+	_, roster, _ := local.GenTree(3, true)
+
+	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
+		[]string{"spawn:value", "invoke:value.update"}, signer.Identity())
+	require.Nil(t, err)
+	gDarc := &genesisMsg.GenesisDarc
+
+	genesisMsg.BlockInterval = time.Second
+
+	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
+	require.Nil(t, err)
+
+	myvalue := []byte("1234")
+	ctx := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
+			Spawn: &byzcoin.Spawn{
+				ContractID: ContractValueID,
+				Args: []byzcoin.Argument{{
+					Name:  "value",
+					Value: myvalue,
+				}},
+			},
+			SignerCounter: []uint64{1},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	myID := ctx.Instructions[0].DeriveID("")
+	pr, err := cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, myvalue)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+
+	v0, _, _, err := pr.Get(myID.Slice())
+	require.Nil(t, err)
+	require.Equal(t, myvalue, v0)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+
+	//
+	// Invoke part
+	//
+	myvalue = []byte("5678")
+	ctx = byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: myID,
+			Invoke: &byzcoin.Invoke{
+				ContractID: ContractValueID,
+				Command:    "update",
+				Args: []byzcoin.Argument{{
+					Name:  "value",
+					Value: myvalue,
+				}},
+			},
+			SignerCounter: []uint64{2},
+		}},
+	}
+	require.Nil(t, ctx.FillSignersAndSignWith(signer))
+
+	_, err = cl.AddTransaction(ctx)
+	require.Nil(t, err)
+
+	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, myvalue)
+	require.Nil(t, err)
+	require.True(t, pr.InclusionProof.Match(myID.Slice()))
+
+	v0, _, _, err = pr.Get(myID.Slice())
+	require.Nil(t, err)
+	require.Equal(t, myvalue, v0)
+
+	local.WaitDone(genesisMsg.BlockInterval)
+}

--- a/byzcoin/statetrie.go
+++ b/byzcoin/statetrie.go
@@ -79,7 +79,8 @@ func (t *stagingStateTrie) Commit() error {
 
 // GetIndex returns the index of the current trie.
 func (t *stagingStateTrie) GetIndex() int {
-	panic("cannot get index in stagingStateTrie")
+	index := binary.LittleEndian.Uint32(t.StagingTrie.GetMetadata([]byte(trieIndexKey)))
+	return int(index)
 }
 
 const trieIndexKey = "trieIndexKey"

--- a/byzcoin/trie/staging.go
+++ b/byzcoin/trie/staging.go
@@ -56,6 +56,11 @@ func (t *StagingTrie) Clone() *StagingTrie {
 	return &out
 }
 
+// GetMetadata ..
+func (t *StagingTrie) GetMetadata(key []byte) []byte {
+	return t.source.GetMetadata(key)
+}
+
 // Get gets the value for the given key.
 func (t *StagingTrie) Get(k []byte) ([]byte, error) {
 	t.Lock()


### PR DESCRIPTION
Fixes #1758.

In summary, here is the data stored and the methods this contract implements:

```go

type DeferredData struct {
	// The transaction that signers must sign and can be executed with an
	// "executeProposedTx".
	ProposedTransaction byzcoin.ClientTransaction
	// If the current block index is greater than this value, any Invoke on the
	// deferred contract is rejected. This provides an expiration mechanism.
	ExpireBlockIndex uint64
	// Hashes of each instruction of the proposed transaction. Those hashes are
	// computed using the special "hashDeferred" method.
	InstructionHashes [][]byte
	// The number of time the proposed transaction can be executed. This number
	// decreases for each successful invocation of "executeProposedTx" and its
	// default value is set to 1.
	NumExecution uint64
	// This array is filled with the instruction IDs of each executed
	// instruction when a successful "executeProposedTx" happens.
	ExecResult [][]byte
}

// Functions available translated to pseudo-code
Spawn(transaction ClientTransaction, expireBlockIndex uint64, numExecution=1 uint64) DeferredData
Invoke_addProof(identity Identity, signature []byte, index uint32) DeferredData
Invoke_execProposedTx() DeferredData

```

To agree on an instruction, a client must sign a special hash that is generated for each instruction stored in the given proposed transaction. Those hashes do not take into account the signers nor the signer counters. However, to make each hash uniq, we inclue the instanceID of the deferred contract to the hashing method.

We made the following considerations:

- In order to prevent useless garbage, a call to "addProof" with a wrong signature is rejected
- A call to "addProof" with an identity already stored is rejected (uniqueness of identities stored)
- Each instruction hash is uniq because we inclue the instanceID of the deferred contract
- A proposed transaction has an "expiration date" based on the given `ExpireBlockIndex`
- Each call to this contract use the standard `Verify()` method, which include the signer counters
- The proposed transaction is executed only if every instruction it contains are successful. 
- Instead of having a flag that indicates if the proposed transaction has already been executed, we give the flexibility to specify how many time the proposed transaction can be executed with the `NumExecution` attribute. This attribute is decreased each time a successful "execProposedTx" is launched. When it reaches 0, any "Invoke" is rejected. By default it is set to 1.