### PR TITLE
Optimize block proof

### DIFF
--- a/blscosi/protocol/protocol.go
+++ b/blscosi/protocol/protocol.go
@@ -83,11 +83,15 @@ func GlobalRegisterDefaultProtocols() {
 	onet.GlobalProtocolRegister(DefaultSubProtocolName, NewDefaultSubProtocol)
 }
 
+// DefaultFaultyThreshold computes the maximum number of faulty nodes
+func DefaultFaultyThreshold(n int) int {
+	return (n - 1) / 3
+}
+
 // DefaultThreshold computes the minimal threshold authorized using
 // the formula 3f+1
 func DefaultThreshold(n int) int {
-	f := (n - 1) / 3
-	return n - f
+	return n - DefaultFaultyThreshold(n)
 }
 
 // NewBlsCosi method is used to define the blscosi protocol.

--- a/byzcoin/viewchange_test.go
+++ b/byzcoin/viewchange_test.go
@@ -71,6 +71,8 @@ func testViewChange(t *testing.T, nHosts, nFailures int, interval time.Duration)
 	// has taken over. First, we sleep for the duration that an honest node
 	// will wait before starting a view-change. Then, we sleep a little
 	// longer for the view-change transaction to be stored in the block.
+	time.Sleep(s.interval * rw)
+
 	for i := 0; i < nFailures; i++ {
 		time.Sleep(time.Duration(math.Pow(2, float64(i+1))) * s.interval * rw)
 	}

--- a/byzcoinx/byzcoinx.go
+++ b/byzcoinx/byzcoinx.go
@@ -317,10 +317,10 @@ func InitBFTCoSiProtocol(suite *pairing.SuiteBn256, c *onet.Context, vf, ack pro
 
 // FaultThreshold computes the number of faults that byzcoinx tolerates.
 func FaultThreshold(n int) int {
-	return (n - 1) / 3
+	return protocol.DefaultFaultyThreshold(n)
 }
 
 // Threshold computes the number of nodes needed for successful operation.
 func Threshold(n int) int {
-	return n - FaultThreshold(n)
+	return protocol.DefaultThreshold(n)
 }

--- a/scmgr/commands.go
+++ b/scmgr/commands.go
@@ -172,6 +172,22 @@ func getCommands() cli.Commands {
 						},
 					},
 				},
+				{
+					Name:    "optimize",
+					Usage:   "create missing forward link to optimize the proof of a given block",
+					Aliases: []string{"o"},
+					Action:  scOptimize,
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "roster",
+							Usage: "conodes where to propagate",
+						},
+						cli.StringFlag{
+							Name:  "id",
+							Usage: "target block or skipchain to optimize",
+						},
+					},
+				},
 			},
 		},
 

--- a/scmgr/test.sh
+++ b/scmgr/test.sh
@@ -11,6 +11,7 @@ main(){
 	startTest
 	buildConode go.dedis.ch/cothority/v3/skipchain
 	CFG=$BUILDDIR/scmgr_config
+	run testOptimize
 	run testDNSUpdate
 	run testRestart
 	run testConfig
@@ -25,7 +26,6 @@ main(){
 	run testFollow
 	run testNewChain
 	run testFailure
-	run testOptimize
 	stopTest
 }
 
@@ -283,9 +283,10 @@ testConfig(){
 testOptimize() {
 	startCl
 	setupGenesis
-	for n in $( seq 4 ); do
-		testOK runSc skipchain block add --roster public.toml $ID
-	done
+	testOK runSc skipchain block add --roster public.toml $ID
+	testOK runSc skipchain block add --roster public.toml $ID
+	testOK runSc skipchain block add --roster public.toml $ID
+	testOK runSc skipchain block add --roster public.toml $ID
 
 	testFail runSc skipchain optimize
 	testFail runSc skipchain optimize --roster public.toml

--- a/scmgr/test.sh
+++ b/scmgr/test.sh
@@ -25,6 +25,7 @@ main(){
 	run testFollow
 	run testNewChain
 	run testFailure
+	run testOptimize
 	stopTest
 }
 
@@ -277,6 +278,19 @@ testConfig(){
 
 	# $CFG/data cannot be empty
 	testFail [ -d "$CFG/data" ]
+}
+
+testOptimize() {
+	startCl
+	setupGenesis
+	for n in $( seq 4 ); do
+		testOK runSc skipchain block add --roster public.toml $ID
+	done
+
+	testFail runSc skipchain optimize
+	testFail runSc skipchain optimize --roster public.toml
+	testFail runSc skipchain optimize --roster public.toml --id abcd
+	testGrep "Chain optimized with 3 blocks" runSc skipchain optimize --roster public.toml --id $ID
 }
 
 runSc(){

--- a/skipchain/api.go
+++ b/skipchain/api.go
@@ -216,7 +216,8 @@ func (c *Client) CreateGenesis(ro *onet.Roster, baseH, maxH int, ver []VerifierI
 func (c *Client) OptimizeProof(ro *onet.Roster, id SkipBlockID) (*OptimizeProofReply, error) {
 	reply := &OptimizeProofReply{}
 
-	err := c.SendProtobuf(ro.List[0], &OptimizeProofRequest{
+	si := ro.RandomServerIdentity()
+	err := c.SendProtobuf(si, &OptimizeProofRequest{
 		Roster: ro,
 		ID:     id,
 	}, reply)

--- a/skipchain/api.go
+++ b/skipchain/api.go
@@ -211,6 +211,19 @@ func (c *Client) CreateGenesis(ro *onet.Roster, baseH, maxH int, ver []VerifierI
 	return c.CreateGenesisSignature(ro, baseH, maxH, ver, data, nil)
 }
 
+// OptimizeProof asks for the proof of the block ID to the roster and creates
+// missing forward-links if any.
+func (c *Client) OptimizeProof(ro *onet.Roster, id SkipBlockID) (*OptimizeProofReply, error) {
+	reply := &OptimizeProofReply{}
+
+	err := c.SendProtobuf(ro.List[0], &OptimizeProofRequest{
+		Roster: ro,
+		ID:     id,
+	}, reply)
+
+	return reply, err
+}
+
 // GetUpdateChain will return the chain of SkipBlocks going from the 'latest' to
 // the most current SkipBlock of the chain. It takes a roster that knows the
 // 'latest' skipblock and the id (=hash) of the latest skipblock.

--- a/skipchain/msgs.go
+++ b/skipchain/msgs.go
@@ -94,7 +94,8 @@ type OptimizeProofRequest struct {
 	Roster *onet.Roster
 }
 
-// OptimizeProofReply returns the result of the request
+// OptimizeProofReply returns the proof with the newly created forward-links
+// if they have been created.
 type OptimizeProofReply struct {
 	Proof Proof
 }

--- a/skipchain/msgs.go
+++ b/skipchain/msgs.go
@@ -12,6 +12,8 @@ func init() {
 		// Store new skipblock
 		&StoreSkipBlock{},
 		&StoreSkipBlockReply{},
+		&OptimizeProofRequest{},
+		&OptimizeProofReply{},
 		// Requests for data
 		&GetUpdateChain{},
 		&GetUpdateChainReply{},
@@ -49,6 +51,7 @@ func init() {
 		&PropagateProof{},
 		// Request forward-signature
 		&ForwardSignature{},
+		&ForwardSignatureReply{},
 		// - Data structures
 		&SkipBlockFix{},
 		&SkipBlock{},
@@ -83,6 +86,17 @@ type StoreSkipBlock struct {
 type StoreSkipBlockReply struct {
 	Previous *SkipBlock
 	Latest   *SkipBlock
+}
+
+// OptimizeProofRequest is request to create missing forward links
+type OptimizeProofRequest struct {
+	ID     SkipBlockID
+	Roster *onet.Roster
+}
+
+// OptimizeProofReply returns the result of the request
+type OptimizeProofReply struct {
+	Proof Proof
 }
 
 // GetUpdateChain - the client sends the hash of the last known
@@ -162,6 +176,11 @@ type ForwardSignature struct {
 	// Links holds the forwardlinks to prove that 'Newest' is valid. For
 	// the level-0 forwardlink, this is empty.
 	Links []*ForwardLink
+}
+
+// ForwardSignatureReply returns the new forward-link
+type ForwardSignatureReply struct {
+	Link *ForwardLink
 }
 
 // GetSingleBlock asks for a single block.

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -1832,7 +1832,7 @@ func newSkipchainService(c *onet.Context) (onet.Service, error) {
 	}
 	log.ErrFatal(s.RegisterHandlers(s.StoreSkipBlock, s.GetUpdateChain,
 		s.GetSingleBlock, s.GetSingleBlockByIndex, s.GetAllSkipchains,
-		s.GetAllSkipChainIDs,
+		s.GetAllSkipChainIDs, s.OptimizeProof,
 		s.CreateLinkPrivate, s.Unlink, s.AddFollow, s.ListFollow,
 		s.DelFollow, s.Listlink, s.ForwardLinkHandler))
 	s.ServiceProcessor.RegisterStatusReporter("Skipblock", s.db)

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -390,7 +390,7 @@ func (s *Service) StoreSkipBlockInternal(psbd *StoreSkipBlock) (*StoreSkipBlockR
 	return reply, nil
 }
 
-// sendForwardLinkRequest sends a request to the given until until either the forward-link is
+// sendForwardLinkRequest sends requests to conodes in the given roster until either the forward-link is
 // created or there's not enough online nodes to get a valid signature.
 func sendForwardLinkRequest(ro *onet.Roster, req *ForwardSignature, reply *ForwardSignatureReply) (err error) {
 	cl := NewClient()
@@ -450,19 +450,19 @@ func (s *Service) OptimizeProof(req *OptimizeProofRequest) (*OptimizeProofReply,
 			}
 			reply := &ForwardSignatureReply{}
 
-			log.Lvlf2("Request to create forward-link at index %d with height %d / %d", sb.Index, h, index)
+			log.Lvlf2("requesting missing forward-link at index %d with height %d / %d", sb.Index, h, index)
 			// The signature must be asked to the roster of the block
 			err := sendForwardLinkRequest(sb.Roster, req, reply)
 
 			if err != nil {
-				log.Error("couldn't create a forward link:", err)
+				log.Error("could not create a missing forward link:", err)
 				// reset the index to try to create lower levels
 				index = sb.Index
 			} else {
 				// save the new forward link
 				err = sb.AddForwardLink(reply.Link, h)
 				if err != nil {
-					log.Error("couldn't store the forward-link:", err)
+					log.Error("could not store the missing forward-link:", err)
 					index = sb.Index
 				}
 			}

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -1282,12 +1282,19 @@ func (s *Service) forwardLink(req *network.Envelope) error {
 
 // ForwardLinkHandler receives a forward-link signature request for a block already
 // appended to the chain (height >= 1).
-func (s *Service) ForwardLinkHandler(fs *ForwardSignature) (*ForwardSignatureReply, error) {
+func (s *Service) ForwardLinkHandler(req *ForwardSignature) (*ForwardSignatureReply, error) {
 	err := s.incrementWorking()
 	if err != nil {
 		return nil, err
 	}
 	defer s.decrementWorking()
+
+	fs := &ForwardSignature{
+		TargetHeight: req.TargetHeight,
+		Previous:     req.Previous,
+		Newest:       req.Newest.Copy(),
+		Links:        make([]*ForwardLink, 0),
+	}
 
 	fl, err := func() (*ForwardLink, error) {
 		if fs.TargetHeight >= len(fs.Newest.BackLinkIDs) {

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -390,17 +390,6 @@ func (s *Service) StoreSkipBlockInternal(psbd *StoreSkipBlock) (*StoreSkipBlockR
 	return reply, nil
 }
 
-// searchBlock returns the block with the given index or nil
-func searchBlock(blocks Proof, index int) *SkipBlock {
-	for _, sb := range blocks {
-		if sb.Index == index {
-			return sb
-		}
-	}
-
-	return nil
-}
-
 // sendForwardLinkRequest sends a request to the given until until either the forward-link is
 // created or there's not enough online nodes to get a valid signature.
 func sendForwardLinkRequest(ro *onet.Roster, req *ForwardSignature, reply *ForwardSignatureReply) (err error) {
@@ -449,7 +438,7 @@ func (s *Service) OptimizeProof(req *OptimizeProofRequest) (*OptimizeProofReply,
 			// precision but unlike the previous division, this will always
 			// produce the index minus ε < 10^-9.
 			index = sb.Index + int(math.Round(math.Exp(float64(h)*base)))
-			to := searchBlock(pr, index)
+			to := pr.Search(index)
 			if to == nil {
 				return nil, errors.New("chain is inconsistent")
 			}

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -1289,6 +1289,7 @@ func (s *Service) ForwardLinkHandler(req *ForwardSignature) (*ForwardSignatureRe
 	}
 	defer s.decrementWorking()
 
+	// Copy to prevent data race when the message is sent to itself.
 	fs := &ForwardSignature{
 		TargetHeight: req.TargetHeight,
 		Previous:     req.Previous,

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -1035,8 +1035,6 @@ func TestService_LeaderChange(t *testing.T) {
 }
 
 func addBlockToChain(s *Service, scid SkipBlockID, sb *SkipBlock) (latest *SkipBlock, err error) {
-	s.SetPropTimeout(2 * time.Second)
-
 	reply, err := s.StoreSkipBlock(
 		&StoreSkipBlock{TargetSkipChainID: scid,
 			NewBlock: sb,

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -1480,7 +1480,23 @@ func TestService_MissingForwardLinks(t *testing.T) {
 	require.Equal(t, 2, len(sbAtIndex2FromC4.SkipBlock.ForwardLink))
 }
 
-func TestService_OptimizeProof(t *testing.T) {
+// Test if the optimization works as expected for a normal situation.
+func TestService_OptimizeProofSimple(t *testing.T) {
+	testOptimizeProof(t, 23, 2, 32, 5)
+}
+
+// Test if the optimization works as expected when the maximum height
+// has to be used.
+func TestService_OptimizeProofMaxHeight(t *testing.T) {
+	testOptimizeProof(t, 23, 2, 2, 13)
+}
+
+// Test that a base of 1 doesn't panic (division by zero because of the log)
+func TestService_OptimizeProofBase1(t *testing.T) {
+	testOptimizeProof(t, 15, 1, 1, 16)
+}
+
+func testOptimizeProof(t *testing.T, numBlock, base, max, expected int) {
 	local := onet.NewLocalTest(cothority.Suite)
 	defer local.CloseAll()
 	srvs, ro, service := local.MakeSRS(cothority.Suite, 6, skipchainSID)
@@ -1490,7 +1506,7 @@ func TestService_OptimizeProof(t *testing.T) {
 	sk5 := srvs[4].Service(ServiceName).(*Service)
 	sk6 := srvs[5].Service(ServiceName).(*Service)
 
-	sbRoot, err := makeGenesisRosterArgs(sk1, roster, nil, VerificationStandard, 2, 32)
+	sbRoot, err := makeGenesisRosterArgs(sk1, roster, nil, VerificationStandard, base, max)
 	require.NoError(t, err)
 
 	sb := NewSkipBlock()
@@ -1499,7 +1515,7 @@ func TestService_OptimizeProof(t *testing.T) {
 	sk1.disableForwardLink = true
 
 	var reply *StoreSkipBlockReply
-	for i := 0; i < 23; i++ {
+	for i := 0; i < numBlock; i++ {
 		reply, err = sk1.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: sbRoot.Hash, NewBlock: sb})
 		require.NoError(t, err)
 	}
@@ -1511,10 +1527,10 @@ func TestService_OptimizeProof(t *testing.T) {
 	// Ask host 5 to optimize (not the leader)
 	opr, err := sk5.OptimizeProof(&OptimizeProofRequest{Roster: ro, ID: reply.Latest.Hash})
 	require.NoError(t, err)
-	require.Equal(t, 6, len(opr.Proof))
+	require.Equal(t, expected, len(opr.Proof))
 
 	// And verify the proof is propagated to the roster we asked for
 	sbs, err := sk6.db.GetProofForID(reply.Latest.Hash)
 	require.NoError(t, err)
-	require.Equal(t, 6, len(sbs))
+	require.Equal(t, expected, len(sbs))
 }

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -1088,7 +1088,7 @@ func (db *SkipBlockDB) GetProofForID(bid SkipBlockID) (sbs Proof, err error) {
 			return err
 		}
 		if sb == nil {
-			// It should never happen if the previous is found..
+			// It should never happen if the previous is found.
 			return errors.New("couldn't find the genesis block")
 		}
 

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -1097,7 +1097,10 @@ func (db *SkipBlockDB) GetProofForID(bid SkipBlockID) (sbs Proof, err error) {
 		for !sb.Hash.Equal(bid) && len(sb.ForwardLink) > 0 {
 			diff := math.Log(float64(target.Index - sb.Index))
 			base := math.Log(float64(sb.BaseHeight))
-			maxHeight := int(math.Min(diff/base, float64(len(sb.ForwardLink)-1)))
+			maxHeight := 0
+			if base != 0 {
+				maxHeight = int(math.Min(diff/base, float64(len(sb.ForwardLink)-1)))
+			}
 
 			id := sb.ForwardLink[maxHeight].To
 			sb, err = db.getFromTx(tx, id)

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -495,6 +495,17 @@ func (sb *SkipBlock) updateHash() SkipBlockID {
 // using the shortest path
 type Proof []*SkipBlock
 
+// Search returns the block with the given index or nil
+func (sbs Proof) Search(index int) *SkipBlock {
+	for _, sb := range sbs {
+		if sb.Index == index {
+			return sb
+		}
+	}
+
+	return nil
+}
+
 // Verify checks that the proof is correct by checking individual
 // blocks and their back and forward links
 func (sbs Proof) Verify() error {
@@ -1062,9 +1073,7 @@ func (db *SkipBlockDB) GetProof(sid SkipBlockID) (sbs []*SkipBlock, err error) {
 
 // GetProofForID returns the shortest chain known from the genesis to the given
 // block using the heighest forward-links available in the local db.
-func (db *SkipBlockDB) GetProofForID(bid SkipBlockID) (sbs []*SkipBlock, err error) {
-	sbs = make([]*SkipBlock, 0)
-
+func (db *SkipBlockDB) GetProofForID(bid SkipBlockID) (sbs Proof, err error) {
 	err = db.View(func(tx *bbolt.Tx) error {
 		target, err := db.getFromTx(tx, bid)
 		if err != nil {

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -2,6 +2,7 @@ package skipchain
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -289,6 +290,34 @@ func TestSkipBlock_Payload(t *testing.T) {
 	h := sb.CalculateHash()
 	sb.Payload = []byte{1, 2, 3}
 	require.Equal(t, h, sb.CalculateHash())
+}
+
+// Vector testing of the function to get the index of the next
+// block when following the chain.
+func TestSkipBlock_PathForIndex(t *testing.T) {
+	sb := NewSkipBlock()
+
+	vectors := []struct{ index, height, base, target, expected int }{
+		{0, 6, 2, 32, 32},
+		{0, 6, 4, 32, 16},
+		{0, 2, 4, 32, 4},
+		{1, 1, 2, 3, 2},
+		{0, 6, 2, 31, 16},
+		{0, 1, 2, 0, 0},
+		{1, 1, 2, 1, 1},
+		// backwards test
+		{32, 6, 2, 0, 0},
+		{32, 6, 2, 1, 16},
+	}
+
+	for _, v := range vectors {
+		sb.Index = v.index
+		sb.Height = v.height
+		sb.BaseHeight = v.base
+
+		_, idx := sb.pathForIndex(v.target)
+		require.Equal(t, v.expected, idx, fmt.Sprintf("%v", v))
+	}
 }
 
 // This checks if the it returns the shortest path or an error

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -293,7 +293,7 @@ func TestSkipBlock_Payload(t *testing.T) {
 
 // This checks if the it returns the shortest path or an error
 // when blocks are missing
-func TestGetProof(t *testing.T) {
+func TestSkipBlockDB_GetProof(t *testing.T) {
 	local := onet.NewLocalTest(suite)
 	_, ro, _ := local.GenTree(2, false)
 	defer local.CloseAll()
@@ -305,16 +305,20 @@ func TestGetProof(t *testing.T) {
 	root.Roster = ro
 	root.Index = 0
 	root.Height = 2
+	root.BaseHeight = 2
 	root.updateHash()
 	sb1 := NewSkipBlock()
 	sb1.Roster = ro
 	sb1.Index = 1
 	sb1.Height = 1
+	sb1.BaseHeight = 2
 	sb1.BackLinkIDs = []SkipBlockID{root.Hash}
 	sb1.updateHash()
 	sb2 := NewSkipBlock()
 	sb2.Roster = ro
 	sb2.Index = 2
+	sb2.BaseHeight = 2
+	sb2.GenesisID = root.Hash
 	sb2.BackLinkIDs = []SkipBlockID{sb1.Hash}
 	sb2.updateHash()
 	sb1.ForwardLink = []*ForwardLink{&ForwardLink{From: sb1.Hash, To: sb2.Hash}}
@@ -327,10 +331,15 @@ func TestGetProof(t *testing.T) {
 	require.NoError(t, root.ForwardLink[1].sign(ro))
 
 	_, err := db.StoreBlocks([]*SkipBlock{root, sb1, sb2})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	blocks, err := db.GetProof(root.Hash)
-	require.Nil(t, err)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(blocks))
+	require.True(t, blocks[1].Hash.Equal(sb2.Hash))
+
+	blocks, err = db.GetProofForID(sb2.Hash)
+	require.NoError(t, err)
 	require.Equal(t, 2, len(blocks))
 	require.True(t, blocks[1].Hash.Equal(sb2.Hash))
 
@@ -340,7 +349,10 @@ func TestGetProof(t *testing.T) {
 	require.Nil(t, err)
 
 	_, err = db.GetProof(root.Hash)
-	require.NotNil(t, err)
+	require.Error(t, err)
+
+	_, err = db.GetProofForID(sb2.Hash)
+	require.Error(t, err)
 }
 
 // Test the edge cases of the verification function


### PR DESCRIPTION
In other words, this PR implements a tool to create missing forward-links by checking that the proof of a given block is the shortest possible and then propagate it to the given roster. If the block ID is a genesis, it will fetch the latest block and use it as the target.

Fixes #1907 