### PR TITLE
conode setup: improve non-interactive mode

### DIFF
--- a/conode/conode.go
+++ b/conode/conode.go
@@ -75,7 +75,7 @@ func main() {
 				cli.StringFlag{
 					Name:  "host",
 					Usage: "which host to listen on",
-					Value: "localhost",
+					Value: "",
 				},
 				cli.IntFlag{
 					Name:  "port",

--- a/conode/conode.go
+++ b/conode/conode.go
@@ -218,13 +218,6 @@ func checkConfig(c *cli.Context) error {
 }
 
 func setup(c *cli.Context) error {
-	if c.String("config") != "" {
-		log.Fatal("[-] Configuration file option cannot be used for the 'setup' command")
-	}
-	if c.String("debug") != "" {
-		log.Fatal("[-] Debug option cannot be used for the 'setup' command")
-	}
-
 	if c.Bool("non-interactive") {
 		host := c.String("host")
 		port := c.Int("port")

--- a/conode/conode.go
+++ b/conode/conode.go
@@ -72,6 +72,11 @@ func main() {
 					Name:  "non-interactive",
 					Usage: "generate private.toml in non-interactive mode",
 				},
+				cli.StringFlag{
+					Name:  "host",
+					Usage: "which host to listen on",
+					Value: "localhost",
+				},
 				cli.IntFlag{
 					Name:  "port",
 					Usage: "which port to listen on",
@@ -221,10 +226,11 @@ func setup(c *cli.Context) error {
 	}
 
 	if c.Bool("non-interactive") {
+		host := c.String("host")
 		port := c.Int("port")
 		portStr := fmt.Sprintf("%v", port)
 
-		serverBinding := network.NewAddress(network.TLS, net.JoinHostPort("", portStr))
+		serverBinding := network.NewAddress(network.TLS, net.JoinHostPort(host, portStr))
 		kp := key.NewKeyPair(cothority.Suite)
 
 		pub, _ := encoding.PointToStringHex(cothority.Suite, kp.Public)

--- a/conode/conode.go
+++ b/conode/conode.go
@@ -239,7 +239,7 @@ func setup(c *cli.Context) error {
 			Services:    app.GenerateServiceKeyPairs(),
 		}
 
-		out := path.Join(cfgpath.GetConfigPath(DefaultName), app.DefaultServerConfig)
+		out := c.GlobalString("config")
 		err := conf.Save(out)
 		if err == nil {
 			fmt.Fprintf(os.Stderr, "Wrote config file to %v\n", out)


### PR DESCRIPTION
Currently, `conode setup --non-interactive` doesn't respect given config path (always saved to `$HOME/.config` on Linux) and only allow the creation of nodes with loopback address.

* added `--host` to allow to select host
* use `--config` directly (the default is the same anyway)
* remove a bit of dead code
  * "config" and "debug" should be read via `cli.GlobalString`, path was never triggered
  * btw, to actually have the wanted check in place, it would be best to have non-interactive as a subcmd 