### PR TITLE
Nicer description

### DIFF
--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -63,10 +63,11 @@ var cmds = cli.Commands{
 	},
 
 	{
-		Name:      "link",
-		Usage:     "create a BC config file that sets the specified roster, darc and identity. If no identity is provided, it will use an empty one. Same for the darc param. This allows one that has no private key to perform basic operations that do not require authentication.",
-		Aliases:   []string{"login"},
-		ArgsUsage: "roster.toml [byzcoin id]",
+		Name:        "link",
+		Usage:       "create a BC config file that sets the specified roster, darc and identity",
+		Description: "If no identity is provided, it will use an empty one. Same for the darc param. This allows one that has no private key to perform basic operations that do not require authentication.",
+		Aliases:     []string{"login"},
+		ArgsUsage:   "roster.toml [byzcoin id]",
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "darc",


### PR DESCRIPTION
Instead of putting a long `Usage` field, better use the `Description` that is only shown with

```bash
bcadmin link --help
```