### PR TITLE
Improvements and fix for deferred

### DIFF
--- a/byzcoin/bcadmin/clicontracts/deferred.go
+++ b/byzcoin/bcadmin/clicontracts/deferred.go
@@ -34,8 +34,10 @@ func DeferredSpawn(c *cli.Context) error {
 	proposedTransaction := byzcoin.ClientTransaction{}
 	err = protobuf.Decode(proposedTransactionBuf, &proposedTransaction)
 	if err != nil {
-		return errors.New("failed to decode transaction: " + err.Error())
+		return errors.New("failed to decode transaction, did you use --redirect ? " + err.Error())
 	}
+
+	fmt.Fprintf(c.App.Writer, "Here is the proposed Tx: \n%s\n", proposedTransaction)
 
 	// ---
 	// 2.

--- a/byzcoin/contract_darc.go
+++ b/byzcoin/contract_darc.go
@@ -40,6 +40,17 @@ func (s *Service) contractSecureDarcFromBytes(in []byte) (Contract, error) {
 	return c, nil
 }
 
+// VerifyDeferredInstruction does the same as the standard VerifyInstruction
+// method in the diferrence that it does not take into account the counters. We
+// need the Darc contract to opt in for deferred transaction because it is used
+// by default when spawning new contracts.
+func (c *contractSecureDarc) VerifyDeferredInstruction(rst ReadOnlyStateTrie, inst Instruction, ctxHash []byte) error {
+	if err := inst.VerifyWithOption(rst, ctxHash, false); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (c *contractSecureDarc) Spawn(rst ReadOnlyStateTrie, inst Instruction, coins []Coin) (sc []StateChange, cout []Coin, err error) {
 	cout = coins
 

--- a/byzcoin/contracts/insecure_darc.go
+++ b/byzcoin/contracts/insecure_darc.go
@@ -60,7 +60,7 @@ func (c *contractInsecureDarc) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin
 	// into the trie.
 	c2, err := cfact(nil)
 	if err != nil {
-		return nil, nil, fmt.Errorf("coult not spawn new zero instance: %v", err)
+		return nil, nil, fmt.Errorf("could not spawn new zero instance: %v", err)
 	}
 	return c2.Spawn(rst, inst, coins)
 }

--- a/byzcoin/struct.go
+++ b/byzcoin/struct.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -666,4 +667,31 @@ func (c ChainConfig) checkNewRoster(newRoster onet.Roster) error {
 		return errors.New("can only change one node at a time - adding or removing")
 	}
 	return nil
+}
+
+// String implements a nicer text representation of a Chainconfig.
+//
+// Here is an example of what it outputs:
+//
+// ```
+// ChainConfig
+// - BlockInterval: 7s
+// - Roster: {1e89775c-636a-536a-bc39-1ec951c86dc9 [tls://localhost:2002 tls://localhost:2004 tls://localhost:2006] 467abd382f78222e898d323194c0fb30f7096bb6bb885ea31284979f794e558a}
+// - MaxBlockSize: 5000000
+// - DarcContractIDs:
+// -- darc contract ID 0: darc
+// -- darc contract ID 1: darc2
+// -- darc contract ID 2: darc3'
+// ```
+func (c ChainConfig) String() string {
+	var res strings.Builder
+	res.WriteString("ChainConfig\n")
+	fmt.Fprintf(&res, "- BlockInterval: %s\n", c.BlockInterval.String())
+	fmt.Fprintf(&res, "- Roster: %s\n", c.Roster)
+	fmt.Fprintf(&res, "- MaxBlockSize: %d\n", c.MaxBlockSize)
+	res.WriteString("- DarcContractIDs:\n")
+	for i, darcID := range c.DarcContractIDs {
+		fmt.Fprintf(&res, "-- darc contract ID %d: %s\n", i, darcID)
+	}
+	return res.String()
 }


### PR DESCRIPTION
This PR contains the side stuff that had to be implemented/refactored in order to use the deferred update_config from bcadmin.

This PR does the following:

- Adds a `VerifyDeferredInstruction(...)` for the Darc and Config contracts
- Fixes a wrong mechanism in the deferred contract when getting contract instances of proposed transactions
- Adds a String representation of a ChainConfig struct

I have another PR ready that depends on this one, which implements the deferred update_config of from bcadmin.