### PR TITLE
CothorityJS: fix ed25519 identity

### DIFF
--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@dedis/cothority",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A typescript implementation of the cothority",
   "main": "index.js",
   "browser": "bundle.min.js",

--- a/external/js/cothority/src/darc/identity-ed25519.ts
+++ b/external/js/cothority/src/darc/identity-ed25519.ts
@@ -1,8 +1,7 @@
 import { curve, Point, PointFactory, sign } from "@dedis/kyber";
 import { Message, Properties } from "protobufjs/light";
-import Log from "../log";
-import { EMPTY_BUFFER, registerMessage } from "../protobuf";
-import IdentityWrapper, { IIdentity } from "./identity-wrapper";
+import { registerMessage } from "../protobuf";
+import { IIdentity } from "./identity-wrapper";
 
 const {schnorr} = sign;
 const ed25519 = curve.newCurve("edwards25519");
@@ -17,8 +16,7 @@ export default class IdentityEd25519 extends Message<IdentityEd25519> implements
      */
     get public(): Point {
         if (!this._public) {
-            this._public = ed25519.point();
-            this._public.unmarshalBinary(this.point);
+            this._public = PointFactory.fromProto(this.point);
         }
 
         return this._public;
@@ -34,7 +32,7 @@ export default class IdentityEd25519 extends Message<IdentityEd25519> implements
      * Initialize an IdentityEd25519 from a point.
      */
     static fromPoint(p: Point): IdentityEd25519 {
-        return new IdentityEd25519({point: p.marshalBinary()});
+        return new IdentityEd25519({point: p.toProto()});
     }
 
     readonly point: Buffer;
@@ -43,11 +41,6 @@ export default class IdentityEd25519 extends Message<IdentityEd25519> implements
 
     constructor(props?: Properties<IdentityEd25519>) {
         super(props);
-
-        this.point = Buffer.from(this.point || EMPTY_BUFFER);
-        if (this.point.length === 40) {
-            throw new Error("need a marshalled point, not a protobuf-point");
-        }
     }
 
     /** @inheritdoc */

--- a/external/js/cothority/src/darc/identity-wrapper.ts
+++ b/external/js/cothority/src/darc/identity-wrapper.ts
@@ -27,7 +27,9 @@ export default class IdentityWrapper extends Message<IdentityWrapper> {
      */
     static fromString(idStr: string): IdentityWrapper {
         if (idStr.startsWith("ed25519:")) {
-            const id = new IdentityEd25519({point: Buffer.from(idStr.slice(8), "hex")});
+            const point = new Ed25519Point();
+            point.unmarshalBinary(Buffer.from(idStr.slice(8), "hex"));
+            const id = IdentityEd25519.fromPoint(point);
             return new IdentityWrapper({ed25519: id});
         }
         if (idStr.startsWith("darc:")) {

--- a/external/js/cothority/src/darc/signer-ed25519.ts
+++ b/external/js/cothority/src/darc/signer-ed25519.ts
@@ -34,7 +34,7 @@ export default class SignerEd25519 extends IdentityEd25519 implements ISigner {
     private priv: Scalar;
 
     constructor(pub: Point, priv: Scalar) {
-        super({point: pub.marshalBinary()});
+        super({point: pub.toProto()});
         this.priv = priv;
     }
 


### PR DESCRIPTION
This fixes the point buffer to be in the protobuf shape as it should
be and correctly casted into a Point when needed.

This revert the changes from #1843 