### PR TITLE
Deferred contract: Makes expireBlockIndex optional

### DIFF
--- a/byzcoin/bcadmin/clicontracts/deferred.go
+++ b/byzcoin/bcadmin/clicontracts/deferred.go
@@ -71,10 +71,6 @@ func DeferredSpawn(c *cli.Context) error {
 		return err
 	}
 
-	expireBlockIndexInt := uint64(6000)
-	expireBlockIndexBuf := make([]byte, 8)
-	binary.LittleEndian.PutUint64(expireBlockIndexBuf, expireBlockIndexInt)
-
 	counters, err := cl.GetSignerCounters(signer.Identity().String())
 
 	spawn := byzcoin.Spawn{
@@ -83,10 +79,6 @@ func DeferredSpawn(c *cli.Context) error {
 			{
 				Name:  "proposedTransaction",
 				Value: proposedTransactionBuf,
-			},
-			{
-				Name:  "expireBlockIndex",
-				Value: expireBlockIndexBuf,
 			},
 		},
 	}


### PR DESCRIPTION
If expireBlockIndex is not given, we use `current_blockIdx + 50` as the default value. This gives more flexibility for clients that do not have strong requirements for the expiration of the proposed transaction.