### PR TITLE
Updates darc.String()

### DIFF
--- a/byzcoin/bcadmin/main_test.go
+++ b/byzcoin/bcadmin/main_test.go
@@ -77,7 +77,7 @@ func TestCli(t *testing.T) {
 	args = []string{"bcadmin", "darc", "show"}
 	err = cliApp.Run(args)
 	require.NoError(t, err)
-	require.Contains(t, string(b.Bytes()), "Ver:\t0")
+	require.Contains(t, string(b.Bytes()), "-- Version: 0")
 
 	log.Lvl1("darc rule: ")
 	b = &bytes.Buffer{}
@@ -95,7 +95,7 @@ func TestCli(t *testing.T) {
 	args = []string{"bcadmin", "darc", "show"}
 	err = cliApp.Run(args)
 	require.NoError(t, err)
-	require.Contains(t, string(b.Bytes()), "Ver:\t1")
-	require.Contains(t, string(b.Bytes()), "spawn:xxx")
+	require.Contains(t, string(b.Bytes()), "-- Version: 1")
+	require.Contains(t, string(b.Bytes()), "--- spawn:xxx")
 
 }

--- a/darc/darc.go
+++ b/darc/darc.go
@@ -467,16 +467,21 @@ func (r *Request) VerifyWithCB(d *Darc, getDarc GetDarc) error {
 
 // String returns a human-readable string representation of the darc.
 func (d Darc) String() string {
-	s := fmt.Sprintf("ID:\tdarc:%x (Description: %-v)\nBase:\tdarc:%x\nPrev:\tdarc:%x\nVer:\t%d\nRules:",
-		d.GetID(), strconv.Quote(string(d.Description)), d.GetBaseID(), d.PrevID, d.Version)
+	var res strings.Builder
+	res.WriteString("- Darc:\n")
+	fmt.Fprintf(&res, "-- Description: %-v\n", strconv.Quote(string(d.Description)))
+	fmt.Fprintf(&res, "-- BaseID: darc:%x\n", d.GetBaseID())
+	fmt.Fprintf(&res, "-- PrevID: darc:%x\n", d.PrevID)
+	fmt.Fprintf(&res, "-- Version: %d\n", d.Version)
+	res.WriteString("-- Rules:")
 	for _, v := range d.Rules.List {
-		s += fmt.Sprintf("\n\t%s - \"%s\"", v.Action, v.Expr)
+		fmt.Fprintf(&res, "\n--- %s - \"%s\"", v.Action, v.Expr)
 	}
-	s += "\nSignatures:"
+	res.WriteString("\n-- Signatures:")
 	for i, sig := range d.Signatures {
-		s += fmt.Sprintf("\n\t%d - id: %s, sig: %x", i, sig.Signer.String(), sig.Signature)
+		fmt.Fprintf(&res, "\n--- %d - id: %s, sig: %x", i, sig.Signer.String(), sig.Signature)
 	}
-	return s
+	return res.String()
 }
 
 // IsNull returns true if this DarcID is not initialised.


### PR DESCRIPTION
Removes the darcID, which is useless. Only the base ID is usefull to show.

See #1924