### PR TITLE
Parallel sending of messages

### DIFF
--- a/external/js/cothority/src/network/connection.ts
+++ b/external/js/cothority/src/network/connection.ts
@@ -44,7 +44,7 @@ export interface IConnection {
  * Single peer connection
  */
 export class WebSocketConnection implements IConnection {
-    protected url: string;
+    url: string;
     private service: string;
     private timeout: number;
 
@@ -113,16 +113,15 @@ export class WebSocketConnection implements IConnection {
             });
 
             ws.onClose((code: number, reason: string) => {
-                if (code === 1000) {
-                    Log.lvl3("Normal closing of connection");
-                    return;
+                if (code !== 1000) {
+                    Log.error("Got close:", code, reason);
+                    reject(new Error(reason));
                 }
-                Log.error("Got error close:", code, reason);
-                reject(new Error(reason));
             });
 
             ws.onError((err: Error) => {
                 clearTimeout(timer);
+
                 reject(new Error("error in websocket " + path + ": " + err));
             });
         });
@@ -132,42 +131,85 @@ export class WebSocketConnection implements IConnection {
 /**
  * Multi peer connection that tries all nodes one after another
  */
-export class RosterWSConnection extends WebSocketConnection {
+export class RosterWSConnection {
+    static parallel: number = 2;
     addresses: string[];
+    addressNext: number;
+    connections: WebSocketConnection[] = [];
 
     /**
      * @param r         The roster to use
      * @param service   The name of the service to reach
-     * @param retry = 2 How many times to retry a failing connection with another node
      */
-    constructor(r: Roster, service: string, private retry: number = 2) {
-        super("", service);
+    constructor(r: Roster, service: string) {
         this.addresses = r.list.map((conode) => conode.getWebSocketAddress());
         shuffle(this.addresses);
+        this.addressNext = RosterWSConnection.parallel;
+        if (this.addressNext > this.addresses.length) {
+            this.addressNext = this.addresses.length;
+        }
+        for (let i = 0; i < this.addressNext; i++) {
+            this.connections.push(new WebSocketConnection(this.addresses[i], service));
+        }
     }
 
-    /** @inheritdoc */
+    /**
+     * Sends a message to conodes in parallel. As soon as one of the conodes returns
+     * success, the message is returned. If a conode returns an error (or times out),
+     * a next conode from this.addresses is contacted. If all conodes return an error,
+     * the promise is rejected.
+     *
+     * @param message the message to send
+     * @param reply the type of the message to return
+     */
     async send<T extends Message>(message: Message, reply: typeof Message): Promise<T> {
         const errors: string[] = [];
-        for (let i = 0; i < this.addresses.length; i++) {
-            this.url = this.addresses[0];
-            Log.lvl3("sending", message.constructor.name, "to address", this.url);
+        let rotate = this.addresses.length - this.connections.length;
 
-            try {
-                // we need to await here to catch and try another conode
-                return await super.send(message, reply);
-            } catch (e) {
-                Log.lvl3(`failed to send on ${this.url} with error:`, e);
-                errors.push(e.message);
-                if (i > this.retry) {
-                    return Promise.reject(errors.join(" :: "));
-                }
-                Log.error("Error while sending - trying with next node");
-                this.addresses = [...this.addresses.slice(1), this.url];
-            }
-        }
+        // Get the first reply - need to take care not to return a reject too soon, else
+        // all other promises will be ignored.
+        return Promise.race(this.connections.map((connection) => {
+            return new Promise<T>(async (resolve, reject) => {
+                do {
+                    try {
+                        const sub = await connection.send(message, reply);
+                        // Signal to other connections that have an error that they don't need
+                        // to retry.
+                        rotate = -1;
+                        resolve(sub as T);
+                    } catch (e) {
+                        errors.push(e);
+                        if (errors.length === this.addresses.length) {
+                            // It's the last connection that also threw an error, so let's quit
+                            reject(errors);
+                        }
+                        rotate--;
+                        if (rotate >= 0) {
+                            // Only switch to next address if the other promises didn't exhaust all
+                            // our addresses yet.
+                            this.addressNext = (this.addressNext + 1) % this.addresses.length;
+                            connection.url = this.addresses[this.addressNext];
+                        }
+                    }
+                } while (rotate >= 0);
+            });
+        }));
+    }
 
-        throw new Error(`send fails with errors: [${errors.join("; ")}]`);
+    /**
+     * To be conform with an IConnection
+     */
+    getURL(): string {
+        return this.connections[0].url;
+    }
+
+    /**
+     * To be conform with an IConnection - sets the timeout on all connections.
+     */
+    setTimeout(value: number) {
+        this.connections.forEach((conn) => {
+            conn.setTimeout(value);
+        });
     }
 }
 


### PR DESCRIPTION
When using the cothority-ts in the omniledger-demonstrator I see sometimes a big
lag in the messages, specifically if dedis.nella.org is replying (I love that node
exactly for this reason!)

This PR solves the problem by sending all messages in parallel and returning the first
successful reply. It still tries to fetch all nodes, in case there are multiple
errors.