### PR TITLE
Adds a GetNonce() method on a ReadOnlyStateTrie

### DIFF
--- a/byzcoin/contracts/coins_test.go
+++ b/byzcoin/contracts/coins_test.go
@@ -317,6 +317,10 @@ func (ct cvTest) ForEach(f func(k, v []byte) error) error {
 	return errors.New("not implemented")
 }
 
+func (ct cvTest) GetNonce() ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (ct cvTest) setSignatureCounter(id string, v uint64) {
 	key := sha256.Sum256([]byte("signercounter_" + id))
 	verBuf := make([]byte, 8)

--- a/byzcoin/statetrie.go
+++ b/byzcoin/statetrie.go
@@ -18,6 +18,7 @@ type ReadOnlyStateTrie interface {
 	GetValues(key []byte) (value []byte, version uint64, contractID string, darcID darc.ID, err error)
 	GetProof(key []byte) (*trie.Proof, error)
 	GetIndex() int
+	GetNonce() ([]byte, error)
 	ForEach(func(k, v []byte) error) error
 }
 

--- a/byzcoin/trie/staging.go
+++ b/byzcoin/trie/staging.go
@@ -34,6 +34,11 @@ type StagingTrie struct {
 	sync.Mutex
 }
 
+// GetNonce returns the nonce from the source Trie.
+func (t *StagingTrie) GetNonce() ([]byte, error) {
+	return t.source.nonce, nil
+}
+
 // Clone makes a clone of the uncommitted data of the staging trie. The source
 // trie used for creating the staging trie is not cloned.
 func (t *StagingTrie) Clone() *StagingTrie {

--- a/byzcoin/trie/trie.go
+++ b/byzcoin/trie/trie.go
@@ -18,6 +18,11 @@ type Trie struct {
 	noHashKey bool
 }
 
+// GetNonce returns the stored nonce.
+func (t *Trie) GetNonce() ([]byte, error) {
+	return t.nonce, nil
+}
+
 // LoadTrie loads the trie from a BoltDB database, it must exist otherwise an
 // error is returned. It does not check the consistency after loading the
 // database. If that is required, call IsValid.


### PR DESCRIPTION
This method is needed during the process of creating a new `StagingStateTrie` out of a `ReadOnlyStateTrie`. Here is the scenario:

```go
nonce, err := rst.GetNonce()
sst, err := newMemStagingStateTrie(nonce)
rst.ForEach(sst.Set)
```

Needed for #1837