### PR TITLE
Byzcoin proof attack

### DIFF
--- a/byzcoin/api.go
+++ b/byzcoin/api.go
@@ -501,7 +501,7 @@ func (c *Client) getServer() *network.ServerIdentity {
 func (c *Client) fetchGenesis() error {
 	skClient := skipchain.NewClient()
 
-	// Integrity is done by the request function.
+	// Integrity check is done by the request function.
 	sb, err := skClient.GetSingleBlock(&c.Roster, c.ID)
 	if err != nil {
 		return err

--- a/byzcoin/api.go
+++ b/byzcoin/api.go
@@ -134,9 +134,10 @@ func (c *Client) GetProof(key []byte) (*GetProofResponse, error) {
 // starting from the latest known block by this client. The proof
 // can prove the existence or the absence of the key. Note that the integrity
 // of the proof is verified.
-// Caution: the proof will be verifiable only by client/service that know the
-// state of the chain up to the block. If you want to share the proof, you may
-// prefer to use GetProof.
+// Caution: the proof will be verifiable only by client/service that knows the
+// state of the chain up to the block. If you need to pass the Proof onwards to
+// another server, you must use GetProof in order to create a complete standalone
+// proof starting from the genesis block.
 func (c *Client) GetProofFromLatest(key []byte) (*GetProofResponse, error) {
 	if c.Latest == nil {
 		return c.GetProof(key)
@@ -149,8 +150,9 @@ func (c *Client) GetProofFromLatest(key []byte) (*GetProofResponse, error) {
 // from the block given in parameter. The proof can prove the existence or
 // the absence of the key. Note that the integrity of the proof is verified.
 // Caution: the proof will be verifiable only by client/service that know the
-// state of the chain up to the block. If you want to share the proof, you may
-// prefer to use GetProof.
+// state of the chain up to the block. If you need to pass the Proof onwards to
+// another server, you must use GetProof in order to create a complete standalone
+// proof starting from the genesis block.
 func (c *Client) GetProofFrom(key []byte, from *skipchain.SkipBlock) (*GetProofResponse, error) {
 	reply := &GetProofResponse{}
 	err := c.SendProtobuf(c.getServer(), &GetProof{

--- a/byzcoin/api.go
+++ b/byzcoin/api.go
@@ -115,9 +115,9 @@ func (c *Client) AddTransactionAndWait(tx ClientTransaction, wait int) (*AddTxRe
 	return reply, nil
 }
 
-// GetProof returns a proof for the key stored in the skipchain by sending a
-// message to the node on index 0 of the roster. The proof can prove the existence
-// or the absence of the key. Note that the integrity of the proof is verified.
+// GetProof returns a proof for the key stored in the skipchain starting from
+// the genesis block. The proof can prove the existence or the absence of the
+// key. Note that the integrity of the proof is verified.
 // The Client's Roster and ID should be initialized before calling this method
 // (see NewClientFromConfig).
 func (c *Client) GetProof(key []byte) (*GetProofResponse, error) {
@@ -130,11 +130,12 @@ func (c *Client) GetProof(key []byte) (*GetProofResponse, error) {
 	return c.GetProofFrom(key, c.Genesis)
 }
 
-// GetProofFromLatest returns a proof for the key stored in the skipchain. The proof
+// GetProofFromLatest returns a proof for the key stored in the skipchain
+// starting from the latest known block by this client. The proof
 // can prove the existence or the absence of the key. Note that the integrity
 // of the proof is verified.
 // Caution: the proof will be verifiable only by client/service that know the
-// state of the chain up to the block. If you want to share the proof, we may
+// state of the chain up to the block. If you want to share the proof, you may
 // prefer to use GetProof.
 func (c *Client) GetProofFromLatest(key []byte) (*GetProofResponse, error) {
 	if c.Latest == nil {
@@ -144,11 +145,11 @@ func (c *Client) GetProofFromLatest(key []byte) (*GetProofResponse, error) {
 	return c.GetProofFrom(key, c.Latest)
 }
 
-// GetProofFrom returns a proof for the key stored in the skipchain. The proof
-// can prove the existence or the absence of the key. Note that the integrity
-// of the proof is verified.
+// GetProofFrom returns a proof for the key stored in the skipchain starting
+// from the block given in parameter. The proof can prove the existence or
+// the absence of the key. Note that the integrity of the proof is verified.
 // Caution: the proof will be verifiable only by client/service that know the
-// state of the chain up to the block. If you want to share the proof, we may
+// state of the chain up to the block. If you want to share the proof, you may
 // prefer to use GetProof.
 func (c *Client) GetProofFrom(key []byte, from *skipchain.SkipBlock) (*GetProofResponse, error) {
 	reply := &GetProofResponse{}
@@ -194,7 +195,7 @@ func (c *Client) CheckAuthorization(dID darc.ID, ids ...darc.Identity) ([]darc.A
 // Genesis Darc from ByzCoin and parses it.
 func (c *Client) GetGenDarc() (*darc.Darc, error) {
 	// Get proof of the genesis darc.
-	p, err := c.GetProof(NewInstanceID(nil).Slice())
+	p, err := c.GetProofFromLatest(NewInstanceID(nil).Slice())
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +217,7 @@ func (c *Client) GetGenDarc() (*darc.Darc, error) {
 	}
 
 	// Find the actual darc.
-	p, err = c.GetProof(darcID)
+	p, err = c.GetProofFromLatest(darcID)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +247,7 @@ func (c *Client) GetGenDarc() (*darc.Darc, error) {
 // GetChainConfig uses the GetProof method to fetch the chain config
 // from ByzCoin.
 func (c *Client) GetChainConfig() (*ChainConfig, error) {
-	p, err := c.GetProof(NewInstanceID(nil).Slice())
+	p, err := c.GetProofFromLatest(NewInstanceID(nil).Slice())
 	if err != nil {
 		return nil, err
 	}

--- a/byzcoin/api_test.go
+++ b/byzcoin/api_test.go
@@ -158,13 +158,13 @@ func TestClient_GetProofCorrupted(t *testing.T) {
 	service := servers[0].Service(testServiceName).(*corruptedService)
 
 	c := &Client{
-		Client:      onet.NewClient(cothority.Suite, testServiceName),
-		Roster:      *roster,
-		KnownBlocks: make(map[string]*skipchain.SkipBlock),
+		Client: onet.NewClient(cothority.Suite, testServiceName),
+		Roster: *roster,
 	}
 	gen := skipchain.NewSkipBlock()
-	c.ID = gen.CalculateHash()
-	c.KnownBlocks[string(c.ID)] = gen
+	gen.Hash = gen.CalculateHash()
+	c.ID = gen.Hash
+	c.Genesis = gen
 
 	sb := skipchain.NewSkipBlock()
 	sb.Data = []byte{1, 2, 3}

--- a/byzcoin/api_test.go
+++ b/byzcoin/api_test.go
@@ -158,18 +158,20 @@ func TestClient_GetProofCorrupted(t *testing.T) {
 	service := servers[0].Service(testServiceName).(*corruptedService)
 
 	c := &Client{
-		Client:  onet.NewClient(cothority.Suite, testServiceName),
-		Roster:  *roster,
-		Genesis: skipchain.NewSkipBlock(),
+		Client:      onet.NewClient(cothority.Suite, testServiceName),
+		Roster:      *roster,
+		KnownBlocks: make(map[string]*skipchain.SkipBlock),
 	}
-	c.ID = c.Genesis.CalculateHash()
+	gen := skipchain.NewSkipBlock()
+	c.ID = gen.CalculateHash()
+	c.KnownBlocks[string(c.ID)] = gen
 
 	sb := skipchain.NewSkipBlock()
 	sb.Data = []byte{1, 2, 3}
 	service.GetProofResponse = &GetProofResponse{
 		Proof: Proof{
 			Latest: *sb,
-			Links:  []skipchain.ForwardLink{skipchain.ForwardLink{}},
+			Links:  []skipchain.ForwardLink{skipchain.ForwardLink{To: c.ID}},
 		},
 	}
 

--- a/byzcoin/api_test.go
+++ b/byzcoin/api_test.go
@@ -124,30 +124,24 @@ func TestClient_GetProof(t *testing.T) {
 	kind := "dummy"
 	tx, err := createOneClientTx(d.GetBaseID(), kind, value, signer)
 	require.Nil(t, err)
-	_, err = c.AddTransaction(tx)
+	_, err = c.AddTransactionAndWait(tx, 10)
 	require.Nil(t, err)
 
 	// We should have a proof of our transaction in the skipchain.
 	newID := tx.Instructions[0].Hash()
-	var p *GetProofResponse
-	var i int
-	for i = 0; i < 10; i++ {
-		time.Sleep(4 * msg.BlockInterval)
-		var err error
-		p, err = c.GetProof(newID)
-		if err != nil {
-			continue
-		}
-		if p.Proof.InclusionProof.Match(newID) {
-			break
-		}
-	}
-	require.NotEqual(t, 10, i, "didn't get proof in time")
+	p, err := c.GetProof(newID)
+	require.NoError(t, err)
 	require.Nil(t, p.Proof.Verify(csr.Skipblock.SkipChainID()))
+	require.Equal(t, 2, len(p.Proof.Links))
 	k, v0, _, _, err := p.Proof.KeyValue()
 	require.Nil(t, err)
 	require.Equal(t, k, newID)
 	require.Equal(t, value, v0)
+
+	// The proof should now be smaller as we learnt about the block
+	p, err = c.GetProofFromLatest(newID)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(p.Proof.Links))
 }
 
 func TestClient_GetProofCorrupted(t *testing.T) {

--- a/byzcoin/api_test.go
+++ b/byzcoin/api_test.go
@@ -158,14 +158,19 @@ func TestClient_GetProofCorrupted(t *testing.T) {
 	service := servers[0].Service(testServiceName).(*corruptedService)
 
 	c := &Client{
-		Client: onet.NewClient(cothority.Suite, testServiceName),
-		Roster: *roster,
+		Client:  onet.NewClient(cothority.Suite, testServiceName),
+		Roster:  *roster,
+		Genesis: skipchain.NewSkipBlock(),
 	}
+	c.ID = c.Genesis.CalculateHash()
 
 	sb := skipchain.NewSkipBlock()
 	sb.Data = []byte{1, 2, 3}
 	service.GetProofResponse = &GetProofResponse{
-		Proof: Proof{Latest: *sb},
+		Proof: Proof{
+			Latest: *sb,
+			Links:  []skipchain.ForwardLink{skipchain.ForwardLink{}},
+		},
 	}
 
 	_, err := c.GetProof([]byte{})

--- a/byzcoin/bcadmin/clicontracts/config.go
+++ b/byzcoin/bcadmin/clicontracts/config.go
@@ -48,7 +48,7 @@ func ConfigInvokeUpdateConfig(c *cli.Context) error {
 	}
 
 	// Get the latest chain config
-	pr, err := cl.GetProof(byzcoin.ConfigInstanceID.Slice())
+	pr, err := cl.GetProofFromLatest(byzcoin.ConfigInstanceID.Slice())
 	if err != nil {
 		return errors.New("couldn't get proof for chainConfig: " + err.Error())
 	}
@@ -142,7 +142,7 @@ func ConfigInvokeUpdateConfig(c *cli.Context) error {
 	// ---
 	// 3.
 	// ---
-	pr, err = cl.GetProof(byzcoin.ConfigInstanceID.Slice())
+	pr, err = cl.GetProofFromLatest(byzcoin.ConfigInstanceID.Slice())
 	if err != nil {
 		return errors.New("couldn't get proof for config: " + err.Error())
 	}
@@ -183,7 +183,7 @@ func ConfigGet(c *cli.Context) error {
 	}
 
 	// Get the latest chain config
-	pr, err := cl.GetProof(byzcoin.ConfigInstanceID.Slice())
+	pr, err := cl.GetProofFromLatest(byzcoin.ConfigInstanceID.Slice())
 	if err != nil {
 		return errors.New("couldn't get proof for chainConfig: " + err.Error())
 	}

--- a/byzcoin/bcadmin/clicontracts/config.go
+++ b/byzcoin/bcadmin/clicontracts/config.go
@@ -53,10 +53,6 @@ func ConfigInvokeUpdateConfig(c *cli.Context) error {
 		return errors.New("couldn't get proof for chainConfig: " + err.Error())
 	}
 	proof := pr.Proof
-	err = proof.Verify(cl.ID)
-	if err != nil {
-		return errors.New("failed to verify proof: " + err.Error())
-	}
 
 	_, value, _, _, err := proof.KeyValue()
 	if err != nil {
@@ -151,10 +147,6 @@ func ConfigInvokeUpdateConfig(c *cli.Context) error {
 		return errors.New("couldn't get proof for config: " + err.Error())
 	}
 	proof = pr.Proof
-	err = proof.Verify(cl.ID)
-	if err != nil {
-		return errors.New("failed to verify proof: " + err.Error())
-	}
 
 	_, resultBuf, _, _, err := proof.KeyValue()
 	if err != nil {
@@ -196,10 +188,6 @@ func ConfigGet(c *cli.Context) error {
 		return errors.New("couldn't get proof for chainConfig: " + err.Error())
 	}
 	proof := pr.Proof
-	err = proof.Verify(cl.ID)
-	if err != nil {
-		return errors.New("failed to verify proof: " + err.Error())
-	}
 
 	_, value, _, _, err := proof.KeyValue()
 	if err != nil {

--- a/byzcoin/bcadmin/clicontracts/deferred.go
+++ b/byzcoin/bcadmin/clicontracts/deferred.go
@@ -122,10 +122,6 @@ func DeferredSpawn(c *cli.Context) error {
 		return errors.New("couldn't get proof for admin-darc: " + err.Error())
 	}
 	proof := pr.Proof
-	err = proof.Verify(cl.ID)
-	if err != nil {
-		return errors.New("failed to verify proof: " + err.Error())
-	}
 
 	_, resultBuf, _, _, err := proof.KeyValue()
 	if err != nil {
@@ -269,10 +265,6 @@ func DeferredInvokeAddProof(c *cli.Context) error {
 		return errors.New("couldn't get proof for admin-darc: " + err.Error())
 	}
 	proof := pr.Proof
-	err = proof.Verify(cl.ID)
-	if err != nil {
-		return errors.New("failed to verify proof: " + err.Error())
-	}
 
 	_, resultBuf, _, _, err := proof.KeyValue()
 	if err != nil {
@@ -371,10 +363,6 @@ func ExecProposedTx(c *cli.Context) error {
 		return errors.New("couldn't get proof for admin-darc: " + err.Error())
 	}
 	proof := pr.Proof
-	err = proof.Verify(cl.ID)
-	if err != nil {
-		return errors.New("failed to verify proof: " + err.Error())
-	}
 
 	_, resultBuf, _, _, err := proof.KeyValue()
 	if err != nil {
@@ -419,10 +407,6 @@ func DeferredGet(c *cli.Context) error {
 		return errors.New("couldn't get proof: " + err.Error())
 	}
 	proof := pr.Proof
-	err = proof.Verify(cl.ID)
-	if err != nil {
-		return errors.New("failed to verify proof: " + err.Error())
-	}
 
 	exist, err := proof.InclusionProof.Exists(instIDBuf)
 	if err != nil {

--- a/byzcoin/bcadmin/clicontracts/deferred.go
+++ b/byzcoin/bcadmin/clicontracts/deferred.go
@@ -117,7 +117,7 @@ func DeferredSpawn(c *cli.Context) error {
 	// ---
 	// 3.
 	// ---
-	pr, err := cl.GetProof(instID)
+	pr, err := cl.GetProofFromLatest(instID)
 	if err != nil {
 		return errors.New("couldn't get proof for admin-darc: " + err.Error())
 	}
@@ -260,7 +260,7 @@ func DeferredInvokeAddProof(c *cli.Context) error {
 	// ---
 	// 4.
 	// ---
-	pr, err := cl.GetProof(instIDBuf)
+	pr, err := cl.GetProofFromLatest(instIDBuf)
 	if err != nil {
 		return errors.New("couldn't get proof for admin-darc: " + err.Error())
 	}
@@ -358,7 +358,7 @@ func ExecProposedTx(c *cli.Context) error {
 	// ---
 	// 3.
 	// ---
-	pr, err := cl.GetProof(instIDBuf)
+	pr, err := cl.GetProofFromLatest(instIDBuf)
 	if err != nil {
 		return errors.New("couldn't get proof for admin-darc: " + err.Error())
 	}
@@ -402,7 +402,7 @@ func DeferredGet(c *cli.Context) error {
 		return errors.New("failed to decode the instid string")
 	}
 
-	pr, err := cl.GetProof(instIDBuf)
+	pr, err := cl.GetProofFromLatest(instIDBuf)
 	if err != nil {
 		return errors.New("couldn't get proof: " + err.Error())
 	}

--- a/byzcoin/bcadmin/clicontracts/value.go
+++ b/byzcoin/bcadmin/clicontracts/value.go
@@ -209,7 +209,7 @@ func ValueGet(c *cli.Context) error {
 		return errors.New("failed to decode the instID string")
 	}
 
-	pr, err := cl.GetProof(instIDBuf)
+	pr, err := cl.GetProofFromLatest(instIDBuf)
 	if err != nil {
 		return errors.New("couldn't get proof: " + err.Error())
 	}

--- a/byzcoin/bcadmin/clicontracts/value.go
+++ b/byzcoin/bcadmin/clicontracts/value.go
@@ -214,10 +214,6 @@ func ValueGet(c *cli.Context) error {
 		return errors.New("couldn't get proof: " + err.Error())
 	}
 	proof := pr.Proof
-	err = proof.Verify(cl.ID)
-	if err != nil {
-		return errors.New("failed to verify proof: " + err.Error())
-	}
 
 	exist, err := proof.InclusionProof.Exists(instIDBuf)
 	if err != nil {

--- a/byzcoin/bcadmin/lib/utils.go
+++ b/byzcoin/bcadmin/lib/utils.go
@@ -49,7 +49,7 @@ func GetDarcByString(cl *byzcoin.Client, id string) (*darc.Darc, error) {
 
 // GetDarcByID returns a DARC given its ID as a byte array
 func GetDarcByID(cl *byzcoin.Client, id []byte) (*darc.Darc, error) {
-	pr, err := cl.GetProof(id)
+	pr, err := cl.GetProofFromLatest(id)
 	if err != nil {
 		return nil, err
 	}

--- a/byzcoin/bcadmin/lib/utils.go
+++ b/byzcoin/bcadmin/lib/utils.go
@@ -55,10 +55,6 @@ func GetDarcByID(cl *byzcoin.Client, id []byte) (*darc.Darc, error) {
 	}
 
 	p := &pr.Proof
-	err = p.Verify(cl.ID)
-	if err != nil {
-		return nil, err
-	}
 
 	vs, cid, _, err := p.Get(id)
 	if err != nil {

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -876,11 +876,6 @@ func link(c *cli.Context) error {
 				return errors.New("couldn't get proof for darc: " + err.Error())
 			}
 
-			err = p.Proof.Verify(id)
-			if err != nil {
-				return errors.New("proof for darc is wrong: " + err.Error())
-			}
-
 			_, darcBuf, cid, _, err := p.Proof.KeyValue()
 			if err != nil {
 				return errors.New("cannot get value for darc: " + err.Error())
@@ -973,11 +968,6 @@ func latest(c *cli.Context) error {
 
 	// Find the latest block by asking for the Proof of the config instance.
 	p, err := cl.GetProof(byzcoin.ConfigInstanceID.Slice())
-	if err != nil {
-		return err
-	}
-
-	err = p.Proof.Verify(cfg.ByzCoinID)
 	if err != nil {
 		return err
 	}

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -871,7 +871,7 @@ func link(c *cli.Context) error {
 				return errors.New("failed to parse darc: " + err.Error())
 			}
 
-			p, err := cl.GetProof(darcID)
+			p, err := cl.GetProofFromLatest(darcID)
 			if err != nil {
 				return errors.New("couldn't get proof for darc: " + err.Error())
 			}
@@ -967,7 +967,7 @@ func latest(c *cli.Context) error {
 	}
 
 	// Find the latest block by asking for the Proof of the config instance.
-	p, err := cl.GetProof(byzcoin.ConfigInstanceID.Slice())
+	p, err := cl.GetProofFromLatest(byzcoin.ConfigInstanceID.Slice())
 	if err != nil {
 		return err
 	}
@@ -1024,7 +1024,7 @@ func getBcKey(c *cli.Context) (cfg lib.Config, cl *byzcoin.Client, signer *darc.
 	}
 
 	log.Lvl2("Getting latest chainConfig")
-	pr, err := cl.GetProof(byzcoin.ConfigInstanceID.Slice())
+	pr, err := cl.GetProofFromLatest(byzcoin.ConfigInstanceID.Slice())
 	if err != nil {
 		err = errors.New("couldn't get proof for chainConfig: " + err.Error())
 		return
@@ -1172,7 +1172,7 @@ func mint(c *cli.Context) error {
 	}
 	counters := cReply.Counters
 
-	p, err := cl.GetProof(account.Slice())
+	p, err := cl.GetProofFromLatest(account.Slice())
 	if err != nil {
 		return err
 	}

--- a/byzcoin/contracts/contract_deferred_test.go
+++ b/byzcoin/contracts/contract_deferred_test.go
@@ -2011,7 +2011,7 @@ func TestDeferred_ScenarioUpdateConfig(t *testing.T) {
 	// ------------------------------------------------------------------------
 
 	// Get the latest chain config
-	prr, err := cl.GetProof(byzcoin.ConfigInstanceID.Slice())
+	prr, err := cl.GetProofFromLatest(byzcoin.ConfigInstanceID.Slice())
 	require.Nil(t, err)
 	proof := prr.Proof
 
@@ -2679,7 +2679,7 @@ func TestDeferred_SimpleDelete(t *testing.T) {
 
 	myID := ctx.Instructions[0].DeriveID("")
 
-	prr, err := cl.GetProof(ctx.Instructions[0].DeriveID("").Slice())
+	prr, err := cl.GetProofFromLatest(ctx.Instructions[0].DeriveID("").Slice())
 	require.Nil(t, err)
 	exist, err := prr.Proof.InclusionProof.Exists(myID.Slice())
 	require.Nil(t, err)
@@ -2721,7 +2721,7 @@ func TestDeferred_SimpleDelete(t *testing.T) {
 	_, err = cl.AddTransactionAndWait(ctx, 10)
 	require.Nil(t, err)
 
-	prr, err = cl.GetProof(myID.Slice())
+	prr, err = cl.GetProofFromLatest(myID.Slice())
 	require.Nil(t, err)
 	exist, err = prr.Proof.InclusionProof.Exists(myID.Slice())
 	require.Nil(t, err)
@@ -2809,7 +2809,7 @@ func TestDeferred_PublicDelete(t *testing.T) {
 
 	myID := ctx.Instructions[0].DeriveID("")
 
-	prr, err := cl.GetProof(ctx.Instructions[0].DeriveID("").Slice())
+	prr, err := cl.GetProofFromLatest(ctx.Instructions[0].DeriveID("").Slice())
 	require.Nil(t, err)
 	exist, err := prr.Proof.InclusionProof.Exists(myID.Slice())
 	require.Nil(t, err)
@@ -2854,7 +2854,7 @@ func TestDeferred_PublicDelete(t *testing.T) {
 	_, err = cl.AddTransactionAndWait(ctx, 10)
 	require.Nil(t, err)
 
-	prr, err = cl.GetProof(myID.Slice())
+	prr, err = cl.GetProofFromLatest(myID.Slice())
 	require.Nil(t, err)
 	exist, err = prr.Proof.InclusionProof.Exists(myID.Slice())
 	require.Nil(t, err)

--- a/byzcoin/proof.go
+++ b/byzcoin/proof.go
@@ -85,7 +85,7 @@ var ErrorMalformedForwardLink = errors.New("missing new roster from the forward-
 // that the merkle-root is stored in the skipblock of the proof and the fact that
 // the skipblock is indeed part of the skipchain. It also uses the provided block
 // to insure the first roster is correct. If all verifications are correct, the error
-// will be nil. It does not verify wether a certain key/pair pair exists in the proof.
+// will be nil. It does not verify wether a certain key/value pair exists in the proof.
 func (p Proof) VerifyFromBlock(verifiedBlock *skipchain.SkipBlock) error {
 	if len(p.Links) > 0 {
 		// Hash of the block has been verified previously so we can trust the roster
@@ -105,7 +105,7 @@ func (p Proof) VerifyFromBlock(verifiedBlock *skipchain.SkipBlock) error {
 // not verify whether a certain key/value pair exists in the proof.
 //
 // Notice: this verification alone is not sufficient. The roster of the first link
-// must be verified beforehands. See Proof.VerifyFromBlock for example.
+// must be verified before. See Proof.VerifyFromBlock for example.
 func (p Proof) Verify(sbID skipchain.SkipBlockID) error {
 	err := p.VerifyInclusionProof(&p.Latest)
 	if err != nil {
@@ -120,7 +120,7 @@ func (p Proof) Verify(sbID skipchain.SkipBlockID) error {
 	}
 
 	// Get the first from the synthetic link which is assumed to be verified
-	// beforehands against the block with ID stored in the To field by the caller.
+	// before against the block with ID stored in the To field by the caller.
 	publics := p.Links[0].NewRoster.ServicePublics(skipchain.ServiceName)
 
 	for _, l := range p.Links[1:] {

--- a/byzcoin/proof_test.go
+++ b/byzcoin/proof_test.go
@@ -46,6 +46,7 @@ func TestVerify(t *testing.T) {
 	require.Equal(t, s.value, val)
 
 	require.Equal(t, ErrorVerifySkipchain, p.Verify(s.genesis2.SkipChainID()))
+	require.Equal(t, ErrorMismatchGenesis, p.VerifyFromBlock(s.genesis2.SkipChainID(), s.genesis))
 
 	p.Latest.BaseHeight = 123
 	require.Equal(t, ErrorVerifyHash, p.Verify(s.genesis.SkipChainID()))

--- a/byzcoin/proof_test.go
+++ b/byzcoin/proof_test.go
@@ -46,7 +46,6 @@ func TestVerify(t *testing.T) {
 	require.Equal(t, s.value, val)
 
 	require.Equal(t, ErrorVerifySkipchain, p.Verify(s.genesis2.SkipChainID()))
-	require.Equal(t, ErrorMismatchGenesis, p.VerifyFromBlock(s.genesis2.SkipChainID(), s.genesis))
 
 	p.Latest.BaseHeight = 123
 	require.Equal(t, ErrorVerifyHash, p.Verify(s.genesis.SkipChainID()))

--- a/byzcoin/wallet/main.go
+++ b/byzcoin/wallet/main.go
@@ -143,7 +143,7 @@ func show(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	resp, err := cl.GetProof(iid.Slice())
+	resp, err := cl.GetProofFromLatest(iid.Slice())
 	if err != nil {
 		return err
 	}
@@ -192,7 +192,7 @@ func transfer(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	resp, err := cl.GetProof(iid.Slice())
+	resp, err := cl.GetProofFromLatest(iid.Slice())
 	if err != nil {
 		return err
 	}

--- a/calypso/service.go
+++ b/calypso/service.go
@@ -35,6 +35,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"go.dedis.ch/kyber/v3/sign/schnorr"
@@ -88,8 +89,14 @@ func init() {
 // Service is our calypso-service. It stores all created LTSs.
 type Service struct {
 	*onet.ServiceProcessor
-	storage      *storage
-	afterReshare func() // for use by testing only
+	storage *storage
+	// Genesis blocks are stored here instead of the usual skipchain DB as we don't
+	// want to override authorized skipchains or related security. The blocks are
+	// only used to insure that proofs start with the expected roster.
+	genesisBlocks     map[string]*skipchain.SkipBlock
+	genesisBlocksLock sync.Mutex
+	// for use by testing only
+	afterReshare func()
 }
 
 // pubPoly is a serializable version of share.PubPoly
@@ -200,7 +207,7 @@ func (s *Service) Authorize(req *Authorize) (*AuthorizeReply, error) {
 // participate in the DKG. Every node will store its private key and wait for
 // decryption requests. The LTSID should be the InstanceID.
 func (s *Service) CreateLTS(req *CreateLTS) (reply *CreateLTSReply, err error) {
-	if err := s.verifyProof(&req.Proof, nil); err != nil {
+	if err := s.verifyProof(&req.Proof); err != nil {
 		return nil, err
 	}
 
@@ -277,7 +284,7 @@ func (s *Service) ReshareLTS(req *ReshareLTS) (*ReshareLTSReply, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := s.verifyProof(&req.Proof, roster); err != nil {
+	if err := s.verifyProof(&req.Proof); err != nil {
 		return nil, err
 	}
 
@@ -384,7 +391,7 @@ func (s *Service) ReshareLTS(req *ReshareLTS) (*ReshareLTSReply, error) {
 	return &ReshareLTSReply{}, nil
 }
 
-func (s *Service) verifyProof(proof *byzcoin.Proof, roster *onet.Roster) error {
+func (s *Service) verifyProof(proof *byzcoin.Proof) error {
 	scID := proof.Latest.SkipChainID()
 	s.storage.Lock()
 	defer s.storage.Unlock()
@@ -392,12 +399,32 @@ func (s *Service) verifyProof(proof *byzcoin.Proof, roster *onet.Roster) error {
 		return errors.New("this ByzCoin ID is not authorised")
 	}
 
-	// We used to check that the roster ID did not change here, but with
-	// resharing, it is expected that the roster can change.
-	// TODO: Confirm with Kelong that this is correct to remove; that this
-	// does not open us up to abuse/attack.
+	sb, err := s.fetchGenesisBlock(scID, proof.Links[0].NewRoster)
+	if err != nil {
+		return err
+	}
 
-	return proof.Verify(scID)
+	return proof.VerifyFromBlock(sb)
+}
+
+func (s *Service) fetchGenesisBlock(scID skipchain.SkipBlockID, roster *onet.Roster) (*skipchain.SkipBlock, error) {
+	s.genesisBlocksLock.Lock()
+	defer s.genesisBlocksLock.Unlock()
+	sb := s.genesisBlocks[string(scID)]
+	if sb != nil {
+		return sb, nil
+	}
+
+	cl := skipchain.NewClient()
+	sb, err := cl.GetSingleBlock(roster, scID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Genesis block can be reused later on.
+	s.genesisBlocks[string(scID)] = sb
+
+	return sb, nil
 }
 
 func (s *Service) getLtsRoster(proof *byzcoin.Proof) (*onet.Roster, byzcoin.InstanceID, error) {
@@ -443,13 +470,12 @@ func (s *Service) DecryptKey(dkr *DecryptKey) (reply *DecryptKeyReply, err error
 		s.storage.Unlock()
 		return nil, fmt.Errorf("don't know the LTSID '%v' stored in write", id)
 	}
-	scID := make([]byte, 32)
-	copy(scID, s.storage.Replies[id].ByzCoinID)
 	s.storage.Unlock()
-	if err = dkr.Read.Verify(scID); err != nil {
+
+	if err = s.verifyProof(&dkr.Read); err != nil {
 		return nil, errors.New("read proof cannot be verified to come from scID: " + err.Error())
 	}
-	if err = dkr.Write.Verify(scID); err != nil {
+	if err = s.verifyProof(&dkr.Write); err != nil {
 		return nil, errors.New("write proof cannot be verified to come from scID: " + err.Error())
 	}
 
@@ -542,7 +568,7 @@ func (s *Service) NewProtocol(tn *onet.TreeNodeInstance, conf *onet.GenericConfi
 		if err := protobuf.DecodeWithConstructors(conf.Data, &cfg, network.DefaultConstructors(cothority.Suite)); err != nil {
 			return nil, err
 		}
-		if err := s.verifyProof(&cfg.Proof, tn.Roster()); err != nil {
+		if err := s.verifyProof(&cfg.Proof); err != nil {
 			return nil, err
 		}
 		inst, _, _, _, err := cfg.KeyValue()
@@ -589,7 +615,7 @@ func (s *Service) NewProtocol(tn *onet.TreeNodeInstance, conf *onet.GenericConfi
 		if err := protobuf.DecodeWithConstructors(conf.Data, &cfg, network.DefaultConstructors(cothority.Suite)); err != nil {
 			return nil, err
 		}
-		if err := s.verifyProof(&cfg.Proof, tn.Roster()); err != nil {
+		if err := s.verifyProof(&cfg.Proof); err != nil {
 			return nil, err
 		}
 
@@ -742,6 +768,7 @@ func (s *Service) verifyReencryption(rc *protocol.Reencrypt) bool {
 func newService(c *onet.Context) (onet.Service, error) {
 	s := &Service{
 		ServiceProcessor: onet.NewServiceProcessor(c),
+		genesisBlocks:    make(map[string]*skipchain.SkipBlock),
 	}
 	if err := s.RegisterHandlers(s.CreateLTS, s.ReshareLTS, s.DecryptKey,
 		s.GetLTSReply, s.Authorise, s.Authorize); err != nil {

--- a/calypso/service_test.go
+++ b/calypso/service_test.go
@@ -475,7 +475,6 @@ func (s *ts) waitInstID(t *testing.T, instID byzcoin.InstanceID) *byzcoin.Proof 
 	for i := 0; i < 10; i++ {
 		pr, err = s.cl.WaitProof(instID, s.genesisMsg.BlockInterval, nil)
 		if err == nil {
-			require.Nil(t, pr.Verify(s.gbReply.Skipblock.Hash))
 			break
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/eventlog/api.go
+++ b/eventlog/api.go
@@ -130,7 +130,7 @@ func (c *Client) LogAndWait(numInterval int, ev ...Event) ([]LogID, error) {
 
 // GetEvent asks the service to retrieve an event.
 func (c *Client) GetEvent(key []byte) (*Event, error) {
-	reply, err := c.ByzCoin.GetProof(key)
+	reply, err := c.ByzCoin.GetProofFromLatest(key)
 	if err != nil {
 		return nil, err
 	}

--- a/personhood/contract_popparty.go
+++ b/personhood/contract_popparty.go
@@ -407,7 +407,7 @@ func PopPartyMine(cl *byzcoin.Client, popIID byzcoin.InstanceID, kp key.Pair,
 		return errors.New("either set coinIID or d, but not both")
 	}
 	if atts == nil {
-		popProof, err := cl.GetProof(popIID.Slice())
+		popProof, err := cl.GetProofFromLatest(popIID.Slice())
 		if err != nil {
 			return err
 		}
@@ -480,7 +480,7 @@ func PopPartyMineDarcToCoin(cl *byzcoin.Client, d *darc.Darc) (coinIID byzcoin.I
 	coinIID = byzcoin.NewInstanceID(h.Sum(nil))
 
 	var proof *byzcoin.GetProofResponse
-	proof, err = cl.GetProof(coinIID.Slice())
+	proof, err = cl.GetProofFromLatest(coinIID.Slice())
 	if err != nil {
 		return
 	}

--- a/personhood/contract_popparty.go
+++ b/personhood/contract_popparty.go
@@ -411,10 +411,6 @@ func PopPartyMine(cl *byzcoin.Client, popIID byzcoin.InstanceID, kp key.Pair,
 		if err != nil {
 			return err
 		}
-		err = popProof.Proof.Verify(cl.ID)
-		if err != nil {
-			return err
-		}
 		_, value, cID, _, err := popProof.Proof.KeyValue()
 		if err != nil {
 			return err

--- a/personhood/phapp/main.go
+++ b/personhood/phapp/main.go
@@ -470,7 +470,7 @@ func show(c *cli.Context) error {
 	}
 	credIID := byzcoin.NewInstanceID(credBuf)
 
-	p, err := cl.GetProof(credIID.Slice())
+	p, err := cl.GetProofFromLatest(credIID.Slice())
 	if err != nil {
 		return err
 	}
@@ -516,7 +516,7 @@ func combineInstrsAndSign(cl *byzcoin.Client, signer darc.Signer, instrs ...byzc
 
 func verifyAdminDarc(cl *byzcoin.Client, cfg lib.Config, signer darc.Signer) error {
 	gdID := cfg.AdminDarc.GetBaseID()
-	p, err := cl.GetProof(gdID)
+	p, err := cl.GetProofFromLatest(gdID)
 	if err != nil {
 		return err
 	}

--- a/personhood/service.go
+++ b/personhood/service.go
@@ -292,7 +292,7 @@ func (s *Service) PartyList(rq *PartyList) (*PartyListResponse, error) {
 
 func getParty(p *Party) (cpp *ContractPopParty, err error) {
 	cl := byzcoin.NewClient(p.ByzCoinID, p.Roster)
-	pr, err := cl.GetProof(p.InstanceID.Slice())
+	pr, err := cl.GetProofFromLatest(p.InstanceID.Slice())
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This fixes the Byzcoin proof attack by making sure the roster provided inside the first link is correct and not tampered. It also adds an API to ask for shorter proofs but the default request keeps asking for the proof from the genesis block so that this proof can be shared among peers.

Also: remove duplication of the proof verification already done by the request API

Part of #1959 