### PR TITLE
Skip to next block if link creation fails

### DIFF
--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -448,9 +448,7 @@ func (s *Service) OptimizeProof(req *OptimizeProofRequest) (*OptimizeProofReply,
 			err := sendForwardLinkRequest(sb.Roster, req, reply)
 
 			if err != nil {
-				log.Error("could not create a missing forward link:", err)
-				// reset the index to try to create lower levels
-				index = sb.Index
+				log.Warn("could not create missing forward link, trying next block:", err)
 			} else {
 				// save the new forward link
 				err = sb.AddForwardLink(reply.Link, h)


### PR DESCRIPTION
PR to make it clearer what is happening. The previous code was supposed to try lower-level links, but actually did the same as here: just skipping to the next skipblock and trying to get a new forward-link there.