### PR TITLE
fixes the mask-aggregate

### DIFF
--- a/external/js/kyber/package.json
+++ b/external/js/kyber/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@dedis/kyber",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "A typescript implementation of Kyber interfaces",
   "main": "index.js",
   "browser": "bundle.min.js",

--- a/external/js/kyber/spec/sign/mask.spec.ts
+++ b/external/js/kyber/spec/sign/mask.spec.ts
@@ -15,8 +15,6 @@ describe('Mask Tests', () => {
 
             if (i % 2 === 0) {
                 agg = agg.add(agg, publics[i]);
-            } else {
-                agg = agg.add(agg, new BN256G2Point().neg(publics[i]));
             }
         }
 

--- a/external/js/kyber/src/sign/mask.ts
+++ b/external/js/kyber/src/sign/mask.ts
@@ -25,9 +25,6 @@ export default class Mask {
 
             if ((mask[k] & msk) !== 0) {
                 this.aggregate.add(this.aggregate, publics[i]);
-            } else {
-                const neg = publics[i].clone().neg(publics[i]);
-                this.aggregate.add(this.aggregate, neg);
             }
         }
     }


### PR DESCRIPTION
The previous mask-aggregation misbehaved if one of the public keys was masked.
As the test misbehaved in the same way, it did pass anyway...
This PR makes it behave the same way as in the dedis/kyber library.

Closes #1881 