### PR TITLE
Calypso java client optimization

### DIFF
--- a/external/java/pom.xml
+++ b/external/java/pom.xml
@@ -2,11 +2,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
 
     <groupId>ch.epfl.dedis</groupId>
     <artifactId>cothority</artifactId>
-    <version>3.0.2</version>
+    <version>3.0.3</version>
     <name>Cothority client library for Java</name>
     <description>A client library for communicating with cothorities (a collective authority).</description>
     <url>https://github.com/dedis/cothority</url>
@@ -224,5 +223,6 @@
         </profile>
     </profiles>
 
+    <modelVersion>4.0.0</modelVersion>
 </project>
 

--- a/external/java/src/main/java/ch/epfl/dedis/calypso/CalypsoRPC.java
+++ b/external/java/src/main/java/ch/epfl/dedis/calypso/CalypsoRPC.java
@@ -49,7 +49,7 @@ public class CalypsoRPC extends ByzCoinRPC {
     }
 
     /**
-     * Private constructor to keep reconnections to static methods called fromCalypso.
+     * Construct a CalypsoRPC from existing bc and lts.
      * @param bc existing byzcoin service
      * @param ltsId id of the Long Term Secret
      * @throws CothorityCommunicationException
@@ -186,6 +186,18 @@ public class CalypsoRPC extends ByzCoinRPC {
      */
     public static CalypsoRPC fromCalypso(Roster roster, SkipblockId byzcoinId, LTSId ltsId) throws CothorityException {
         return new CalypsoRPC(ByzCoinRPC.fromByzCoin(roster, byzcoinId), ltsId);
+    }
+
+    /**
+     * Connects to an existing Long Term Secret using a ByzCoinRPC.
+     *
+     * @param bc        the ByzCoinRPC to use to talk to the ledger
+     * @param ltsId     the id of the Long Term Secret to use
+     * @return CalypsoRPC if everything was found
+     * @throws CothorityException if something goes wrong
+     */
+    public static CalypsoRPC fromCalypso(ByzCoinRPC bc, LTSId ltsId) throws CothorityException {
+        return new CalypsoRPC(bc, ltsId);
     }
 
     /**

--- a/external/java/src/test/java/ch/epfl/dedis/calypso/CalypsoTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/calypso/CalypsoTest.java
@@ -407,15 +407,15 @@ class CalypsoTest {
             testInstanceController.startConode(i);
         }
 
+        // Reconnect to the ledger.
+        ByzCoinRPC bc = ByzCoinRPC.fromByzCoin(calypso.getRoster(), calypso.getGenesisBlock().getSkipchainId());
+
         // Dropping connection by re-creating an calypso. The following elements are needed:
-        // - roster
-        // - byzcoin-ic
         // - LTS-id
         // - WriteData-id
         // - reader-signer
         // - publisher-signer
-        CalypsoRPC calypso2 = CalypsoRPC.fromCalypso(calypso.getRoster(), calypso.getGenesisBlock().getSkipchainId(),
-                calypso.getLTSId());
+        CalypsoRPC calypso2 = CalypsoRPC.fromCalypso(bc, calypso.getLTSId());
         Signer reader2 = new SignerEd25519();
         SecureDarcInstance di = SecureDarcInstance.fromByzCoin(calypso2, readerDarc);
         readerDarc.addIdentity(Darc.RuleSignature, reader2.getIdentity(), Rules.OR);


### PR DESCRIPTION
Yann Gabbud noticed that the existing fromCalypso method was recreating
a ByxCoinRPC which was resulting in many more network round trips than
necessary. Add a new fromCalypso to allow him to correct this problem.