### PR TITLE
Implements the spawn and invoke update of the value contract

### DIFF
--- a/byzcoin/bcadmin/clicontracts/value.go
+++ b/byzcoin/bcadmin/clicontracts/value.go
@@ -1,0 +1,177 @@
+package clicontracts
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"go.dedis.ch/cothority/v3/byzcoin"
+	"go.dedis.ch/cothority/v3/byzcoin/bcadmin/lib"
+	"go.dedis.ch/cothority/v3/byzcoin/contracts"
+	"go.dedis.ch/cothority/v3/darc"
+	"gopkg.in/urfave/cli.v1"
+)
+
+// ValueSpawn is used to spawn a new contract.
+func ValueSpawn(c *cli.Context) error {
+	bcArg := c.String("bc")
+	if bcArg == "" {
+		return errors.New("--bc flag is required")
+	}
+
+	value := c.String("value")
+	if value == "" {
+		return errors.New("--value flag is required")
+	}
+	valueBuf := []byte(value)
+
+	cfg, cl, err := lib.LoadConfig(bcArg)
+	if err != nil {
+		return err
+	}
+
+	dstr := c.String("darc")
+	if dstr == "" {
+		dstr = cfg.AdminDarc.GetIdentityString()
+	}
+	d, err := lib.GetDarcByString(cl, dstr)
+	if err != nil {
+		return err
+	}
+
+	var signer *darc.Signer
+
+	sstr := c.String("sign")
+	if sstr == "" {
+		signer, err = lib.LoadKey(cfg.AdminIdentity)
+	} else {
+		signer, err = lib.LoadKeyFromString(sstr)
+	}
+	if err != nil {
+		return err
+	}
+
+	counters, err := cl.GetSignerCounters(signer.Identity().String())
+
+	spawn := byzcoin.Spawn{
+		ContractID: contracts.ContractValueID,
+		Args: []byzcoin.Argument{
+			{
+				Name:  "value",
+				Value: valueBuf,
+			},
+		},
+	}
+
+	ctx := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{
+			{
+				InstanceID:    byzcoin.NewInstanceID(d.GetBaseID()),
+				Spawn:         &spawn,
+				SignerCounter: []uint64{counters.Counters[0] + 1},
+			},
+		},
+	}
+	err = ctx.FillSignersAndSignWith(*signer)
+	if err != nil {
+		return err
+	}
+
+	_, err = cl.AddTransactionAndWait(ctx, 10)
+	if err != nil {
+		return err
+	}
+
+	instID := ctx.Instructions[0].DeriveID("").Slice()
+	_, err = fmt.Fprintf(c.App.Writer, "Spawned new value contract. Instance id is: \n%x\n", instID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ValueInvokeUpdate is able to update the value of a value contract
+func ValueInvokeUpdate(c *cli.Context) error {
+	bcArg := c.String("bc")
+	if bcArg == "" {
+		return errors.New("--bc flag is required")
+	}
+
+	value := c.String("value")
+	if value == "" {
+		return errors.New("--value flag is required")
+	}
+	valueBuf := []byte(value)
+
+	instID := c.String("instID")
+	if instID == "" {
+		return errors.New("--instID flag is required")
+	}
+	instIDBuf, err := hex.DecodeString(instID)
+	if err != nil {
+		return errors.New("failed to decode the instID string")
+	}
+
+	cfg, cl, err := lib.LoadConfig(bcArg)
+	if err != nil {
+		return err
+	}
+
+	dstr := c.String("darc")
+	if dstr == "" {
+		dstr = cfg.AdminDarc.GetIdentityString()
+	}
+
+	var signer *darc.Signer
+
+	sstr := c.String("sign")
+	if sstr == "" {
+		signer, err = lib.LoadKey(cfg.AdminIdentity)
+	} else {
+		signer, err = lib.LoadKeyFromString(sstr)
+	}
+	if err != nil {
+		return err
+	}
+
+	counters, err := cl.GetSignerCounters(signer.Identity().String())
+
+	invoke := byzcoin.Invoke{
+		ContractID: contracts.ContractValueID,
+		Command:    "update",
+		Args: []byzcoin.Argument{
+			{
+				Name:  "value",
+				Value: valueBuf,
+			},
+		},
+	}
+
+	ctx := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{
+			{
+				InstanceID:    byzcoin.NewInstanceID([]byte(instIDBuf)),
+				Invoke:        &invoke,
+				SignerCounter: []uint64{counters.Counters[0] + 1},
+			},
+		},
+	}
+	err = ctx.FillSignersAndSignWith(*signer)
+	if err != nil {
+		return err
+	}
+
+	_, err = cl.AddTransactionAndWait(ctx, 10)
+	if err != nil {
+		return err
+	}
+
+	newInstID := ctx.Instructions[0].DeriveID("").Slice()
+	_, err = fmt.Fprintf(c.App.Writer, "Value contract updated! (instance ID is %x)\n", newInstID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/byzcoin/bcadmin/lib/utils.go
+++ b/byzcoin/bcadmin/lib/utils.go
@@ -1,0 +1,72 @@
+package lib
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.dedis.ch/cothority/v3/byzcoin"
+	"go.dedis.ch/cothority/v3/darc"
+)
+
+// StringToDarcID converts a string representation of a DARC to a byte array
+func StringToDarcID(id string) ([]byte, error) {
+	if id == "" {
+		return nil, errors.New("no string given")
+	}
+	if strings.HasPrefix(id, "darc:") {
+		id = id[5:]
+	}
+	return hex.DecodeString(id)
+}
+
+// StringToEd25519Buf converts the string representation of an ed25519 key to a
+// byte array
+func StringToEd25519Buf(pub string) ([]byte, error) {
+	if pub == "" {
+		return nil, errors.New("no string given")
+	}
+	if strings.HasPrefix(pub, "ed25519:") {
+		pub = pub[8:]
+	}
+	return hex.DecodeString(pub)
+}
+
+// GetDarcByString returns a DARC given its ID as a string
+func GetDarcByString(cl *byzcoin.Client, id string) (*darc.Darc, error) {
+	xrep, err := StringToDarcID(id)
+	if err != nil {
+		return nil, err
+	}
+	return GetDarcByID(cl, xrep)
+}
+
+// GetDarcByID returns a DARC given its ID as a byte array
+func GetDarcByID(cl *byzcoin.Client, id []byte) (*darc.Darc, error) {
+	pr, err := cl.GetProof(id)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &pr.Proof
+	err = p.Verify(cl.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	vs, cid, _, err := p.Get(id)
+	if err != nil {
+		return nil, fmt.Errorf("could not find darc for %x", id)
+	}
+	if cid != byzcoin.ContractDarcID {
+		return nil, fmt.Errorf("unexpected contract %v, expected a darc", cid)
+	}
+
+	d, err := darc.NewFromProtobuf(vs)
+	if err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -1181,7 +1181,7 @@ func darcCdesc(c *cli.Context) error {
 		dstr = cfg.AdminDarc.GetIdentityString()
 	}
 
-	d, err := getDarcByString(cl, dstr)
+	d, err := lib.GetDarcByString(cl, dstr)
 	if err != nil {
 		return err
 	}

--- a/byzcoin/bcadmin/test.sh
+++ b/byzcoin/bcadmin/test.sh
@@ -33,6 +33,7 @@ main(){
     run testExpression
     run testLinkPermission
     run testQR
+    run testContractValue
     stopTest
 }
 
@@ -234,6 +235,34 @@ testQR() {
   [ -z "$BC" ] && exit 1
 
   testOK ./"$APP" qr -admin
+}
+
+testContractValue() {
+  # In this test we spawn a value contract and then update its value
+  runCoBG 1 2 3
+  runGrepSed "export BC=" "" runBA create --roster public.toml --interval .5s
+  eval $SED
+  [ -z "$BC" ] && exit 1
+
+  # Add the spawn:value and invoke:value.update rules
+  testOK runBA darc add -out_id ./darc_id.txt -out_key ./darc_key.txt -unrestricted
+  ID=`cat ./darc_id.txt`
+  KEY=`cat ./darc_key.txt`
+  testOK runBA darc rule -rule "spawn:value" --identity "$KEY" --darc "$ID" --sign "$KEY"
+  
+  # Spawn a new value contract, we save the output to the res.txt file
+  testOK runBA darc rule -rule "invoke:value.update" --identity "$KEY" --darc "$ID" --sign "$KEY"
+  OUTFILE=res.txt && testOK runBA contract value spawn --value "myValue" --darc "$ID" --sign "$KEY"
+  OUTFILE=""
+  
+  # Check if we got the expected output
+  testGrep "Spawned new value contract. Instance id is:" cat res.txt
+  
+  # Extract the instance ID of the newly created value instance
+  VALUE_INSTANCE_ID=`sed -n 2p res.txt`
+  
+  # Update the value instance based on the instance ID
+  testOK runBA contract value invoke update --value "newValue" --instID $VALUE_INSTANCE_ID --darc "$ID" --sign "$KEY"
 }
 
 main


### PR DESCRIPTION
This is the first step of using deferred contracts with bcadmin. The plan is to implement the manipulation of contracts in the `bcadmin/clicontracts`* package.
 
Each contract should be usable on its own. For example, creating a new value contract with `bcadmin contract value spawn --value "myValue"`), but also on its deferred version, where a pipe and a special param (like `--redirect`) is used to redirect the transaction to a deferred contract:

- `bcadmin contract value spawn --value "myValue" --redirect | bcadmin contract deferred spawn`

with this, the value contract is not directly spawned, but the transaction is passed as argument to the spawn of a deferred contract.

**The changes of this PR**:
- Moves utility functions to lib/utils.go
- Adds a new package "clicontracts", which will hold the handling of contracts for bcadmin
- Implements the value contract in the "clicontracts" package

We use the following logic to manipulate contracts:
- `bcadmin contract <contract name> <action> [command] [--<arg1> <value arg1>, ... ] [--instID <instID>]`

For example (this is what is implemented with this PR):
- `bcadmin contract value spawn --value "myValue"`
- `bcadmin contract value invoke update --value "newValue" --instID deadbeef1234`

 (* "cli" stands for "Command Line Interface". This idea is to provide the "cli" version of a contract. Let me know if there is a better name.)