### PR TITLE
Adds config clicontract with invoke:update_config

### DIFF
--- a/byzcoin/bcadmin/clicontracts/README.md
+++ b/byzcoin/bcadmin/clicontracts/README.md
@@ -29,6 +29,7 @@ contract's data given its instance id with `--instID`.
 * *instr* stands for *instruction*
 * *id* stands for *identifier*
 * *idx* stands for *index*
+* commands of the invoke are always in camelcase
 
 **Command examples**:
 

--- a/byzcoin/bcadmin/clicontracts/README.md
+++ b/byzcoin/bcadmin/clicontracts/README.md
@@ -83,8 +83,8 @@ bcadmin darc rule --identity ed25519:... --rule invoke:deferred.execProposedTx
 bcadmin contract config invoke updateConfig
 
 # Perform an update that is redirected to the spawn of a deferred contract
-bcadmin contract config invoke updateConfig --blockInterval 7s\
-                                            --maxBlockSize 5000000\
+bcadmin contract config invoke updateConfig --blockInterval 7s \
+                                            --maxBlockSize 5000000 \
                                             --darcContractIDs darc,darc2 \
                                             --redirect | bcadmin contract deferred spawn
 

--- a/byzcoin/bcadmin/clicontracts/README.md
+++ b/byzcoin/bcadmin/clicontracts/README.md
@@ -13,12 +13,7 @@ commands and functionalities among clicontracts.
 
 **Commands convention**:
 
-```bash
-$ bcadmin contract <contract name> {spawn,invoke <command>, delete, get}\
-                                   [--<param name> <param value>, ...]\
-                                   [--sign <signer id>] [--darc <darc id>]\
-                                   [--redirect]
-```
+Use `bcadmin contract -h` to get the usage.
 
 **Functionalities**:
 
@@ -60,5 +55,46 @@ Invoke an addProof on a deferred contract:
 
 ```bash
 # The --hash and --instID values are given when we spawn the deferred contract
-bcadmin contract deferred invoke addProof --hash ... --instID ... --iid 0
+bcadmin contract deferred invoke addProof --hash ... --instID ... --instrIdx 0
 ```
+
+**Config update deferred scenario**:
+
+```bash
+# Change it to your setup:
+export COTHORITY=~/Github/cothority
+
+# Run the nodes, create roster and set up the config
+./run_nodes.sh -n 5 -c -t -v 2
+export BC_CONFIG=$COTHORITY/conode
+bcadmin create -roster $COTHORITY/conode/public.toml 
+# (Copy/Paste from the output of the previous command)
+export BC=...
+
+# Add the rules specific to the deferred contract.
+# We use the admin identity.
+bcadmin darc rule --identity ed25519:... --rule spawn:deferred
+bcadmin darc rule --identity ed25519:... --rule invoke:deferred.addProof
+bcadmin darc rule --identity ed25519:... --rule invoke:deferred.execProposedTx
+
+# This command will return the current state of the config by performing an
+# empty update
+bcadmin contract config invoke updateConfig
+
+# Perform an update that is redirected to the spawn of a deferred contract
+bcadmin contract config invoke updateConfig --blockInterval 7s\
+                                            --maxBlockSize 5000000\
+                                            --darcContractIDs darc,darc2 \
+                                            --redirect | bcadmin contract deferred spawn
+
+# Add the proof on the single instruction of the deferred transaction 
+# (the --hash and --instID values are given when we spawn the deferred contract)
+bcadmin contract deferred invoke addProof --hash ... --instID ... --instrIdx 0
+
+# Finally execute the deferred transaction.
+# This will call the Spawn:value(myValue) transaction.
+# If we hadn't called the addProof before, it wouldn't have worked.
+bcadmin contract deferred invoke execProposedTx --instID ...
+
+# Now we can perform a zero update juste to get the result 
+bcadmin contract config invoke updateConfig

--- a/byzcoin/bcadmin/clicontracts/config.go
+++ b/byzcoin/bcadmin/clicontracts/config.go
@@ -1,0 +1,192 @@
+package clicontracts
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"go.dedis.ch/cothority/v3"
+	"go.dedis.ch/cothority/v3/byzcoin"
+	"go.dedis.ch/cothority/v3/byzcoin/bcadmin/lib"
+	"go.dedis.ch/cothority/v3/darc"
+	"go.dedis.ch/onet/v3/network"
+	"go.dedis.ch/protobuf"
+	"gopkg.in/urfave/cli.v1"
+)
+
+// ConfigInvokeUpdateConfig perform an Invoke:update_config on a config contract
+func ConfigInvokeUpdateConfig(c *cli.Context) error {
+	// Here is what this function does:
+	//   1. Get the current config and parse the arguments
+	//   2. Build the transaction and send it to stdout if --redirect is given
+	//   3. Get the result back and output it
+
+	// ---
+	// 1.
+	// ---
+	bcArg := c.String("bc")
+	if bcArg == "" {
+		return errors.New("--bc flag is required")
+	}
+
+	cfg, cl, err := lib.LoadConfig(bcArg)
+	if err != nil {
+		return err
+	}
+
+	var signer *darc.Signer
+
+	sstr := c.String("sign")
+	if sstr == "" {
+		signer, err = lib.LoadKey(cfg.AdminIdentity)
+	} else {
+		signer, err = lib.LoadKeyFromString(sstr)
+	}
+	if err != nil {
+		return err
+	}
+
+	// Get the latest chain config
+	pr, err := cl.GetProof(byzcoin.ConfigInstanceID.Slice())
+	if err != nil {
+		return errors.New("couldn't get proof for chainConfig: " + err.Error())
+	}
+	proof := pr.Proof
+
+	_, value, _, _, err := proof.KeyValue()
+	if err != nil {
+		return errors.New("couldn't get value out of proof: " + err.Error())
+	}
+	config := byzcoin.ChainConfig{}
+	err = protobuf.DecodeWithConstructors(value, &config, network.DefaultConstructors(cothority.Suite))
+	if err != nil {
+		return errors.New("couldn't decode chainConfig: " + err.Error())
+	}
+
+	// BlockInterval
+	blockInterval := c.String("blockInterval")
+
+	if blockInterval != "" {
+		duration, err := time.ParseDuration(blockInterval)
+		if err != nil {
+			return errors.New("couldn't parse blockInterval: " + err.Error())
+		}
+		config.BlockInterval = duration
+	}
+
+	// MaxBlockSize
+	maxBlockSize := c.Int("maxBlockSize")
+	if maxBlockSize > 0 {
+		if maxBlockSize < 16000 && maxBlockSize > 8e6 {
+			return errors.New("maxBlockSize out of bounds: must be between 16e3 and 8e6")
+		}
+		config.MaxBlockSize = maxBlockSize
+	}
+
+	// DarcContractIDs
+	// we need the IDs to be separated by commas
+	darcContractIDs := c.String("darcContractIDs")
+	if darcContractIDs != "" {
+		darcContractIDsSlice := strings.Split(darcContractIDs, ",")
+		config.DarcContractIDs = darcContractIDsSlice
+	}
+
+	configBuf, err := protobuf.Encode(&config)
+	if err != nil {
+		return errors.New("failed to encode config: " + err.Error())
+	}
+
+	counters, err := cl.GetSignerCounters(signer.Identity().String())
+	if err != nil {
+		return errors.New("couldn't get counters: " + err.Error())
+	}
+
+	invoke := byzcoin.Invoke{
+		ContractID: byzcoin.ContractConfigID,
+		Command:    "update_config",
+		Args: []byzcoin.Argument{
+			{
+				Name:  "config",
+				Value: configBuf,
+			},
+		},
+	}
+
+	// ---
+	// 2.
+	// ---
+	redirect := c.Bool("redirect")
+	// In the case the --redirect flag is provided, the transaction is not
+	// applied but sent to stdout.
+	if redirect {
+		proposedTransaction := byzcoin.ClientTransaction{
+			Instructions: []byzcoin.Instruction{
+				byzcoin.Instruction{
+					InstanceID: byzcoin.ConfigInstanceID,
+					Invoke:     &invoke,
+				},
+			},
+		}
+		proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
+		if err != nil {
+			return errors.New("couldn't encode the transaction: " + err.Error())
+		}
+		reader := bytes.NewReader(proposedTransactionBuf)
+		_, err = io.Copy(c.App.Writer, reader)
+		if err != nil {
+			return errors.New("failed to copy to stdout: " + err.Error())
+		}
+		return nil
+	}
+
+	ctx := byzcoin.ClientTransaction{
+		Instructions: []byzcoin.Instruction{{
+			InstanceID:    byzcoin.ConfigInstanceID,
+			Invoke:        &invoke,
+			SignerCounter: []uint64{counters.Counters[0] + 1},
+		}},
+	}
+
+	err = ctx.FillSignersAndSignWith(*signer)
+	if err != nil {
+		return err
+	}
+
+	_, err = cl.AddTransactionAndWait(ctx, 10)
+	if err != nil {
+		return err
+	}
+
+	// ---
+	// 3.
+	// ---
+	pr, err = cl.GetProof(byzcoin.ConfigInstanceID.Slice())
+	if err != nil {
+		return errors.New("couldn't get proof for config: " + err.Error())
+	}
+	proof = pr.Proof
+
+	_, resultBuf, _, _, err := proof.KeyValue()
+	if err != nil {
+		return errors.New("couldn't get value out of proof: " + err.Error())
+	}
+
+	contractConfig := byzcoin.ChainConfig{}
+	err = protobuf.Decode(resultBuf, &contractConfig)
+	if err != nil {
+		return errors.New("failed to decode contractConfig: " + err.Error())
+	}
+
+	newInstID := ctx.Instructions[0].DeriveID("").Slice()
+	_, err = fmt.Fprintf(c.App.Writer, "Config contract updated! (instance ID is %x)\n", newInstID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(c.App.Writer, "Here is the config data: \n%s", contractConfig)
+
+	return nil
+}

--- a/byzcoin/bcadmin/clicontracts/config.go
+++ b/byzcoin/bcadmin/clicontracts/config.go
@@ -55,6 +55,10 @@ func ConfigInvokeUpdateConfig(c *cli.Context) error {
 		return errors.New("couldn't get proof for chainConfig: " + err.Error())
 	}
 	proof := pr.Proof
+	err = proof.Verify(cl.ID)
+	if err != nil {
+		return errors.New("failed to verify proof: " + err.Error())
+	}
 
 	_, value, _, _, err := proof.KeyValue()
 	if err != nil {
@@ -168,6 +172,10 @@ func ConfigInvokeUpdateConfig(c *cli.Context) error {
 		return errors.New("couldn't get proof for config: " + err.Error())
 	}
 	proof = pr.Proof
+	err = proof.Verify(cl.ID)
+	if err != nil {
+		return errors.New("failed to verify proof: " + err.Error())
+	}
 
 	_, resultBuf, _, _, err := proof.KeyValue()
 	if err != nil {
@@ -209,6 +217,10 @@ func ConfigGet(c *cli.Context) error {
 		return errors.New("couldn't get proof for chainConfig: " + err.Error())
 	}
 	proof := pr.Proof
+	err = proof.Verify(cl.ID)
+	if err != nil {
+		return errors.New("failed to verify proof: " + err.Error())
+	}
 
 	_, value, _, _, err := proof.KeyValue()
 	if err != nil {

--- a/byzcoin/bcadmin/clicontracts/config.go
+++ b/byzcoin/bcadmin/clicontracts/config.go
@@ -190,3 +190,37 @@ func ConfigInvokeUpdateConfig(c *cli.Context) error {
 
 	return nil
 }
+
+// ConfigGet displays the latest chain config contract instance
+func ConfigGet(c *cli.Context) error {
+	bcArg := c.String("bc")
+	if bcArg == "" {
+		return errors.New("--bc flag is required")
+	}
+
+	_, cl, err := lib.LoadConfig(bcArg)
+	if err != nil {
+		return err
+	}
+
+	// Get the latest chain config
+	pr, err := cl.GetProof(byzcoin.ConfigInstanceID.Slice())
+	if err != nil {
+		return errors.New("couldn't get proof for chainConfig: " + err.Error())
+	}
+	proof := pr.Proof
+
+	_, value, _, _, err := proof.KeyValue()
+	if err != nil {
+		return errors.New("couldn't get value out of proof: " + err.Error())
+	}
+	config := byzcoin.ChainConfig{}
+	err = protobuf.DecodeWithConstructors(value, &config, network.DefaultConstructors(cothority.Suite))
+	if err != nil {
+		return errors.New("couldn't decode chainConfig: " + err.Error())
+	}
+
+	fmt.Fprintf(c.App.Writer, "Here is the config data: \n%s", config)
+
+	return nil
+}

--- a/byzcoin/bcadmin/clicontracts/config_test.sh
+++ b/byzcoin/bcadmin/clicontracts/config_test.sh
@@ -2,6 +2,7 @@
 
 testContractConfig() {
     run testContractConfigInvoke
+    testContractConfigGet
 }
 
 # In this test we check the behavior of the invoke:update_config function. We
@@ -42,4 +43,24 @@ testContractConfigInvoke() {
     testGrep "\-\- darc contract ID 0: darc" echo "$OUTRES"
     testGrep "\-\- darc contract ID 1: darc2" echo "$OUTRES"
     testGrep "\-\- darc contract ID 2: darc3" echo "$OUTRES"
+}
+
+# In this test we simply get the config contract and check the result.
+testContractConfigGet() {
+    runCoBG 1 2 3
+    runGrepSed "export BC=" "" runBA create --roster public.toml --interval .5s
+    eval $SED
+    [ -z "$BC" ] && exit 1
+
+    # Get the config instance
+    OUTRES=`runBA contract config get`
+
+    # Check the result
+    testGrep "Here is the config data:" echo "$OUTRES"
+    testGrep "ChainConfig" echo "$OUTRES"
+    testGrep "\- BlockInterval: [a-z0-9]+" echo "$OUTRES"
+    testGrep "\- Roster: \{.*\}" echo "$OUTRES"
+    testGrep "\- MaxBlockSize: [0-9]+" echo "$OUTRES"
+    testGrep "\- DarcContractIDs:" echo "$OUTRES"
+    testGrep "\-\- darc contract ID 0: darc" echo "$OUTRES"
 }

--- a/byzcoin/bcadmin/clicontracts/config_test.sh
+++ b/byzcoin/bcadmin/clicontracts/config_test.sh
@@ -1,0 +1,45 @@
+# This method should be called from the byzcoin/bcadmin/test.sh script
+
+testContractConfig() {
+    run testContractConfigInvoke
+}
+
+# In this test we check the behavior of the invoke:update_config function. We
+# first perform an update with nothing, then we update all the parameter and
+# check the result.
+testContractConfigInvoke() {
+    runCoBG 1 2 3
+    runGrepSed "export BC=" "" runBA create --roster public.toml --interval .5s
+    eval $SED
+    [ -z "$BC" ] && exit 1
+
+    # Run an update with no argument, we should have in return the current
+    # config.
+    OUTRES=`runBA contract config invoke updateConfig`
+
+    testGrep "Config contract updated! \(instance ID is [a-f0-9]+\)" echo "$OUTRES"
+    testGrep "Here is the config data:" echo "$OUTRES"
+    testGrep "ChainConfig" echo "$OUTRES"
+    testGrep "\- BlockInterval: [a-z0-9]+" echo "$OUTRES"
+    testGrep "\- Roster: \{.*\}" echo "$OUTRES"
+    testGrep "\- MaxBlockSize: [0-9]+" echo "$OUTRES"
+    testGrep "\- DarcContractIDs:" echo "$OUTRES"
+    testGrep "\-\- darc contract ID 0: darc" echo "$OUTRES"
+
+    # Update all the arguments. We check if the return corresponds.
+    OUTRES=`runBA contract config invoke updateConfig\
+                --blockInterval 7s\
+                --maxBlockSize 5000000\
+                --darcContractIDs darc,darc2,darc3`
+    
+    testGrep "Config contract updated! \(instance ID is [a-f0-9]+\)" echo "$OUTRES"
+    testGrep "Here is the config data:" echo "$OUTRES"
+    testGrep "ChainConfig" echo "$OUTRES"
+    testGrep "\- BlockInterval: 7s" echo "$OUTRES"
+    testGrep "\- Roster: \{.*\}" echo "$OUTRES"
+    testGrep "\- MaxBlockSize: 5000000" echo "$OUTRES"
+    testGrep "\- DarcContractIDs:" echo "$OUTRES"
+    testGrep "\-\- darc contract ID 0: darc" echo "$OUTRES"
+    testGrep "\-\- darc contract ID 1: darc2" echo "$OUTRES"
+    testGrep "\-\- darc contract ID 2: darc3" echo "$OUTRES"
+}

--- a/byzcoin/bcadmin/clicontracts/config_test.sh
+++ b/byzcoin/bcadmin/clicontracts/config_test.sh
@@ -2,7 +2,7 @@
 
 testContractConfig() {
     run testContractConfigInvoke
-    testContractConfigGet
+    run testContractConfigGet
 }
 
 # In this test we check the behavior of the invoke:update_config function. We

--- a/byzcoin/bcadmin/clicontracts/deferred.go
+++ b/byzcoin/bcadmin/clicontracts/deferred.go
@@ -119,6 +119,10 @@ func DeferredSpawn(c *cli.Context) error {
 		return errors.New("couldn't get proof for admin-darc: " + err.Error())
 	}
 	proof := pr.Proof
+	err = proof.Verify(cl.ID)
+	if err != nil {
+		return errors.New("failed to verify proof: " + err.Error())
+	}
 
 	_, resultBuf, _, _, err := proof.KeyValue()
 	if err != nil {
@@ -257,6 +261,10 @@ func DeferredInvokeAddProof(c *cli.Context) error {
 		return errors.New("couldn't get proof for admin-darc: " + err.Error())
 	}
 	proof := pr.Proof
+	err = proof.Verify(cl.ID)
+	if err != nil {
+		return errors.New("failed to verify proof: " + err.Error())
+	}
 
 	_, resultBuf, _, _, err := proof.KeyValue()
 	if err != nil {
@@ -350,6 +358,10 @@ func ExecProposedTx(c *cli.Context) error {
 		return errors.New("couldn't get proof for admin-darc: " + err.Error())
 	}
 	proof := pr.Proof
+	err = proof.Verify(cl.ID)
+	if err != nil {
+		return errors.New("failed to verify proof: " + err.Error())
+	}
 
 	_, resultBuf, _, _, err := proof.KeyValue()
 	if err != nil {
@@ -394,6 +406,10 @@ func DeferredGet(c *cli.Context) error {
 		return errors.New("couldn't get proof: " + err.Error())
 	}
 	proof := pr.Proof
+	err = proof.Verify(cl.ID)
+	if err != nil {
+		return errors.New("failed to verify proof: " + err.Error())
+	}
 
 	exist, err := proof.InclusionProof.Exists(instIDBuf)
 	if err != nil {

--- a/byzcoin/bcadmin/clicontracts/value.go
+++ b/byzcoin/bcadmin/clicontracts/value.go
@@ -231,6 +231,10 @@ func ValueGet(c *cli.Context) error {
 		return errors.New("couldn't get proof: " + err.Error())
 	}
 	proof := pr.Proof
+	err = proof.Verify(cl.ID)
+	if err != nil {
+		return errors.New("failed to verify proof: " + err.Error())
+	}
 
 	exist, err := proof.InclusionProof.Exists(instIDBuf)
 	if err != nil {

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -355,8 +355,28 @@ var cmds = cli.Commands{
 	},
 
 	{
-		Name:  "contract",
-		Usage: "a tool to manipulate contracts",
+		Name: "contract",
+		// Use space instead of tabs for correct formatting
+		Usage: fmt.Sprint(`
+   bcadmin contract CONTRACT { spawn  --bc <byzcoin config> 
+                                      [--<arg name> <arg value>, ...]
+                                      [--darc <darc id>] 
+                                      [--sign <pub key>] 
+                                      [--redirect],
+                               invoke <command>
+                                      --bc <byzcoin config>
+                                      --instID <instance ID>
+                                      [--<arg name> <arg value>, ...]
+                                      [--darc <darc id>] 
+                                      [--sign <pub key>],
+                               get    --bc <byzcoin config>
+                                      --instID <instance ID>,
+                               delete --bc <byzcoin config>
+                                      --instID <instance ID>
+                                      [--darc <darc id>] 
+                                      [--sign <pub key>]     
+                             }
+   CONTRAT   {value,deferred}`),
 		Subcommands: cli.Commands{
 			{
 				Name:  "value",
@@ -523,6 +543,50 @@ var cmds = cli.Commands{
 									cli.StringFlag{
 										Name:  "sign",
 										Usage: "public key of the signing entity (default is the admin public key)",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name:  "config",
+				Usage: "Manipulate a config contract",
+				Subcommands: cli.Commands{
+					{
+						Name:  "invoke",
+						Usage: "invoke on a config contract ",
+						Subcommands: cli.Commands{
+							{
+								Name:   "updateConfig",
+								Usage:  "changes the roster's leader",
+								Action: clicontracts.ConfigInvokeUpdateConfig,
+								Flags: []cli.Flag{
+									cli.StringFlag{
+										Name:   "bc",
+										EnvVar: "BC",
+										Usage:  "the ByzCoin config to use (required)",
+									},
+									cli.StringFlag{
+										Name:  "sign",
+										Usage: "public key of the signing entity (default is the admin public key)",
+									},
+									cli.StringFlag{
+										Name:  "blockInterval",
+										Usage: "blockInterval, for example 2s (optional)",
+									},
+									cli.IntFlag{
+										Name:  "maxBlockSize",
+										Usage: "maxBlockSize (optional)",
+									},
+									cli.StringFlag{
+										Name:  "darcContractIDs",
+										Usage: "darcContractIDs separated by comas (optional)",
+									},
+									cli.BoolFlag{
+										Name:  "redirect",
+										Usage: "redirects the transaction to stdout",
 									},
 								},
 							},

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -376,7 +376,7 @@ var cmds = cli.Commands{
                                       [--darc <darc id>] 
                                       [--sign <pub key>]     
                              }
-   CONTRAT   {value,deferred}`),
+   CONTRAT   {value,deferred,config}`),
 		Subcommands: cli.Commands{
 			{
 				Name:  "value",

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -658,6 +658,18 @@ var cmds = cli.Commands{
 							},
 						},
 					},
+					{
+						Name:   "get",
+						Usage:  "displays the latest chain config",
+						Action: clicontracts.ConfigGet,
+						Flags: []cli.Flag{
+							cli.StringFlag{
+								Name:   "bc",
+								EnvVar: "BC",
+								Usage:  "the ByzCoin config to use (required)",
+							},
+						},
+					},
 				},
 			},
 		},

--- a/byzcoin/bcadmin/test.sh
+++ b/byzcoin/bcadmin/test.sh
@@ -17,8 +17,9 @@ export -n BC_CONFIG
 export -n BC
 
 . "../../libtest.sh"
-. "../clicontracts/value_test.sh"
+. "../clicontracts/config_test.sh"
 . "../clicontracts/deferred_test.sh"
+. "../clicontracts/value_test.sh"
 
 main(){
     startTest
@@ -39,6 +40,7 @@ main(){
     run testUpdateDarcDesc
     run testContractValue
     run testContractDeferred
+    run testContractConfig
     stopTest
 }
 


### PR DESCRIPTION
It is now possible to update the contract config with a deferred transaction. There is a complete scenario in the readme, but here is the main command:

```bash
bcadmin contract config invoke updateConfig --blockInterval 7s \
                                            --maxBlockSize 5000000 \
                                            --darcContractIDs darc,darc2 \
                                            --redirect | bcadmin contract deferred spawn
```

UPDATE:

I added the get method, which displays the latest chain config:

```bash
bcadmin contract config get
```