### PR TITLE
Ignores the bin folder and .project of external/java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ scmgr/scmgr
 cisc/cisc
 cosi/simulation/build/
 cosi/simulation/test_data/
+external/java/bin
+external/java/.project
 *~
 .tags*
 **/build/


### PR DESCRIPTION
Those are generated during the build and should not be checked in.