### PR TITLE
CothorityJS: provide API to add proto definition from outside

### DIFF
--- a/external/js/cothority/spec/protobuf/index.spec.ts
+++ b/external/js/cothority/spec/protobuf/index.spec.ts
@@ -1,0 +1,27 @@
+import { Message } from "protobufjs/light";
+import { addJSON, registerMessage } from "../../src/protobuf";
+
+class MessageTest extends Message<MessageTest> {
+    readonly testField: string;
+}
+
+describe("Protobuf Tests", () => {
+    it("should add the new model to the root", () => {
+        const json = {
+            nested: {
+                TestMessage: {
+                    fields: {
+                        testField: { type: "string", id: 1 },
+                    },
+                },
+            },
+        };
+
+        addJSON(json);
+        registerMessage("TestMessage", MessageTest);
+
+        const buf = MessageTest.encode(new MessageTest({ testField: "abc" })).finish();
+        const msg = MessageTest.decode(buf);
+        expect(msg.testField).toBe("abc");
+    });
+});

--- a/external/js/cothority/src/protobuf/index.ts
+++ b/external/js/cothority/src/protobuf/index.ts
@@ -1,5 +1,5 @@
 import Long from "long";
-import protobuf, { Reader } from "protobufjs/light";
+import protobuf, { INamespace, Reader } from "protobufjs/light";
 import Log from "../log";
 import models from "./models.json";
 
@@ -43,6 +43,15 @@ interface IRegistrationMessage extends protobuf.Constructor<{}> {
     register(): void;
 }
 
+/**
+ * Register the message to be encoded/decoded by protobufjs. The name
+ * should match the one in the model and the dependencies of the
+ * message should be provided to insure their registration.
+ *
+ * @param name          The name of the message in the protobuf definition
+ * @param ctor          The message class
+ * @param dependencies  The message classes of the dependencies
+ */
 export function registerMessage(
     name: string,
     ctor: protobuf.Constructor<{}>,
@@ -62,4 +71,13 @@ export function registerMessage(
     m.ctor = ctor;
 
     Log.lvl3(`Message registered: ${ctor.name}`);
+}
+
+/**
+ * Add a JSON definition to the existing root
+ *
+ * @param json The definition imported from a json file
+ */
+export function addJSON(json: INamespace): void {
+    root.addJSON(json.nested);
 }


### PR DESCRIPTION
This adds a function that takes json formatted definition and will
add it to the existing root so that they can be encoded/decoded.