### PR TITLE
Correct the ed25519_signer representation

### DIFF
--- a/external/js/cothority/src/darc/identity-wrapper.ts
+++ b/external/js/cothority/src/darc/identity-wrapper.ts
@@ -27,9 +27,7 @@ export default class IdentityWrapper extends Message<IdentityWrapper> {
      */
     static fromString(idStr: string): IdentityWrapper {
         if (idStr.startsWith("ed25519:")) {
-            const point = new Ed25519Point();
-            point.unmarshalBinary(Buffer.from(idStr.slice(8), "hex"));
-            const id = IdentityEd25519.fromPoint(point);
+            const id = new IdentityEd25519({point: Buffer.from(idStr.slice(8), "hex")});
             return new IdentityWrapper({ed25519: id});
         }
         if (idStr.startsWith("darc:")) {

--- a/external/js/cothority/src/darc/signer-ed25519.ts
+++ b/external/js/cothority/src/darc/signer-ed25519.ts
@@ -34,7 +34,7 @@ export default class SignerEd25519 extends IdentityEd25519 implements ISigner {
     private priv: Scalar;
 
     constructor(pub: Point, priv: Scalar) {
-        super({point: pub.toProto()});
+        super({point: pub.marshalBinary()});
         this.priv = priv;
     }
 


### PR DESCRIPTION
Before: ed25519_signer hex values were represented as protobuf-encoded values
Now: ed25519_signer hex values are the raw MarshalBinary values

Why: this is how it is handled in the go-code. It also makes more sense, as the
hex-values are always preceded by 'ed25519:', so it is clear what kind of point
it is.