### PR TITLE
View change improvement

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -2288,7 +2288,7 @@ func (s *Service) startChain(genesisID skipchain.SkipBlockID) error {
 	s.heartbeats.start(string(genesisID), interval*s.rotationWindow, s.heartbeatsTimeout)
 
 	// initiate the view-change manager
-	initialDur, err := s.computeInitialDuration(genesisID)
+	initialDur, err := s.computeInitialDuration(latest.Hash)
 	if err != nil {
 		return err
 	}

--- a/byzcoin/viewchange.go
+++ b/byzcoin/viewchange.go
@@ -235,7 +235,15 @@ func (s *Service) handleViewChangeReq(env *network.Envelope) error {
 		// This is because the node is out-of-sync with others. If the current leader happens
 		// to be offline, it won't catch up because it doesn't get the requests to collect
 		// transactions so we need to trigger a catch up here to the distant peer.
-		// TODO: how ?
+
+		// The simplest solution is to pro-actively send it the current state of the chain
+		// and the distant peer will detect the Trie index difference.
+		ro := onet.NewRoster([]*network.ServerIdentity{env.ServerIdentity})
+		err := s.skService().PropagateProof(ro, req.View.Gen)
+		if err != nil {
+			log.Errorf("View change failed to propagate a proof: %s", err.Error())
+		}
+
 		return fmt.Errorf("%v view-change should not happen for blocks that are not the latest", s.ServerIdentity())
 	}
 

--- a/byzcoin/viewchange.go
+++ b/byzcoin/viewchange.go
@@ -232,6 +232,10 @@ func (s *Service) handleViewChangeReq(env *network.Envelope) error {
 		return fmt.Errorf("%v we do not know this view", s.ServerIdentity())
 	}
 	if len(reqLatest.ForwardLink) != 0 {
+		// This is because the node is out-of-sync with others. If the current leader happens
+		// to be offline, it won't catch up because it doesn't get the requests to collect
+		// transactions so we need to trigger a catch up here to the distant peer.
+		// TODO: how ?
 		return fmt.Errorf("%v view-change should not happen for blocks that are not the latest", s.ServerIdentity())
 	}
 

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -1552,6 +1552,20 @@ func (s *Service) propagateForwardLinkHandler(msg network.Message) error {
 	return nil
 }
 
+// PropagateProof is a simple function that will build the proof of a given
+// skipchain and send it the given roster.
+func (s *Service) PropagateProof(roster *onet.Roster, sid SkipBlockID) error {
+	proof, err := s.db.GetProof(sid)
+	if err != nil {
+		return err
+	}
+
+	// The propagation protocol expect this server to be present in the roster.
+	rosterWithRoot := roster.Concat(s.ServerIdentity())
+
+	return s.startPropagation(s.propagateProof, rosterWithRoot, &PropagateProof{proof})
+}
+
 // propagateProofHandler handles a chain propagation message that
 // announces a skipchain to a new conode
 func (s *Service) propagateProofHandler(msg network.Message) error {


### PR DESCRIPTION
A proof will be propagated when one of the peer is trying to request
a view change for a old block which means it is out-of-sync and as the
leader is offline, it never tries to catch up.