### PR TITLE
fixes behaviour for credential-contract

### DIFF
--- a/personhood/contract_spawner.go
+++ b/personhood/contract_spawner.go
@@ -278,5 +278,11 @@ func (ss *SpawnerStruct) parseArgs(args byzcoin.Arguments) error {
 		}
 		log.Lvl2("Setting cost of", cost.name, "to", cost.cost.Value)
 	}
+	// This is a check to make sure that older spawn-instructions don't get
+	// a wrong data.
+	if args.Search("costRoPaSci") == nil {
+		ss.CostCWrite = nil
+		ss.CostCRead = nil
+	}
 	return nil
 }

--- a/personhood/contract_test.go
+++ b/personhood/contract_test.go
@@ -34,6 +34,7 @@ func TestContractSpawner(t *testing.T) {
 			Args: byzcoin.Arguments{
 				{Name: "costDarc", Value: costBuf},
 				{Name: "costCRead", Value: costBuf},
+				{Name: "costRoPaSci", Value: costBuf},
 			},
 		},
 	}


### PR DESCRIPTION
Uses the arguments to decide how to behave. Once we have block-versions, this
will be much easier.