### PR TITLE
Refactors the clicontract/value.go test

### DIFF
--- a/byzcoin/bcadmin/clicontracts/value_test.sh
+++ b/byzcoin/bcadmin/clicontracts/value_test.sh
@@ -1,0 +1,29 @@
+# This method should be called from the byzcoin/bcadmin/test.sh script
+
+testContractValue() {
+    # In this test we spawn a value contract and then update its value
+    runCoBG 1 2 3
+    runGrepSed "export BC=" "" runBA create --roster public.toml --interval .5s
+    eval $SED
+    [ -z "$BC" ] && exit 1
+
+    # Add the spawn:value and invoke:value.update rules
+    testOK runBA darc add -out_id ./darc_id.txt -out_key ./darc_key.txt -unrestricted
+    ID=`cat ./darc_id.txt`
+    KEY=`cat ./darc_key.txt`
+    testOK runBA darc rule -rule "spawn:value" --identity "$KEY" --darc "$ID" --sign "$KEY"
+
+    # Spawn a new value contract, we save the output to the res.txt file
+    testOK runBA darc rule -rule "invoke:value.update" --identity "$KEY" --darc "$ID" --sign "$KEY"
+    OUTFILE=res.txt && testOK runBA contract value spawn --value "myValue" --darc "$ID" --sign "$KEY"
+    OUTFILE=""
+
+    # Check if we got the expected output
+    testGrep "Spawned new value contract. Instance id is:" cat res.txt
+
+    # Extract the instance ID of the newly created value instance
+    VALUE_INSTANCE_ID=`sed -n 2p res.txt`
+
+    # Update the value instance based on the instance ID
+    testOK runBA contract value invoke update --value "newValue" --instID $VALUE_INSTANCE_ID --darc "$ID" --sign "$KEY"
+}

--- a/byzcoin/bcadmin/test.sh
+++ b/byzcoin/bcadmin/test.sh
@@ -17,6 +17,7 @@ export -n BC_CONFIG
 export -n BC
 
 . "../../libtest.sh"
+. "../clicontracts/value_test.sh"
 
 main(){
     startTest
@@ -33,8 +34,8 @@ main(){
     run testExpression
     run testLinkPermission
     run testQR
-    run testContractValue
     run testUpdateDarcDesc
+    run testContractValue
     stopTest
 }
 
@@ -256,33 +257,5 @@ testUpdateDarcDesc() {
   testOK runBA darc cdesc --desc "New description" --darc "$ID"
   testGrep "New description" runBA darc show
 }
-
-testContractValue() {
-	  # In this test we spawn a value contract and then update its value
-	  runCoBG 1 2 3
-	  runGrepSed "export BC=" "" runBA create --roster public.toml --interval .5s
-	  eval $SED
-	  [ -z "$BC" ] && exit 1
-	
-	  # Add the spawn:value and invoke:value.update rules
-	  testOK runBA darc add -out_id ./darc_id.txt -out_key ./darc_key.txt -unrestricted
-	  ID=`cat ./darc_id.txt`
-	  KEY=`cat ./darc_key.txt`
-	  testOK runBA darc rule -rule "spawn:value" --identity "$KEY" --darc "$ID" --sign "$KEY"
-	
-	  # Spawn a new value contract, we save the output to the res.txt file
-	  testOK runBA darc rule -rule "invoke:value.update" --identity "$KEY" --darc "$ID" --sign "$KEY"
-	  OUTFILE=res.txt && testOK runBA contract value spawn --value "myValue" --darc "$ID" --sign "$KEY"
-	  OUTFILE=""
-	
-	  # Check if we got the expected output
-	  testGrep "Spawned new value contract. Instance id is:" cat res.txt
-	
-	  # Extract the instance ID of the newly created value instance
-	  VALUE_INSTANCE_ID=`sed -n 2p res.txt`
-	
-	  # Update the value instance based on the instance ID
-	  testOK runBA contract value invoke update --value "newValue" --instID $VALUE_INSTANCE_ID --darc "$ID" --sign "$KEY"
-	}
 
 main


### PR DESCRIPTION
Since I am adding more contracts to `bcadmin/clicontracts`, I think its best to have each contract's corresponding tests within the `bcadmin/clicontracts` folder.

What I did:
- created a new `bcadmin/clicontracts/value_test.sh` file
- Moved the function `testContractValue()` from `bcadmin/test.sh` to `bcadmin/clicontracts/value_test.sh`

This is a small step towards using deferred contracts from bcadmin 