### PR TITLE
Adds a "get" function to the value clicontract

### DIFF
--- a/byzcoin/bcadmin/clicontracts/value_test.sh
+++ b/byzcoin/bcadmin/clicontracts/value_test.sh
@@ -98,4 +98,7 @@ testGet() {
     OUTFILE=""
 
     testGrep "newValue" cat res.txt
+
+    # Try to get a wrong instance ID
+    testFail runBA contract value get --iid deadbeef
 }

--- a/byzcoin/bcadmin/clicontracts/value_test.sh
+++ b/byzcoin/bcadmin/clicontracts/value_test.sh
@@ -3,6 +3,7 @@
 testContractValue() {
     run testSpawn
     run testSpawnRedirect
+    run testGet
 }
 
 testSpawn() {
@@ -53,4 +54,48 @@ testSpawnRedirect() {
 
     # Check if we got the expected output
     testGrep "myValue" cat res.txt
+}
+
+testGet() {
+    # In this test we spawn a value contract and then retrieve the value stored
+    # with the "get" function. We then perform an update and test if we can get
+    # the updated value. We partially use the same code as the spawn function.
+    runCoBG 1 2 3
+    runGrepSed "export BC=" "" runBA create --roster public.toml --interval .5s
+    eval $SED
+    [ -z "$BC" ] && exit 1
+
+    # Add the spawn:value and invoke:value.update rules
+    testOK runBA darc add -out_id ./darc_id.txt -out_key ./darc_key.txt -unrestricted
+    ID=`cat ./darc_id.txt`
+    KEY=`cat ./darc_key.txt`
+    testOK runBA darc rule -rule "spawn:value" --identity "$KEY" --darc "$ID" --sign "$KEY"
+    testOK runBA darc rule -rule "invoke:value.update" --identity "$KEY" --darc "$ID" --sign "$KEY"
+
+    # Spawn a new value contract, we save the output to the res.txt file
+    OUTFILE=res.txt && testOK runBA contract value spawn --value "myValue" --darc "$ID" --sign "$KEY"
+    OUTFILE=""
+
+    # Check if we got the expected output
+    testGrep "Spawned new value contract. Instance id is:" cat res.txt
+
+    # Extract the instance ID of the newly created value instance
+    VALUE_INSTANCE_ID=`sed -n 2p res.txt`
+
+    # Use the "get" function and save the output to the res.txt file. This file
+    # should contain the saved value.
+    OUTFILE=res.txt && testOK runBA contract value get --iid "$VALUE_INSTANCE_ID"
+    OUTFILE=""
+
+    testGrep "myValue" cat res.txt
+
+    # Update the value instance based on the instance ID
+    testOK runBA contract value invoke update --value "newValue" --instID $VALUE_INSTANCE_ID --darc "$ID" --sign "$KEY"
+
+    # Use the "get" function and save the output to the res.txt file. This file
+    # should contain the newly updated value.
+    OUTFILE=res.txt && testOK runBA contract value get --iid "$VALUE_INSTANCE_ID"
+    OUTFILE=""
+
+    testGrep "newValue" cat res.txt
 }

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -424,6 +424,22 @@ var cmds = cli.Commands{
 							},
 						},
 					},
+					{
+						Name:  "get",
+						Usage: "if the proof matches, get the content of the given value instance ID",
+						Flags: []cli.Flag{
+							cli.StringFlag{
+								Name:   "bc",
+								EnvVar: "BC",
+								Usage:  "the ByzCoin config to use (required)",
+							},
+							cli.StringFlag{
+								Name:  "iid",
+								Usage: "the instance id (required)",
+							},
+						},
+						Action: clicontracts.ValueGet,
+					},
 				},
 			},
 		},

--- a/conode/log/conode_co1_7770-190513-1409.log
+++ b/conode/log/conode_co1_7770-190513-1409.log
@@ -1,0 +1,14 @@
+[0;37;1mI 19/13/05 14:09:49.521567000: (                       main.init.0.func1:  42) - File descriptor limit is: 24576
+[0m[0;36m2 19/13/05 14:09:49.552609000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7770 started heartbeat monitor for block 5 of b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:09:49.556538000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7770 started heartbeat monitor for block 3 of 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;33m1 19/13/05 14:09:49.561224000: (                             service.new:  814) - Pin: 90933a02a1ae626c7cdb7f4465671b45
+[0m[0;36m2 19/13/05 14:09:49.561597000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7770 Catching up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;33m1 19/13/05 14:09:49.562102000: (                      v3.(*Server).Start:  206) - Starting server at 2019-05-13 14:09:49 on address tls://localhost:7770 with public key 39a2a3f04ae309d9000dea1b953d389877c7840c646401c419f5f1c1127c3b99
+[0m[0;36m2 19/13/05 14:09:49.562436000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7770 Done catch up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:09:49.563249000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7770 Catching up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:09:49.564143000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7770 Done catch up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:09:49.564184000: (                   v3.(*WebSocket).start:  104) - Starting to listen on 0.0.0.0:7771
+[0m[0;33m1 19/13/05 14:09:49.568582000: (                 network.(*Router).Start:  103) - New router with address tls://[::]:7770 and public key 39a2a3f04ae309d9000dea1b953d389877c7840c646401c419f5f1c1127c3b99
+[0m[0;36m2 19/13/05 14:09:52.081030000: (network.NewTLSListenerWithListenAddr.func1:  249) - Got new connection request from: [::1]:58668
+[0m[0;36m2 19/13/05 14:09:52.082486000: (network.NewTLSListenerWithListenAddr.func1:  249) - Got new connection request from: [::1]:58666
+[0m

--- a/conode/log/conode_co1_7770-190513-1410.log
+++ b/conode/log/conode_co1_7770-190513-1410.log
@@ -1,0 +1,12 @@
+[0;37;1mI 19/13/05 14:10:58.042686000: (                       main.init.0.func1:  42) - File descriptor limit is: 24576
+[0m[0;36m2 19/13/05 14:10:58.085515000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7770 started heartbeat monitor for block 5 of b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:10:58.094831000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7770 started heartbeat monitor for block 3 of 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;36m2 19/13/05 14:10:58.099739000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7770 Catching up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:10:58.100385000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7770 Done catch up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:10:58.101003000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7770 Catching up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:10:58.101839000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7770 Done catch up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;33m1 19/13/05 14:10:58.103537000: (                             service.new:  814) - Pin: e555de3cde0ecd6725769d803a6dd759
+[0m[0;33m1 19/13/05 14:10:58.107370000: (                      v3.(*Server).Start:  206) - Starting server at 2019-05-13 14:10:58 on address tls://localhost:7770 with public key 39a2a3f04ae309d9000dea1b953d389877c7840c646401c419f5f1c1127c3b99
+[0m[0;36m2 19/13/05 14:10:58.108052000: (                   v3.(*WebSocket).start:  104) - Starting to listen on 0.0.0.0:7771
+[0m[0;33m1 19/13/05 14:10:58.108359000: (                 network.(*Router).Start:  103) - New router with address tls://[::]:7770 and public key 39a2a3f04ae309d9000dea1b953d389877c7840c646401c419f5f1c1127c3b99
+[0m

--- a/conode/log/conode_co1_7770-190513-1411.log
+++ b/conode/log/conode_co1_7770-190513-1411.log
@@ -1,0 +1,14 @@
+[0;37;1mI 19/13/05 14:11:27.173257000: (                       main.init.0.func1:  42) - File descriptor limit is: 24576
+[0m[0;36m2 19/13/05 14:11:27.226303000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7770 started heartbeat monitor for block 5 of b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:11:27.228374000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7770 started heartbeat monitor for block 3 of 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;33m1 19/13/05 14:11:27.229599000: (                             service.new:  814) - Pin: 9ad3054b970ecd8c90fa46e0a6daf684
+[0m[0;33m1 19/13/05 14:11:27.230006000: (                      v3.(*Server).Start:  206) - Starting server at 2019-05-13 14:11:27 on address tls://localhost:7770 with public key 39a2a3f04ae309d9000dea1b953d389877c7840c646401c419f5f1c1127c3b99
+[0m[0;33m1 19/13/05 14:11:27.230166000: (                 network.(*Router).Start:  103) - New router with address tls://[::]:7770 and public key 39a2a3f04ae309d9000dea1b953d389877c7840c646401c419f5f1c1127c3b99
+[0m[0;36m2 19/13/05 14:11:27.230292000: (                   v3.(*WebSocket).start:  104) - Starting to listen on 0.0.0.0:7771
+[0m[0;36m2 19/13/05 14:11:27.231352000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7770 Catching up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:11:27.231780000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7770 Done catch up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:11:27.232180000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7770 Catching up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:11:27.232754000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7770 Done catch up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:11:29.728357000: (network.NewTLSListenerWithListenAddr.func1:  249) - Got new connection request from: [::1]:59589
+[0m[0;36m2 19/13/05 14:11:29.728497000: (network.NewTLSListenerWithListenAddr.func1:  249) - Got new connection request from: [::1]:59587
+[0m

--- a/conode/log/conode_co2_7772-190513-1409.log
+++ b/conode/log/conode_co2_7772-190513-1409.log
@@ -1,0 +1,14 @@
+[0;37;1mI 19/13/05 14:09:49.526384000: (                       main.init.0.func1:  42) - File descriptor limit is: 24576
+[0m[0;36m2 19/13/05 14:09:49.548428000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7772 started heartbeat monitor for block 5 of b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:09:49.551295000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7772 started heartbeat monitor for block 3 of 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;33m1 19/13/05 14:09:49.556821000: (                             service.new:  814) - Pin: 7f1fe03fcd70eed73dbd7a7bde1c1ef9
+[0m[0;36m2 19/13/05 14:09:49.556864000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7772 Catching up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:09:49.557662000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7772 Done catch up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:09:49.558284000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7772 Catching up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:09:49.559128000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7772 Done catch up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;33m1 19/13/05 14:09:49.559397000: (                      v3.(*Server).Start:  206) - Starting server at 2019-05-13 14:09:49 on address tls://localhost:7772 with public key 61d7502a9a73d56612f4cb5b622b287ef55acb25053f1101b42983754f47d516
+[0m[0;36m2 19/13/05 14:09:49.560077000: (                   v3.(*WebSocket).start:  104) - Starting to listen on 0.0.0.0:7773
+[0m[0;33m1 19/13/05 14:09:49.560297000: (                 network.(*Router).Start:  103) - New router with address tls://[::]:7772 and public key 61d7502a9a73d56612f4cb5b622b287ef55acb25053f1101b42983754f47d516
+[0m[0;36m2 19/13/05 14:09:52.081164000: (network.NewTLSListenerWithListenAddr.func1:  249) - Got new connection request from: [::1]:58671
+[0m[0;36m2 19/13/05 14:09:52.082609000: (network.NewTLSListenerWithListenAddr.func1:  249) - Got new connection request from: [::1]:58670
+[0m

--- a/conode/log/conode_co2_7772-190513-1410.log
+++ b/conode/log/conode_co2_7772-190513-1410.log
@@ -1,0 +1,12 @@
+[0;37;1mI 19/13/05 14:10:58.047158000: (                       main.init.0.func1:  42) - File descriptor limit is: 24576
+[0m[0;36m2 19/13/05 14:10:58.073477000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7772 started heartbeat monitor for block 5 of b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:10:58.077702000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7772 started heartbeat monitor for block 3 of 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;33m1 19/13/05 14:10:58.080353000: (                             service.new:  814) - Pin: 57e5ac8b4cba229e836104aaac8452cf
+[0m[0;33m1 19/13/05 14:10:58.080675000: (                      v3.(*Server).Start:  206) - Starting server at 2019-05-13 14:10:58 on address tls://localhost:7772 with public key 61d7502a9a73d56612f4cb5b622b287ef55acb25053f1101b42983754f47d516
+[0m[0;33m1 19/13/05 14:10:58.080814000: (                 network.(*Router).Start:  103) - New router with address tls://[::]:7772 and public key 61d7502a9a73d56612f4cb5b622b287ef55acb25053f1101b42983754f47d516
+[0m[0;36m2 19/13/05 14:10:58.080851000: (                   v3.(*WebSocket).start:  104) - Starting to listen on 0.0.0.0:7773
+[0m[0;36m2 19/13/05 14:10:58.081499000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7772 Catching up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:10:58.082283000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7772 Done catch up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:10:58.082901000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7772 Catching up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:10:58.083730000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7772 Done catch up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m

--- a/conode/log/conode_co2_7772-190513-1411.log
+++ b/conode/log/conode_co2_7772-190513-1411.log
@@ -1,0 +1,14 @@
+[0;37;1mI 19/13/05 14:11:27.177357000: (                       main.init.0.func1:  42) - File descriptor limit is: 24576
+[0m[0;36m2 19/13/05 14:11:27.203520000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7772 started heartbeat monitor for block 5 of b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:11:27.206868000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7772 started heartbeat monitor for block 3 of 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;36m2 19/13/05 14:11:27.210519000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7772 Catching up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:11:27.211211000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7772 Done catch up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:11:27.211841000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7772 Catching up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:11:27.212668000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7772 Done catch up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;33m1 19/13/05 14:11:27.213413000: (                             service.new:  814) - Pin: 5e41d42aba794e6154d5fffe8a307bf3
+[0m[0;33m1 19/13/05 14:11:27.214144000: (                      v3.(*Server).Start:  206) - Starting server at 2019-05-13 14:11:27 on address tls://localhost:7772 with public key 61d7502a9a73d56612f4cb5b622b287ef55acb25053f1101b42983754f47d516
+[0m[0;33m1 19/13/05 14:11:27.214298000: (                 network.(*Router).Start:  103) - New router with address tls://[::]:7772 and public key 61d7502a9a73d56612f4cb5b622b287ef55acb25053f1101b42983754f47d516
+[0m[0;36m2 19/13/05 14:11:27.214386000: (                   v3.(*WebSocket).start:  104) - Starting to listen on 0.0.0.0:7773
+[0m[0;36m2 19/13/05 14:11:29.726921000: (network.NewTLSListenerWithListenAddr.func1:  249) - Got new connection request from: [::1]:59593
+[0m[0;36m2 19/13/05 14:11:29.727083000: (network.NewTLSListenerWithListenAddr.func1:  249) - Got new connection request from: [::1]:59586
+[0m

--- a/conode/log/conode_co3_7774-190513-1409.log
+++ b/conode/log/conode_co3_7774-190513-1409.log
@@ -1,0 +1,14 @@
+[0;37;1mI 19/13/05 14:09:49.531404000: (                       main.init.0.func1:  42) - File descriptor limit is: 24576
+[0m[0;36m2 19/13/05 14:09:49.556408000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7774 started heartbeat monitor for block 5 of b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:09:49.560381000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7774 started heartbeat monitor for block 3 of 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;36m2 19/13/05 14:09:49.566891000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7774 Catching up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;33m1 19/13/05 14:09:49.567012000: (                             service.new:  814) - Pin: a9f11e490c6bdff32d5f66c65e003a24
+[0m[0;36m2 19/13/05 14:09:49.567603000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7774 Done catch up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:09:49.568317000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7774 Catching up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:09:49.569397000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7774 Done catch up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;33m1 19/13/05 14:09:49.569566000: (                      v3.(*Server).Start:  206) - Starting server at 2019-05-13 14:09:49 on address tls://localhost:7774 with public key 384cd8210b3d62efe940337efc3d87c89bbb12fe32eb735f3a87f0abcfc3ac41
+[0m[0;33m1 19/13/05 14:09:49.569902000: (                 network.(*Router).Start:  103) - New router with address tls://[::]:7774 and public key 384cd8210b3d62efe940337efc3d87c89bbb12fe32eb735f3a87f0abcfc3ac41
+[0m[0;36m2 19/13/05 14:09:49.569973000: (                   v3.(*WebSocket).start:  104) - Starting to listen on 0.0.0.0:7775
+[0m[0;36m2 19/13/05 14:09:52.081106000: (network.NewTLSListenerWithListenAddr.func1:  249) - Got new connection request from: [::1]:58672
+[0m[0;36m2 19/13/05 14:09:52.082454000: (network.NewTLSListenerWithListenAddr.func1:  249) - Got new connection request from: [::1]:58669
+[0m

--- a/conode/log/conode_co3_7774-190513-1410.log
+++ b/conode/log/conode_co3_7774-190513-1410.log
@@ -1,0 +1,12 @@
+[0;37;1mI 19/13/05 14:10:58.050117000: (                       main.init.0.func1:  42) - File descriptor limit is: 24576
+[0m[0;36m2 19/13/05 14:10:58.078125000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7774 started heartbeat monitor for block 5 of b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:10:58.083950000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7774 started heartbeat monitor for block 3 of 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;33m1 19/13/05 14:10:58.085443000: (                             service.new:  814) - Pin: 9e324c21418959f2b0cca1f1b40716b1
+[0m[0;33m1 19/13/05 14:10:58.087461000: (                      v3.(*Server).Start:  206) - Starting server at 2019-05-13 14:10:58 on address tls://localhost:7774 with public key 384cd8210b3d62efe940337efc3d87c89bbb12fe32eb735f3a87f0abcfc3ac41
+[0m[0;33m1 19/13/05 14:10:58.087611000: (                 network.(*Router).Start:  103) - New router with address tls://[::]:7774 and public key 384cd8210b3d62efe940337efc3d87c89bbb12fe32eb735f3a87f0abcfc3ac41
+[0m[0;36m2 19/13/05 14:10:58.087653000: (                   v3.(*WebSocket).start:  104) - Starting to listen on 0.0.0.0:7775
+[0m[0;36m2 19/13/05 14:10:58.089273000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7774 Catching up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:10:58.090274000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7774 Done catch up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:10:58.090924000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7774 Catching up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:10:58.091573000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7774 Done catch up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m

--- a/conode/log/conode_co3_7774-190513-1411.log
+++ b/conode/log/conode_co3_7774-190513-1411.log
@@ -1,0 +1,14 @@
+[0;37;1mI 19/13/05 14:11:27.186287000: (                       main.init.0.func1:  42) - File descriptor limit is: 24576
+[0m[0;36m2 19/13/05 14:11:27.214078000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7774 started heartbeat monitor for block 5 of b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:11:27.218670000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7774 started heartbeat monitor for block 3 of 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;36m2 19/13/05 14:11:27.223078000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7774 Catching up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:11:27.223810000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7774 Done catch up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;33m1 19/13/05 14:11:27.224200000: (                             service.new:  814) - Pin: 402cc790da4250c3a9aa4b4522b9bc33
+[0m[0;36m2 19/13/05 14:11:27.224467000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7774 Catching up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;33m1 19/13/05 14:11:27.224608000: (                      v3.(*Server).Start:  206) - Starting server at 2019-05-13 14:11:27 on address tls://localhost:7774 with public key 384cd8210b3d62efe940337efc3d87c89bbb12fe32eb735f3a87f0abcfc3ac41
+[0m[0;33m1 19/13/05 14:11:27.224800000: (                 network.(*Router).Start:  103) - New router with address tls://[::]:7774 and public key 384cd8210b3d62efe940337efc3d87c89bbb12fe32eb735f3a87f0abcfc3ac41
+[0m[0;36m2 19/13/05 14:11:27.225280000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7774 Done catch up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:11:27.225921000: (                   v3.(*WebSocket).start:  104) - Starting to listen on 0.0.0.0:7775
+[0m[0;36m2 19/13/05 14:11:29.727152000: (network.NewTLSListenerWithListenAddr.func1:  249) - Got new connection request from: [::1]:59591
+[0m[0;36m2 19/13/05 14:11:29.728505000: (network.NewTLSListenerWithListenAddr.func1:  249) - Got new connection request from: [::1]:59590
+[0m

--- a/conode/log/conode_co4_7776-190513-1409.log
+++ b/conode/log/conode_co4_7776-190513-1409.log
@@ -1,0 +1,14 @@
+[0;37;1mI 19/13/05 14:09:49.536274000: (                       main.init.0.func1:  42) - File descriptor limit is: 24576
+[0m[0;36m2 19/13/05 14:09:49.557603000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7776 started heartbeat monitor for block 5 of b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:09:49.560900000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7776 started heartbeat monitor for block 3 of 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;36m2 19/13/05 14:09:49.564947000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7776 Catching up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:09:49.565764000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7776 Done catch up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:09:49.566472000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7776 Catching up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:09:49.568514000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7776 Done catch up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;33m1 19/13/05 14:09:49.570663000: (                             service.new:  814) - Pin: c4d7a33c19996db46fbe681f292cfba9
+[0m[0;33m1 19/13/05 14:09:49.571061000: (                      v3.(*Server).Start:  206) - Starting server at 2019-05-13 14:09:49 on address tls://localhost:7776 with public key b4af82e5b4be677d42d7761c69037dcf0e2208236b148900cf5e13daa330c22e
+[0m[0;36m2 19/13/05 14:09:49.571445000: (                   v3.(*WebSocket).start:  104) - Starting to listen on 0.0.0.0:7777
+[0m[0;33m1 19/13/05 14:09:49.571640000: (                 network.(*Router).Start:  103) - New router with address tls://[::]:7776 and public key b4af82e5b4be677d42d7761c69037dcf0e2208236b148900cf5e13daa330c22e
+[0m[0;36m2 19/13/05 14:09:52.081023000: (network.NewTLSListenerWithListenAddr.func1:  249) - Got new connection request from: [::1]:58667
+[0m[0;36m2 19/13/05 14:09:52.081736000: (network.NewTLSListenerWithListenAddr.func1:  249) - Got new connection request from: [::1]:58665
+[0m

--- a/conode/log/conode_co4_7776-190513-1410.log
+++ b/conode/log/conode_co4_7776-190513-1410.log
@@ -1,0 +1,12 @@
+[0;37;1mI 19/13/05 14:10:58.048525000: (                       main.init.0.func1:  42) - File descriptor limit is: 24576
+[0m[0;36m2 19/13/05 14:10:58.091669000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7776 started heartbeat monitor for block 5 of b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:10:58.097505000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7776 started heartbeat monitor for block 3 of 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;36m2 19/13/05 14:10:58.107275000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7776 Catching up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;33m1 19/13/05 14:10:58.107855000: (                             service.new:  814) - Pin: a2524361da2e7311b62613d48a92ec5a
+[0m[0;36m2 19/13/05 14:10:58.108092000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7776 Done catch up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;33m1 19/13/05 14:10:58.108221000: (                      v3.(*Server).Start:  206) - Starting server at 2019-05-13 14:10:58 on address tls://localhost:7776 with public key b4af82e5b4be677d42d7761c69037dcf0e2208236b148900cf5e13daa330c22e
+[0m[0;33m1 19/13/05 14:10:58.108584000: (                 network.(*Router).Start:  103) - New router with address tls://[::]:7776 and public key b4af82e5b4be677d42d7761c69037dcf0e2208236b148900cf5e13daa330c22e
+[0m[0;36m2 19/13/05 14:10:58.108632000: (                   v3.(*WebSocket).start:  104) - Starting to listen on 0.0.0.0:7777
+[0m[0;36m2 19/13/05 14:10:58.108953000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7776 Catching up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:10:58.109783000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7776 Done catch up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m

--- a/conode/log/conode_co4_7776-190513-1411.log
+++ b/conode/log/conode_co4_7776-190513-1411.log
@@ -1,0 +1,14 @@
+[0;37;1mI 19/13/05 14:11:27.172516000: (                       main.init.0.func1:  42) - File descriptor limit is: 24576
+[0m[0;36m2 19/13/05 14:11:27.197981000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7776 started heartbeat monitor for block 5 of b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:11:27.200529000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7776 started heartbeat monitor for block 3 of 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;33m1 19/13/05 14:11:27.201846000: (                             service.new:  814) - Pin: 5a3f47173a81ae3c5683560db0d22ab1
+[0m[0;33m1 19/13/05 14:11:27.202487000: (                      v3.(*Server).Start:  206) - Starting server at 2019-05-13 14:11:27 on address tls://localhost:7776 with public key b4af82e5b4be677d42d7761c69037dcf0e2208236b148900cf5e13daa330c22e
+[0m[0;36m2 19/13/05 14:11:27.202590000: (                   v3.(*WebSocket).start:  104) - Starting to listen on 0.0.0.0:7777
+[0m[0;33m1 19/13/05 14:11:27.203659000: (                 network.(*Router).Start:  103) - New router with address tls://[::]:7776 and public key b4af82e5b4be677d42d7761c69037dcf0e2208236b148900cf5e13daa330c22e
+[0m[0;36m2 19/13/05 14:11:27.203828000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7776 Catching up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:11:27.204500000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7776 Done catch up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:11:27.205201000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7776 Catching up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:11:27.206011000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7776 Done catch up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:11:29.727081000: (network.NewTLSListenerWithListenAddr.func1:  249) - Got new connection request from: [::1]:59592
+[0m[0;36m2 19/13/05 14:11:29.728471000: (network.NewTLSListenerWithListenAddr.func1:  249) - Got new connection request from: [::1]:59588
+[0m

--- a/conode/log/conode_co5_7778-190513-1409.log
+++ b/conode/log/conode_co5_7778-190513-1409.log
@@ -1,0 +1,22 @@
+[0;37;1mI 19/13/05 14:09:49.540950000: (                       main.init.0.func1:  42) - File descriptor limit is: 24576
+[0m[0;36m2 19/13/05 14:09:49.562395000: (       byzcoin.(*Service).startAllChains: 2220) - tls://localhost:7778: Starting as a leader for chain b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:09:49.562954000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7778 started heartbeat monitor for block 5 of b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:09:49.567586000: (       byzcoin.(*Service).startAllChains: 2220) - tls://localhost:7778: Starting as a leader for chain 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;36m2 19/13/05 14:09:49.567861000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7778 started heartbeat monitor for block 3 of 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;33m1 19/13/05 14:09:49.571765000: (                             service.new:  814) - Pin: 15399a9dd8c0d589b38b60b354dc38b5
+[0m[0;33m1 19/13/05 14:09:49.572110000: (                      v3.(*Server).Start:  206) - Starting server at 2019-05-13 14:09:49 on address tls://localhost:7778 with public key c46c5b690220f815a9cee3c0d91efbda075df67bfeb76ecb8188245630909469
+[0m[0;36m2 19/13/05 14:09:49.572210000: (                   v3.(*WebSocket).start:  104) - Starting to listen on 0.0.0.0:7779
+[0m[0;36m2 19/13/05 14:09:49.572821000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7778 Catching up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;33m1 19/13/05 14:09:49.573286000: (                 network.(*Router).Start:  103) - New router with address tls://[::]:7778 and public key c46c5b690220f815a9cee3c0d91efbda075df67bfeb76ecb8188245630909469
+[0m[0;36m2 19/13/05 14:09:49.573442000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7778 Done catch up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:09:49.574049000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7778 Catching up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:09:49.574851000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7778 Done catch up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:09:52.077817000: (                      network.NewTLSConn:  407) - NewTLSConn to: tls://localhost:7774
+[0m[0;36m2 19/13/05 14:09:52.077953000: (                      network.NewTLSConn:  407) - NewTLSConn to: tls://localhost:7770
+[0m[0;36m2 19/13/05 14:09:52.078583000: (                      network.NewTLSConn:  407) - NewTLSConn to: tls://localhost:7770
+[0m[0;36m2 19/13/05 14:09:52.078700000: (                      network.NewTLSConn:  407) - NewTLSConn to: tls://localhost:7776
+[0m[0;36m2 19/13/05 14:09:52.079011000: (                      network.NewTLSConn:  407) - NewTLSConn to: tls://localhost:7772
+[0m[0;36m2 19/13/05 14:09:52.079111000: (                      network.NewTLSConn:  407) - NewTLSConn to: tls://localhost:7774
+[0m[0;36m2 19/13/05 14:09:52.079508000: (                      network.NewTLSConn:  407) - NewTLSConn to: tls://localhost:7772
+[0m[0;36m2 19/13/05 14:09:52.079716000: (                      network.NewTLSConn:  407) - NewTLSConn to: tls://localhost:7776
+[0m

--- a/conode/log/conode_co5_7778-190513-1410.log
+++ b/conode/log/conode_co5_7778-190513-1410.log
@@ -1,0 +1,14 @@
+[0;37;1mI 19/13/05 14:10:58.037375000: (                       main.init.0.func1:  42) - File descriptor limit is: 24576
+[0m[0;36m2 19/13/05 14:10:58.079922000: (       byzcoin.(*Service).startAllChains: 2220) - tls://localhost:7778: Starting as a leader for chain b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:10:58.080609000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7778 started heartbeat monitor for block 5 of b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:10:58.085924000: (       byzcoin.(*Service).startAllChains: 2220) - tls://localhost:7778: Starting as a leader for chain 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;36m2 19/13/05 14:10:58.086258000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7778 started heartbeat monitor for block 3 of 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;36m2 19/13/05 14:10:58.091482000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7778 Catching up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:10:58.092522000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7778 Done catch up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;33m1 19/13/05 14:10:58.093172000: (                             service.new:  814) - Pin: a0798d648289cb1054ce6bf02886a833
+[0m[0;36m2 19/13/05 14:10:58.093339000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7778 Catching up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;33m1 19/13/05 14:10:58.093647000: (                      v3.(*Server).Start:  206) - Starting server at 2019-05-13 14:10:58 on address tls://localhost:7778 with public key c46c5b690220f815a9cee3c0d91efbda075df67bfeb76ecb8188245630909469
+[0m[0;36m2 19/13/05 14:10:58.094015000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7778 Done catch up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:10:58.094059000: (                   v3.(*WebSocket).start:  104) - Starting to listen on 0.0.0.0:7779
+[0m[0;33m1 19/13/05 14:10:58.094264000: (                 network.(*Router).Start:  103) - New router with address tls://[::]:7778 and public key c46c5b690220f815a9cee3c0d91efbda075df67bfeb76ecb8188245630909469
+[0m

--- a/conode/log/conode_co5_7778-190513-1411.log
+++ b/conode/log/conode_co5_7778-190513-1411.log
@@ -1,0 +1,22 @@
+[0;37;1mI 19/13/05 14:11:27.191821000: (                       main.init.0.func1:  42) - File descriptor limit is: 24576
+[0m[0;36m2 19/13/05 14:11:27.212629000: (       byzcoin.(*Service).startAllChains: 2220) - tls://localhost:7778: Starting as a leader for chain b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:11:27.213086000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7778 started heartbeat monitor for block 5 of b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32
+[0m[0;36m2 19/13/05 14:11:27.215916000: (       byzcoin.(*Service).startAllChains: 2220) - tls://localhost:7778: Starting as a leader for chain 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;36m2 19/13/05 14:11:27.216243000: (       byzcoin.(*Service).startAllChains: 2239) - tls://localhost:7778 started heartbeat monitor for block 3 of 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b
+[0m[0;33m1 19/13/05 14:11:27.220116000: (                             service.new:  814) - Pin: 45d01bfc76405bcdb5b35923912f67a9
+[0m[0;36m2 19/13/05 14:11:27.220247000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7778 Catching up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:11:27.220904000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7778 Done catch up b3d1eb4db98a68f9a8712c9d4f5d1e0f36fa2585154987243b1fa9196923fa32 / 5
+[0m[0;36m2 19/13/05 14:11:27.221472000: (              byzcoin.(*Service).catchUp: 1119) - tls://localhost:7778 Catching up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;36m2 19/13/05 14:11:27.222237000: (              byzcoin.(*Service).catchUp: 1179) - tls://localhost:7778 Done catch up 72a60058fd888e82f8815bf1d798f0dc7c195d54cdcbedfb81c08703f6d5967b / 3
+[0m[0;33m1 19/13/05 14:11:27.222546000: (                      v3.(*Server).Start:  206) - Starting server at 2019-05-13 14:11:27 on address tls://localhost:7778 with public key c46c5b690220f815a9cee3c0d91efbda075df67bfeb76ecb8188245630909469
+[0m[0;36m2 19/13/05 14:11:27.222630000: (                   v3.(*WebSocket).start:  104) - Starting to listen on 0.0.0.0:7779
+[0m[0;33m1 19/13/05 14:11:27.222713000: (                 network.(*Router).Start:  103) - New router with address tls://[::]:7778 and public key c46c5b690220f815a9cee3c0d91efbda075df67bfeb76ecb8188245630909469
+[0m[0;36m2 19/13/05 14:11:29.723323000: (                      network.NewTLSConn:  407) - NewTLSConn to: tls://localhost:7774
+[0m[0;36m2 19/13/05 14:11:29.723513000: (                      network.NewTLSConn:  407) - NewTLSConn to: tls://localhost:7772
+[0m[0;36m2 19/13/05 14:11:29.724068000: (                      network.NewTLSConn:  407) - NewTLSConn to: tls://localhost:7776
+[0m[0;36m2 19/13/05 14:11:29.724685000: (                      network.NewTLSConn:  407) - NewTLSConn to: tls://localhost:7770
+[0m[0;36m2 19/13/05 14:11:29.724949000: (                      network.NewTLSConn:  407) - NewTLSConn to: tls://localhost:7770
+[0m[0;36m2 19/13/05 14:11:29.725069000: (                      network.NewTLSConn:  407) - NewTLSConn to: tls://localhost:7776
+[0m[0;36m2 19/13/05 14:11:29.725213000: (                      network.NewTLSConn:  407) - NewTLSConn to: tls://localhost:7774
+[0m[0;36m2 19/13/05 14:11:29.725263000: (                      network.NewTLSConn:  407) - NewTLSConn to: tls://localhost:7772
+[0m


### PR DESCRIPTION
One can now get the value of a value contract with:
`bcadmin contract value get --iid <instance ID>`

We plan to add this to every clicontract. This makes debugging and testing easier.