### PR TITLE
makes SpawnerInstance wait for proofs

### DIFF
--- a/external/js/cothority/src/byzcoin/contracts/darc-instance.ts
+++ b/external/js/cothority/src/byzcoin/contracts/darc-instance.ts
@@ -11,6 +11,9 @@ export default class DarcInstance extends Instance {
     static readonly commandEvolve = "evolve";
     static readonly commandEvolveUnrestricted = "evolve_unrestricted";
     static readonly argumentDarc = "darc";
+    static readonly ruleEvolve = "invoke:" + DarcInstance.argumentDarc + "." + DarcInstance.commandEvolve;
+    static readonly ruleEvolveUnrestricted = "invoke:" + DarcInstance.argumentDarc + "." +
+        DarcInstance.commandEvolveUnrestricted;
 
     /**
      * Initializes using an existing coinInstance from ByzCoin

--- a/external/js/cothority/src/calypso/calypso-instance.ts
+++ b/external/js/cothority/src/calypso/calypso-instance.ts
@@ -109,8 +109,9 @@ export class CalypsoWriteInstance extends Instance {
      * @param iid   The instance ID
      * @returns a promise that resolves with the coin instance
      */
-    static async fromByzcoin(bc: ByzCoinRPC, iid: InstanceID): Promise<CalypsoWriteInstance> {
-        return new CalypsoWriteInstance(bc, await Instance.fromByzcoin(bc, iid));
+    static async fromByzcoin(bc: ByzCoinRPC, iid: InstanceID, waitMatch: number = 0, interval: number = 1000):
+        Promise<CalypsoWriteInstance> {
+        return new CalypsoWriteInstance(bc, await Instance.fromByzcoin(bc, iid, waitMatch, interval));
     }
     write: Write;
 

--- a/external/js/cothority/src/personhood/spawner-instance.ts
+++ b/external/js/cothority/src/personhood/spawner-instance.ts
@@ -207,7 +207,7 @@ export default class SpawnerInstance extends Instance {
         await ctx.updateCountersAndSign(this.rpc, [signers, []]);
         await this.rpc.sendTransactionAndWait(ctx);
 
-        return CoinInstance.fromByzcoin(this.rpc, CoinInstance.coinIID(coinID));
+        return CoinInstance.fromByzcoin(this.rpc, CoinInstance.coinIID(coinID), 2);
     }
 
     /**
@@ -257,7 +257,7 @@ export default class SpawnerInstance extends Instance {
         await ctx.updateCountersAndSign(this.rpc, [signers, []]);
         await this.rpc.sendTransactionAndWait(ctx);
 
-        return CredentialInstance.fromByzcoin(this.rpc, finalCredID);
+        return CredentialInstance.fromByzcoin(this.rpc, finalCredID, 2);
     }
 
     /**
@@ -311,7 +311,7 @@ export default class SpawnerInstance extends Instance {
 
         await this.rpc.sendTransactionAndWait(ctx);
 
-        return PopPartyInstance.fromByzcoin(this.rpc, ctx.instructions[2].deriveId());
+        return PopPartyInstance.fromByzcoin(this.rpc, ctx.instructions[2].deriveId(), 2);
     }
 
     /**
@@ -368,7 +368,7 @@ export default class SpawnerInstance extends Instance {
 
         await this.rpc.sendTransactionAndWait(ctx);
 
-        const rpsi = await RoPaSciInstance.fromByzcoin(this.rpc, ctx.instructions[1].deriveId());
+        const rpsi = await RoPaSciInstance.fromByzcoin(this.rpc, ctx.instructions[1].deriveId(), 2);
         rpsi.setChoice(choice, fillup);
 
         return rpsi;
@@ -427,7 +427,7 @@ export default class SpawnerInstance extends Instance {
         await ctx.updateCountersAndSign(this.rpc, [signers, []]);
         await this.rpc.sendTransactionAndWait(ctx);
 
-        return CalypsoWriteInstance.fromByzcoin(this.rpc, ctx.instructions[1].deriveId());
+        return CalypsoWriteInstance.fromByzcoin(this.rpc, ctx.instructions[1].deriveId(), 2);
     }
 }
 


### PR DESCRIPTION
A common failure in ByzCoin operation is that the instance is created on one node,
and the client asks another node for the proof, which fails, if that other node
did not get the new block yet.

This PR adds a default wait to the SpawnerInstance, and also fixes the
CalypsoWriteInstance which did not have the wait argument.