### PR TITLE
Try other nodes if command fails

### DIFF
--- a/external/js/cothority/spec/network/connection.spec.ts
+++ b/external/js/cothority/spec/network/connection.spec.ts
@@ -67,8 +67,8 @@ describe("WebSocketAdapter Tests", () => {
         });
         const roster = new Roster({
             list: [
-                new ServerIdentity({ address: "a", public: ROSTER.list[0].public }),
-                new ServerIdentity({ address: "b", public: ROSTER.list[0].public }),
+                new ServerIdentity({address: "a", public: ROSTER.list[0].public}),
+                new ServerIdentity({address: "b", public: ROSTER.list[0].public}),
             ],
         });
 
@@ -82,8 +82,8 @@ describe("WebSocketAdapter Tests", () => {
         setFactory(() => new TestWebSocket(null, new Error(), 1000));
         const roster = new Roster({
             list: [
-                new ServerIdentity({ address: "a", public: ROSTER.list[0].public }),
-                new ServerIdentity({ address: "b", public: ROSTER.list[0].public }),
+                new ServerIdentity({address: "a", public: ROSTER.list[0].public}),
+                new ServerIdentity({address: "b", public: ROSTER.list[0].public}),
             ],
         });
 
@@ -95,8 +95,8 @@ describe("WebSocketAdapter Tests", () => {
     it("should send a request to the leader", async () => {
         const roster = new Roster({
             list: [
-                new ServerIdentity({ address: "a", public: ROSTER.list[0].public }),
-                new ServerIdentity({ address: "b", public: ROSTER.list[0].public }),
+                new ServerIdentity({address: "a", public: ROSTER.list[0].public}),
+                new ServerIdentity({address: "b", public: ROSTER.list[0].public}),
             ],
         });
 

--- a/external/js/cothority/spec/skipchain/skipchain-rpc.spec.ts
+++ b/external/js/cothority/spec/skipchain/skipchain-rpc.spec.ts
@@ -55,7 +55,8 @@ describe("SkipchainRPC Tests", () => {
     it("should fail to get the block", async () => {
         const rpc = new SkipchainRPC(roster);
 
-        await expectAsync(rpc.getSkipBlock(Buffer.from([1, 2, 3]))).toBeRejectedWith("No such block");
+        await expectAsync(rpc.getSkipBlock(Buffer.from([1, 2, 3])))
+            .toBeRejectedWith("No such block :: No such block :: No such block :: No such block");
 
         await expectAsync(rpc.getLatestBlock(Buffer.from([1, 2, 3]))).toBeRejected("Couldn't find latest skipblock");
     });


### PR DESCRIPTION
This PR switches to a next node if the current node returns an error. It
tries to keep the same 'working' node as long as possible.