### PR TITLE
Implement ForEach for Trie and StagingTrie

### DIFF
--- a/byzcoin/contracts/coins_test.go
+++ b/byzcoin/contracts/coins_test.go
@@ -313,6 +313,10 @@ func (ct cvTest) GetIndex() int {
 	return ct.index
 }
 
+func (ct cvTest) ForEach(f func(k, v []byte) error) error {
+	return errors.New("not implemented")
+}
+
 func (ct cvTest) setSignatureCounter(id string, v uint64) {
 	key := sha256.Sum256([]byte("signercounter_" + id))
 	verBuf := make([]byte, 8)

--- a/byzcoin/statetrie.go
+++ b/byzcoin/statetrie.go
@@ -18,6 +18,7 @@ type ReadOnlyStateTrie interface {
 	GetValues(key []byte) (value []byte, version uint64, contractID string, darcID darc.ID, err error)
 	GetProof(key []byte) (*trie.Proof, error)
 	GetIndex() int
+	ForEach(func(k, v []byte) error) error
 }
 
 // stagingStateTrie is a wrapper around trie.StagingTrie that allows for use in

--- a/byzcoin/trie/dfs.go
+++ b/byzcoin/trie/dfs.go
@@ -67,3 +67,19 @@ func (p *countNodeProcessor) OnInterior(n interiorNode, k, v []byte) error {
 	p.total++
 	return nil
 }
+
+type leafCallbackProcessor struct {
+	cb func(k, v []byte) error
+}
+
+func (p *leafCallbackProcessor) OnEmpty(n emptyNode, k, v []byte) error {
+	return nil
+}
+
+func (p *leafCallbackProcessor) OnLeaf(n leafNode, k, v []byte) error {
+	return p.cb(n.Key, n.Value)
+}
+
+func (p *leafCallbackProcessor) OnInterior(n interiorNode, k, v []byte) error {
+	return nil
+}

--- a/byzcoin/trie/trie.go
+++ b/byzcoin/trie/trie.go
@@ -561,6 +561,20 @@ func (t *Trie) del(depth int, nodeKey []byte, bits []bool, key []byte, b Bucket)
 	return nil, errors.New("invalid node type")
 }
 
+// ForEach runs the callback cb on every key/value pair of the trie. The
+// iteration stops and the function returns an error when the callback returns
+// an error.
+func (t *Trie) ForEach(cb func(k, v []byte) error) error {
+	p := leafCallbackProcessor{cb}
+	return t.db.View(func(b Bucket) error {
+		rootKey := t.GetRootWithBucket(b)
+		if rootKey == nil {
+			return errors.New("no root key")
+		}
+		return t.dfs(&p, rootKey, b)
+	})
+}
+
 // IsValid checks whether the trie is valid.
 func (t *Trie) IsValid() error {
 	p := countNodeProcessor{}


### PR DESCRIPTION
This PR implements the ForEach feature in Trie and StagingTrie, similar
to the ForEach in the trie.DB interface. Unlike the one in DB,
Trie.ForEach only considers the leaf nodes.