### PR TITLE
bcadmin: Refactors --redirect to a global --export (-x)

### DIFF
--- a/byzcoin/bcadmin/clicontracts/README.md
+++ b/byzcoin/bcadmin/clicontracts/README.md
@@ -17,7 +17,7 @@ Use `bcadmin contract -h` to get the usage.
 
 **Functionalities**:
 
-* With the `--redirect`, the contract's transaction should not be executed, but
+* With the `--export` (`--x`), the contract's transaction should not be executed, but
 redirected to stdout.
 
 * Each contract should have a `get` function, which allows one to get the
@@ -49,7 +49,7 @@ $ bcadmin contract value invoke update --value "Bye World" --instid ...
 Spawn a deferred contract with a value contract as the proposed transaction:
 
 ```bash
-$ bcadmin contract value spawn --value "Hello Word" --redirect | bcadmin contract deferred spawn
+$ bcadmin --export contract value spawn --value "Hello Word" | bcadmin contract deferred spawn
 ```
 
 Invoke an addProof on a deferred contract:
@@ -77,7 +77,7 @@ bcadmin darc rule -rule invoke:deferred.addProof --identity ed25519:...
 bcadmin darc rule -rule invoke:deferred.execProposedTx --identity ed25519:...                                                                                                                                                     
 
 # Spawn a value contract, but redirect the transaction to the spawn of a deferred contract
-bcadmin contract value spawn --value myValue --redirect | bcadmin contract deferred spawn
+bcadmin --export contract value spawn --value myValue | bcadmin contract deferred spawn
 
 # Add the proof on the single instruction of the deferred transaction 
 # (the --hash and --instid values are given when we spawn the deferred contract)
@@ -110,10 +110,10 @@ bcadmin darc rule --identity ed25519:... --rule invoke:deferred.execProposedTx
 bcadmin contract config invoke updateConfig
 
 # Perform an update that is redirected to the spawn of a deferred contract
-bcadmin contract config invoke updateConfig --blockInterval 7s \
-                                            --maxBlockSize 5000000 \
-                                            --darcContractIDs darc,darc2 \
-                                            --redirect | bcadmin contract deferred spawn
+bcadmin -x contract config invoke updateConfig --blockInterval 7s \
+                                               --maxBlockSize 5000000 \
+                                               --darcContractIDs darc,darc2 \
+                                               | bcadmin contract deferred spawn
 
 # Add the proof on the single instruction of the deferred transaction 
 # (the --hash and --instid values are given when we spawn the deferred contract)

--- a/byzcoin/bcadmin/clicontracts/config.go
+++ b/byzcoin/bcadmin/clicontracts/config.go
@@ -133,7 +133,12 @@ func ConfigInvokeUpdateConfig(c *cli.Context) error {
 		return err
 	}
 
-	_, err = lib.AddTransactionAndWaitWithOption(c, cl, ctx, 10)
+	if lib.FindRecursivefBool("export", c) {
+		err = lib.ExportTransactionAndExit(ctx)
+		return errors.New("failed to export transaction: " + err.Error())
+	}
+
+	_, err = cl.AddTransactionAndWait(ctx, 10)
 	if err != nil {
 		return err
 	}

--- a/byzcoin/bcadmin/clicontracts/deferred.go
+++ b/byzcoin/bcadmin/clicontracts/deferred.go
@@ -98,7 +98,12 @@ func DeferredSpawn(c *cli.Context) error {
 		return err
 	}
 
-	_, err = lib.AddTransactionAndWaitWithOption(c, cl, ctx, 10)
+	if lib.FindRecursivefBool("export", c) {
+		err = lib.ExportTransactionAndExit(ctx)
+		return errors.New("failed to export transaction: " + err.Error())
+	}
+
+	_, err = cl.AddTransactionAndWait(ctx, 10)
 	if err != nil {
 		return err
 	}
@@ -246,7 +251,12 @@ func DeferredInvokeAddProof(c *cli.Context) error {
 		return err
 	}
 
-	_, err = lib.AddTransactionAndWaitWithOption(c, cl, ctx, 10)
+	if lib.FindRecursivefBool("export", c) {
+		err = lib.ExportTransactionAndExit(ctx)
+		return errors.New("failed to export transaction: " + err.Error())
+	}
+
+	_, err = cl.AddTransactionAndWait(ctx, 10)
 	if err != nil {
 		return err
 	}
@@ -343,7 +353,12 @@ func ExecProposedTx(c *cli.Context) error {
 		return err
 	}
 
-	_, err = lib.AddTransactionAndWaitWithOption(c, cl, ctx, 10)
+	if lib.FindRecursivefBool("export", c) {
+		err = lib.ExportTransactionAndExit(ctx)
+		return errors.New("failed to export transaction: " + err.Error())
+	}
+
+	_, err = cl.AddTransactionAndWait(ctx, 10)
 	if err != nil {
 		return err
 	}
@@ -496,7 +511,12 @@ func DeferredDelete(c *cli.Context) error {
 		return err
 	}
 
-	_, err = lib.AddTransactionAndWaitWithOption(c, cl, ctx, 10)
+	if lib.FindRecursivefBool("export", c) {
+		err = lib.ExportTransactionAndExit(ctx)
+		return errors.New("failed to export transaction: " + err.Error())
+	}
+
+	_, err = cl.AddTransactionAndWait(ctx, 10)
 	if err != nil {
 		return err
 	}

--- a/byzcoin/bcadmin/clicontracts/deferred.go
+++ b/byzcoin/bcadmin/clicontracts/deferred.go
@@ -34,7 +34,7 @@ func DeferredSpawn(c *cli.Context) error {
 	proposedTransaction := byzcoin.ClientTransaction{}
 	err = protobuf.Decode(proposedTransactionBuf, &proposedTransaction)
 	if err != nil {
-		return errors.New("failed to decode transaction, did you use --redirect ? " + err.Error())
+		return errors.New("failed to decode transaction, did you use --export ? " + err.Error())
 	}
 
 	// ---
@@ -98,7 +98,7 @@ func DeferredSpawn(c *cli.Context) error {
 		return err
 	}
 
-	_, err = cl.AddTransactionAndWait(ctx, 10)
+	_, err = lib.AddTransactionAndWaitWithOption(c, cl, ctx, 10)
 	if err != nil {
 		return err
 	}
@@ -246,7 +246,7 @@ func DeferredInvokeAddProof(c *cli.Context) error {
 		return err
 	}
 
-	_, err = cl.AddTransactionAndWait(ctx, 10)
+	_, err = lib.AddTransactionAndWaitWithOption(c, cl, ctx, 10)
 	if err != nil {
 		return err
 	}
@@ -343,7 +343,7 @@ func ExecProposedTx(c *cli.Context) error {
 		return err
 	}
 
-	_, err = cl.AddTransactionAndWait(ctx, 10)
+	_, err = lib.AddTransactionAndWaitWithOption(c, cl, ctx, 10)
 	if err != nil {
 		return err
 	}
@@ -496,7 +496,7 @@ func DeferredDelete(c *cli.Context) error {
 		return err
 	}
 
-	_, err = cl.AddTransactionAndWait(ctx, 10)
+	_, err = lib.AddTransactionAndWaitWithOption(c, cl, ctx, 10)
 	if err != nil {
 		return err
 	}

--- a/byzcoin/bcadmin/clicontracts/deferred_test.sh
+++ b/byzcoin/bcadmin/clicontracts/deferred_test.sh
@@ -28,7 +28,7 @@ testContractDeferredSpawn() {
 
     # Spawn a new value contract that is piped to the spawn of a deferred
     # contract. We save the output to the OUTRES variable.
-    OUTRES=`runBA -x contract value spawn --value "myValue" --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
+    OUTRES=`runBA contract -x value spawn --value "myValue" --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
 
     # Check if we got the expected output
     testGrep "Here is the deferred data:" echo "$OUTRES"
@@ -63,7 +63,7 @@ testContractDeferredInvoke() {
 
     # Spawn a new value contract that is piped to the spawn of a deferred
     # contract.
-    OUTRES=`runBA -x contract value spawn --value "myValue" --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
+    OUTRES=`runBA contract -x value spawn --value "myValue" --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
 
     # We know the instance ID is the next line after "Spawned new deferred contract..."
     DEFERRED_INSTANCE_ID=`echo "$OUTRES" | sed -n ' 
@@ -109,7 +109,7 @@ testGet() {
 
     # Spawn a new value contract that is piped to the spawn of a deferred
     # contract.
-    OUTRES=`runBA -x contract value spawn --value "myValue" --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
+    OUTRES=`runBA contract -x value spawn --value "myValue" --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
 
     # We know the instance ID is the next line after "Spawned new deferred contract..."
     DEFERRED_INSTANCE_ID=`echo "$OUTRES" | sed -n ' 
@@ -182,7 +182,7 @@ testDel() {
 
     # Spawn a new value contract that is piped to the spawn of a deferred
     # contract.
-    OUTRES=`runBA -x contract value spawn --value "myValue" --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
+    OUTRES=`runBA contract -x value spawn --value "myValue" --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
 
     # We know the instance ID is the next line after "Spawned new deferred contract..."
     DEFERRED_INSTANCE_ID=`echo "$OUTRES" | sed -n ' 
@@ -228,7 +228,7 @@ testContractDeferredInvokeDeferred() {
 
     # Spawn a new value contract that is piped to the spawn of a deferred
     # contract.
-    OUTRES=`runBA -x contract value spawn --value "myValue" --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
+    OUTRES=`runBA contract -x value spawn --value "myValue" --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
 
     # We know the instance ID is the next line after "Spawned new deferred contract..."
     DEFERRED_INSTANCE_ID=`echo "$OUTRES" | sed -n ' 
@@ -251,7 +251,7 @@ testContractDeferredInvokeDeferred() {
     
     # Now we create a new deferred contract that performs an addProof on the
     # first deferred contract
-    OUTRES2=`runBA -x contract deferred invoke addProof --instid "$DEFERRED_INSTANCE_ID" --hash "$HASH"\
+    OUTRES2=`runBA contract -x deferred invoke addProof --instid "$DEFERRED_INSTANCE_ID" --hash "$HASH"\
                                                    --instrIdx 0 --sign "$KEY" --darc "$ID" |\
                                                    runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
 

--- a/byzcoin/bcadmin/clicontracts/deferred_test.sh
+++ b/byzcoin/bcadmin/clicontracts/deferred_test.sh
@@ -5,11 +5,13 @@ testContractDeferred() {
     run testContractDeferredInvoke
     run testGet
     run testDel
+    # This test do not work yet due to an error with rst.GetIndex(), see #1938
+    # run testContractDeferredInvokeDeferred
 }
 
 # We rely on the value contract to make our tests.
 testContractDeferredSpawn() {
-    # In this test we spawn a value with the --redirect flag and then pipe it
+    # In this test we spawn a value with the --export (-x) flag and then pipe it
     # to the deferred spawn. We then check the output and see if the proposed
     # transaction is there.
     runCoBG 1 2 3
@@ -26,7 +28,7 @@ testContractDeferredSpawn() {
 
     # Spawn a new value contract that is piped to the spawn of a deferred
     # contract. We save the output to the OUTRES variable.
-    OUTRES=`runBA contract value spawn --value "myValue" --redirect --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
+    OUTRES=`runBA -x contract value spawn --value "myValue" --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
 
     # Check if we got the expected output
     testGrep "Here is the deferred data:" echo "$OUTRES"
@@ -61,7 +63,7 @@ testContractDeferredInvoke() {
 
     # Spawn a new value contract that is piped to the spawn of a deferred
     # contract.
-    OUTRES=`runBA contract value spawn --value "myValue" --redirect --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
+    OUTRES=`runBA -x contract value spawn --value "myValue" --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
 
     # We know the instance ID is the next line after "Spawned new deferred contract..."
     DEFERRED_INSTANCE_ID=`echo "$OUTRES" | sed -n ' 
@@ -107,7 +109,7 @@ testGet() {
 
     # Spawn a new value contract that is piped to the spawn of a deferred
     # contract.
-    OUTRES=`runBA contract value spawn --value "myValue" --redirect --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
+    OUTRES=`runBA -x contract value spawn --value "myValue" --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
 
     # We know the instance ID is the next line after "Spawned new deferred contract..."
     DEFERRED_INSTANCE_ID=`echo "$OUTRES" | sed -n ' 
@@ -180,7 +182,7 @@ testDel() {
 
     # Spawn a new value contract that is piped to the spawn of a deferred
     # contract.
-    OUTRES=`runBA contract value spawn --value "myValue" --redirect --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
+    OUTRES=`runBA -x contract value spawn --value "myValue" --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
 
     # We know the instance ID is the next line after "Spawned new deferred contract..."
     DEFERRED_INSTANCE_ID=`echo "$OUTRES" | sed -n ' 
@@ -201,4 +203,83 @@ testDel() {
 
     # Use the "delete" function, should fail since it does not exist anymore
     testFail runBA contract deferred delete --instid "$VALUE_INSTANCE_ID" --darc "$ID" --sign "$KEY"
+}
+
+# This method relies on testContractDeferredSpawn() and performs an addProof
+# on the proposed transaction and an execProposedTx.
+testContractDeferredInvokeDeferred() {
+    # In this test we normally create a deferred spawn:value but then we
+    # invoke a deferred deferred:invoke.addProof. So the addProof operation
+    # will be made with a deferred contract. Crazy hu?
+    runCoBG 1 2 3
+    runGrepSed "export BC=" "" runBA create --roster public.toml --interval .5s
+    eval $SED
+    [ -z "$BC" ] && exit 1
+
+    # Add the spawn:value, spawn:deferred, invoke:deferred.addProof and
+    # invoke:deferred:execProposedTx rules
+    testOK runBA darc add -out_id ./darc_id.txt -out_key ./darc_key.txt -unrestricted
+    ID=`cat ./darc_id.txt`
+    KEY=`cat ./darc_key.txt`
+    testOK runBA darc rule -rule "spawn:value" --identity "$KEY" --darc "$ID" --sign "$KEY"
+    testOK runBA darc rule -rule "spawn:deferred" --identity "$KEY" --darc "$ID" --sign "$KEY"
+    testOK runBA darc rule -rule "invoke:deferred.addProof" --identity "$KEY" --darc "$ID" --sign "$KEY"
+    testOK runBA darc rule -rule "invoke:deferred.execProposedTx" --identity "$KEY" --darc "$ID" --sign "$KEY"
+
+    # Spawn a new value contract that is piped to the spawn of a deferred
+    # contract.
+    OUTRES=`runBA -x contract value spawn --value "myValue" --darc "$ID" --sign "$KEY" | runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
+
+    # We know the instance ID is the next line after "Spawned new deferred contract..."
+    DEFERRED_INSTANCE_ID=`echo "$OUTRES" | sed -n ' 
+        /Spawned new deferred contract/ {
+            n
+            p
+        }'`
+    echo -e "Here is the instance ID:\t$DEFERRED_INSTANCE_ID"
+
+    # We know the array conaining the hash to sign is the second line after
+    # "- Instruction hashes:" and we remove the "--- " prefix.
+    HASH=`echo "$OUTRES" | sed -n ' 
+        /- Instruction hashes:/ {
+            n
+            n
+            s/--- //
+            p
+        }'`
+    echo -e "Here is the hash:\t\t$HASH"
+    
+    # Now we create a new deferred contract that performs an addProof on the
+    # first deferred contract
+    OUTRES2=`runBA -x contract deferred invoke addProof --instid "$DEFERRED_INSTANCE_ID" --hash "$HASH"\
+                                                   --instrIdx 0 --sign "$KEY" --darc "$ID" |\
+                                                   runBA contract deferred spawn --darc "$ID" --sign "$KEY"`
+
+    # We know the instance ID is the next line after "Spawned new deferred contract..."
+    DEFERRED_INSTANCE_ID_2=`echo "$OUTRES2" | sed -n ' 
+        /Spawned new deferred contract/ {
+            n
+            p
+        }'`
+    echo -e "Here is the instance ID:\t$DEFERRED_INSTANCE_ID_2"
+
+    # We know the array conaining the hash to sign is the second line after
+    # "- Instruction hashes:" and we remove the "--- " prefix.
+    HASH2=`echo "$OUTRES2" | sed -n ' 
+        /- Instruction hashes:/ {
+            n
+            n
+            s/--- //
+            p
+        }'`
+    echo -e "Here is the hash:\t\t$HASH2"
+
+    # Now we must execute the second deferred contract that will add a proof to
+    # the first one.
+    testOK runBA contract deferred invoke addProof --instid "$DEFERRED_INSTANCE_ID_2" --hash "$HASH2"\
+                                                   --instrIdx 0 --sign "$KEY" --darc "$ID"
+    testOK runBA contract deferred invoke execProposedTx --instid "$DEFERRED_INSTANCE_ID_2" --sign "$KEY" --darc "$ID"
+    
+    runBA contract deferred get --instid "$DEFERRED_INSTANCE_ID"
+    testOK runBA contract deferred invoke execProposedTx --instid "$DEFERRED_INSTANCE_ID" --sign "$KEY" --darc "$ID"
 }

--- a/byzcoin/bcadmin/clicontracts/value.go
+++ b/byzcoin/bcadmin/clicontracts/value.go
@@ -78,7 +78,12 @@ func ValueSpawn(c *cli.Context) error {
 		return err
 	}
 
-	_, err = lib.AddTransactionAndWaitWithOption(c, cl, ctx, 10)
+	if lib.FindRecursivefBool("export", c) {
+		err = lib.ExportTransactionAndExit(ctx)
+		return errors.New("failed to export transaction: " + err.Error())
+	}
+
+	_, err = cl.AddTransactionAndWait(ctx, 10)
 	if err != nil {
 		return err
 	}
@@ -163,7 +168,12 @@ func ValueInvokeUpdate(c *cli.Context) error {
 		return err
 	}
 
-	_, err = lib.AddTransactionAndWaitWithOption(c, cl, ctx, 10)
+	if lib.FindRecursivefBool("export", c) {
+		err = lib.ExportTransactionAndExit(ctx)
+		return errors.New("failed to export transaction: " + err.Error())
+	}
+
+	_, err = cl.AddTransactionAndWait(ctx, 10)
 	if err != nil {
 		return err
 	}
@@ -290,7 +300,12 @@ func ValueDelete(c *cli.Context) error {
 		return err
 	}
 
-	_, err = lib.AddTransactionAndWaitWithOption(c, cl, ctx, 10)
+	if lib.FindRecursivefBool("export", c) {
+		err = lib.ExportTransactionAndExit(ctx)
+		return errors.New("failed to export transaction: " + err.Error())
+	}
+
+	_, err = cl.AddTransactionAndWait(ctx, 10)
 	if err != nil {
 		return err
 	}

--- a/byzcoin/bcadmin/clicontracts/value.go
+++ b/byzcoin/bcadmin/clicontracts/value.go
@@ -1,17 +1,14 @@
 package clicontracts
 
 import (
-	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 
 	"go.dedis.ch/cothority/v3/byzcoin"
 	"go.dedis.ch/cothority/v3/byzcoin/bcadmin/lib"
 	"go.dedis.ch/cothority/v3/byzcoin/contracts"
 	"go.dedis.ch/cothority/v3/darc"
-	"go.dedis.ch/protobuf"
 	"gopkg.in/urfave/cli.v1"
 )
 
@@ -66,30 +63,6 @@ func ValueSpawn(c *cli.Context) error {
 		},
 	}
 
-	redirect := c.Bool("redirect")
-	// In the case the --redirect flag is provided, the transaction is not
-	// applied but sent to stdout.
-	if redirect {
-		proposedTransaction := byzcoin.ClientTransaction{
-			Instructions: []byzcoin.Instruction{
-				byzcoin.Instruction{
-					InstanceID: byzcoin.NewInstanceID(d.GetBaseID()),
-					Spawn:      &spawn,
-				},
-			},
-		}
-		proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
-		if err != nil {
-			return errors.New("couldn't encode the transaction: " + err.Error())
-		}
-		reader := bytes.NewReader(proposedTransactionBuf)
-		_, err = io.Copy(c.App.Writer, reader)
-		if err != nil {
-			return errors.New("failed to copy to stdout: " + err.Error())
-		}
-		return nil
-	}
-
 	ctx := byzcoin.ClientTransaction{
 		Instructions: []byzcoin.Instruction{
 			{
@@ -105,7 +78,7 @@ func ValueSpawn(c *cli.Context) error {
 		return err
 	}
 
-	_, err = cl.AddTransactionAndWait(ctx, 10)
+	_, err = lib.AddTransactionAndWaitWithOption(c, cl, ctx, 10)
 	if err != nil {
 		return err
 	}
@@ -190,7 +163,7 @@ func ValueInvokeUpdate(c *cli.Context) error {
 		return err
 	}
 
-	_, err = cl.AddTransactionAndWait(ctx, 10)
+	_, err = lib.AddTransactionAndWaitWithOption(c, cl, ctx, 10)
 	if err != nil {
 		return err
 	}
@@ -317,7 +290,7 @@ func ValueDelete(c *cli.Context) error {
 		return err
 	}
 
-	_, err = cl.AddTransactionAndWait(ctx, 10)
+	_, err = lib.AddTransactionAndWaitWithOption(c, cl, ctx, 10)
 	if err != nil {
 		return err
 	}

--- a/byzcoin/bcadmin/clicontracts/value_test.sh
+++ b/byzcoin/bcadmin/clicontracts/value_test.sh
@@ -50,7 +50,7 @@ testSpawnRedirect() {
     testOK runBA darc rule -rule "spawn:value" --identity "$KEY" --darc "$ID" --sign "$KEY"
 
     # Spawn a new value contract, we save the output to the res.txt file
-    OUTFILE=res.txt && testOK runBA --export contract value spawn --value "myValue" --darc "$ID" --sign "$KEY"
+    OUTFILE=res.txt && testOK runBA contract --export value spawn --value "myValue" --darc "$ID" --sign "$KEY"
     OUTFILE=""
 
     # Check if we got the expected output
@@ -72,7 +72,7 @@ testInvokeUpdateRedirect() {
     testOK runBA darc rule -rule "invoke:value.update" --identity "$KEY" --darc "$ID" --sign "$KEY"
 
     # Spawn a new value contract, we save the output to the res.txt file
-    OUTFILE=res.txt && testOK runBA --export contract value invoke update --value "newValue" -i aef123 --darc "$ID" --sign "$KEY"
+    OUTFILE=res.txt && testOK runBA contract --export value invoke update --value "newValue" -i aef123 --darc "$ID" --sign "$KEY"
     OUTFILE=""
 
     # Check if we got the expected output
@@ -94,7 +94,7 @@ testDeleteRedirect() {
     testOK runBA darc rule -rule "delete:value" --identity "$KEY" --darc "$ID" --sign "$KEY"
 
     # Spawn a new value contract, we save the output to the res.txt file
-    OUTFILE=res.txt && testOK runBA --export contract value invoke update --value "newValue" -i aef123 --darc "$ID" --sign "$KEY"
+    OUTFILE=res.txt && testOK runBA contract --export value invoke update --value "newValue" -i aef123 --darc "$ID" --sign "$KEY"
     OUTFILE=""
 
     # Check if we got the expected output

--- a/byzcoin/bcadmin/clicontracts/value_test.sh
+++ b/byzcoin/bcadmin/clicontracts/value_test.sh
@@ -3,6 +3,7 @@
 testContractValue() {
     run testSpawn
     run testSpawnRedirect
+    run testInvokeUpdateRedirect
     run testGet
     run testDel
 }
@@ -36,25 +37,69 @@ testSpawn() {
 }
 
 testSpawnRedirect() {
-   # In this test we spawn a value with the --redirect flag
+   # In this test we spawn a value with the --export flag
     runCoBG 1 2 3
     runGrepSed "export BC=" "" runBA create --roster public.toml --interval .5s
     eval $SED
     [ -z "$BC" ] && exit 1
 
-    # Add the spawn:value and invoke:value.update rules
+    # Add the rules
     testOK runBA darc add -out_id ./darc_id.txt -out_key ./darc_key.txt -unrestricted
     ID=`cat ./darc_id.txt`
     KEY=`cat ./darc_key.txt`
     testOK runBA darc rule -rule "spawn:value" --identity "$KEY" --darc "$ID" --sign "$KEY"
-    testOK runBA darc rule -rule "invoke:value.update" --identity "$KEY" --darc "$ID" --sign "$KEY"
 
     # Spawn a new value contract, we save the output to the res.txt file
-    OUTFILE=res.txt && testOK runBA contract value spawn --value "myValue" --redirect --darc "$ID" --sign "$KEY"
+    OUTFILE=res.txt && testOK runBA --export contract value spawn --value "myValue" --darc "$ID" --sign "$KEY"
     OUTFILE=""
 
     # Check if we got the expected output
+    testGrep "value" cat res.txt
     testGrep "myValue" cat res.txt
+}
+
+testInvokeUpdateRedirect() {
+   # In this test we update a fake instance with exported output
+    runCoBG 1 2 3
+    runGrepSed "export BC=" "" runBA create --roster public.toml --interval .5s
+    eval $SED
+    [ -z "$BC" ] && exit 1
+
+    # Add the rules
+    testOK runBA darc add -out_id ./darc_id.txt -out_key ./darc_key.txt -unrestricted
+    ID=`cat ./darc_id.txt`
+    KEY=`cat ./darc_key.txt`
+    testOK runBA darc rule -rule "invoke:value.update" --identity "$KEY" --darc "$ID" --sign "$KEY"
+
+    # Spawn a new value contract, we save the output to the res.txt file
+    OUTFILE=res.txt && testOK runBA --export contract value invoke update --value "newValue" -i aef123 --darc "$ID" --sign "$KEY"
+    OUTFILE=""
+
+    # Check if we got the expected output
+    testGrep "value" cat res.txt
+    testGrep "newValue" cat res.txt
+}
+
+testDeleteRedirect() {
+   # In this test we delete a fake instance with exported output
+    runCoBG 1 2 3
+    runGrepSed "export BC=" "" runBA create --roster public.toml --interval .5s
+    eval $SED
+    [ -z "$BC" ] && exit 1
+
+    # Add the rules
+    testOK runBA darc add -out_id ./darc_id.txt -out_key ./darc_key.txt -unrestricted
+    ID=`cat ./darc_id.txt`
+    KEY=`cat ./darc_key.txt`
+    testOK runBA darc rule -rule "delete:value" --identity "$KEY" --darc "$ID" --sign "$KEY"
+
+    # Spawn a new value contract, we save the output to the res.txt file
+    OUTFILE=res.txt && testOK runBA --export contract value invoke update --value "newValue" -i aef123 --darc "$ID" --sign "$KEY"
+    OUTFILE=""
+
+    # Check if we got the expected output
+    testGrep "value" cat res.txt
+    testGrep "newValue" cat res.txt
 }
 
 testGet() {
@@ -66,12 +111,13 @@ testGet() {
     eval $SED
     [ -z "$BC" ] && exit 1
 
-    # Add the spawn:value and invoke:value.update rules
+    # Add the delete rule
     testOK runBA darc add -out_id ./darc_id.txt -out_key ./darc_key.txt -unrestricted
     ID=`cat ./darc_id.txt`
     KEY=`cat ./darc_key.txt`
     testOK runBA darc rule -rule "spawn:value" --identity "$KEY" --darc "$ID" --sign "$KEY"
     testOK runBA darc rule -rule "invoke:value.update" --identity "$KEY" --darc "$ID" --sign "$KEY"
+    testOK runBA darc rule -rule "delete:value" --identity "$KEY" --darc "$ID" --sign "$KEY"
 
     # Spawn a new value contract, we save the output to the res.txt file
     OUTFILE=res.txt && testOK runBA contract value spawn --value "myValue" --darc "$ID" --sign "$KEY"
@@ -112,7 +158,7 @@ testDel() {
     eval $SED
     [ -z "$BC" ] && exit 1
 
-    # Add the spawn:value and invoke:value.update rules
+    # Add the rules
     testOK runBA darc add -out_id ./darc_id.txt -out_key ./darc_key.txt -unrestricted
     ID=`cat ./darc_id.txt`
     KEY=`cat ./darc_key.txt`

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -358,6 +358,12 @@ var cmds = cli.Commands{
 		Name: "contract",
 		// Use space instead of tabs for correct formatting
 		Usage: "Provides cli interface for contracts",
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "export, x",
+				Usage: "redirects the transaction to stdout",
+			},
+		},
 		// UsageText should be used instead, but its not working:
 		// see https://github.com/urfave/cli/issues/592
 		Description: fmt.Sprint(`
@@ -694,10 +700,6 @@ func init() {
 			EnvVar: "BC_CONFIG",
 			Value:  getDataPath(cliApp.Name),
 			Usage:  "path to configuration-directory",
-		},
-		cli.BoolFlag{
-			Name:  "export, x",
-			Usage: "redirects the transaction to stdout",
 		},
 	}
 	cliApp.Before = func(c *cli.Context) error {

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -361,11 +361,11 @@ var cmds = cli.Commands{
 		// UsageText should be used instead, but its not working:
 		// see https://github.com/urfave/cli/issues/592
 		Description: fmt.Sprint(`
-   bcadmin contract CONTRACT { spawn  --bc <byzcoin config> 
+   bcadmin [--export] contract CONTRACT { 
+                               spawn  --bc <byzcoin config> 
                                       [--<arg name> <arg value>, ...]
                                       [--darc <darc id>] 
-                                      [--sign <pub key>] 
-                                      [--redirect],
+                                      [--sign <pub key>],
                                invoke <command>
                                       --bc <byzcoin config>
                                       --instid, i <instance ID>
@@ -406,10 +406,6 @@ var cmds = cli.Commands{
 							cli.StringFlag{
 								Name:  "sign",
 								Usage: "public key of the signing entity (default is the admin public key)",
-							},
-							cli.BoolFlag{
-								Name:  "redirect",
-								Usage: "redirects the transaction to stdout",
 							},
 						},
 					},
@@ -653,10 +649,6 @@ var cmds = cli.Commands{
 										Name:  "darcContractIDs",
 										Usage: "darcContractIDs separated by comas (optional)",
 									},
-									cli.BoolFlag{
-										Name:  "redirect",
-										Usage: "redirects the transaction to stdout",
-									},
 								},
 							},
 						},
@@ -702,6 +694,10 @@ func init() {
 			EnvVar: "BC_CONFIG",
 			Value:  getDataPath(cliApp.Name),
 			Usage:  "path to configuration-directory",
+		},
+		cli.BoolFlag{
+			Name:  "export, x",
+			Usage: "redirects the transaction to stdout",
 		},
 	}
 	cliApp.Before = func(c *cli.Context) error {


### PR DESCRIPTION
Now any transaction can be exported using the `--export` (`--x`) option and the `lib.AddTransactionAndWaitWithOption(..)` method, which automaticaly detects if the global `--export` argument is used.

Note: Test with --export and deferred contract is written but commented because of a bug: see #1938