### PR TITLE
Bcadmin: deferred clicontract

### DIFF
--- a/byzcoin/bcadmin/clicontracts/README.md
+++ b/byzcoin/bcadmin/clicontracts/README.md
@@ -1,0 +1,64 @@
+# CLI Contracts
+
+Command Line Interface for Contracts.
+
+**The idea**:
+
+By implementing a CLI version of a contract, we provide an interface to
+manipulate contracts directly from the shell. Each clicontract should stay in
+its own file accompagned by its test file.
+
+To make things simpler to use, implement, and maintain, we use the same set of
+commands and functionalities among clicontracts.
+
+**Commands convention**:
+
+```bash
+$ bcadmin contract <contract name> {spawn,invoke <command>, delete, get}\
+                                   [--<param name> <param value>, ...]\
+                                   [--sign <signer id>] [--darc <darc id>]\
+                                   [--redirect]
+```
+
+**Functionalities**:
+
+* With the `--redirect`, the contract's transaction should not be executed, but
+redirected to stdout.
+
+* Each contract should have a `get` function, which allows one to get the
+contract's data given its instance id with `--instID`.
+
+**Global conventions**:
+
+* *inst* stands for *instance*
+* *instr* stands for *instruction*
+* *id* stands for *identifier*
+* *idx* stands for *index*
+
+**Command examples**:
+
+Spawn a value contract:
+
+```bash
+$ bcadmin contract value spawn --value "Hello World"
+```
+
+Update a value contract:
+
+```bash
+# The --instID is given when we spawn the value contract
+$ bcadmin contract value invoke update --value "Bye World" --instID ...
+```
+
+Spawn a deferred contract with a value contract as the proposed transaction:
+
+```bash
+$ bcadmin contract value spawn --value "Hello Word" --redirect | bcadmin contract deferred spawn
+```
+
+Invoke an addProof on a deferred contract:
+
+```bash
+# The --hash and --instID values are given when we spawn the deferred contract
+bcadmin contract deferred invoke addProof --hash ... --instID ... --iid 0
+```

--- a/byzcoin/bcadmin/clicontracts/deferred.go
+++ b/byzcoin/bcadmin/clicontracts/deferred.go
@@ -28,13 +28,13 @@ func DeferredSpawn(c *cli.Context) error {
 	// ---
 	proposedTransactionBuf, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
-		return errors.New("Failed to read from stding: " + err.Error())
+		return errors.New("failed to read from stding: " + err.Error())
 	}
 
 	proposedTransaction := byzcoin.ClientTransaction{}
 	err = protobuf.Decode(proposedTransactionBuf, &proposedTransaction)
 	if err != nil {
-		return errors.New("Failed to decode transaction: " + err.Error())
+		return errors.New("failed to decode transaction: " + err.Error())
 	}
 
 	// ---
@@ -184,7 +184,7 @@ func DeferredInvokeAddProof(c *cli.Context) error {
 	}
 	hash, err := hex.DecodeString(hashStr)
 	if err != nil {
-		return errors.New("Coulndn't decode the hash string: " + err.Error())
+		return errors.New("coulndn't decode the hash string: " + err.Error())
 	}
 
 	instID := c.String("instID")
@@ -207,12 +207,12 @@ func DeferredInvokeAddProof(c *cli.Context) error {
 	identity := signer.Identity()
 	identityBuf, err := protobuf.Encode(&identity)
 	if err != nil {
-		return errors.New("Coulndn't encode the identity: " + err.Error())
+		return errors.New("coulndn't encode the identity: " + err.Error())
 	}
 
 	signature, err := signer.Sign(hash)
 	if err != nil {
-		return errors.New("Couldn't sign the hash: " + err.Error())
+		return errors.New("couldn't sign the hash: " + err.Error())
 	}
 
 	// ---

--- a/byzcoin/bcadmin/clicontracts/deferred.go
+++ b/byzcoin/bcadmin/clicontracts/deferred.go
@@ -1,0 +1,374 @@
+package clicontracts
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"go.dedis.ch/cothority/v3/byzcoin"
+	"go.dedis.ch/cothority/v3/byzcoin/bcadmin/lib"
+	"go.dedis.ch/cothority/v3/darc"
+	"go.dedis.ch/protobuf"
+	"gopkg.in/urfave/cli.v1"
+)
+
+// DeferredSpawn is used to spawn a new deferred contract. It expects stdin to
+// contain the proposed transaction.
+func DeferredSpawn(c *cli.Context) error {
+	// Here is what this function does:
+	//   1. Parses the stdin in order to get the proposed transaction
+	//   2. Fires a spawn instruction for the deferred contract
+	//   3. Gets the response back
+
+	// ---
+	// 1.
+	// ---
+	proposedTransactionBuf, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		return errors.New("Failed to read from stding: " + err.Error())
+	}
+
+	proposedTransaction := byzcoin.ClientTransaction{}
+	err = protobuf.Decode(proposedTransactionBuf, &proposedTransaction)
+	if err != nil {
+		return errors.New("Failed to decode transaction: " + err.Error())
+	}
+
+	// ---
+	// 2.
+	// ---
+	bcArg := c.String("bc")
+	if bcArg == "" {
+		return errors.New("--bc flag is required")
+	}
+
+	cfg, cl, err := lib.LoadConfig(bcArg)
+	if err != nil {
+		return err
+	}
+
+	dstr := c.String("darc")
+	if dstr == "" {
+		dstr = cfg.AdminDarc.GetIdentityString()
+	}
+	d, err := lib.GetDarcByString(cl, dstr)
+	if err != nil {
+		return err
+	}
+
+	var signer *darc.Signer
+
+	sstr := c.String("sign")
+	if sstr == "" {
+		signer, err = lib.LoadKey(cfg.AdminIdentity)
+	} else {
+		signer, err = lib.LoadKeyFromString(sstr)
+	}
+	if err != nil {
+		return err
+	}
+
+	expireBlockIndexInt := uint64(6000)
+	expireBlockIndexBuf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(expireBlockIndexBuf, expireBlockIndexInt)
+
+	counters, err := cl.GetSignerCounters(signer.Identity().String())
+
+	spawn := byzcoin.Spawn{
+		ContractID: byzcoin.ContractDeferredID,
+		Args: []byzcoin.Argument{
+			{
+				Name:  "proposedTransaction",
+				Value: proposedTransactionBuf,
+			},
+			{
+				Name:  "expireBlockIndex",
+				Value: expireBlockIndexBuf,
+			},
+		},
+	}
+
+	ctx := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{
+			{
+				InstanceID:    byzcoin.NewInstanceID(d.GetBaseID()),
+				Spawn:         &spawn,
+				SignerCounter: []uint64{counters.Counters[0] + 1},
+			},
+		},
+	}
+
+	err = ctx.FillSignersAndSignWith(*signer)
+	if err != nil {
+		return err
+	}
+
+	_, err = cl.AddTransactionAndWait(ctx, 10)
+	if err != nil {
+		return err
+	}
+
+	instID := ctx.Instructions[0].DeriveID("").Slice()
+	_, err = fmt.Fprintf(c.App.Writer, "Spawned new deferred contract, its instance id is: \n%x\n", instID)
+	if err != nil {
+		return err
+	}
+
+	// ---
+	// 3.
+	// ---
+	pr, err := cl.GetProof(instID)
+	if err != nil {
+		return errors.New("couldn't get proof for admin-darc: " + err.Error())
+	}
+	proof := pr.Proof
+
+	_, resultBuf, _, _, err := proof.KeyValue()
+	if err != nil {
+		return errors.New("couldn't get value out of proof: " + err.Error())
+	}
+
+	result := byzcoin.DeferredData{}
+	err = protobuf.Decode(resultBuf, &result)
+	if err != nil {
+		return errors.New("couldn't decode the result: " + err.Error())
+	}
+
+	fmt.Fprintf(c.App.Writer, "Here is the deferred data: \n%s\n", result)
+
+	return nil
+}
+
+// DeferredInvokeAddProof is used to add the proof of a proposed transaction's
+// instruction. The proof is computed on the given --hash and based on the
+// identity provided by --sign or, by default, the admin.
+func DeferredInvokeAddProof(c *cli.Context) error {
+	// Here is what this function does:
+	//   1. Parses the inoput arguments
+	//   2. Computes the signature based on the identity (--sign), the
+	//      instruction id (--iid), and the hash (--hash)
+	//   3. Sends the addProof transaction
+	//   4. Reads the transaction return value (deferred data)
+
+	// ---
+	// 1.
+	// ---
+	bcArg := c.String("bc")
+	if bcArg == "" {
+		return errors.New("--bc flag is required")
+	}
+
+	cfg, cl, err := lib.LoadConfig(bcArg)
+	if err != nil {
+		return err
+	}
+
+	var signer *darc.Signer
+
+	sstr := c.String("sign")
+	if sstr == "" {
+		signer, err = lib.LoadKey(cfg.AdminIdentity)
+	} else {
+		signer, err = lib.LoadKeyFromString(sstr)
+	}
+	if err != nil {
+		return err
+	}
+
+	hashStr := c.String("hash")
+	if hashStr == "" {
+		return errors.New("--hash not found")
+	}
+	hash, err := hex.DecodeString(hashStr)
+	if err != nil {
+		return errors.New("Coulndn't decode the hash string: " + err.Error())
+	}
+
+	instID := c.String("instID")
+	if instID == "" {
+		return errors.New("--instID flag is required")
+	}
+	instIDBuf, err := hex.DecodeString(instID)
+	if err != nil {
+		return errors.New("failed to decode the instID string: " + err.Error())
+	}
+
+	iid := c.Uint("iid")
+	index := uint32(iid)
+	indexBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(indexBuf, uint32(index))
+
+	// ---
+	// 2.
+	// ---
+	identity := signer.Identity()
+	identityBuf, err := protobuf.Encode(&identity)
+	if err != nil {
+		return errors.New("Coulndn't encode the identity: " + err.Error())
+	}
+
+	signature, err := signer.Sign(hash)
+	if err != nil {
+		return errors.New("Couldn't sign the hash: " + err.Error())
+	}
+
+	// ---
+	// 3.
+	// ---
+	counters, err := cl.GetSignerCounters(signer.Identity().String())
+
+	ctx := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: byzcoin.NewInstanceID(instIDBuf),
+			Invoke: &byzcoin.Invoke{
+				ContractID: byzcoin.ContractDeferredID,
+				Command:    "addProof",
+				Args: []byzcoin.Argument{
+					{
+						Name:  "identity",
+						Value: identityBuf,
+					},
+					{
+						Name:  "signature",
+						Value: signature,
+					},
+					{
+						Name:  "index",
+						Value: indexBuf,
+					},
+				},
+			},
+			SignerCounter: []uint64{counters.Counters[0] + 1},
+		}},
+	}
+
+	err = ctx.FillSignersAndSignWith(*signer)
+	if err != nil {
+		return err
+	}
+
+	_, err = cl.AddTransactionAndWait(ctx, 10)
+	if err != nil {
+		return err
+	}
+
+	// ---
+	// 4.
+	// ---
+	pr, err := cl.GetProof(instIDBuf)
+	if err != nil {
+		return errors.New("couldn't get proof for admin-darc: " + err.Error())
+	}
+	proof := pr.Proof
+
+	_, resultBuf, _, _, err := proof.KeyValue()
+	if err != nil {
+		return errors.New("couldn't get value out of proof: " + err.Error())
+	}
+
+	result := byzcoin.DeferredData{}
+	err = protobuf.Decode(resultBuf, &result)
+	if err != nil {
+		return errors.New("couldn't decode the result: " + err.Error())
+	}
+
+	fmt.Fprintf(c.App.Writer, "Here is the deferred data: \n%s\n", result)
+
+	return nil
+}
+
+// ExecProposedTx is used to execute the proposed transaction if all the
+// instructions are correctly signed.
+func ExecProposedTx(c *cli.Context) error {
+	// Here is what this function does:
+	//   1. Parses the input argument
+	//   2. Sends an "execProposedTx" transaction
+	//   3. Reads the return back and prints it
+
+	// ---
+	// 1.
+	// ---
+	bcArg := c.String("bc")
+	if bcArg == "" {
+		return errors.New("--bc flag is required")
+	}
+
+	cfg, cl, err := lib.LoadConfig(bcArg)
+	if err != nil {
+		return err
+	}
+
+	var signer *darc.Signer
+
+	sstr := c.String("sign")
+	if sstr == "" {
+		signer, err = lib.LoadKey(cfg.AdminIdentity)
+	} else {
+		signer, err = lib.LoadKeyFromString(sstr)
+	}
+	if err != nil {
+		return err
+	}
+
+	instID := c.String("instID")
+	if instID == "" {
+		return errors.New("--instID flag is required")
+	}
+	instIDBuf, err := hex.DecodeString(instID)
+	if err != nil {
+		return errors.New("failed to decode the instID string")
+	}
+
+	// ---
+	// 2.
+	// ---
+	counters, err := cl.GetSignerCounters(signer.Identity().String())
+
+	ctx := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID: byzcoin.NewInstanceID(instIDBuf),
+			Invoke: &byzcoin.Invoke{
+				ContractID: byzcoin.ContractDeferredID,
+				Command:    "execProposedTx",
+			},
+			SignerCounter: []uint64{counters.Counters[0] + 1},
+		}},
+	}
+
+	err = ctx.FillSignersAndSignWith(*signer)
+	if err != nil {
+		return err
+	}
+
+	_, err = cl.AddTransactionAndWait(ctx, 10)
+	if err != nil {
+		return err
+	}
+
+	// ---
+	// 3.
+	// ---
+	pr, err := cl.GetProof(instIDBuf)
+	if err != nil {
+		return errors.New("couldn't get proof for admin-darc: " + err.Error())
+	}
+	proof := pr.Proof
+
+	_, resultBuf, _, _, err := proof.KeyValue()
+	if err != nil {
+		return errors.New("couldn't get value out of proof: " + err.Error())
+	}
+
+	result := byzcoin.DeferredData{}
+	err = protobuf.Decode(resultBuf, &result)
+	if err != nil {
+		return errors.New("couldn't decode the result: " + err.Error())
+	}
+
+	fmt.Fprintf(c.App.Writer, "Here is the deferred data: \n%s\n", result)
+
+	return nil
+}

--- a/byzcoin/bcadmin/clicontracts/deferred.go
+++ b/byzcoin/bcadmin/clicontracts/deferred.go
@@ -149,7 +149,7 @@ func DeferredInvokeAddProof(c *cli.Context) error {
 	// Here is what this function does:
 	//   1. Parses the inoput arguments
 	//   2. Computes the signature based on the identity (--sign), the
-	//      instruction id (--iid), and the hash (--hash)
+	//      instruction id (--instrIdx), and the hash (--hash)
 	//   3. Sends the addProof transaction
 	//   4. Reads the transaction return value (deferred data)
 
@@ -196,8 +196,8 @@ func DeferredInvokeAddProof(c *cli.Context) error {
 		return errors.New("failed to decode the instID string: " + err.Error())
 	}
 
-	iid := c.Uint("iid")
-	index := uint32(iid)
+	instrIdx := c.Uint("instrIdx")
+	index := uint32(instrIdx)
 	indexBuf := make([]byte, 4)
 	binary.LittleEndian.PutUint32(indexBuf, uint32(index))
 

--- a/byzcoin/bcadmin/clicontracts/deferred_test.sh
+++ b/byzcoin/bcadmin/clicontracts/deferred_test.sh
@@ -80,7 +80,7 @@ testContractDeferredInvoke() {
         }'`
     echo -e "Here is the hash:\t\t$HASH"
     
-    testOK runBA contract deferred invoke addProof --instID "$DEFERRED_INSTANCE_ID" --hash "$HASH" --iid 0 --sign "$KEY" --darc "$ID"
+    testOK runBA contract deferred invoke addProof --instID "$DEFERRED_INSTANCE_ID" --hash "$HASH" --instrIdx 0 --sign "$KEY" --darc "$ID"
 
     testOK runBA contract deferred invoke execProposedTx --instID "$DEFERRED_INSTANCE_ID" --sign "$KEY"
 }

--- a/byzcoin/bcadmin/clicontracts/deferred_test.sh
+++ b/byzcoin/bcadmin/clicontracts/deferred_test.sh
@@ -1,0 +1,86 @@
+# This method should be called from the byzcoin/bcadmin/test.sh script
+
+testContractDeferred() {
+    run testContractDeferredSpawn
+    run testContractDeferredInvoke
+}
+
+# We rely on the value contract to make our tests.
+testContractDeferredSpawn() {
+    # In this test we spawn a value with the --redirect flag and then pipe it
+    # to the deferred spawn. We then check the output and see if the proposed
+    # transaction is there.
+    runCoBG 1 2 3
+    runGrepSed "export BC=" "" runBA create --roster public.toml --interval .5s
+    eval $SED
+    [ -z "$BC" ] && exit 1
+
+    # Add the spawn:value and spawn:deferred rules
+    testOK runBA darc add -out_id ./darc_id.txt -out_key ./darc_key.txt -unrestricted
+    ID=`cat ./darc_id.txt`
+    KEY=`cat ./darc_key.txt`
+    testOK runBA darc rule -rule "spawn:value" --identity "$KEY" --darc "$ID" --sign "$KEY"
+    testOK runBA darc rule -rule "spawn:deferred" --identity "$KEY" --darc "$ID" --sign "$KEY"
+
+    # Spawn a new value contract that is piped to the spawn of a deferred
+    # contract. We save the output to the OUTRES variable.
+    OUTRES=`runBA contract value spawn --value "myValue" --redirect --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
+
+    # Check if we got the expected output
+    testGrep "Here is the deferred data:" echo "$OUTRES"
+    testGrep "action: spawn:value" echo "$OUTRES"
+    testGrep "identities: \[\]" echo "$OUTRES"
+    testGrep "counters: \[\]" echo "$OUTRES"
+    testGrep "signatures: 0" echo "$OUTRES"
+    testGrep "Spawn:	value" echo "$OUTRES"
+    testGrep "Args:value" echo "$OUTRES"
+    testGrep "Spawned new deferred contract, its instance id is:" echo "$OUTRES"
+}
+
+# This method relies on testContractDeferredSpawn() and performs an addProof
+# on the proposed transaction.
+testContractDeferredInvoke() {
+    # In this test we do the same as testContractDeferredSpawn() but we then
+    # perform an addProof followed by an execProposedTx.
+    runCoBG 1 2 3
+    runGrepSed "export BC=" "" runBA create --roster public.toml --interval .5s
+    eval $SED
+    [ -z "$BC" ] && exit 1
+
+    # Add the spawn:value, spawn:deferred, invoke:deferred.addProof and
+    # invoke:deferred:execProposedTx rules
+    testOK runBA darc add -out_id ./darc_id.txt -out_key ./darc_key.txt -unrestricted
+    ID=`cat ./darc_id.txt`
+    KEY=`cat ./darc_key.txt`
+    testOK runBA darc rule -rule "spawn:value" --identity "$KEY" --darc "$ID" --sign "$KEY"
+    testOK runBA darc rule -rule "spawn:deferred" --identity "$KEY" --darc "$ID" --sign "$KEY"
+    testOK runBA darc rule -rule "invoke:deferred.addProof" --identity "$KEY" --darc "$ID" --sign "$KEY"
+    testOK runBA darc rule -rule "invoke:deferred.execProposedTx" --identity "$KEY" --darc "$ID" --sign "$KEY"
+
+    # Spawn a new value contract that is piped to the spawn of a deferred
+    # contract.
+    OUTRES=`runBA contract value spawn --value "myValue" --redirect --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
+
+    # We know the instance ID is the next line after "Spawned new deferred contract..."
+    DEFERRED_INSTANCE_ID=`echo "$OUTRES" | sed -n ' 
+        /Spawned new deferred contract/ {
+            n
+            p
+        }'`
+    echo -e "Here is the instance ID:\t$DEFERRED_INSTANCE_ID"
+
+    # We know the array conaining the hash to sign is the second line after
+    # "- Instruction hashes:" and we remove the "--- " prefix.
+    HASH=`echo "$OUTRES" | sed -n ' 
+        /- Instruction hashes:/ {
+            n
+            n
+            s/--- //
+            p
+        }'`
+    echo -e "Here is the hash:\t\t$HASH"
+    
+    testOK runBA contract deferred invoke addProof --instID "$DEFERRED_INSTANCE_ID" --hash "$HASH" --iid 0 --sign "$KEY" --darc "$ID"
+
+    testOK runBA contract deferred invoke execProposedTx --instID "$DEFERRED_INSTANCE_ID" --sign "$KEY"
+}

--- a/byzcoin/bcadmin/clicontracts/deferred_test.sh
+++ b/byzcoin/bcadmin/clicontracts/deferred_test.sh
@@ -38,7 +38,7 @@ testContractDeferredSpawn() {
 }
 
 # This method relies on testContractDeferredSpawn() and performs an addProof
-# on the proposed transaction.
+# on the proposed transaction and an execProposedTx.
 testContractDeferredInvoke() {
     # In this test we do the same as testContractDeferredSpawn() but we then
     # perform an addProof followed by an execProposedTx.

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -377,6 +377,10 @@ var cmds = cli.Commands{
 								Name:  "sign",
 								Usage: "public key of the signing entity (default is the admin public key)",
 							},
+							cli.BoolFlag{
+								Name:  "redirect",
+								Usage: "redirects the transaction to stdout",
+							},
 						},
 					},
 					{
@@ -404,6 +408,94 @@ var cmds = cli.Commands{
 									cli.StringFlag{
 										Name:  "darc",
 										Usage: "DARC with the right to invoke.update a value contract (default is the admin DARC)",
+									},
+									cli.StringFlag{
+										Name:  "sign",
+										Usage: "public key of the signing entity (default is the admin public key)",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name:  "deferred",
+				Usage: "Manipulate a vadeferred contract",
+				Subcommands: cli.Commands{
+					{
+						Name:   "spawn",
+						Usage:  "spawn a deferred contract with the proposed transaction in stdin",
+						Action: clicontracts.DeferredSpawn,
+						Flags: []cli.Flag{
+							cli.StringFlag{
+								Name:   "bc",
+								EnvVar: "BC",
+								Usage:  "the ByzCoin config to use (required)",
+							},
+							cli.StringFlag{
+								Name:  "darc",
+								Usage: "DARC with the right to spawn a deferred contract (default is the admin DARC)",
+							},
+							cli.StringFlag{
+								Name:  "sign",
+								Usage: "public key of the signing entity (default is the admin public key)",
+							},
+						},
+					},
+					{
+						Name:  "invoke",
+						Usage: "invokw on a deferred contract ",
+						Subcommands: cli.Commands{
+							{
+								Name:   "addProof",
+								Usage:  "adds a signature and an identity on an instruction of the proposed transaction",
+								Action: clicontracts.DeferredInvokeAddProof,
+								Flags: []cli.Flag{
+									cli.StringFlag{
+										Name:   "bc",
+										EnvVar: "BC",
+										Usage:  "the ByzCoin config to use (required)",
+									},
+									cli.UintFlag{
+										Name:  "iid",
+										Usage: "the instruction index of the transaction (starts from 0) (fefault is 0)",
+									},
+									cli.StringFlag{
+										Name:  "hash",
+										Usage: "the instruction hash that will be signed",
+									},
+									cli.StringFlag{
+										Name:  "instID",
+										Usage: "the instance ID of the deferred contract",
+									},
+									cli.StringFlag{
+										Name:  "darc",
+										Usage: "DARC with the right to invoke.addProof a deferred contract (default is the admin DARC)",
+									},
+									cli.StringFlag{
+										Name:  "sign",
+										Usage: "public key of the signing entity (default is the admin public key)",
+									},
+								},
+							},
+							{
+								Name:   "execProposedTx",
+								Usage:  "executes the proposed transaction if the instructions are correctly signed",
+								Action: clicontracts.ExecProposedTx,
+								Flags: []cli.Flag{
+									cli.StringFlag{
+										Name:   "bc",
+										EnvVar: "BC",
+										Usage:  "the ByzCoin config to use (required)",
+									},
+									cli.StringFlag{
+										Name:  "instID",
+										Usage: "the instance ID of the deferred contract",
+									},
+									cli.StringFlag{
+										Name:  "darc",
+										Usage: "DARC with the right to invoke.execProposedTx a deferred contract (default is the admin DARC)",
 									},
 									cli.StringFlag{
 										Name:  "sign",

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -428,7 +428,7 @@ var cmds = cli.Commands{
 			},
 			{
 				Name:  "deferred",
-				Usage: "Manipulate a vadeferred contract",
+				Usage: "Manipulate a deferred contract",
 				Subcommands: cli.Commands{
 					{
 						Name:   "spawn",
@@ -452,7 +452,7 @@ var cmds = cli.Commands{
 					},
 					{
 						Name:  "invoke",
-						Usage: "invokw on a deferred contract ",
+						Usage: "invoke on a deferred contract ",
 						Subcommands: cli.Commands{
 							{
 								Name:   "addProof",
@@ -465,8 +465,8 @@ var cmds = cli.Commands{
 										Usage:  "the ByzCoin config to use (required)",
 									},
 									cli.UintFlag{
-										Name:  "iid",
-										Usage: "the instruction index of the transaction (starts from 0) (fefault is 0)",
+										Name:  "instrIdx",
+										Usage: "the instruction index of the transaction (starts from 0) (default is 0)",
 									},
 									cli.StringFlag{
 										Name:  "hash",

--- a/byzcoin/bcadmin/test.sh
+++ b/byzcoin/bcadmin/test.sh
@@ -18,6 +18,7 @@ export -n BC
 
 . "../../libtest.sh"
 . "../clicontracts/value_test.sh"
+. "../clicontracts/deferred_test.sh"
 
 main(){
     startTest
@@ -36,6 +37,7 @@ main(){
     run testQR
     run testUpdateDarcDesc
     run testContractValue
+    run testContractDeferred
     stopTest
 }
 
@@ -259,3 +261,4 @@ testUpdateDarcDesc() {
 }
 
 main
+


### PR DESCRIPTION
Finally implements the cli version of a deferred contract. I added all the functions except delete of the deferred contract: 

* Spawn:deferred
* Invoke:deferred.addProof
* Invoke:deferred.execProposedTx

Combined with the value contract, we can successfully defer the invocation of a transaction (at least with the value contract yet). Here is a scenario that works:

```bash
# Run the nodes, create roster and set up the config
➜ ./run_nodes.sh -n 5 -c -t -v 2
➜ export BC_CONFIG=~/GitHub/cothority/conode
➜ bcadmin create -roster ~/GitHub/cothority/conode/public.toml 

# Add the rules specific to the value and deferred contracts.
# We use the admin identity.
➜ bcadmin darc rule -rule spawn:value --identity ed25519:... 
➜ bcadmin darc rule -rule spawn:deferred --identity ed25519:...                                                         
➜ bcadmin darc rule -rule invoke:deferred.addProof --identity ed25519:...        
➜ bcadmin darc rule -rule invoke:deferred.execProposedTx --identity ed25519:...                                                                                                                                                     

# Spawn a value contract, but redirect the transaction to the spawn of a deferred contract
➜ bcadmin contract value spawn --value myValue --redirect | bcadmin contract deferred spawn

# Add the proof on the single instruction of the deferred transaction 
# (the --hash and --instID values are given when we spawn the deferred contract)
➜ bcadmin contract deferred invoke addProof --hash ... --instID ... --iid 0

# Finally execute the deferred transaction.
# This will call the Spawn:value(myValue) transaction.
# If we hadn't called the addProof before, it wouldn't have worked.
➜ bcadmin contract deferred invoke execProposedTx --instID ...
```

Moreover, instead of using pipe, we can also save the proposed transaction to a file, and then pass it to the spawn of a deferred contract:

```bash
➜ bcadmin contract value spawn --value myValue --redirect > export.bin
➜ bcadmin contract deferred spawn < export.bin
```