### PR TITLE
Use a seed for scmgr for random requests

### DIFF
--- a/scmgr/app.go
+++ b/scmgr/app.go
@@ -9,12 +9,14 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"os"
 	"path"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"go.dedis.ch/cothority/v3"
 	"go.dedis.ch/cothority/v3/byzcoin"
@@ -56,6 +58,8 @@ func init() {
 var gitTag = "dev"
 
 func main() {
+	rand.Seed(time.Now().Unix())
+
 	cliApp := cli.NewApp()
 	cliApp.Name = "scmgr"
 	cliApp.Usage = "Create, modify and query skipchains"


### PR DESCRIPTION
This makes the use of random identity when fetching information
actually random by using a seed.