### PR TITLE
Fix nist point marshaling

### DIFF
--- a/external/js/kyber/spec/helpers/jsverify.ts
+++ b/external/js/kyber/spec/helpers/jsverify.ts
@@ -12,7 +12,7 @@ beforeEach(function () {
     toHold: function () {
       return {
         compare: function (actual, done) {
-          var r = jsc.check(actual);
+          var r = jsc.check(actual, { tests: 100 });
           if (done) {
             Promise.resolve().then(function () { return r; }).then(function (v) {
               // TODO: update jsverify after the fix is merged: https://github.com/jsverify/jsverify/pull/283

--- a/external/js/kyber/spec/sign/schnorr/schnorr.spec.ts
+++ b/external/js/kyber/spec/sign/schnorr/schnorr.spec.ts
@@ -1,3 +1,4 @@
+import jsc from 'jsverify';
 import Nist from '../../../src/curve/nist';
 import { schnorr } from '../../../src/sign';
 
@@ -51,8 +52,22 @@ describe("Schnorr Signature", () => {
     });
 
     it("returns true for a well formed signature", () => {
-        const sig = sign(group, secretKey, message);
+        const prop = jsc.forall(jsc.string, jsc.array(jsc.nat), (msg, k) => {
+            const message = Buffer.from(msg);
+            const secret = group.scalar().pick()
+            const pub = group.point().mul(secret, null);
 
-        expect(verify(group, publicKey, message, sig)).toBeTruthy();
+            const sig = sign(group, secret, message);
+            const res = verify(group, pub, message, sig);
+
+            if (!res) {
+                console.log("failing scalar: "+secret.toString());
+            }
+
+            return res;
+        });
+
+        // @ts-ignore
+        expect(prop).toHold();
     });
 });

--- a/external/js/kyber/src/curve/nist/point.ts
+++ b/external/js/kyber/src/curve/nist/point.ts
@@ -178,7 +178,7 @@ export default class NistPoint implements Point {
     /** @inheritdoc */
     marshalBinary(): Buffer {
         const byteLen = this.ref.curve.coordLen();
-        const buf = Buffer.allocUnsafe(this.ref.curve.pointLen());
+        const buf = Buffer.alloc(this.ref.curve.pointLen(), 0);
         buf[0] = 4; // uncompressed point
         
         let xBytes = Buffer.from(this.ref.point.x.fromRed().toArray("be"));


### PR DESCRIPTION
This allocates the buffer filled with zeros instead of an unsafe
allocation that is causing wrong marshaling.

Fixes #1917