### PR TITLE
Eventlog streaming

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -2401,7 +2401,10 @@ func newService(c *onet.Context) (onet.Service, error) {
 		return nil, err
 	}
 
-	skipchain.RegisterVerification(c, Verify, s.verifySkipBlock)
+	if err := skipchain.RegisterVerification(c, Verify, s.verifySkipBlock); err != nil {
+		log.ErrFatal(err)
+	}
+
 	if _, err := s.ProtocolRegister(collectTxProtocol, NewCollectTxProtocol(s.getTxs)); err != nil {
 		return nil, err
 	}

--- a/eventlog/api.go
+++ b/eventlog/api.go
@@ -3,6 +3,8 @@ package eventlog
 import (
 	"bytes"
 	"errors"
+
+	"go.dedis.ch/cothority/v3/skipchain"
 	"go.dedis.ch/onet/v3/network"
 
 	"go.dedis.ch/cothority/v3"
@@ -22,6 +24,7 @@ type Client struct {
 	Signers    []darc.Signer
 	Instance   byzcoin.InstanceID
 	c          *onet.Client
+	sc         *skipchain.Client
 	signerCtrs []uint64
 }
 
@@ -31,6 +34,7 @@ func NewClient(ol *byzcoin.Client) *Client {
 	return &Client{
 		ByzCoin:    ol,
 		c:          onet.NewClient(cothority.Suite, ServiceName),
+		sc:         skipchain.NewClient(),
 		signerCtrs: nil,
 	}
 }
@@ -204,52 +208,133 @@ func (c *Client) Search(req *SearchRequest) (*SearchResponse, error) {
 	return reply, nil
 }
 
-// StreamEvents streams TODO
-func (c *Client) StreamEvents(handler func(Event, error)) error {
+// StreamHandler is the signature of the handler used when streaming events.
+type StreamHandler func(event Event, blockID []byte, err error)
+
+// Close closes all the websocket connections.
+func (c *Client) Close() error {
+	err := c.ByzCoin.Close()
+	if err2 := c.sc.Close(); err != nil {
+		err = err2
+	}
+	if err2 := c.c.Close(); err != nil {
+		err = err2
+	}
+	return err
+}
+
+// StreamEvents is a blocking call where it calls the handler on even new event until the connection is closed or the
+// server stops.
+func (c *Client) StreamEvents(handler StreamHandler) error {
 	h := func(resp byzcoin.StreamingResponse, err error) {
 		if err != nil {
-			handler(Event{}, err)
+			handler(Event{}, nil, err)
 			return
 		}
-		// Get the DataHeader and the DataBody of the block.
-		sb := resp.Block
-		var header byzcoin.DataHeader
-		err = protobuf.DecodeWithConstructors(sb.Data, &header, network.DefaultConstructors(cothority.Suite))
-		if err != nil {
-			handler(Event{}, errors.New("could not unmarshal header while streaming events " + err.Error()))
-			return
-		}
-
-		var body byzcoin.DataBody
-		err = protobuf.DecodeWithConstructors(sb.Payload, &body, network.DefaultConstructors(cothority.Suite))
-		if err != nil {
-			handler(Event{}, errors.New("could not unmarshal body while streaming events " + err.Error()))
-			return
-		}
-
-		for _, tx := range body.TxResults {
-			if tx.Accepted {
-				for _, instr := range tx.ClientTransaction.Instructions {
-					if instr.Invoke == nil {
-						continue
-					}
-					if instr.Invoke.ContractID != contractName || instr.Invoke.Command != logCmd {
-						continue
-					}
-					eventBuf := instr.Invoke.Args.Search("event")
-					if eventBuf == nil {
-						continue
-					}
-					event := &Event{}
-					if err := protobuf.Decode(eventBuf, event); err != nil {
-						handler(Event{}, errors.New("could not decode the event " + err.Error()))
-						continue
-					}
-					handler(*event, nil)
-				}
-			}
-		}
+		// don't need to handle error because it's given to the handler
+		_ = handleBlocks(handler, resp.Block)
 	}
 	// the following blocks
 	return c.ByzCoin.StreamTransactions(h)
+}
+
+// StreamEventsFrom is a blocking call where it calls the handler on even new event from (inclusive) the given block ID
+// until the connection is closed or the server stops.
+func (c *Client) StreamEventsFrom(handler StreamHandler, id []byte) error {
+	// 1. stream to a buffer (because we don't know which ones will be duplicates yet)
+	blockChan := make(chan blockOrErr, 100)
+	streamDone := make(chan error)
+	go func() {
+		err := c.ByzCoin.StreamTransactions(func(resp byzcoin.StreamingResponse, err error) {
+			blockChan <- blockOrErr{resp.Block, err}
+		})
+		streamDone <- err
+	}()
+
+	// 2. use GetUpdateChain to find the missing events and call handler
+	blocks, err := c.sc.GetUpdateChainLevel(&c.ByzCoin.Roster, id, 0, -1)
+	if err != nil {
+		return err
+	}
+	for _, b := range blocks {
+		// to keep the behaviour of the other streaming functions, we don't return an error but let the handler decide
+		// what to do with the error
+		_ = handleBlocks(handler, b)
+	}
+
+	var latest *skipchain.SkipBlock
+	if len(blocks) > 0 {
+		latest = blocks[len(blocks)-1]
+	}
+
+	// 3. read from the buffer, remove duplicates and call the handler
+	var foundLink bool
+	for {
+		select {
+		case bOrErr := <-blockChan:
+			if bOrErr.err != nil {
+				handler(Event{}, nil, bOrErr.err)
+				break
+			}
+			if !foundLink {
+				if bOrErr.block.BackLinkIDs[0].Equal(latest.Hash) {
+					foundLink = true
+				}
+			}
+			if foundLink {
+				_ = handleBlocks(handler, bOrErr.block)
+			}
+		case err := <-streamDone:
+			return err
+		}
+	}
+}
+
+type blockOrErr struct {
+	block *skipchain.SkipBlock
+	err   error
+}
+
+// handleBlocks calls the handler on the events of the block
+func handleBlocks(handler StreamHandler, sb *skipchain.SkipBlock) error {
+	var err error
+	var header byzcoin.DataHeader
+	err = protobuf.DecodeWithConstructors(sb.Data, &header, network.DefaultConstructors(cothority.Suite))
+	if err != nil {
+		err = errors.New("could not unmarshal header while streaming events " + err.Error())
+		handler(Event{}, nil, err)
+		return err
+	}
+
+	var body byzcoin.DataBody
+	err = protobuf.DecodeWithConstructors(sb.Payload, &body, network.DefaultConstructors(cothority.Suite))
+	if err != nil {
+		err = errors.New("could not unmarshal body while streaming events " + err.Error())
+		handler(Event{}, nil, err)
+		return err
+	}
+
+	for _, tx := range body.TxResults {
+		if tx.Accepted {
+			for _, instr := range tx.ClientTransaction.Instructions {
+				if instr.Invoke == nil {
+					continue
+				}
+				if instr.Invoke.ContractID != contractName || instr.Invoke.Command != logCmd {
+					continue
+				}
+				eventBuf := instr.Invoke.Args.Search("event")
+				if eventBuf == nil {
+					continue
+				}
+				event := &Event{}
+				if err := protobuf.Decode(eventBuf, event); err != nil {
+					handler(Event{}, nil, errors.New("could not decode the event "+err.Error()))
+					continue
+				}
+				handler(*event, sb.Hash, nil)
+			}
+		}
+	}
+	return nil
 }

--- a/eventlog/api.go
+++ b/eventlog/api.go
@@ -194,8 +194,8 @@ func (c *Client) prepareTx(events []Event) (*byzcoin.ClientTransaction, []LogID,
 	return &tx, keys, nil
 }
 
-// Search executes a search on the filter in req. See the definition of
-// type SearchRequest for additional details about how the filter is interpreted.
+// Search executes a search on the filter in req. See the definition of type
+// SearchRequest for additional details about how the filter is interpreted.
 // The ID and Instance fields of the SearchRequest will be filled in from c.
 func (c *Client) Search(req *SearchRequest) (*SearchResponse, error) {
 	req.ID = c.ByzCoin.ID
@@ -223,8 +223,8 @@ func (c *Client) Close() error {
 	return err
 }
 
-// StreamEvents is a blocking call where it calls the handler on even new event until the connection is closed or the
-// server stops.
+// StreamEvents is a blocking call where it calls the handler on even new event
+// until the connection is closed or the server stops.
 func (c *Client) StreamEvents(handler StreamHandler) error {
 	h := func(resp byzcoin.StreamingResponse, err error) {
 		if err != nil {
@@ -238,8 +238,9 @@ func (c *Client) StreamEvents(handler StreamHandler) error {
 	return c.ByzCoin.StreamTransactions(h)
 }
 
-// StreamEventsFrom is a blocking call where it calls the handler on even new event from (inclusive) the given block ID
-// until the connection is closed or the server stops.
+// StreamEventsFrom is a blocking call where it calls the handler on even new
+// event from (inclusive) the given block ID until the connection is closed or
+// the server stops.
 func (c *Client) StreamEventsFrom(handler StreamHandler, id []byte) error {
 	// 1. stream to a buffer (because we don't know which ones will be duplicates yet)
 	blockChan := make(chan blockOrErr, 100)
@@ -257,8 +258,9 @@ func (c *Client) StreamEventsFrom(handler StreamHandler, id []byte) error {
 		return err
 	}
 	for _, b := range blocks {
-		// to keep the behaviour of the other streaming functions, we don't return an error but let the handler decide
-		// what to do with the error
+		// to keep the behaviour of the other streaming functions, we
+		// don't return an error but let the handler decide what to do
+		// with the error
 		_ = handleBlocks(handler, b)
 	}
 

--- a/eventlog/api.go
+++ b/eventlog/api.go
@@ -4,14 +4,13 @@ import (
 	"bytes"
 	"errors"
 
-	"go.dedis.ch/cothority/v3/skipchain"
-	"go.dedis.ch/onet/v3/network"
-
 	"go.dedis.ch/cothority/v3"
 	"go.dedis.ch/cothority/v3/byzcoin"
 	"go.dedis.ch/cothority/v3/darc"
+	"go.dedis.ch/cothority/v3/skipchain"
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
+	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/protobuf"
 )
 

--- a/eventlog/api.go
+++ b/eventlog/api.go
@@ -213,17 +213,17 @@ type StreamHandler func(event Event, blockID []byte, err error)
 // Close closes all the websocket connections.
 func (c *Client) Close() error {
 	err := c.ByzCoin.Close()
-	if err2 := c.sc.Close(); err != nil {
+	if err2 := c.sc.Close(); err2 != nil {
 		err = err2
 	}
-	if err2 := c.c.Close(); err != nil {
+	if err2 := c.c.Close(); err2 != nil {
 		err = err2
 	}
 	return err
 }
 
-// StreamEvents is a blocking call where it calls the handler on even new event
-// until the connection is closed or the server stops.
+// StreamEvents is a blocking call where it calls the handler on every new
+// event until the connection is closed or the server stops.
 func (c *Client) StreamEvents(handler StreamHandler) error {
 	h := func(resp byzcoin.StreamingResponse, err error) {
 		if err != nil {

--- a/eventlog/api_test.go
+++ b/eventlog/api_test.go
@@ -3,6 +3,7 @@ package eventlog
 import (
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -168,24 +169,6 @@ func TestClient_Log200(t *testing.T) {
 	require.Nil(t, s.local.WaitDone(10*time.Second))
 }
 
-func checkProof(t *testing.T, omni *byzcoin.Service, key []byte, scID skipchain.SkipBlockID) []byte {
-	req := &byzcoin.GetProof{
-		Version: byzcoin.CurrentVersion,
-		Key:     key,
-		ID:      scID,
-	}
-	resp, err := omni.GetProof(req)
-	require.Nil(t, err)
-
-	p := resp.Proof
-	require.True(t, p.InclusionProof.Match(key), "proof of exclusion of index")
-
-	v0, _, _, err := p.Get(key)
-	require.NoError(t, err)
-
-	return v0
-}
-
 func TestClient_Search(t *testing.T) {
 	s, c := newSer(t)
 	leader := s.services[0]
@@ -283,6 +266,92 @@ func TestClient_Search(t *testing.T) {
 	require.NotNil(t, resp)
 	require.Equal(t, 1, len(resp.Events))
 	require.False(t, resp.Truncated)
+}
+
+func TestClient_StreamEvents(t *testing.T) {
+	s, c := newSer(t)
+	leader := s.services[0]
+	defer s.close()
+
+	require.Nil(t, c.Create())
+	require.NotNil(t, c.Instance)
+	waitForKey(t, leader.omni, c.ByzCoin.ID, c.Instance.Slice(), testBlockInterval)
+
+
+	events := []Event{
+		NewEvent("auth", "user alice logged out"),
+		NewEvent("auth", "user bob logged out"),
+		NewEvent("auth", "user bob logged back in"),
+	}
+
+	// set up the listener
+	done := make(chan bool)
+	var ctr int
+	var ctrMutex sync.Mutex
+	h := func(e Event, err error) {
+		ctrMutex.Lock()
+		defer ctrMutex.Unlock()
+
+		// we only care about the first three events
+		if ctr >= len(events) - 1 {
+			return
+		}
+
+		require.NoError(t, err)
+		require.Equal(t, e.Topic, events[ctr].Topic)
+		require.Equal(t, e.Content, events[ctr].Content)
+		ctr++
+
+		if ctr == len(events)-1 {
+			close(done)
+		}
+	}
+	go func() {
+		require.NoError(t, c.StreamEvents(h))
+	}()
+
+	// log the events
+	ids, err := c.Log(events...)
+	require.NoError(t, err)
+
+	// the events should've been streamed to us.
+	select {
+	case <-done:
+	case <-time.After(testBlockInterval + time.Second):
+		require.Fail(t, "should have got n transactions")
+	}
+
+	// check the proof
+	for _, id := range ids {
+		checkProof(t, leader.omni, id, c.ByzCoin.ID)
+	}
+
+	require.NoError(t, c.ByzCoin.Close())
+
+	// send a couple more to close the stream, see byzcoin/api_test.go:TestClient_Streaming
+	for i := 0; i < 2; i++ {
+		finalID, err := c.Log(NewEvent("dummy", "dummy"))
+		require.NoError(t, err)
+		waitForKey(t, leader.omni, c.ByzCoin.ID, finalID[0], testBlockInterval)
+	}
+}
+
+func checkProof(t *testing.T, omni *byzcoin.Service, key []byte, scID skipchain.SkipBlockID) []byte {
+	req := &byzcoin.GetProof{
+		Version: byzcoin.CurrentVersion,
+		Key:     key,
+		ID:      scID,
+	}
+	resp, err := omni.GetProof(req)
+	require.Nil(t, err)
+
+	p := resp.Proof
+	require.True(t, p.InclusionProof.Match(key), "proof of exclusion of index")
+
+	v0, _, _, err := p.Get(key)
+	require.NoError(t, err)
+
+	return v0
 }
 
 func waitForKey(t *testing.T, s *byzcoin.Service, scID skipchain.SkipBlockID, key []byte, interval time.Duration) {

--- a/eventlog/api_test.go
+++ b/eventlog/api_test.go
@@ -273,11 +273,6 @@ func TestClient_StreamEvents(t *testing.T) {
 	leader := s.services[0]
 	defer s.close()
 
-	require.Nil(t, c.Create())
-	require.NotNil(t, c.Instance)
-	waitForKey(t, leader.omni, c.ByzCoin.ID, c.Instance.Slice(), testBlockInterval)
-
-
 	events := []Event{
 		NewEvent("auth", "user alice logged out"),
 		NewEvent("auth", "user bob logged out"),
@@ -288,18 +283,18 @@ func TestClient_StreamEvents(t *testing.T) {
 	done := make(chan bool)
 	var ctr int
 	var ctrMutex sync.Mutex
-	h := func(e Event, err error) {
+	h := func(e Event, sb []byte, err error) {
 		ctrMutex.Lock()
 		defer ctrMutex.Unlock()
 
-		// we only care about the first three events
-		if ctr >= len(events) - 1 {
+		if ctr >= len(events)-1 {
 			return
 		}
 
 		require.NoError(t, err)
 		require.Equal(t, e.Topic, events[ctr].Topic)
 		require.Equal(t, e.Content, events[ctr].Content)
+		require.NotNil(t, sb)
 		ctr++
 
 		if ctr == len(events)-1 {
@@ -309,6 +304,12 @@ func TestClient_StreamEvents(t *testing.T) {
 	go func() {
 		require.NoError(t, c.StreamEvents(h))
 	}()
+
+	// we do the create after starting the listener because it'll add a new transaction that is not an event
+	// so the stream function should filter it out
+	require.Nil(t, c.Create())
+	require.NotNil(t, c.Instance)
+	waitForKey(t, leader.omni, c.ByzCoin.ID, c.Instance.Slice(), testBlockInterval)
 
 	// log the events
 	ids, err := c.Log(events...)
@@ -326,7 +327,90 @@ func TestClient_StreamEvents(t *testing.T) {
 		checkProof(t, leader.omni, id, c.ByzCoin.ID)
 	}
 
-	require.NoError(t, c.ByzCoin.Close())
+	require.NoError(t, c.Close())
+
+	// send a couple more to close the stream, see byzcoin/api_test.go:TestClient_Streaming
+	for i := 0; i < 2; i++ {
+		finalID, err := c.Log(NewEvent("dummy", "dummy"))
+		require.NoError(t, err)
+		waitForKey(t, leader.omni, c.ByzCoin.ID, finalID[0], testBlockInterval)
+	}
+}
+
+func TestClient_StreamEventsFrom(t *testing.T) {
+	s, c := newSer(t)
+	leader := s.services[0]
+	defer s.close()
+
+	require.Nil(t, c.Create())
+	require.NotNil(t, c.Instance)
+	waitForKey(t, leader.omni, c.ByzCoin.ID, c.Instance.Slice(), testBlockInterval)
+
+	// instead of starting the streaming at the beginning, we start it after adding some events
+	batch1 := []Event{
+		NewEvent("auth", "user alice logged out"),
+		NewEvent("auth", "user bob logged out"),
+		NewEvent("auth", "user bob logged back in"),
+	}
+	batch2 := []Event{
+		NewEvent("read", "user alice read X"),
+		NewEvent("writ", "user bob wrote Y"),
+		NewEvent("read", "user bob read Z"),
+	}
+	events := append(batch1, batch2...)
+
+	// log the first batch
+	ids, err := c.Log(batch1...)
+	require.NoError(t, err)
+	waitForKey(t, leader.omni, c.ByzCoin.ID, ids[len(batch1)-1], testBlockInterval)
+	for _, id := range ids {
+		checkProof(t, leader.omni, id, c.ByzCoin.ID)
+	}
+
+	// set up the listener, it starts listening from the genesis block so even when we start after logging the first
+	// batch, it should see the events from the first batch
+	done := make(chan bool)
+	var ctr int
+	var ctrMutex sync.Mutex
+	h := func(e Event, sb []byte, err error) {
+		ctrMutex.Lock()
+		defer ctrMutex.Unlock()
+
+		if ctr >= len(events)-1 {
+			return
+		}
+
+		require.NoError(t, err)
+		require.Equal(t, e.Topic, events[ctr].Topic)
+		require.Equal(t, e.Content, events[ctr].Content)
+		require.NotNil(t, sb)
+		ctr++
+
+		if ctr == len(events)-1 {
+			close(done)
+		}
+	}
+	go func() {
+		require.NoError(t, c.StreamEventsFrom(h, c.ByzCoin.ID))
+	}()
+
+	// write the second batch
+	ids2, err := c.Log(batch2...)
+	require.NoError(t, err)
+
+	// all the events should've been streamed to us.
+	select {
+	case <-done:
+	case <-time.After(2*testBlockInterval + time.Second):
+		require.Fail(t, "should have got n transactions")
+	}
+
+	// check the proof
+	for _, id := range ids2 {
+		checkProof(t, leader.omni, id, c.ByzCoin.ID)
+	}
+
+	require.NoError(t, c.Close())
 
 	// send a couple more to close the stream, see byzcoin/api_test.go:TestClient_Streaming
 	for i := 0; i < 2; i++ {

--- a/external/java/src/main/java/ch/epfl/dedis/byzcoin/ByzCoinRPC.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzcoin/ByzCoinRPC.java
@@ -449,8 +449,8 @@ public class ByzCoinRPC {
     }
 
     /**
-     * Subscribes to all new skipBlocks that might arrive. The subscription is implemented using a polling
-     * approach until we have a working streaming solution.
+     * Subscribes to all new skipBlocks that might arrive. This function does not block, the receiver is called
+     * in a new thread.
      *
      * @param sbr is a SkipBlockReceiver that will be called with any new block(s) available.
      * @throws CothorityCommunicationException if something goes wrong

--- a/external/java/src/main/java/ch/epfl/dedis/eventlog/EventLogInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/eventlog/EventLogInstance.java
@@ -312,6 +312,7 @@ public class EventLogInstance {
 
     /**
      * Register the handler to listen to new events.
+     * If an error is thrown, the caller should unsubscribe the tag.
      *
      * @param handler is the event handler, it will be called in a different thread.
      * @return an integer tag that can be used to unregister the handler.
@@ -326,7 +327,9 @@ public class EventLogInstance {
     }
 
     /**
-     * Register the handler to listen to new events from a certain block.
+     * Register the handler to listen to new events from the given block.
+     * The function blocks while it reads old events from the given block.
+     * If an error is thrown, the caller should unsubscribe the tag.
      *
      * @param handler is the event handler, it will be called in a different thread.
      * @param from is the block which marks the beginning of the subscription.
@@ -342,6 +345,7 @@ public class EventLogInstance {
         this.bc.subscribeSkipBlock(r);
 
         // 2. use GetUpdateChain to find the missing events and call handler
+        // if the skipblock ID is wrong or does not exist the function will throw an exception
         List<SkipBlock> blocks = this.bc.getSkipchain().getUpdateChain(new SkipblockId(from));
 
         // 3. read from the buffer, remove duplicates and call the handler

--- a/external/java/src/main/java/ch/epfl/dedis/eventlog/EventLogInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/eventlog/EventLogInstance.java
@@ -285,7 +285,7 @@ public class EventLogInstance {
                 else if (current != null && Arrays.equals(p.block.getBackLinks().get(0).getId(), current.getHash())) {
                     super.receive(p.block);
                 } else {
-                    // do nothing because there might be a duplicate
+                    // do nothing because this is a duplicate block
                 }
             }
             flushed = true;

--- a/external/java/src/main/java/ch/epfl/dedis/eventlog/EventLogInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/eventlog/EventLogInstance.java
@@ -3,6 +3,7 @@ package ch.epfl.dedis.eventlog;
 import ch.epfl.dedis.byzcoin.*;
 import ch.epfl.dedis.byzcoin.transaction.*;
 import ch.epfl.dedis.lib.SkipBlock;
+import ch.epfl.dedis.lib.SkipblockId;
 import ch.epfl.dedis.lib.darc.DarcId;
 import ch.epfl.dedis.lib.darc.Signer;
 import ch.epfl.dedis.lib.exception.CothorityCommunicationException;
@@ -184,6 +185,131 @@ public class EventLogInstance {
         void error(String s);
     }
 
+    class EventLogReceiver implements Subscription.SkipBlockReceiver {
+        private EventHandler handler;
+        EventLogReceiver(EventHandler h) {
+            handler = h;
+        }
+
+        @Override
+        public void receive(SkipBlock block) {
+            // check the header is correct
+            try {
+                ByzCoinProto.DataHeader.parseFrom(block.getData());
+            } catch (InvalidProtocolBufferException e) {
+                handler.error(e.getMessage());
+                return;
+            }
+            // parse the payload
+            DataBody body;
+            try {
+                body = new DataBody(ByzCoinProto.DataBody.parseFrom(block.getPayload()));
+            } catch (InvalidProtocolBufferException | CothorityCryptoException e) {
+                handler.error(e.getMessage());
+                return;
+            }
+
+            // parse the transactions
+            for (TxResult tx : body.getTxResults()) {
+                if (!tx.isAccepted()){
+                    continue;
+                }
+                for (Instruction instr : tx.getClientTransaction().getInstructions()) {
+                    if (instr.getInvoke() == null) {
+                        continue;
+                    }
+                    if (!instr.getInvoke().getContractID().equals(ContractId) || !instr.getInvoke().getCommand().equals(LogCmd)) {
+                        continue;
+                    }
+                    // try to find the event argument
+                    Optional<Argument> opArg = instr.getInvoke().getArguments().stream()
+                            .filter(x -> x.getName().equals("event"))
+                            .findFirst();
+                    if (!opArg.isPresent()) {
+                        continue;
+                    }
+                    // parse the event argument
+                    Event event;
+                    try {
+                        event = new Event(EventLogProto.Event.parseFrom(opArg.get().getValue()));
+                    } catch (InvalidProtocolBufferException e) {
+                        handler.error(e.getMessage());
+                        continue;
+                    }
+                    handler.process(event, block.getId().getId());
+                }
+            }
+        }
+
+        @Override
+        public void error(String s) {
+            handler.error(s);
+        }
+    }
+
+    /**
+     * Concurrent class.
+     */
+    class BufferedEventLogReceiver extends EventLogReceiver {
+        class Pair {
+            final SkipBlock block;
+            final String error;
+            Pair(SkipBlock b, String s) {
+                block = b;
+                error = s;
+            }
+        }
+
+        List<Pair> buffer;
+        Boolean flushed = false;
+
+        BufferedEventLogReceiver(EventHandler h) {
+            super(h);
+            buffer = new ArrayList<>();
+        }
+
+        synchronized void flush(List<SkipBlock> prepend) {
+            SkipBlock current = null;
+            for (SkipBlock b : prepend) {
+                current = b;
+                super.receive(b);
+            }
+
+            for (Pair p : buffer) {
+                if (p.block == null) {
+                    super.error(p.error);
+                }
+                else if (p.block.getBackLinks().size() == 0) {
+                    super.error("no black links");
+                }
+                else if (current != null && Arrays.equals(p.block.getBackLinks().get(0).getId(), current.getHash())) {
+                    super.receive(p.block);
+                } else {
+                    // do nothing because there might be a duplicate
+                }
+            }
+            flushed = true;
+        }
+
+        @Override
+        public synchronized void receive(SkipBlock block) {
+            if (flushed) {
+                super.receive(block);
+            } else {
+                buffer.add(new Pair(block, null));
+            }
+        }
+
+        @Override
+        public synchronized void error(String s) {
+            if (flushed) {
+                super.error(s);
+            } else {
+                buffer.add(new Pair(null, s));
+            }
+        }
+    }
+
     /**
      * Register the handler to listen to new events.
      *
@@ -192,65 +318,35 @@ public class EventLogInstance {
      * @throws CothorityCommunicationException when the server fails or refuses to accept the subscription.
      */
     public int subscribeEvents(EventHandler handler) throws CothorityCommunicationException {
-        Subscription.SkipBlockReceiver sbr = new Subscription.SkipBlockReceiver() {
-            @Override
-            public void receive(SkipBlock block) {
-                // check the header is correct
-                try {
-                    ByzCoinProto.DataHeader.parseFrom(block.getData());
-                } catch (InvalidProtocolBufferException e) {
-                    handler.error(e.getMessage());
-                    return;
-                }
-                // parse the payload
-                DataBody body;
-                try {
-                    body = new DataBody(ByzCoinProto.DataBody.parseFrom(block.getPayload()));
-                } catch (InvalidProtocolBufferException | CothorityCryptoException e) {
-                    handler.error(e.getMessage());
-                    return;
-                }
-
-                // parse the transactions
-                for (TxResult tx : body.getTxResults()) {
-                    if (!tx.isAccepted()){
-                        continue;
-                    }
-                    for (Instruction instr : tx.getClientTransaction().getInstructions()) {
-                        if (instr.getInvoke() == null) {
-                            continue;
-                        }
-                        if (!instr.getInvoke().getContractID().equals(ContractId) || !instr.getInvoke().getCommand().equals(LogCmd)) {
-                            continue;
-                        }
-                        // try to find the event argument
-                        Optional<Argument> opArg = instr.getInvoke().getArguments().stream()
-                                .filter(x -> x.getName().equals("event"))
-                                .findFirst();
-                        if (!opArg.isPresent()) {
-                            continue;
-                        }
-                        // parse the event argument
-                        Event event;
-                        try {
-                            event = new Event(EventLogProto.Event.parseFrom(opArg.get().getValue()));
-                        } catch (InvalidProtocolBufferException e) {
-                            handler.error(e.getMessage());
-                            continue;
-                        }
-                        handler.process(event, block.getId().getId());
-                    }
-                }
-            }
-
-            @Override
-            public void error(String s) {
-                handler.error(s);
-            }
-        };
+        EventLogReceiver r = new EventLogReceiver(handler);
         int tag = rnd.nextInt();
-        this.handlers.put(tag, sbr);
-        this.bc.subscribeSkipBlock(sbr);
+        this.handlers.put(tag, r);
+        this.bc.subscribeSkipBlock(r);
+        return tag;
+    }
+
+    /**
+     * Register the handler to listen to new events from a certain block.
+     *
+     * @param handler is the event handler, it will be called in a different thread.
+     * @param from is the block which marks the beginning of the subscription.
+     * @return an integer tag that can be used to unregister the handler.
+     * @throws CothorityCommunicationException
+     * @throws CothorityCryptoException
+     */
+    public int subscribeEvents(EventHandler handler, byte[] from) throws CothorityCommunicationException, CothorityCryptoException {
+        // 1. stream to a buffer (because we don't know which ones will be duplicates yet)
+        BufferedEventLogReceiver r = new BufferedEventLogReceiver(handler);
+        int tag = rnd.nextInt();
+        this.handlers.put(tag, r);
+        this.bc.subscribeSkipBlock(r);
+
+        // 2. use GetUpdateChain to find the missing events and call handler
+        List<SkipBlock> blocks = this.bc.getSkipchain().getUpdateChain(new SkipblockId(from));
+
+        // 3. read from the buffer, remove duplicates and call the handler
+        r.flush(blocks);
+
         return tag;
     }
 

--- a/external/java/src/main/java/ch/epfl/dedis/eventlog/EventLogInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/eventlog/EventLogInstance.java
@@ -280,7 +280,7 @@ public class EventLogInstance {
                     super.error(p.error);
                 }
                 else if (p.block.getBackLinks().size() == 0) {
-                    super.error("no black links");
+                    super.error("no back links");
                 }
                 else if (current != null && Arrays.equals(p.block.getBackLinks().get(0).getId(), current.getHash())) {
                     super.receive(p.block);

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/EventlogTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/EventlogTest.java
@@ -208,4 +208,14 @@ class EventLogTest {
 
         el.unsubscribeEvents(tag);
     }
+
+    @Test
+    void subscribeFailure() {
+        // subscribe from a block that doesn't exist
+        TestEventHandler handler = new TestEventHandler();
+        assertThrows(CothorityCommunicationException.class, () -> el.subscribeEvents(handler, Hex.parseHexBinary("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")));
+
+        // remove tag that doesn't exist should not throw an error
+        el.unsubscribeEvents(9999);
+    }
 }

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/EventlogTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/EventlogTest.java
@@ -141,4 +141,40 @@ class EventLogTest {
         resp = el.search("", now - 2000, now - 1000);
         assertEquals(0, resp.events.size());
     }
+
+    class TestEventHandler implements EventLogInstance.EventHandler {
+        public List<Event> events = new ArrayList<>();
+        public List<String> errors = new ArrayList<>();
+        @Override
+        public void process(Event e, byte[] id) {
+            events.add(e);
+        }
+        @Override
+        public void error(String s) {
+            errors.add(s);
+        }
+    }
+
+    @Test
+    void subscribe() throws Exception {
+        TestEventHandler handler = new TestEventHandler();
+        int tag = el.subscribeEvents(handler);
+
+        SignerCounters adminCtrs = bc.getSignerCounters(Collections.singletonList(admin.getIdentity().toString()));
+        adminCtrs.increment();
+        List<Event> events = new ArrayList<>();
+        events.add(new Event("hello", "goodbye"));
+        events.add(new Event("bonjour", "au revoir"));
+        events.add(new Event("hola", "adios"));
+
+        el.log(events, Arrays.asList(admin), adminCtrs.getCounters());
+        Thread.sleep(5 * bc.getConfig().getBlockInterval().toMillis());
+
+        for (int i = 0; i < events.size(); i++) {
+            assertEquals(events.get(i), handler.events.get(i));
+        }
+        assertEquals(0, handler.errors.size());
+
+        el.unsubscribeEvents(tag);
+    }
 }


### PR DESCRIPTION
Implement event streaming in go and java. Under the hood, we still use the old skipblock streaming feature of byzcoin but parse the blocks into events using a handler wrapper. The streaming feature allows the user to stream from blocks in the past. In such cases, we read all the blocks from the one given by the client and then call the handler on those, then we call the handler on the new blocks as before (duplicates are removed in the process).