### PR TITLE
Fix tx collection after block failure

### DIFF
--- a/byzcoin/api_test.go
+++ b/byzcoin/api_test.go
@@ -253,20 +253,6 @@ func TestClient_Streaming(t *testing.T) {
 		require.Fail(t, "should have got n transactions")
 	}
 	require.NoError(t, c1.Close())
-
-	// client.Close() won't close the service if there are no more
-	// transactions, so send some more to make sure the service gets an
-	// error and stops its streaming go-routing.
-	for i := 0; i < 2; i++ {
-		value := []byte{5, 6, 7, 8}
-		kind := "dummy"
-		// We added two transactions before, so the latest counter is 2
-		// so we must start the counter here at 3.
-		tx, err := createOneClientTxWithCounter(d.GetBaseID(), kind, value, signer, uint64(i)+3)
-		require.Nil(t, err)
-		_, err = c.AddTransactionAndWait(tx, 4)
-		require.Nil(t, err)
-	}
 }
 
 const testServiceName = "TestByzCoin"

--- a/byzcoin/api_test.go
+++ b/byzcoin/api_test.go
@@ -249,7 +249,7 @@ func TestClient_Streaming(t *testing.T) {
 	}()
 	select {
 	case <-done:
-	case <-time.After(time.Duration(n)*msg.BlockInterval + time.Second):
+	case <-time.After(time.Duration(10) * msg.BlockInterval):
 		require.Fail(t, "should have got n transactions")
 	}
 	require.NoError(t, c1.Close())

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -2115,10 +2115,9 @@ func (s *Service) monitorLeaderFailure() {
 		s.closedMutex.Unlock()
 		return
 	}
-	s.closedMutex.Unlock()
-
 	s.working.Add(1)
 	defer s.working.Done()
+	s.closedMutex.Unlock()
 
 	for {
 		select {

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -2041,7 +2041,7 @@ func (s *Service) getTxs(leader *network.ServerIdentity, roster *onet.Roster, sc
 	}
 
 	// Then we make sure who's the leader. It may happen that the node is one block away
-	// from the leader (i.e. block still processing) but if the leader are matching, we
+	// from the leader (i.e. block still processing) but if the leaders are matching, we
 	// accept to deliver the transactions as an optimization. The leader is expected to
 	// wait on the processing to start collecting and in the worst case scenario, txs will
 	// simply be lost and will have to be resend.

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -2099,6 +2099,7 @@ func (s *Service) cleanupGoroutines() {
 	s.heartbeats.closeAll()
 	s.closeLeaderMonitorChan <- true
 	s.viewChangeMan.closeAll()
+	s.streamingMan.stopAll()
 
 	s.pollChanMut.Lock()
 	for k, c := range s.pollChan {

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -37,6 +37,7 @@ const invalidContract = "invalid"
 const stateChangeCacheContract = "stateChangeCacheTest"
 
 func TestMain(m *testing.M) {
+	log.SetShowTime(true)
 	log.MainTest(m)
 }
 

--- a/byzcoin/streaming.go
+++ b/byzcoin/streaming.go
@@ -70,7 +70,17 @@ func (s *Service) StreamTransactions(msg *StreamingRequest) (chan *StreamingResp
 	stopChan := make(chan bool)
 	key := string(msg.ID)
 	outChan, idx := s.streamingMan.newListener(key)
+
 	go func() {
+		s.closedMutex.Lock()
+		if s.closed {
+			s.closedMutex.Unlock()
+			return
+		}
+		s.working.Add(1)
+		defer s.working.Done()
+		s.closedMutex.Unlock()
+
 		<-stopChan
 		s.streamingMan.stopListener(key, idx)
 	}()

--- a/byzcoin/streaming.go
+++ b/byzcoin/streaming.go
@@ -33,7 +33,7 @@ func (s *streamingManager) notify(scID string, block *skipchain.SkipBlock) {
 	}
 }
 
-func (s *streamingManager) newListener(scID string) (chan *StreamingResponse, int) {
+func (s *streamingManager) newListener(scID string) chan *StreamingResponse {
 	s.Lock()
 	defer s.Unlock()
 
@@ -42,26 +42,42 @@ func (s *streamingManager) newListener(scID string) (chan *StreamingResponse, in
 	}
 
 	ls := s.listeners[scID]
-	id := len(s.listeners)
 	outChan := make(chan *StreamingResponse)
 	ls = append(ls, outChan)
 	s.listeners[scID] = ls
-	return outChan, id
+	return outChan
 }
 
-func (s *streamingManager) stopListener(scID string, i int) {
+func (s *streamingManager) stopListener(scID string, outChan chan *StreamingResponse) {
 	s.Lock()
 	defer s.Unlock()
 
-	ls, ok := s.listeners[scID]
-	if !ok || i >= len(ls) {
-		panic("listener does not exist")
+	ls := s.listeners[scID]
+	if ls == nil {
+		return
 	}
 
-	close(ls[i])
+	for i, listener := range ls {
+		if listener == outChan {
+			close(listener)
+			s.listeners[scID] = append(ls[:i], ls[i+1:]...)
+			return
+		}
+	}
+}
 
-	ls = append(ls[:i], ls[i+1:]...)
-	s.listeners[scID] = ls
+func (s *streamingManager) stopAll() {
+	s.Lock()
+	defer s.Unlock()
+
+	for key, l := range s.listeners {
+		for _, c := range l {
+			// Force the streaming connection in Onet to close.
+			close(c)
+		}
+
+		delete(s.listeners, key)
+	}
 }
 
 // StreamTransactions will stream all transactions IDs to the client until the
@@ -69,7 +85,7 @@ func (s *streamingManager) stopListener(scID string, i int) {
 func (s *Service) StreamTransactions(msg *StreamingRequest) (chan *StreamingResponse, chan bool, error) {
 	stopChan := make(chan bool)
 	key := string(msg.ID)
-	outChan, idx := s.streamingMan.newListener(key)
+	outChan := s.streamingMan.newListener(key)
 
 	go func() {
 		s.closedMutex.Lock()
@@ -81,8 +97,11 @@ func (s *Service) StreamTransactions(msg *StreamingRequest) (chan *StreamingResp
 		defer s.working.Done()
 		s.closedMutex.Unlock()
 
+		// Either the service is closing and we force the connection to stop or
+		// the streaming connection is closed upfront.
 		<-stopChan
-		s.streamingMan.stopListener(key, idx)
+		// In both cases we clean the listener.
+		s.streamingMan.stopListener(key, outChan)
 	}()
 	return outChan, stopChan, nil
 }

--- a/byzcoin/tx_pipeline.go
+++ b/byzcoin/tx_pipeline.go
@@ -97,7 +97,7 @@ func (s *defaultTxProcessor) CollectTx() ([]ClientTransaction, error) {
 
 	sb, doCatchUp := s.skService().WaitBlock(s.scID, nil)
 	if sb == nil && !doCatchUp {
-		// block is still processing but the skipchain is known
+		log.Lvl2("Skip tx collection during block processing")
 		return nil, nil
 	}
 

--- a/eventlog/api_test.go
+++ b/eventlog/api_test.go
@@ -384,7 +384,11 @@ func TestClient_StreamEventsFrom(t *testing.T) {
 		}
 	}
 
+	wg := sync.WaitGroup{}
 	go func() {
+		wg.Add(1)
+		defer wg.Done()
+
 		require.NoError(t, c.StreamEventsFrom(h, c.ByzCoin.ID))
 	}()
 
@@ -405,6 +409,8 @@ func TestClient_StreamEventsFrom(t *testing.T) {
 	}
 
 	require.NoError(t, c.Close())
+
+	wg.Wait()
 }
 
 func checkProof(t *testing.T, omni *byzcoin.Service, key []byte, scID skipchain.SkipBlockID) []byte {

--- a/eventlog/api_test.go
+++ b/eventlog/api_test.go
@@ -328,13 +328,6 @@ func TestClient_StreamEvents(t *testing.T) {
 	}
 
 	require.NoError(t, c.Close())
-
-	// send a couple more to close the stream, see byzcoin/api_test.go:TestClient_Streaming
-	for i := 0; i < 2; i++ {
-		finalID, err := c.Log(NewEvent("dummy", "dummy"))
-		require.NoError(t, err)
-		waitForKey(t, leader.omni, c.ByzCoin.ID, finalID[0], testBlockInterval)
-	}
 }
 
 func TestClient_StreamEventsFrom(t *testing.T) {
@@ -391,11 +384,7 @@ func TestClient_StreamEventsFrom(t *testing.T) {
 		}
 	}
 
-	wg := sync.WaitGroup{}
 	go func() {
-		wg.Add(1)
-		defer wg.Done()
-
 		require.NoError(t, c.StreamEventsFrom(h, c.ByzCoin.ID))
 	}()
 
@@ -416,15 +405,6 @@ func TestClient_StreamEventsFrom(t *testing.T) {
 	}
 
 	require.NoError(t, c.Close())
-
-	// send a couple more to close the stream, see byzcoin/api_test.go:TestClient_Streaming
-	for i := 0; i < 2; i++ {
-		finalID, err := c.Log(NewEvent("dummy", "dummy"))
-		require.NoError(t, err)
-		waitForKey(t, leader.omni, c.ByzCoin.ID, finalID[0], testBlockInterval)
-	}
-
-	wg.Wait()
 }
 
 func checkProof(t *testing.T, omni *byzcoin.Service, key []byte, scID skipchain.SkipBlockID) []byte {

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -355,6 +355,12 @@ func (s *Service) StoreSkipBlockInternal(psbd *StoreSkipBlock) (*StoreSkipBlockR
 		// forward links can depend on this forward link.
 		// After creating the forward link, it will propagate it to all nodes.
 		if err := s.forwardLinkLevel0(prev, prop); err != nil {
+			// As the block's creation failed, we need to clean the block buffer so
+			// that other services know that no block are proposed.
+			// This is done only on the leader and then children won't be noticed until
+			// a different block is proposed.
+			s.blockBuffer.clear(prev.SkipChainID())
+
 			return nil, errors.New(
 				"Couldn't get forward signature on block: " + err.Error())
 		}

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -357,8 +357,8 @@ func (s *Service) StoreSkipBlockInternal(psbd *StoreSkipBlock) (*StoreSkipBlockR
 		if err := s.forwardLinkLevel0(prev, prop); err != nil {
 			// As the block's creation failed, we need to clean the block buffer so
 			// that other services know that no block are proposed.
-			// This is done only on the leader and then children won't be noticed until
-			// a different block is proposed.
+			// This is done only on the leader side and then children won't be
+			// notified until a different block is proposed.
 			s.blockBuffer.clear(prev.SkipChainID())
 
 			return nil, errors.New(


### PR DESCRIPTION
This fixes the pipeline by cleaning the block buffer so that the tx collection will proceed after a block signature has failed (happening on the leader's side). It also changes the callback to be slightly less restrictive so that the heartbeat won't be missed.

Also: fixes some issues with leaking goroutines when closing
Also: correctly close open streaming connections when closing