### PR TITLE
View change improvement

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -1275,7 +1275,13 @@ func (s *Service) updateTrieCallback(sbID skipchain.SkipBlockID) error {
 		return nil
 	} else if sb.Index > trieIndex+1 {
 		log.Warn(s.ServerIdentity(), "Got new block while catching up - ignoring block for now")
-		go s.catchUp(sb)
+		go func() {
+			// This new block will catch up at the end of the current catch up (if any)
+			// and be ignored if the block is already known.
+			s.catchingLock.Lock()
+			s.catchUp(sb)
+			s.catchingLock.Unlock()
+		}()
 
 		return nil
 	}

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -1908,7 +1908,8 @@ func TestService_DarcToSc(t *testing.T) {
 	for _, service := range s.services {
 		service.darcToSc = make(map[string]skipchain.SkipBlockID)
 		service.TestClose()
-		require.NoError(t, service.startAllChains())
+		service.closed = false
+		require.NoError(t, service.startChain(scID))
 	}
 
 	// check that the mapping is still correct

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -37,7 +37,7 @@ const invalidContract = "invalid"
 const stateChangeCacheContract = "stateChangeCacheTest"
 
 func TestMain(m *testing.M) {
-	log.MainTest(m, 3)
+	log.MainTest(m)
 }
 
 func TestService_CreateGenesisBlock(t *testing.T) {

--- a/byzcoin/viewchange.go
+++ b/byzcoin/viewchange.go
@@ -320,7 +320,7 @@ func (s *Service) verifyViewChange(msg []byte, data []byte) bool {
 		return len(signers), len(views)
 	}()
 	f := s.getFaultThreshold(sb.Hash)
-	if uniqueSigners < 2*f {
+	if uniqueSigners <= 2*f {
 		log.Error(s.ServerIdentity(), "not enough proofs")
 		return false
 	}

--- a/byzcoin/viewchange.go
+++ b/byzcoin/viewchange.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math"
 	"sync"
 	"time"
 
@@ -203,7 +202,7 @@ func (s *Service) computeInitialDuration(scID skipchain.SkipBlockID) (time.Durat
 
 func (s *Service) getFaultThreshold(sbID skipchain.SkipBlockID) int {
 	sb := s.db().GetByID(sbID)
-	return len(sb.Roster.List) / 3
+	return (len(sb.Roster.List) - 1) / 3
 }
 
 // handleViewChangeReq should be registered as a handler for viewchange.InitReq
@@ -271,18 +270,11 @@ func (s *Service) startViewChangeCosi(req viewchange.NewViewReq) ([]byte, error)
 		return nil, err
 	}
 
-	n := len(sb.Roster.List)
 	cosiProto := proto.(*protocol.BlsCosi)
 	cosiProto.Msg = req.Hash()
 	cosiProto.Data = payload
 	cosiProto.CreateProtocol = s.CreateProtocol
 	cosiProto.Timeout = interval * 2
-	cosiProto.Threshold = n - n/3
-
-	err = cosiProto.SetNbrSubTree(int(math.Pow(float64(n), 1.0/3.0)))
-	if err != nil {
-		return nil, err
-	}
 
 	if err := cosiProto.Start(); err != nil {
 		return nil, err
@@ -327,8 +319,8 @@ func (s *Service) verifyViewChange(msg []byte, data []byte) bool {
 		}
 		return len(signers), len(views)
 	}()
-	f := len(sb.Roster.List) / 3
-	if uniqueSigners < 2*f+1 {
+	f := s.getFaultThreshold(sb.Hash)
+	if uniqueSigners < 2*f {
 		log.Error(s.ServerIdentity(), "not enough proofs")
 		return false
 	}

--- a/byzcoin/viewchange/viewchange.go
+++ b/byzcoin/viewchange/viewchange.go
@@ -182,7 +182,7 @@ func (c *Controller) Start(myID network.ServerIdentityID, genesis skipchain.Skip
 				continue
 			}
 			if view.Equal(meta.currOf(ctr)) {
-				log.Lvl3("view-change completed successfully for view: ", view)
+				log.Lvl1("view-change completed successfully for view: ", view)
 			} else {
 				// Usually this should not happen, if it does,
 				// that means the controller decided to move on
@@ -207,7 +207,7 @@ func (c *Controller) Start(myID network.ServerIdentityID, genesis skipchain.Skip
 				Gen:         genesis,
 				LeaderIndex: ctr + 1,
 			}
-			log.Lvl4("view-change timer expired, creating new view:", view)
+			log.Lvl1("view-change timer expired, creating new view:", view)
 			req := InitReq{
 				View:     view,
 				SignerID: myID,

--- a/byzcoin/viewchange/viewchange.go
+++ b/byzcoin/viewchange/viewchange.go
@@ -15,7 +15,6 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
-	"math"
 	"time"
 
 	"go.dedis.ch/cothority/v3"
@@ -159,11 +158,11 @@ func (c *Controller) Start(myID network.ServerIdentityID, genesis skipchain.Skip
 					ctr = c.processAnomaly(reqNew, &meta, ctr)
 				}
 			}
-			if meta.countOf(ctr) > 2*f && meta.stateOf(ctr) < startedTimerState && meta.acceptOf(ctr) {
+			if meta.countOf(ctr) >= 2*f && meta.stateOf(ctr) < startedTimerState && meta.acceptOf(ctr) {
 				// To avoid starting the next view-change too
 				// soon, start view-change timer after
-				// receiving 2*f+1 view-change messages.
-				timer.Reset(time.Duration(math.Pow(2, float64(ctr))) * initialDuration)
+				// receiving 2*f view-change messages.
+				timer.Reset(initialDuration * 2)
 				meta.nextStateFor(ctr)
 				select {
 				case c.startTimerChan <- ctr:
@@ -250,7 +249,7 @@ func (c *Controller) processAnomaly(req InitReq, meta *stateLogs, ctr int) int {
 		// controller has already moved on and it will
 		// only wait for relevant messages for its
 		// current or later view.
-		log.Warn("Controller is not accepting anomalies for earlier views")
+		log.Lvl4("Controller is not accepting anomalies for earlier views")
 	}
 	return ctr
 }

--- a/byzcoin/viewchange_test.go
+++ b/byzcoin/viewchange_test.go
@@ -32,7 +32,9 @@ func TestViewChange_Basic3(t *testing.T) {
 		t.Skip("not for Travis")
 	}
 
-	testViewChange(t, 10, 3, testInterval)
+	// Enough nodes and failing ones to test what happens when propagation
+	// fails due to offline nodes in the higher level of the tree.
+	testViewChange(t, 10, 3, 4*testInterval)
 }
 
 func testWaitPropagation(id skipchain.SkipBlockID, service *skipchain.Service, interval time.Duration) {

--- a/byzcoin/viewchange_test.go
+++ b/byzcoin/viewchange_test.go
@@ -1,12 +1,13 @@
 package byzcoin
 
 import (
-	"math"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/cothority/v3/byzcoin/viewchange"
+	"go.dedis.ch/cothority/v3/skipchain"
 	"go.dedis.ch/onet/v3/log"
 )
 
@@ -23,10 +24,22 @@ func TestViewChange_Basic(t *testing.T) {
 }
 
 func TestViewChange_Basic2(t *testing.T) {
-	if testing.Short() {
-		t.Skip("doesn't work on travis correctly due to byzcoinx timeout issue, see #1428")
-	}
 	testViewChange(t, 7, 2, testInterval)
+}
+
+func TestViewChange_Basic3(t *testing.T) {
+	if testing.Short() {
+		t.Skip("not for Travis")
+	}
+
+	testViewChange(t, 10, 3, testInterval)
+}
+
+func testWaitPropagation(id skipchain.SkipBlockID, service *skipchain.Service, interval time.Duration) {
+	var sb *skipchain.SkipBlock
+	for doCatchUp := false; !doCatchUp && sb == nil; sb, doCatchUp = service.WaitBlock(id, nil) {
+		time.Sleep(interval)
+	}
 }
 
 func testViewChange(t *testing.T, nHosts, nFailures int, interval time.Duration) {
@@ -56,11 +69,9 @@ func testViewChange(t *testing.T, nHosts, nFailures int, interval time.Duration)
 	// will wait before starting a view-change. Then, we sleep a little
 	// longer for the view-change transaction to be stored in the block.
 	for i := 0; i < nFailures; i++ {
-		time.Sleep(time.Duration(math.Pow(2, float64(i+1))) * s.interval * rw)
+		time.Sleep(2 * s.interval * rw)
 	}
-	for doCatchUp := false; !doCatchUp; _, doCatchUp = s.services[nFailures].skService().WaitBlock(s.genesis.SkipChainID(), nil) {
-		time.Sleep(interval)
-	}
+	testWaitPropagation(s.genesis.Hash, s.services[nFailures].skService(), s.interval)
 	config, err := s.services[nFailures].LoadConfig(s.genesis.SkipChainID())
 	require.NoError(t, err)
 	log.Lvl2("Verifying roster", config.Roster.List)
@@ -68,15 +79,13 @@ func testViewChange(t *testing.T, nHosts, nFailures int, interval time.Duration)
 
 	// check that the leader is updated for all nodes
 	for _, service := range s.services[nFailures:] {
-		for doCatchUp := false; !doCatchUp; _, doCatchUp = service.skService().WaitBlock(s.genesis.SkipChainID(), nil) {
-			time.Sleep(interval)
-		}
+		testWaitPropagation(s.genesis.Hash, service.skService(), s.interval)
 
 		// everyone should have the same leader after the genesis block is stored
 		leader, err := service.getLeader(s.genesis.SkipChainID())
 		require.NoError(t, err)
 		require.NotNil(t, leader)
-		require.True(t, leader.Equal(s.services[nFailures].ServerIdentity()))
+		require.True(t, leader.Equal(s.services[nFailures].ServerIdentity()), fmt.Sprintf("%v", leader))
 	}
 
 	// try to send a transaction to the node on index nFailures+1, which is
@@ -107,9 +116,7 @@ func testViewChange(t *testing.T, nHosts, nFailures int, interval time.Duration)
 		pr = s.waitProofWithIdx(t, tx1.Instructions[0].InstanceID.Slice(), i)
 		require.True(t, pr.InclusionProof.Match(tx1.Instructions[0].InstanceID.Slice()))
 	}
-	for doCatchUp := false; !doCatchUp; _, doCatchUp = s.services[nFailures].skService().WaitBlock(s.genesis.SkipChainID(), nil) {
-		time.Sleep(s.interval)
-	}
+	testWaitPropagation(s.genesis.Hash, s.services[nFailures].skService(), s.interval)
 
 	log.Lvl1("Sending 1st tx")
 	tx1, err = createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, s.value, s.signer, 2)

--- a/byzcoin/viewchange_test.go
+++ b/byzcoin/viewchange_test.go
@@ -2,6 +2,7 @@ package byzcoin
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -71,7 +72,7 @@ func testViewChange(t *testing.T, nHosts, nFailures int, interval time.Duration)
 	// will wait before starting a view-change. Then, we sleep a little
 	// longer for the view-change transaction to be stored in the block.
 	for i := 0; i < nFailures; i++ {
-		time.Sleep(2 * s.interval * rw)
+		time.Sleep(time.Duration(math.Pow(2, float64(i+1))) * s.interval * rw)
 	}
 	testWaitPropagation(s.genesis.Hash, s.services[nFailures].skService(), s.interval)
 	config, err := s.services[nFailures].LoadConfig(s.genesis.SkipChainID())

--- a/external/java/src/test/java/ch/epfl/dedis/calypso/CalypsoTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/calypso/CalypsoTest.java
@@ -46,7 +46,7 @@ class CalypsoTest {
     private static String docData;
     private static String extraData;
 
-    private final static Logger logger = LoggerFactory.getLogger(WriteInstanceTest.class);
+    private final static Logger logger = LoggerFactory.getLogger(CalypsoTest.class);
     private TestServerController testInstanceController;
 
     @BeforeEach

--- a/messaging/propagate.go
+++ b/messaging/propagate.go
@@ -105,7 +105,9 @@ func NewPropagationFunc(c propagationContext, name string, f PropagationStore, t
 		if rooted == nil {
 			return 0, errors.New("we're not in the roster")
 		}
-		tree := rooted.GenerateNaryTree(8)
+		// Using a N-ary tree here can prevent from propagating messages to online
+		// conodes if one of the upper level is offline
+		tree := rooted.GenerateStar()
 		if tree == nil {
 			return 0, errors.New("Didn't find root in tree")
 		}

--- a/messaging/propagate.go
+++ b/messaging/propagate.go
@@ -105,9 +105,7 @@ func NewPropagationFunc(c propagationContext, name string, f PropagationStore, t
 		if rooted == nil {
 			return 0, errors.New("we're not in the roster")
 		}
-		// Using a N-ary tree here can prevent from propagating messages to online
-		// conodes if one of the upper level is offline
-		tree := rooted.GenerateStar()
+		tree := rooted.GenerateNaryTree(8)
 		if tree == nil {
 			return 0, errors.New("Didn't find root in tree")
 		}

--- a/messaging/propagate_test.go
+++ b/messaging/propagate_test.go
@@ -49,10 +49,10 @@ func propagate(t *testing.T, nbrNodes, nbrFailures []int) {
 						recvCount++
 						iMut.Unlock()
 						return nil
-					} else {
-						t.Error("Didn't receive correct data")
-						return errors.New("Didn't receive correct data")
 					}
+
+					t.Error("Didn't receive correct data")
+					return errors.New("Didn't receive correct data")
 				}, nbrFailures[i])
 			log.ErrFatal(err)
 		}

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -999,7 +999,7 @@ func (s *Service) forwardLinkLevel0(src, dst *SkipBlock) error {
 	// We send the new forward link to the previous roster only
 	err = s.startPropagation(s.propagateForwardLink, roster, &PropagateForwardLink{fwd, 0})
 	if err != nil {
-		return err
+		log.Error("Failed to propagate the forward link to the previous roster:", err)
 	}
 
 	// We send the shortest chain to the new conodes to let


### PR DESCRIPTION
This PR updates the view change to have an upper bound to the timeout value so that situation where the view change is triggered but the signature fails doesn't create a huge timeout.

Also: more verbose log for future debugging
Also: use two locks for catching and trie update

Fixes #1835 