### PR TITLE
Prevent block with infinite loop

### DIFF
--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -291,6 +291,7 @@ func (s *Service) StoreSkipBlockInternal(psbd *StoreSkipBlock) (*StoreSkipBlockR
 		prop.VerifierIDs = prev.VerifierIDs
 		prop.Index = prev.Index + 1
 		prop.GenesisID = scID
+		prop.ForwardLink = []*ForwardLink{}
 		// And calculate the height of that block.
 		index := prop.Index
 		for prop.Height = 1; index%prop.BaseHeight == 0; prop.Height++ {

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -115,7 +115,14 @@ func storeSkipBlock(t *testing.T, nbrServers int, fail bool) {
 		deadServer.Unpause()
 	}
 
+	// Get the forward link of the genesis to test that forward links are correctly
+	// ignored
+	genesis, err = service.GetSingleBlock(&GetSingleBlock{ID: genesis.Hash})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(genesis.ForwardLink))
+
 	next.Data = []byte("And the Spirit of God moved upon the face of the waters.")
+	next.ForwardLink = genesis.ForwardLink
 	psbr3, err := service.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: psbr2.Latest.Hash, NewBlock: next})
 	assert.NotNil(t, psbr3)
 	assert.NotNil(t, psbr3.Latest)


### PR DESCRIPTION
This cleans the forward links before proposing a block to prevent
old valid forward links to be stored in new blocks.