### PR TITLE
Make el consistent with bcadmin

### DIFF
--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -312,12 +312,12 @@ var cmds = cli.Commands{
 						Usage: "the DARC to update (no default)",
 					},
 					cli.StringFlag{
-						Name:  "rule",
-						Usage: "the rule to be added, updated or deleted",
-					},
-					cli.StringFlag{
 						Name:  "sign",
 						Usage: "public key of the signing entity (default is the admin public key)",
+					},
+					cli.StringFlag{
+						Name:  "rule",
+						Usage: "the rule to be added, updated or deleted",
 					},
 					cli.StringFlag{
 						Name:  "identity",

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -1357,7 +1357,6 @@ func key(c *cli.Context) error {
 			return errors.New("couldn't load signer: " + err.Error())
 		}
 		log.Infof("Private: %s\nPublic: %s", sig.Ed25519.Secret, sig.Ed25519.Point)
-		//log.Infof("Private: 65642e706f696e74%s\nPublic: %s", sig.Ed25519.Secret, sig.Ed25519.Point)
 		return nil
 	}
 	newSigner := darc.NewSignerEd25519(nil, nil)

--- a/eventlog/README.md
+++ b/eventlog/README.md
@@ -36,7 +36,7 @@ below) *must* be authorised to use these rules.
 An example transcript of correctly setting up and using an Eventlog is:
 
 ```
-# make the ByzCoin instance
+# Make the ByzCoin instance
 
 $ bcadmin c -roster ../../conode/public.toml
 Created ByzCoin with ID 7ad741d44e216fc4475da60b8656b904937639415ec27f7003e13408d6e0510c.

--- a/eventlog/README.md
+++ b/eventlog/README.md
@@ -15,7 +15,7 @@ auditability. Below are some of the main features that sets us apart.
   think it is valid, e.g., the timestamp is reasonable, the client is
   authorised and so on.
 - Distributed access control - fine-grained client access control with
-  delegation support is configured using [DARC](../byzcoin/README.md#darc).
+  delegation support is configured using [DARC](../darc/README.md#darc).
 - Configurable acceptance criteria - we execute a smart-contract on all nodes,
   nodes only accept the event if the smart-contract returns a positive result.
 - Existance proof - once an event is logged, an authorised client can request
@@ -23,13 +23,12 @@ auditability. Below are some of the main features that sets us apart.
   that the event is indeed stored in the blockchain and has not been tampered.
 
 ## Running the service
-For the general information about running a conode, or conodes, please see the
-[conode documentation](../conode/README.md). EventLog is not stable, so it is
-not a part of the `cothority.v2` release, please use the `master` branch.
+The EL service is built into conodes. For the general information about
+running a conode, please see the [conode documentation](../conode/README.md).
 
 ## Client API
 
-We offer three ways for clients to connect to the event log service. All the
+We offer three ways for clients to connect to the EL service. All the
 APIs expect an existing ByzCoin object that has a Darc with "spawn:eventlog"
 and "invoke:eventlog" in its rules. The eventlog signer (which we will create
 below) *must* be authorised to use these rules.
@@ -39,67 +38,63 @@ An example transcript of correctly setting up and using an Eventlog is:
 ```
 # make the ByzCoin instance
 
-$ bcadmin c --roster ../../conode/public.toml
+$ bcadmin c -roster ../../conode/public.toml
 Created ByzCoin with ID 7ad741d44e216fc4475da60b8656b904937639415ec27f7003e13408d6e0510c.
 export BC="/Users/jallen/Library/Application Support/bc/data/bc-7ad741d44e216fc4475da60b8656b904937639415ec27f7003e13408d6e0510c.cfg"
 $ export BC="/Users/jallen/Library/Application Support/bc/data/bc-7ad741d44e216fc4475da60b8656b904937639415ec27f7003e13408d6e0510c.cfg"
 
-# make a keypair for the new eventlog, give it permissions on the genesis darc
+# Make a keypair for the new eventlog, give it permissions on the genesis darc.
+# The private key is stored in the el configuration directory.
+$ el key
+ed25519:2a53df71edad603e56477d33e82d675a3499ba4719f809fabea95ce546c16b5f
+$ bcadmin darc rule -rule spawn:eventlog -identity ed25519:2a53df71edad603e56477d33e82d675a3499ba4719f809fabea95ce546c16b5f
+$ bcadmin darc rule -rule invoke:eventlog.log -identity ed25519:2a53df71edad603e56477d33e82d675a3499ba4719f809fabea95ce546c16b5f
 
-$ el create --keys
-Identity: ed25519:2a53df71edad603e56477d33e82d675a3499ba4719f809fabea95ce546c16b5f
-export PRIVATE_KEY=120c9566ebbcf91887675298485945bad2d3f7be3ae7d6a56bdebd5b8378a80a
-$ export PRIVATE_KEY=120c9566ebbcf91887675298485945bad2d3f7be3ae7d6a56bdebd5b8378a80a
-$ bcadmin add spawn:eventlog --identity ed25519:2a53df71edad603e56477d33e82d675a3499ba4719f809fabea95ce546c16b5f
-$ bcadmin add invoke:eventlog --identity ed25519:2a53df71edad603e56477d33e82d675a3499ba4719f809fabea95ce546c16b5f
+# Check the persmissions on the genesis darc.
+$ bcadmin darc show
 
-# check the persmissions on the genesis darc
-
-$ bcadmin show
-
-# make the new eventlog
-
-$ ./el create 
+# Make the new eventlog.
+$ ./el create -sign ed25519:2a53df71edad603e56477d33e82d675a3499ba4719f809fabea95ce546c16b5f
 export EL=b9a6c3868b01e19f6d3d0f62c881582d5a5bd98046dd4e4274b579fd6e66b643
 $ export EL=b9a6c3868b01e19f6d3d0f62c881582d5a5bd98046dd4e4274b579fd6e66b643
 
-# use the eventlog
-
-$ ./el log -content test
+# Use the eventlog.
+$ ./el log -sign ed25519:2a53df71edad603e56477d33e82d675a3499ba4719f809fabea95ce546c16b5f -topic "hello" -content "world"
 $ ./el search
-2018-09-28 13:42:23		test
 ```
 
 ### Go API
 
-For a working example of the Go API, see the `el` directory, where there is
-a command-line interface to the Eventlog.
-
 The detailed API can be found on
-[godoc](https://godoc.org/github.com/dedis/cothority/eventlog).
+[godoc](https://godoc.org/go.dedis.ch/cothority/eventlog). You may find example
+usage in `api_test.go`.
 
 ### Java API
 In java, you need to construct a `EventLogInstance` class. There are two ways
-to initialise it, the first for when you do not have an existing eventlog
-instance on ByzCoin to connect to, the other when you do.
+to initialise it, the first for when you do _not_ have an existing eventlog
+instance on ByzCoin to connect to, the other is when you do. Below we give a
+general overview. Please see the [Java docs](https://www.javadoc.io/doc/ch.epfl.dedis/cothority)
+for more information.
 
 ```java
-// Create the eventlog instance. It expects a ByzCoin RPC, a list of 
-// signers that have the "spawn:eventlog" permission and the darcID for where
-// the permission is stored.
-EventLogInstance el = new EventLogInstance(bcRPC, admins, darcID);
+// Create the eventlog instance. It expects a ByzCoin RPC, 
+// the darc ID that has the "spawn:eventlog" rule, a list of 
+// signers that are authorized to in the "spawn:eventlog" rule
+// and the counters (used for preventing replay attacks).
+// You can get the counters using bcRPC.getSignerCounters.
+EventLogInstance el = new EventLogInstance(bcRPC, darcID, admins, signerCounters);
 ```
 
 If you would like to connect to the same instance, you need to save the result
-of `el.getInstanceId()` and of course the ByzCoin RPC. The constructor
-`EventLogInstance(ByzCoinRPC bc, InstanceId id)` connects to an existing
-instance.
+of `el.getInstanceId()` and the ByzCoin RPC. Then use
+`EventLogInstance.fromByzcoin(ByzCoinRPC bc, InstanceId id)` to connects to an
+existing instance.
 
 It's straightforward to log events, as long as the event is correctly signed.
-The signer must be the one with the "invoke:eventlog" permission.
+The signer must be the one with the "invoke:eventlog.log" permission.
 ```java
 Event event = new Event("login", "alice");
-InstanceId key = this.el.log(event, signers);
+InstanceId key = this.el.log(event, signers, signerCounters);
 // wait for the block to be added
 Event event2 = this.el.get(key);
 assertTrue(event.equals(event2));
@@ -111,10 +106,6 @@ a time-range.
 long now = System.currentTimeMillis() * 1000 * 1000;
 SearchResponse resp = el.search("", now - 1000, now + 1000);
 ```
-
-Please refer to the javadocs for more information. The javadocs are not hosted
-anywhere unfortunately, but it is possible to generate them from the
-[source](https://github.com/dedis/cothority/blob/master/external/java/src/main/java/ch/epfl/dedis/lib/byzcoin/contracts/EventLogInstance.java).
 
 ### CLI
 Please see the `el` documentation [here](el/README.md).

--- a/eventlog/el/README.md
+++ b/eventlog/el/README.md
@@ -8,7 +8,7 @@ el
 
 Here are some examples of how to use el.
 
-## Make a new key pair
+## Make a new key pair and creating an event log
 
 Using the `el` tool, you can create a key pair:
 
@@ -16,37 +16,38 @@ Using the `el` tool, you can create a key pair:
 $ el key
 ```
 
-The keys are printed on stdout. You will give the public key to the
-ByzCoin administrator who will use the "bcadmin add" command to give your
-private key the right to make new event logs (add "spawn:eventlog"
-and "invoke:eventlog" rules to a Darc).
-
-You can now make the event log like this:
-
-```
-$ PRIVATE_KEY=$priv el create -bc $file -darc $darcID
-```
+The public key is printed on stdout. The private one is stored in the `el`
+configuration directory. To use a custom configuration directory use the
+`-config $dir`. You will give the public key to the ByzCoin administrator who
+will use the "bcadmin darc rule" command to give your private key the right to
+make new event logs (add "spawn:eventlog" and "invoke:eventlog.log" rules to a
+Darc). We will not cover how to configure ByzCoin, more information can be 
+found in the [bcadmin documentation](../../byzcoin/bcadmin/README.md).
 
 The ByzCoin admin will give you a ByzCoin config file, which you will use with
 the -bc argument, or you can set the BC environment variable to the name of the
-ByzCoin config file. He/she will also give you a DarcID to use.  A new event log
-will be spawned, and the event log ID will be printed. Set the EL environment
-variable to communicate it to future calls to the `el` program.
+ByzCoin config file. He/she will also give you a DarcID to use. 
 
-You need to give the private key from above, using the PRIVATE_KEY environment
-variable or the `-priv` argument.
+Assuming ByzCoin is configured with the correct permissions, you can now make
+the event log like this:
+
+```
+$ el create -bc $file -darc $darcID -sign $key
+```
+
+A new event log will be spawned, and the event log ID will be printed. Set the
+EL environment variable to communicate it to future calls to the `el` program.
+The $key variable is the key which you created using `el key`.
 
 ## Logging
 
 ```
-$ el log -config 2 -topic Topic -content "The log message"
+$ el log -topic Topic -content "The log message" -sign $key
 ```
 
-Using config #2, log a string to the event log.
-
-If `-topic` is not set, it defaults to the empty string. If `-content`
-is not set, `el log` defaults to reading one line at a time from stdin
-and logging those with the given `-topic`.
+The above command creates a log entry. If `-topic` is not set, it defaults to
+the empty string. If `-content` is not set, `el log` defaults to reading one
+line at a time from stdin and logging those with the given `-topic`.
 
 An interesting test that logs 100 messages, one every .1 second, so
 that you can see the messages arriving over the course of several
@@ -59,16 +60,16 @@ $ seq 100 | (while read i; do echo $i; sleep .1; done) | ./el log
 ## Searching
 
 ```
-$ el search -config 2 -topic Topic -from 12:00 -to 13:00 -count 5
-$ el search -config 2 -topic Topic -from 12:00 -for 1h
+$ el search -topic Topic -from 12:00 -to 13:00 -count 5
+$ el search -topic Topic -from 12:00 -for 1h
 ```
 
 The exit code tells you if the search was truncated or not.
 
 If `-topic` is not set, it defaults to the empty string. If you give
-`-for`, then you must not give `-to`.
+`-from`, then you must not give `-to`.
 
-## OpenID authentication
+## OpenID authentication (needs to be updated)
 
 If the Darc that controls access to the eventlog has the form
 "proxy:$pubkey:$user", then `el` will need to use the

--- a/eventlog/el/test.sh
+++ b/eventlog/el/test.sh
@@ -26,9 +26,7 @@ main(){
 testEventLog(){
 	##### setup phase
 	runCoBG 1 2 3
-	# block interval of 2 seconds to this particular test to fail because of small intervals
-	# (Note: might go back to 0.5 after #1813)
-	runGrepSed "export BC=" "" ./bcadmin -c . create --roster public.toml --interval 1s
+	runGrepSed "export BC=" "" ./bcadmin -c . create --roster public.toml --interval .5s
 	eval "$SED"
 	[ -z "$BC" ] && exit 1
 	

--- a/eventlog/el/test.sh
+++ b/eventlog/el/test.sh
@@ -32,25 +32,20 @@ testEventLog(){
 	eval "$SED"
 	[ -z "$BC" ] && exit 1
 	
+	KEY=$(./el -c . key)
 
-	testOK ./bcadmin -c . darc add -out_key ./key.txt -out_id ./id.txt -unrestricted
-	KEY=$(cat ./key.txt)
-	ID=$(cat ./id.txt)
+	testOK ./bcadmin -c . darc rule -rule spawn:eventlog -identity "$KEY"
+	testOK ./bcadmin -c . darc rule -rule invoke:eventlog.log -identity "$KEY"
 
-	testOK ./bcadmin -c . darc rule -rule spawn:eventlog -identity "$ID"
-	testOK ./bcadmin -c . darc rule -rule spawn:eventlog -identity "$KEY" -darc "$ID" -sign "$KEY"
-	testOK ./bcadmin -c . darc rule -rule invoke:eventlog.log -identity "$KEY" -darc "$ID" -sign "$KEY"
-
-	runGrepSed "export EL=" "" $el --bcconfig . create -sign "$KEY" --darc "$ID"
+	runGrepSed "export EL=" "" $el create -sign "$KEY"
 	eval "$SED"
 	[ -z "$EL" ] && exit 1
 	
 	##### testing phase
-	testOK ./bcadmin -c . darc show --darc "$ID"
-	testOK $el --bcconfig . log -t 'test' -c 'abc' -w 10 -sign "$KEY"
-	testOK $el --bcconfig . log -c 'def' -w 10 -sign "$KEY"
-	echo ghi | testOK $el --bcconfig . log -w 10 -sign "$KEY"
-	seq 10 | testOK $el --bcconfig . log -t seq100 -w 10 -sign "$KEY"
+	testOK $el log -t 'test' -c 'abc' -w 10 -sign "$KEY"
+	testOK $el log -c 'def' -w 10 -sign "$KEY"
+	echo ghi | testOK $el log -w 10 -sign "$KEY"
+	seq 10 | testOK $el log -t seq100 -w 10 -sign "$KEY"
 
 	testGrep "abc" $el search -t test
 	testCountLines 13 $el search


### PR DESCRIPTION
- use the bcadmin library for operations in el
- fix integration test (flakiness on jenkins was observed locally too, it should be fixed on this PR)
- the OpenID authentication are untested and left as before, they will be fixed in a future PR

Discussion point:
I copy pasted the key function from bcadmin to el because the keys for logging events need to stay in the el config directory. Alternatively, we tell el the bcadmin config directory by adding a flag (e.g., `--bcconfig`) and remove the `key` function from el. The first approach has nicer UI, but the second approach removes repeated functionality. 