### PR TITLE
Adds get and delete methods to clicontracts

### DIFF
--- a/byzcoin/bcadmin/clicontracts/README.md
+++ b/byzcoin/bcadmin/clicontracts/README.md
@@ -67,9 +67,11 @@ bcadmin contract deferred invoke addProof --hash ... --instID ... --iid 0
 
 ```bash
 # Run the nodes, create roster and set up the config
-./run_nodes.sh -n 5 -c -t -v 2
-export BC_CONFIG=~/GitHub/cothority/conode
+~/GitHub/cothority/conode/run_nodes.sh -n 5 -c -t -v 2
 bcadmin create -roster ~/GitHub/cothority/conode/public.toml 
+
+# Copy/Paste from the output of the previous command
+export BC="..."
 
 # Add the rules specific to the value and deferred contracts.
 # We use the admin identity.

--- a/byzcoin/bcadmin/clicontracts/README.md
+++ b/byzcoin/bcadmin/clicontracts/README.md
@@ -62,3 +62,31 @@ Invoke an addProof on a deferred contract:
 # The --hash and --instID values are given when we spawn the deferred contract
 bcadmin contract deferred invoke addProof --hash ... --instID ... --iid 0
 ```
+
+**Working scenario**:
+
+```bash
+# Run the nodes, create roster and set up the config
+./run_nodes.sh -n 5 -c -t -v 2
+export BC_CONFIG=~/GitHub/cothority/conode
+bcadmin create -roster ~/GitHub/cothority/conode/public.toml 
+
+# Add the rules specific to the value and deferred contracts.
+# We use the admin identity.
+bcadmin darc rule -rule spawn:value --identity ed25519:... 
+bcadmin darc rule -rule spawn:deferred --identity ed25519:...                                                         
+bcadmin darc rule -rule invoke:deferred.addProof --identity ed25519:...        
+bcadmin darc rule -rule invoke:deferred.execProposedTx --identity ed25519:...                                                                                                                                                     
+
+# Spawn a value contract, but redirect the transaction to the spawn of a deferred contract
+bcadmin contract value spawn --value myValue --redirect | bcadmin contract deferred spawn
+
+# Add the proof on the single instruction of the deferred transaction 
+# (the --hash and --instID values are given when we spawn the deferred contract)
+bcadmin contract deferred invoke addProof --hash ... --instID ... --iid 0
+
+# Finally execute the deferred transaction.
+# This will call the Spawn:value(myValue) transaction.
+# If we hadn't called the addProof before, it wouldn't have worked.
+bcadmin contract deferred invoke execProposedTx --instID ...
+```

--- a/byzcoin/bcadmin/clicontracts/deferred_test.sh
+++ b/byzcoin/bcadmin/clicontracts/deferred_test.sh
@@ -117,7 +117,7 @@ testGet() {
         }'`
     echo -e "Here is the instance ID:\t$DEFERRED_INSTANCE_ID"
 
-    # We know the array conaining the hash to sign is the second line after
+    # We know the array containing the hash to sign is the second line after
     # "- Instruction hashes:" and we remove the "--- " prefix.
     HASH=`echo "$OUTRES" | sed -n ' 
         /- Instruction hashes:/ {
@@ -128,7 +128,7 @@ testGet() {
         }'`
     echo -e "Here is the hash:\t\t$HASH"
 
-    # We know use the get function to check if have the right informations:
+    # We now use the get function to check if we have the right informations:
     OUTRES=`runBA contract deferred get --instID $DEFERRED_INSTANCE_ID`
     testGrep "action: spawn:value" echo "$OUTRES"
     testGrep "identities: \[\]" echo "$OUTRES"
@@ -139,7 +139,7 @@ testGet() {
     
     testOK runBA contract deferred invoke addProof --instID "$DEFERRED_INSTANCE_ID" --hash "$HASH" --instrIdx 0 --sign "$KEY" --darc "$ID"
 
-    # Since we prformed an addProof, the result should now contrain a new
+    # Since we performed an addProof, the result should now contrain a new
     # identity and the field signature set to 1.
     OUTRES=`runBA contract deferred get --instID $DEFERRED_INSTANCE_ID`
     testGrep "action: spawn:value" echo "$OUTRES"
@@ -152,7 +152,7 @@ testGet() {
     # ]+
     # \]            A closing angle bracket
     #
-    testGrep "identities: \[[:a-f0-9]+\]" echo "$OUTRES"
+    testGrep "identities: \[$KEY\]" echo "$OUTRES"
     testGrep "counters: \[\]" echo "$OUTRES"
     testGrep "signatures: 1" echo "$OUTRES"
     testGrep "Spawn:	value" echo "$OUTRES"

--- a/byzcoin/bcadmin/clicontracts/value_test.sh
+++ b/byzcoin/bcadmin/clicontracts/value_test.sh
@@ -4,6 +4,7 @@ testContractValue() {
     run testSpawn
     run testSpawnRedirect
     run testGet
+    run testDel
 }
 
 testSpawn() {
@@ -84,7 +85,7 @@ testGet() {
 
     # Use the "get" function and save the output to the res.txt file. This file
     # should contain the saved value.
-    OUTFILE=res.txt && testOK runBA contract value get --iid "$VALUE_INSTANCE_ID"
+    OUTFILE=res.txt && testOK runBA contract value get --instID "$VALUE_INSTANCE_ID"
     OUTFILE=""
 
     testGrep "myValue" cat res.txt
@@ -94,11 +95,49 @@ testGet() {
 
     # Use the "get" function and save the output to the res.txt file. This file
     # should contain the newly updated value.
-    OUTFILE=res.txt && testOK runBA contract value get --iid "$VALUE_INSTANCE_ID"
+    OUTFILE=res.txt && testOK runBA contract value get --instID "$VALUE_INSTANCE_ID"
     OUTFILE=""
 
     testGrep "newValue" cat res.txt
 
     # Try to get a wrong instance ID
-    testFail runBA contract value get --iid deadbeef
+    testFail runBA contract value get --instID deadbeef
+}
+
+testDel() {
+    # In this test we spawn a value contract, delete it and check if we can get
+    # it. Uses partially the code of the spawn test.
+    runCoBG 1 2 3
+    runGrepSed "export BC=" "" runBA create --roster public.toml --interval .5s
+    eval $SED
+    [ -z "$BC" ] && exit 1
+
+    # Add the spawn:value and invoke:value.update rules
+    testOK runBA darc add -out_id ./darc_id.txt -out_key ./darc_key.txt -unrestricted
+    ID=`cat ./darc_id.txt`
+    KEY=`cat ./darc_key.txt`
+    testOK runBA darc rule -rule "spawn:value" --identity "$KEY" --darc "$ID" --sign "$KEY"
+    testOK runBA darc rule -rule "delete:value" --identity "$KEY" --darc "$ID" --sign "$KEY"
+
+    # Spawn a new value contract, we save the output to the res.txt file
+    OUTFILE=res.txt && testOK runBA contract value spawn --value "myValue" --darc "$ID" --sign "$KEY"
+    OUTFILE=""
+
+    # Check if we got the expected output
+    testGrep "Spawned new value contract. Instance id is:" cat res.txt
+
+    # Extract the instance ID of the newly created value instance
+    VALUE_INSTANCE_ID=`sed -n 2p res.txt`
+
+    # Use the "get" function to retrieve the contract. It should pass.
+    testOK runBA contract value get --instID "$VALUE_INSTANCE_ID"
+
+    # Use the "delete" function
+    testOK runBA contract value delete --instID "$VALUE_INSTANCE_ID" --darc "$ID" --sign "$KEY"
+
+    # Use the "get" function to retrieve the contract. It should fail.
+    testFail runBA contract value get --instID "$VALUE_INSTANCE_ID"
+
+    # Use the "delete" function, should fail since it does not exist anymore
+    testFail runBA contract value delete --instID "$VALUE_INSTANCE_ID" --darc "$ID" --sign "$KEY"
 }

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -425,8 +425,9 @@ var cmds = cli.Commands{
 						},
 					},
 					{
-						Name:  "get",
-						Usage: "if the proof matches, get the content of the given value instance ID",
+						Name:   "get",
+						Usage:  "if the proof matches, get the content of the given value instance ID",
+						Action: clicontracts.ValueGet,
 						Flags: []cli.Flag{
 							cli.StringFlag{
 								Name:   "bc",
@@ -434,11 +435,35 @@ var cmds = cli.Commands{
 								Usage:  "the ByzCoin config to use (required)",
 							},
 							cli.StringFlag{
-								Name:  "iid",
+								Name:  "instID",
 								Usage: "the instance id (required)",
 							},
 						},
-						Action: clicontracts.ValueGet,
+					},
+
+					{
+						Name:   "delete",
+						Usage:  "delete a value contract",
+						Action: clicontracts.ValueDelete,
+						Flags: []cli.Flag{
+							cli.StringFlag{
+								Name:   "bc",
+								EnvVar: "BC",
+								Usage:  "the ByzCoin config to use (required)",
+							},
+							cli.StringFlag{
+								Name:  "instID",
+								Usage: "the instance ID of the value contract",
+							},
+							cli.StringFlag{
+								Name:  "darc",
+								Usage: "DARC with the right to invoke.update a value contract (default is the admin DARC)",
+							},
+							cli.StringFlag{
+								Name:  "sign",
+								Usage: "public key of the signing entity (default is the admin public key)",
+							},
+						},
 					},
 				},
 			},

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -553,6 +553,47 @@ var cmds = cli.Commands{
 							},
 						},
 					},
+					{
+						Name:   "get",
+						Usage:  "if the proof matches, get the content of the given deferred instance ID",
+						Action: clicontracts.DeferredGet,
+						Flags: []cli.Flag{
+							cli.StringFlag{
+								Name:   "bc",
+								EnvVar: "BC",
+								Usage:  "the ByzCoin config to use (required)",
+							},
+							cli.StringFlag{
+								Name:  "instID",
+								Usage: "the instance id (required)",
+							},
+						},
+					},
+
+					{
+						Name:   "delete",
+						Usage:  "delete a deferred contract",
+						Action: clicontracts.DeferredDelete,
+						Flags: []cli.Flag{
+							cli.StringFlag{
+								Name:   "bc",
+								EnvVar: "BC",
+								Usage:  "the ByzCoin config to use (required)",
+							},
+							cli.StringFlag{
+								Name:  "instID",
+								Usage: "the instance ID of the value contract",
+							},
+							cli.StringFlag{
+								Name:  "darc",
+								Usage: "DARC with the right to invoke.update a value contract (default is the admin DARC)",
+							},
+							cli.StringFlag{
+								Name:  "sign",
+								Usage: "public key of the signing entity (default is the admin public key)",
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Until now only the value contract had the "get" method. 

In this PR, I add "get" and "delete" methods to the value and deferred clicontracts.

The get method is particularly convenient for testing. I could one more time verify that a deferred transaction is successfully created by performing a "get" of a proposed transaction after executing `invoke:deferred.execProposedTx`.

I also changed the "--iid" flag to "--instID" for consistency. 