### PR TITLE
Clarify SignerEd25519 constructor

### DIFF
--- a/external/java/src/main/java/ch/epfl/dedis/lib/darc/SignerEd25519.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/darc/SignerEd25519.java
@@ -23,7 +23,9 @@ public class SignerEd25519 implements Signer {
 
     /**
      * Creates a new signer from a slice of bytes. This must correspond to
-     * what Ed25519.prime_order.toBytes() returns.
+     * what Ed25519.prime_order.toBytes() returns. This constructor does not
+     * correctly decode the result of serialize(). Please use
+     * SignerFactory.New instead.
      * @param data a public key in byte form
      */
     public SignerEd25519(byte[] data){
@@ -39,6 +41,7 @@ public class SignerEd25519 implements Signer {
      * @param msg the message
      * @return the signature
      */
+    @Override
     public byte[] sign(byte[] msg) {
         SchnorrSig sig = new SchnorrSig(msg, priv);
         return sig.toBytes();
@@ -49,6 +52,7 @@ public class SignerEd25519 implements Signer {
      *
      * @return the private key
      */
+    @Override
     public Scalar getPrivate() {
         return priv;
     }
@@ -58,6 +62,7 @@ public class SignerEd25519 implements Signer {
      *
      * @return the public key
      */
+    @Override
     public Point getPublic() {
         return pub;
     }
@@ -67,6 +72,7 @@ public class SignerEd25519 implements Signer {
      *
      * @return an identity
      */
+    @Override
     public Identity getIdentity() {
         return IdentityFactory.New(this);
     }
@@ -77,6 +83,7 @@ public class SignerEd25519 implements Signer {
      * @return the serialised signer
      * @throws IOException if something went wrong with I/O
      */
+    @Override
     public byte[] serialize() throws IOException{
         byte[] result = new byte[1 + priv.toBytes().length];
         result[0] = SignerFactory.IDEd25519;

--- a/external/java/src/main/java/ch/epfl/dedis/lib/darc/SignerX509EC.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/darc/SignerX509EC.java
@@ -31,6 +31,7 @@ public abstract class SignerX509EC implements Signer {
      *
      * @return the private key
      */
+    @Override
     public Scalar getPrivate()  {
         throw new RuntimeException("cannot reveal private key");
     }
@@ -40,6 +41,7 @@ public abstract class SignerX509EC implements Signer {
      *
      * @return the public key
      */
+    @Override
     public Point getPublic()  {
         throw new RuntimeException("non-ed25519 public keys not yet implemented");
     }
@@ -49,6 +51,7 @@ public abstract class SignerX509EC implements Signer {
      *
      * @return an identity
      */
+    @Override
     public Identity getIdentity() {
         return IdentityFactory.New(this);
     }
@@ -58,6 +61,7 @@ public abstract class SignerX509EC implements Signer {
      *
      * @return the serialized signer
      */
+    @Override
     public byte[] serialize() throws IOException {
         // TODO - serialize this thing so it can be recognized by go. The byte string must
         // start with a SignerFactory.Keycard byte, then comes whatever representation makes


### PR DESCRIPTION
The constructor does not work as expected because the serialize method
puts an extra byte at the front.