### PR TITLE
Cosmetic updates for bcadmin deferred

### DIFF
--- a/byzcoin/bcadmin/clicontracts/README.md
+++ b/byzcoin/bcadmin/clicontracts/README.md
@@ -21,7 +21,7 @@ Use `bcadmin contract -h` to get the usage.
 redirected to stdout.
 
 * Each contract should have a `get` function, which allows one to get the
-contract's data given its instance id with `--instID`.
+contract's data given its instance id with `--instid`.
 
 **Global conventions**:
 
@@ -42,8 +42,8 @@ $ bcadmin contract value spawn --value "Hello World"
 Update a value contract:
 
 ```bash
-# The --instID is given when we spawn the value contract
-$ bcadmin contract value invoke update --value "Bye World" --instID ...
+# The --instid is given when we spawn the value contract
+$ bcadmin contract value invoke update --value "Bye World" --instid ...
 ```
 
 Spawn a deferred contract with a value contract as the proposed transaction:
@@ -55,8 +55,8 @@ $ bcadmin contract value spawn --value "Hello Word" --redirect | bcadmin contrac
 Invoke an addProof on a deferred contract:
 
 ```bash
-# The --hash and --instID values are given when we spawn the deferred contract
-bcadmin contract deferred invoke addProof --hash ... --instID ... --instrIdx 0
+# The --hash and --instid values are given when we spawn the deferred contract
+bcadmin contract deferred invoke addProof --hash ... --instid ... --instrIdx 0
 ```
 
 **Value spawn deferred scenario**:
@@ -80,13 +80,13 @@ bcadmin darc rule -rule invoke:deferred.execProposedTx --identity ed25519:...
 bcadmin contract value spawn --value myValue --redirect | bcadmin contract deferred spawn
 
 # Add the proof on the single instruction of the deferred transaction 
-# (the --hash and --instID values are given when we spawn the deferred contract)
-bcadmin contract deferred invoke addProof --hash ... --instID ... --iid 0
+# (the --hash and --instid values are given when we spawn the deferred contract)
+bcadmin contract deferred invoke addProof --hash ... --instid ... --iid 0
 
 # Finally execute the deferred transaction.
 # This will call the Spawn:value(myValue) transaction.
 # If we hadn't called the addProof before, it wouldn't have worked.
-bcadmin contract deferred invoke execProposedTx --instID ...
+bcadmin contract deferred invoke execProposedTx --instid ...
 ```
 
 **Config update deferred scenario**:
@@ -116,13 +116,13 @@ bcadmin contract config invoke updateConfig --blockInterval 7s \
                                             --redirect | bcadmin contract deferred spawn
 
 # Add the proof on the single instruction of the deferred transaction 
-# (the --hash and --instID values are given when we spawn the deferred contract)
-bcadmin contract deferred invoke addProof --hash ... --instID ... --instrIdx 0
+# (the --hash and --instid values are given when we spawn the deferred contract)
+bcadmin contract deferred invoke addProof --hash ... --instid ... --instrIdx 0
 
 # Finally execute the deferred transaction.
 # This will call the Spawn:value(myValue) transaction.
 # If we hadn't called the addProof before, it wouldn't have worked.
-bcadmin contract deferred invoke execProposedTx --instID ...
+bcadmin contract deferred invoke execProposedTx --instid ...
 
 # Now we can perform a zero update juste to get the result 
 bcadmin contract config invoke updateConfig

--- a/byzcoin/bcadmin/clicontracts/deferred.go
+++ b/byzcoin/bcadmin/clicontracts/deferred.go
@@ -191,7 +191,7 @@ func DeferredInvokeAddProof(c *cli.Context) error {
 	}
 	instIDBuf, err := hex.DecodeString(instID)
 	if err != nil {
-		return errors.New("failed to decode the instID string: " + err.Error())
+		return errors.New("failed to decode the instid string: " + err.Error())
 	}
 
 	instrIdx := c.Uint("instrIdx")
@@ -321,7 +321,7 @@ func ExecProposedTx(c *cli.Context) error {
 	}
 	instIDBuf, err := hex.DecodeString(instID)
 	if err != nil {
-		return errors.New("failed to decode the instID string")
+		return errors.New("failed to decode the instid string")
 	}
 
 	// ---
@@ -398,7 +398,7 @@ func DeferredGet(c *cli.Context) error {
 	}
 	instIDBuf, err := hex.DecodeString(instID)
 	if err != nil {
-		return errors.New("failed to decode the instID string")
+		return errors.New("failed to decode the instid string")
 	}
 
 	pr, err := cl.GetProof(instIDBuf)
@@ -453,7 +453,7 @@ func DeferredDelete(c *cli.Context) error {
 	}
 	instIDBuf, err := hex.DecodeString(instID)
 	if err != nil {
-		return errors.New("failed to decode the instID string")
+		return errors.New("failed to decode the instid string")
 	}
 
 	cfg, cl, err := lib.LoadConfig(bcArg)

--- a/byzcoin/bcadmin/clicontracts/deferred.go
+++ b/byzcoin/bcadmin/clicontracts/deferred.go
@@ -37,8 +37,6 @@ func DeferredSpawn(c *cli.Context) error {
 		return errors.New("failed to decode transaction, did you use --redirect ? " + err.Error())
 	}
 
-	fmt.Fprintf(c.App.Writer, "Here is the proposed Tx: \n%s\n", proposedTransaction)
-
 	// ---
 	// 2.
 	// ---

--- a/byzcoin/bcadmin/clicontracts/deferred.go
+++ b/byzcoin/bcadmin/clicontracts/deferred.go
@@ -185,9 +185,9 @@ func DeferredInvokeAddProof(c *cli.Context) error {
 		return errors.New("coulndn't decode the hash string: " + err.Error())
 	}
 
-	instID := c.String("instID")
+	instID := c.String("instid")
 	if instID == "" {
-		return errors.New("--instID flag is required")
+		return errors.New("--instid flag is required")
 	}
 	instIDBuf, err := hex.DecodeString(instID)
 	if err != nil {
@@ -315,9 +315,9 @@ func ExecProposedTx(c *cli.Context) error {
 		return err
 	}
 
-	instID := c.String("instID")
+	instID := c.String("instid")
 	if instID == "" {
-		return errors.New("--instID flag is required")
+		return errors.New("--instid flag is required")
 	}
 	instIDBuf, err := hex.DecodeString(instID)
 	if err != nil {
@@ -392,9 +392,9 @@ func DeferredGet(c *cli.Context) error {
 		return err
 	}
 
-	instID := c.String("instID")
+	instID := c.String("instid")
 	if instID == "" {
-		return errors.New("--instID flag is required")
+		return errors.New("--instid flag is required")
 	}
 	instIDBuf, err := hex.DecodeString(instID)
 	if err != nil {
@@ -447,9 +447,9 @@ func DeferredDelete(c *cli.Context) error {
 		return errors.New("--bc flag is required")
 	}
 
-	instID := c.String("instID")
+	instID := c.String("instid")
 	if instID == "" {
-		return errors.New("--instID flag is required")
+		return errors.New("--instid flag is required")
 	}
 	instIDBuf, err := hex.DecodeString(instID)
 	if err != nil {

--- a/byzcoin/bcadmin/clicontracts/deferred_test.sh
+++ b/byzcoin/bcadmin/clicontracts/deferred_test.sh
@@ -82,9 +82,9 @@ testContractDeferredInvoke() {
         }'`
     echo -e "Here is the hash:\t\t$HASH"
     
-    testOK runBA contract deferred invoke addProof --instID "$DEFERRED_INSTANCE_ID" --hash "$HASH" --instrIdx 0 --sign "$KEY" --darc "$ID"
+    testOK runBA contract deferred invoke addProof --instid "$DEFERRED_INSTANCE_ID" --hash "$HASH" --instrIdx 0 --sign "$KEY" --darc "$ID"
 
-    testOK runBA contract deferred invoke execProposedTx --instID "$DEFERRED_INSTANCE_ID" --sign "$KEY"
+    testOK runBA contract deferred invoke execProposedTx --instid "$DEFERRED_INSTANCE_ID" --sign "$KEY"
 }
 
 testGet() {
@@ -129,7 +129,7 @@ testGet() {
     echo -e "Here is the hash:\t\t$HASH"
 
     # We now use the get function to check if we have the right informations:
-    OUTRES=`runBA contract deferred get --instID $DEFERRED_INSTANCE_ID`
+    OUTRES=`runBA contract deferred get --instid $DEFERRED_INSTANCE_ID`
     testGrep "action: spawn:value" echo "$OUTRES"
     testGrep "identities: \[\]" echo "$OUTRES"
     testGrep "counters: \[\]" echo "$OUTRES"
@@ -137,11 +137,11 @@ testGet() {
     testGrep "Spawn:	value" echo "$OUTRES"
     testGrep "Args:value" echo "$OUTRES"
     
-    testOK runBA contract deferred invoke addProof --instID "$DEFERRED_INSTANCE_ID" --hash "$HASH" --instrIdx 0 --sign "$KEY" --darc "$ID"
+    testOK runBA contract deferred invoke addProof --instid "$DEFERRED_INSTANCE_ID" --hash "$HASH" --instrIdx 0 --sign "$KEY" --darc "$ID"
 
     # Since we performed an addProof, the result should now contrain a new
     # identity and the field signature set to 1.
-    OUTRES=`runBA contract deferred get --instID $DEFERRED_INSTANCE_ID`
+    OUTRES=`runBA contract deferred get --instid $DEFERRED_INSTANCE_ID`
     testGrep "action: spawn:value" echo "$OUTRES"
     # Note on the regex used in grep. We want to be sure an identity of form
     # [ed25519:aef123] is added.
@@ -159,7 +159,7 @@ testGet() {
     testGrep "Args:value" echo "$OUTRES"
 
     # Try to get a wrong instance ID
-    testFail runBA contract deferred get --instID deadbeef
+    testFail runBA contract deferred get --instid deadbeef
 }
 
 testDel() {
@@ -191,14 +191,14 @@ testDel() {
     echo -e "Here is the instance ID:\t$DEFERRED_INSTANCE_ID"
 
     # We should be able to get the created deferred instance
-    testOK runBA contract deferred get --instID $DEFERRED_INSTANCE_ID
+    testOK runBA contract deferred get --instid $DEFERRED_INSTANCE_ID
     
     # We delete the instance
-    testOK runBA contract deferred delete --instID $DEFERRED_INSTANCE_ID --darc "$ID" --sign "$KEY"
+    testOK runBA contract deferred delete --instid $DEFERRED_INSTANCE_ID --darc "$ID" --sign "$KEY"
     
     # Now we shouldn't be able to get it back
-    testFail runBA contract deferred get --instID $DEFERRED_INSTANCE_ID
+    testFail runBA contract deferred get --instid $DEFERRED_INSTANCE_ID
 
     # Use the "delete" function, should fail since it does not exist anymore
-    testFail runBA contract deferred delete --instID "$VALUE_INSTANCE_ID" --darc "$ID" --sign "$KEY"
+    testFail runBA contract deferred delete --instid "$VALUE_INSTANCE_ID" --darc "$ID" --sign "$KEY"
 }

--- a/byzcoin/bcadmin/clicontracts/value.go
+++ b/byzcoin/bcadmin/clicontracts/value.go
@@ -132,13 +132,13 @@ func ValueInvokeUpdate(c *cli.Context) error {
 	}
 	valueBuf := []byte(value)
 
-	instID := c.String("instID")
+	instID := c.String("instid")
 	if instID == "" {
-		return errors.New("--instID flag is required")
+		return errors.New("--instid flag is required")
 	}
 	instIDBuf, err := hex.DecodeString(instID)
 	if err != nil {
-		return errors.New("failed to decode the instID string")
+		return errors.New("failed to decode the instid string")
 	}
 
 	cfg, cl, err := lib.LoadConfig(bcArg)
@@ -217,9 +217,9 @@ func ValueGet(c *cli.Context) error {
 		return err
 	}
 
-	instID := c.String("instID")
+	instID := c.String("instid")
 	if instID == "" {
-		return errors.New("--instID flag is required")
+		return errors.New("--instid flag is required")
 	}
 	instIDBuf, err := hex.DecodeString(instID)
 	if err != nil {
@@ -266,13 +266,13 @@ func ValueDelete(c *cli.Context) error {
 		return errors.New("--bc flag is required")
 	}
 
-	instID := c.String("instID")
+	instID := c.String("instid")
 	if instID == "" {
-		return errors.New("--instID flag is required")
+		return errors.New("--instid flag is required")
 	}
 	instIDBuf, err := hex.DecodeString(instID)
 	if err != nil {
-		return errors.New("failed to decode the instID string")
+		return errors.New("failed to decode the instid string")
 	}
 
 	cfg, cl, err := lib.LoadConfig(bcArg)

--- a/byzcoin/bcadmin/clicontracts/value_test.sh
+++ b/byzcoin/bcadmin/clicontracts/value_test.sh
@@ -32,7 +32,7 @@ testSpawn() {
     VALUE_INSTANCE_ID=`sed -n 2p res.txt`
 
     # Update the value instance based on the instance ID
-    testOK runBA contract value invoke update --value "newValue" --instID $VALUE_INSTANCE_ID --darc "$ID" --sign "$KEY"
+    testOK runBA contract value invoke update --value "newValue" --instid $VALUE_INSTANCE_ID --darc "$ID" --sign "$KEY"
 }
 
 testSpawnRedirect() {
@@ -85,23 +85,23 @@ testGet() {
 
     # Use the "get" function and save the output to the res.txt file. This file
     # should contain the saved value.
-    OUTFILE=res.txt && testOK runBA contract value get --instID "$VALUE_INSTANCE_ID"
+    OUTFILE=res.txt && testOK runBA contract value get --instid "$VALUE_INSTANCE_ID"
     OUTFILE=""
 
     testGrep "myValue" cat res.txt
 
     # Update the value instance based on the instance ID
-    testOK runBA contract value invoke update --value "newValue" --instID $VALUE_INSTANCE_ID --darc "$ID" --sign "$KEY"
+    testOK runBA contract value invoke update --value "newValue" --instid $VALUE_INSTANCE_ID --darc "$ID" --sign "$KEY"
 
     # Use the "get" function and save the output to the res.txt file. This file
     # should contain the newly updated value.
-    OUTFILE=res.txt && testOK runBA contract value get --instID "$VALUE_INSTANCE_ID"
+    OUTFILE=res.txt && testOK runBA contract value get --instid "$VALUE_INSTANCE_ID"
     OUTFILE=""
 
     testGrep "newValue" cat res.txt
 
     # Try to get a wrong instance ID
-    testFail runBA contract value get --instID deadbeef
+    testFail runBA contract value get --instid deadbeef
 }
 
 testDel() {
@@ -130,14 +130,14 @@ testDel() {
     VALUE_INSTANCE_ID=`sed -n 2p res.txt`
 
     # Use the "get" function to retrieve the contract. It should pass.
-    testOK runBA contract value get --instID "$VALUE_INSTANCE_ID"
+    testOK runBA contract value get --instid "$VALUE_INSTANCE_ID"
 
     # Use the "delete" function
-    testOK runBA contract value delete --instID "$VALUE_INSTANCE_ID" --darc "$ID" --sign "$KEY"
+    testOK runBA contract value delete --instid "$VALUE_INSTANCE_ID" --darc "$ID" --sign "$KEY"
 
     # Use the "get" function to retrieve the contract. It should fail.
-    testFail runBA contract value get --instID "$VALUE_INSTANCE_ID"
+    testFail runBA contract value get --instid "$VALUE_INSTANCE_ID"
 
     # Use the "delete" function, should fail since it does not exist anymore
-    testFail runBA contract value delete --instID "$VALUE_INSTANCE_ID" --darc "$ID" --sign "$KEY"
+    testFail runBA contract value delete --instid "$VALUE_INSTANCE_ID" --darc "$ID" --sign "$KEY"
 }

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -365,14 +365,14 @@ var cmds = cli.Commands{
                                       [--redirect],
                                invoke <command>
                                       --bc <byzcoin config>
-                                      --instid <instance ID>
+                                      --instid, i <instance ID>
                                       [--<arg name> <arg value>, ...]
                                       [--darc <darc id>] 
                                       [--sign <pub key>],
                                get    --bc <byzcoin config>
-                                      --instid <instance ID>,
+                                      --instid, i <instance ID>,
                                delete --bc <byzcoin config>
-                                      --instid <instance ID>
+                                      --instid, i <instance ID>
                                       [--darc <darc id>] 
                                       [--sign <pub key>]     
                              }
@@ -429,7 +429,7 @@ var cmds = cli.Commands{
 										Usage: "the value to save",
 									},
 									cli.StringFlag{
-										Name:  "instid",
+										Name:  "instid, i",
 										Usage: "the instance ID of the value contract",
 									},
 									cli.StringFlag{
@@ -455,7 +455,7 @@ var cmds = cli.Commands{
 								Usage:  "the ByzCoin config to use (required)",
 							},
 							cli.StringFlag{
-								Name:  "instid",
+								Name:  "instid, i",
 								Usage: "the instance id (required)",
 							},
 						},
@@ -472,7 +472,7 @@ var cmds = cli.Commands{
 								Usage:  "the ByzCoin config to use (required)",
 							},
 							cli.StringFlag{
-								Name:  "instid",
+								Name:  "instid, i",
 								Usage: "the instance ID of the value contract",
 							},
 							cli.StringFlag{
@@ -534,7 +534,7 @@ var cmds = cli.Commands{
 										Usage: "the instruction hash that will be signed",
 									},
 									cli.StringFlag{
-										Name:  "instid",
+										Name:  "instid, i",
 										Usage: "the instance ID of the deferred contract",
 									},
 									cli.StringFlag{
@@ -558,7 +558,7 @@ var cmds = cli.Commands{
 										Usage:  "the ByzCoin config to use (required)",
 									},
 									cli.StringFlag{
-										Name:  "instid",
+										Name:  "instid, i",
 										Usage: "the instance ID of the deferred contract",
 									},
 									cli.StringFlag{
@@ -584,7 +584,7 @@ var cmds = cli.Commands{
 								Usage:  "the ByzCoin config to use (required)",
 							},
 							cli.StringFlag{
-								Name:  "instid",
+								Name:  "instid, i",
 								Usage: "the instance id (required)",
 							},
 						},
@@ -601,7 +601,7 @@ var cmds = cli.Commands{
 								Usage:  "the ByzCoin config to use (required)",
 							},
 							cli.StringFlag{
-								Name:  "instid",
+								Name:  "instid, i",
 								Usage: "the instance ID of the value contract",
 							},
 							cli.StringFlag{

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -365,14 +365,14 @@ var cmds = cli.Commands{
                                       [--redirect],
                                invoke <command>
                                       --bc <byzcoin config>
-                                      --instID <instance ID>
+                                      --instid <instance ID>
                                       [--<arg name> <arg value>, ...]
                                       [--darc <darc id>] 
                                       [--sign <pub key>],
                                get    --bc <byzcoin config>
-                                      --instID <instance ID>,
+                                      --instid <instance ID>,
                                delete --bc <byzcoin config>
-                                      --instID <instance ID>
+                                      --instid <instance ID>
                                       [--darc <darc id>] 
                                       [--sign <pub key>]     
                              }
@@ -429,7 +429,7 @@ var cmds = cli.Commands{
 										Usage: "the value to save",
 									},
 									cli.StringFlag{
-										Name:  "instID",
+										Name:  "instid",
 										Usage: "the instance ID of the value contract",
 									},
 									cli.StringFlag{
@@ -455,7 +455,7 @@ var cmds = cli.Commands{
 								Usage:  "the ByzCoin config to use (required)",
 							},
 							cli.StringFlag{
-								Name:  "instID",
+								Name:  "instid",
 								Usage: "the instance id (required)",
 							},
 						},
@@ -472,7 +472,7 @@ var cmds = cli.Commands{
 								Usage:  "the ByzCoin config to use (required)",
 							},
 							cli.StringFlag{
-								Name:  "instID",
+								Name:  "instid",
 								Usage: "the instance ID of the value contract",
 							},
 							cli.StringFlag{
@@ -534,7 +534,7 @@ var cmds = cli.Commands{
 										Usage: "the instruction hash that will be signed",
 									},
 									cli.StringFlag{
-										Name:  "instID",
+										Name:  "instid",
 										Usage: "the instance ID of the deferred contract",
 									},
 									cli.StringFlag{
@@ -558,7 +558,7 @@ var cmds = cli.Commands{
 										Usage:  "the ByzCoin config to use (required)",
 									},
 									cli.StringFlag{
-										Name:  "instID",
+										Name:  "instid",
 										Usage: "the instance ID of the deferred contract",
 									},
 									cli.StringFlag{
@@ -584,7 +584,7 @@ var cmds = cli.Commands{
 								Usage:  "the ByzCoin config to use (required)",
 							},
 							cli.StringFlag{
-								Name:  "instID",
+								Name:  "instid",
 								Usage: "the instance id (required)",
 							},
 						},
@@ -601,7 +601,7 @@ var cmds = cli.Commands{
 								Usage:  "the ByzCoin config to use (required)",
 							},
 							cli.StringFlag{
-								Name:  "instID",
+								Name:  "instid",
 								Usage: "the instance ID of the value contract",
 							},
 							cli.StringFlag{

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -309,7 +309,7 @@ var cmds = cli.Commands{
 					},
 					cli.StringFlag{
 						Name:  "darc",
-						Usage: "the DARC to update (no default)",
+						Usage: "the DARC to update (default is the admin DARC)",
 					},
 					cli.StringFlag{
 						Name:  "sign",


### PR DESCRIPTION
- Updated `--instID` to `--instid`
- Fixes a wrong description of `-darc` parameter for `bcadmin darc rule`
- Removes unnecessary printing of a proposed Tx
