### PR TITLE
Fix wait group stuck in eventlog if a panic occurs

### DIFF
--- a/eventlog/api.go
+++ b/eventlog/api.go
@@ -244,7 +244,9 @@ func (c *Client) StreamEvents(handler StreamHandler) error {
 func (c *Client) StreamEventsFrom(handler StreamHandler, id []byte) error {
 	// 1. stream to a buffer (because we don't know which ones will be duplicates yet)
 	blockChan := make(chan blockOrErr, 100)
-	streamDone := make(chan error)
+	// The done channel is also buffered if a panic occurs in the client handler which
+	// would prevent the wait group to close correctly.
+	streamDone := make(chan error, 1)
 	wg := sync.WaitGroup{}
 	defer wg.Wait()
 	go func() {


### PR DESCRIPTION
This fixes the Go routine leak in the eventlog test in Jenkins.