### PR TITLE
Detect infinite recursive darc delegation

### DIFF
--- a/darc/darc.go
+++ b/darc/darc.go
@@ -632,6 +632,8 @@ func evalExprDarc(visited map[string]bool, expr expression.Expr, getDarc GetDarc
 				issue = errors.New("cycle detected")
 				return false
 			}
+			// we make a copy so that diamond delegation will work,
+			// seeTestDarc_DelegationDiamond
 			newVisited := make(map[string]bool)
 			for k, v := range visited {
 				newVisited[k] = v

--- a/darc/darc_test.go
+++ b/darc/darc_test.go
@@ -384,10 +384,9 @@ func TestDarc_DelegationChain(t *testing.T) {
 	require.Nil(t, td.darc.VerifyWithCB(getDarc, true))
 }
 
-// TestDarc_DelegationCycle creates two darcs, each will have delegate the
-// "cycle" action to the other darc.
+// TestDarc_DelegationCycle creates n darcs and create a circular delegation
 func TestDarc_DelegationCycle(t *testing.T) {
-	n := 2
+	n := 5
 	darcs := make([]*Darc, n)
 	evolvedDarcs := make([]*Darc, n)
 	owners := make([]Signer, n)
@@ -413,7 +412,7 @@ func TestDarc_DelegationCycle(t *testing.T) {
 	getDarc := DarcsToGetDarcs(evolvedDarcs)
 	err := EvalExpr(evolvedDarcs[0].Rules.Get("cycle"), getDarc, identityStrs...)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "depth exceeded")
+	require.Contains(t, err.Error(), "cycle detected")
 }
 
 func TestDarc_X509(t *testing.T) {

--- a/darc/darc_test.go
+++ b/darc/darc_test.go
@@ -384,7 +384,7 @@ func TestDarc_DelegationChain(t *testing.T) {
 	require.Nil(t, td.darc.VerifyWithCB(getDarc, true))
 }
 
-// TestDarc_DelegationCycle creates n darcs and create a circular delegation
+// TestDarc_DelegationCycle creates n darcs and a circular delegation
 func TestDarc_DelegationCycle(t *testing.T) {
 	n := 5
 	darcs := make([]*Darc, n)
@@ -392,7 +392,7 @@ func TestDarc_DelegationCycle(t *testing.T) {
 	owners := make([]Signer, n)
 	identityStrs := make([]string, n)
 	for i := 0; i < n; i++ {
-		td := createDarc(1, "genesis darcs")
+		td := createDarc(1, "test cycle")
 		darcs[i] = td.darc
 		owners[i] = td.owners[0]
 		identityStrs[i] = td.ids[0].String()
@@ -400,19 +400,47 @@ func TestDarc_DelegationCycle(t *testing.T) {
 	}
 	for i := 0; i < n; i++ {
 		if i == n-1 {
-			evolvedDarcs[i].Rules.AddRule("cycle", []byte(darcs[0].GetIdentityString()))
-			evolvedDarcs[i].Rules.UpdateSign([]byte(darcs[0].GetIdentityString()))
+			require.NoError(t, evolvedDarcs[i].Rules.UpdateSign([]byte(darcs[0].GetIdentityString())))
 		} else {
-			evolvedDarcs[i].Rules.AddRule("cycle", []byte(darcs[i+1].GetIdentityString()))
-			evolvedDarcs[i].Rules.UpdateSign([]byte(darcs[i+1].GetIdentityString()))
+			require.NoError(t, evolvedDarcs[i].Rules.UpdateSign([]byte(darcs[i+1].GetIdentityString())))
 		}
 		require.NoError(t, localEvolution(evolvedDarcs[i], darcs[i], owners[i]))
 	}
 
 	getDarc := DarcsToGetDarcs(evolvedDarcs)
-	err := EvalExpr(evolvedDarcs[0].Rules.Get("cycle"), getDarc, identityStrs...)
+	err := EvalExpr([]byte(darcs[0].GetIdentityString()), getDarc, identityStrs...)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cycle detected")
+}
+
+// TestDarc_DelegationDiamond tests the situation when there are two darcs with
+// the sign rule pointing to a third darc. Evaluating darc:1 && darc:2 on the
+// signer of darc:3 should succeed.
+func TestDarc_DelegationDiamond(t *testing.T) {
+	n := 3
+	darcs := make([]*Darc, n)
+	evolvedDarcs := make([]*Darc, n)
+	owners := make([]Signer, n)
+	identityStrs := make([]string, n)
+	for i := 0; i < n; i++ {
+		td := createDarc(1, "test diamond")
+		darcs[i] = td.darc
+		owners[i] = td.owners[0]
+		identityStrs[i] = td.ids[0].String()
+		evolvedDarcs[i] = darcs[i].Copy()
+	}
+	require.NoError(t, evolvedDarcs[0].Rules.UpdateSign([]byte(darcs[2].GetIdentityString())))
+	require.NoError(t, evolvedDarcs[1].Rules.UpdateSign([]byte(darcs[2].GetIdentityString())))
+	require.NoError(t, evolvedDarcs[2].Rules.UpdateSign([]byte(identityStrs[2])))
+	for i := 0; i < n; i++ {
+		require.NoError(t, localEvolution(evolvedDarcs[i], darcs[i], owners[i]))
+	}
+
+	getDarc := DarcsToGetDarcs(evolvedDarcs)
+	expr := evolvedDarcs[0].GetIdentityString() + " & " + evolvedDarcs[1].GetIdentityString()
+	// use the owner of the third darc to evaluate
+	err := EvalExpr([]byte(expr), getDarc, identityStrs[2])
+	require.NoError(t, err)
 }
 
 func TestDarc_X509(t *testing.T) {


### PR DESCRIPTION
In general, there are two solutions to this problem. The first is to add a depth argument in the recursive call and check that it doesn't become too high. The second is to add a list of visited nodes and check that we don't visit a node in that list. I went for the second solution because picking the depth is tricky. My early implementation using a depth of 10,000 takes 0.3 seconds to return error. Making it too small might prevent legitimate uses. 

Fixes #1308