### PR TITLE
speeds up GetProof by removing verification step

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -402,11 +402,6 @@ func (s *Service) GetProof(req *GetProof) (resp *GetProofResponse, err error) {
 		return
 	}
 
-	// Sanity check
-	if err = proof.Verify(sb.SkipChainID()); err != nil {
-		return
-	}
-
 	_, v := proof.InclusionProof.KeyValue()
 	log.Lvlf3("value is %x", v)
 	resp = &GetProofResponse{


### PR DESCRIPTION
This is an alternative to the PR that adds a field 'NoVerification' to the
'GetProof' message. As the verification has to be done at the client side
anyway, it is not necessary to verify it in the service call.

Closes #1902
Closes #1903 