### PR TITLE
Prevent infinite looping when following forward-links

### DIFF
--- a/byzcoin/proof.go
+++ b/byzcoin/proof.go
@@ -45,6 +45,9 @@ func NewProof(c ReadOnlyStateTrie, s *skipchain.SkipBlockDB, id skipchain.SkipBl
 			if sbTemp == nil {
 				return nil, errors.New("missing block in chain")
 			}
+			if sbTemp.Index <= sb.Index {
+				return nil, skipchain.ErrorInconsistentForwardLink
+			}
 			if sbTemp.Index <= c.GetIndex() {
 				sb = sbTemp
 				break

--- a/byzcoin/proof_test.go
+++ b/byzcoin/proof_test.go
@@ -102,10 +102,12 @@ func createSC(t *testing.T) (s sc) {
 	s.c.StoreAll([]StateChange{{StateAction: Create, InstanceID: s.key, Value: s.value}}, 1)
 
 	s.genesis = skipchain.NewSkipBlock()
+	s.genesis.Height = 1
 	s.genesis.Roster, s.genesisPrivs = genRoster(1)
 	s.genesis.Hash = s.genesis.CalculateHash()
 
 	s.sb2 = skipchain.NewSkipBlock()
+	s.sb2.Height = 1
 	s.sb2.Roster, _ = genRoster(2)
 	s.sb2.Data, err = protobuf.Encode(&DataHeader{
 		TrieRoot: s.c.GetRoot(),
@@ -119,6 +121,7 @@ func createSC(t *testing.T) (s sc) {
 	require.Nil(t, err)
 
 	s.genesis2 = skipchain.NewSkipBlock()
+	s.genesis2.Height = 1
 	s.genesis2.Roster, _ = genRoster(2)
 	s.genesis2.Hash = s.genesis2.CalculateHash()
 	s.s.Store(s.genesis2)

--- a/skipchain/protocol.go
+++ b/skipchain/protocol.go
@@ -261,6 +261,11 @@ func (p *GetBlocks) HandleGetBlocks(msg ProtoStructGetBlocks) error {
 		if s == nil {
 			break
 		}
+		last := len(result) - 1
+		if last >= 0 && s.Index <= result[last].Index {
+			return ErrorInconsistentForwardLink
+		}
+
 		result = append(result, s)
 		n--
 

--- a/skipchain/protocol_test.go
+++ b/skipchain/protocol_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/cothority/v3"
-	"go.dedis.ch/cothority/v3/byzcoinx"
 	"go.dedis.ch/kyber/v3/sign/schnorr"
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
@@ -35,32 +34,42 @@ func TestGB(t *testing.T) {
 
 	sb0 := NewSkipBlock()
 	sb0.Roster = ro
+	sb0.Index = 0
+	sb0.Height = 1
 	sb0.Hash = sb0.CalculateHash()
 	sb1 := NewSkipBlock()
 	sb1.Roster = ro
+	sb1.Index = 1
+	sb1.Height = 2
 	sb1.BackLinkIDs = []SkipBlockID{sb0.Hash}
 	sb1.Hash = sb1.CalculateHash()
 	sig0 := NewForwardLink(sb0, sb1)
-	sig0.Signature = byzcoinx.FinalSignature{Msg: sig0.Hash(), Sig: []byte{}}
+	require.NoError(t, sig0.sign(ro))
 	sb0.ForwardLink = []*ForwardLink{sig0}
 
 	sb2 := NewSkipBlock()
+	sb2.Roster = ro
+	sb2.Index = 2
+	sb2.Height = 1
 	sb2.BackLinkIDs = []SkipBlockID{sb1.Hash}
 	sb2.Hash = sb2.CalculateHash()
 
 	sb3 := NewSkipBlock()
+	sb3.Roster = ro
+	sb3.Index = 3
+	sb3.Height = 1
 	sb3.BackLinkIDs = []SkipBlockID{sb2.Hash}
 	sb3.Hash = sb3.CalculateHash()
 	sig2 := NewForwardLink(sb2, sb3)
-	sig2.Signature = byzcoinx.FinalSignature{Msg: sig2.Hash(), Sig: []byte{}}
+	require.NoError(t, sig2.sign(ro))
 	sb2.ForwardLink = []*ForwardLink{sig2}
 
 	// and make sb1 forward[1] point to sb3 as well.
 	sig12 := NewForwardLink(sb1, sb2)
-	sig12.Signature = byzcoinx.FinalSignature{Msg: sig12.Hash(), Sig: []byte{}}
+	require.NoError(t, sig12.sign(ro))
 
 	sig13 := NewForwardLink(sb1, sb3)
-	sig13.Signature = byzcoinx.FinalSignature{Msg: sig13.Hash(), Sig: []byte{}}
+	require.NoError(t, sig13.sign(ro))
 	sb1.ForwardLink = []*ForwardLink{sig12, sig13}
 
 	db, bucket := ts0.GetAdditionalBucket([]byte("skipblocks"))

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -427,6 +427,11 @@ func (s *Service) GetUpdateChain(guc *GetUpdateChain) (*GetUpdateChainReply, err
 				break
 			}
 		}
+
+		if next.Index <= block.Index {
+			return nil, ErrorInconsistentForwardLink
+		}
+
 		block = next
 		blocks = append(blocks, next.Copy())
 	}

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -773,11 +773,9 @@ func (db *SkipBlockDB) StoreBlocks(blocks []*SkipBlock) ([]SkipBlockID, error) {
 				}
 
 				// As we don't store the target height in the forward-link, there is no
-				// way to insure that it will be stored at the right height if the target
+				// way to ensure that it will be stored at the right height if the target
 				// block is not yet discovered like in a catch up scenario that will end
-				// up in this path. But we can at least check that the forward-link belongs
-				// to the block and is not a leftover when creating a new block and that
-				// we don't have more than expected.
+				// up in this path.
 				// Deprecated: This is a notice for v4 to add the target height in the
 				// forward-link so conodes can sign it.
 				if len(sb.ForwardLink) > sb.Height {
@@ -794,7 +792,6 @@ func (db *SkipBlockDB) StoreBlocks(blocks []*SkipBlock) ([]SkipBlockID, error) {
 						}
 
 						if err := fl.Verify(suite, publics); err != nil {
-							// Only keep a log of the failing forward links but keep trying others.
 							return errors.New("invalid forward-link signature: " + err.Error())
 						}
 					}

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -790,7 +790,7 @@ func (db *SkipBlockDB) StoreBlocks(blocks []*SkipBlock) ([]SkipBlockID, error) {
 				for _, fl := range sb.ForwardLink {
 					if !fl.IsEmpty() {
 						if !fl.From.Equal(sb.Hash) {
-							return fmt.Errorf("found inconsistent forward-link")
+							return ErrorInconsistentForwardLink
 						}
 
 						if err := fl.Verify(suite, publics); err != nil {

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -23,6 +23,10 @@ import (
 	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
+// ErrorInconsistentForwardLink is triggered when the target of a forward-link
+// doesn't respect the consistency of the chain.
+var ErrorInconsistentForwardLink = errors.New("found inconsistent forward-link")
+
 // How long to wait before a timeout is generated in the propagation. It is not
 // set to a constant because we'd like to change it in the test.
 var defaultPropagateTimeout = 15 * time.Second
@@ -1043,6 +1047,12 @@ func (db *SkipBlockDB) GetProof(sid SkipBlockID) (sbs []*SkipBlock, err error) {
 
 			if sb == nil {
 				return errors.New("couldn't find one of the blocks")
+			}
+
+			// One way to insure there is no corrupted forward-link is
+			// to insure the index is monotonically increasing.
+			if sb.Index <= sbs[len(sbs)-1].Index {
+				return ErrorInconsistentForwardLink
 			}
 
 			sbs = append(sbs, sb)

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/cothority/v3"
+	"go.dedis.ch/cothority/v3/byzcoinx"
+	"go.dedis.ch/kyber/v3/pairing"
+	"go.dedis.ch/kyber/v3/sign"
+	"go.dedis.ch/kyber/v3/sign/bls"
 	"go.dedis.ch/kyber/v3/suites"
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
@@ -16,6 +20,8 @@ import (
 	bbolt "go.etcd.io/bbolt"
 	uuid "gopkg.in/satori/go.uuid.v1"
 )
+
+var pairingSuite = pairing.NewSuiteBn256()
 
 func TestSkipBlock_GetResponsible(t *testing.T) {
 	l := onet.NewTCPTest(suite)
@@ -288,19 +294,37 @@ func TestSkipBlock_Payload(t *testing.T) {
 // This checks if the it returns the shortest path or an error
 // when blocks are missing
 func TestGetProof(t *testing.T) {
+	local := onet.NewLocalTest(suite)
+	_, ro, _ := local.GenTree(2, false)
+	defer local.CloseAll()
+
 	db, file := setupSkipBlockDB(t)
 	defer os.Remove(file)
 
 	root := NewSkipBlock()
+	root.Roster = ro
+	root.Index = 0
+	root.Height = 2
 	root.updateHash()
 	sb1 := NewSkipBlock()
+	sb1.Roster = ro
+	sb1.Index = 1
+	sb1.Height = 1
 	sb1.BackLinkIDs = []SkipBlockID{root.Hash}
 	sb1.updateHash()
 	sb2 := NewSkipBlock()
+	sb2.Roster = ro
+	sb2.Index = 2
 	sb2.BackLinkIDs = []SkipBlockID{sb1.Hash}
 	sb2.updateHash()
-	sb1.ForwardLink = []*ForwardLink{&ForwardLink{To: sb2.Hash}}
-	root.ForwardLink = []*ForwardLink{&ForwardLink{To: sb1.Hash}, &ForwardLink{To: sb2.Hash}}
+	sb1.ForwardLink = []*ForwardLink{&ForwardLink{From: sb1.Hash, To: sb2.Hash}}
+	require.NoError(t, sb1.ForwardLink[0].sign(ro))
+	root.ForwardLink = []*ForwardLink{
+		&ForwardLink{From: root.Hash, To: sb1.Hash},
+		&ForwardLink{From: root.Hash, To: sb2.Hash},
+	}
+	require.NoError(t, root.ForwardLink[0].sign(ro))
+	require.NoError(t, root.ForwardLink[1].sign(ro))
 
 	_, err := db.StoreBlocks([]*SkipBlock{root, sb1, sb2})
 	require.Nil(t, err)
@@ -380,4 +404,37 @@ func TestBlockBuffer(t *testing.T) {
 	bb.clear(sid)
 	sb = bb.get(sid, bid)
 	require.Nil(t, sb)
+}
+
+func (fl *ForwardLink) sign(ro *onet.Roster) error {
+	msg := fl.Hash()
+	mask, err := sign.NewMask(pairingSuite, ro.ServicePublics(ServiceName), nil)
+	if err != nil {
+		return err
+	}
+	sigs := make([][]byte, len(ro.List))
+	for i, si := range ro.List {
+		sig, err := bls.Sign(pairingSuite, si.ServicePrivate(ServiceName), msg)
+		if err != nil {
+			return err
+		}
+		sigs[i] = sig
+
+		err = mask.SetBit(i, true)
+		if err != nil {
+			return err
+		}
+	}
+
+	agg, err := bls.AggregateSignatures(pairingSuite, sigs...)
+	if err != nil {
+		return err
+	}
+
+	fl.Signature = byzcoinx.FinalSignature{
+		Msg: msg,
+		Sig: append(agg, mask.Mask()...),
+	}
+
+	return nil
 }

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -118,8 +118,19 @@ func TestSkipBlock_InvalidForwardLinks(t *testing.T) {
 
 	// Try to add a forward link at a wrong height.
 	s.db.Store(sb2)
-
 	require.Contains(t, log.GetStdErr(), "Received a forward link with an invalid height")
+
+	gb2 := s.db.GetByID(sbRoot.Hash)
+	gb2.BackLinkIDs = []SkipBlockID{[]byte{1, 2, 3}}
+	gb2.updateHash()
+	// Try to store a new block with old forward-links
+	s.db.Store(gb2)
+	require.Contains(t, log.GetStdErr(), "found inconsistent forward-link")
+
+	gb2.Height = 0
+	// Try to store a new block with too many forward-links
+	s.db.Store(gb2)
+	require.Contains(t, log.GetStdErr(), "found 1 forward-links for a height of 0")
 }
 
 func TestSkipBlock_Hash1(t *testing.T) {


### PR DESCRIPTION
This adds a check in functions that are following forward-links
to insure that it moves to a more recent block every time and
return an error otherwise.

Also: check forward-links when storing a unknown block.
    
Fixes #1894