### PR TITLE
conode/Dockerfile*: avoid code duplicates

### DIFF
--- a/conode/Dockerfile
+++ b/conode/Dockerfile
@@ -1,19 +1,14 @@
+ARG FROM
+
 FROM golang:1.12 as builder
 ARG BUILD_TAG=none
 ARG ldflags="-s -w -X main.gitTag=unknown"
 RUN go get go.dedis.ch/cothority
 RUN cd /go/src/go.dedis.ch/cothority && git checkout $BUILD_TAG && GO111MODULE=on go install -ldflags="$ldflags" ./conode ./byzcoin/bcadmin ./eventlog/el ./scmgr 
 
-FROM debian:stretch-slim
-RUN apt update; apt install -y procps ca-certificates; apt clean
-WORKDIR /root/
-RUN mkdir /conode_data
-RUN mkdir -p .local/share .config
-RUN ln -s /conode_data .local/share/conode
-RUN ln -s /conode_data .config/conode
+FROM ${FROM}
+
 COPY --from=builder /go/bin/conode .
 COPY --from=builder /go/bin/bcadmin /go/bin/el /go/bin/scmgr /usr/local/bin/
-
-EXPOSE 7770 7771
 
 CMD ["/root/conode", "-d", "2", "server"]

--- a/conode/Dockerfile-base
+++ b/conode/Dockerfile-base
@@ -1,0 +1,9 @@
+FROM debian:stretch-slim
+RUN apt update && apt install -y procps ca-certificates && apt clean
+WORKDIR /root/
+RUN mkdir /conode_data
+RUN mkdir -p .local/share .config
+RUN ln -s /conode_data .local/share/conode
+RUN ln -s /conode_data .config/conode
+
+EXPOSE 7770 7771

--- a/conode/Dockerfile-dev
+++ b/conode/Dockerfile-dev
@@ -1,13 +1,8 @@
-FROM debian:stretch-slim
-WORKDIR /root/
-RUN mkdir /conode_data
-RUN mkdir -p .local/share .config
-RUN ln -s /conode_data .local/share/conode
-RUN ln -s /conode_data .config/conode
-RUN apt update; apt install -y procps ca-certificates; apt clean
+ARG FROM
+
+FROM ${FROM}
+
 COPY run_nodes.sh .
 COPY exe/conode.Linux.x86_64 ./conode
-
-EXPOSE 7770 7771
 
 CMD ["./run_nodes.sh", "-n", "1"]

--- a/conode/Makefile
+++ b/conode/Makefile
@@ -15,15 +15,21 @@ ldflags=-s -w -X main.gitTag=$(TAG)
 
 all: docker
 
+.PHONY: docker-base
+docker-base: Dockerfile-base
+	docker build -t $(IMAGE_NAME)-base:latest -f Dockerfile-base .
+
 # Use this target to build from only published sources.
-docker: clean Dockerfile
+docker: clean Dockerfile docker-base
 	@[ -z "$(BUILD_TAG)" ] && echo "Must specify BUILD_TAG." && exit 1 || true
-	docker build -t $(IMAGE_NAME):$(BUILD_TAG) --build-arg BUILD_TAG="$(BUILD_TAG)" --build-arg ldflags="$(ldflags)" .
+	docker build -t $(IMAGE_NAME):$(BUILD_TAG) \
+		--build-arg BUILD_TAG="$(BUILD_TAG)" --build-arg ldflags="$(ldflags)" \
+		--build-arg FROM=$(IMAGE_NAME)-base:latest .
 	docker tag $(IMAGE_NAME):$(BUILD_TAG) $(IMAGE_NAME):dev
 
 # Use this target to build from local source instead of from publish sources.
-docker_dev: clean Dockerfile-dev verify exe/conode.Linux.x86_64
-	docker build -t $(IMAGE_NAME):$(TAG) -f Dockerfile-dev .
+docker_dev: clean Dockerfile-dev verify exe/conode.Linux.x86_64 docker-base
+	docker build -t $(IMAGE_NAME):$(TAG) -f Dockerfile-dev --build-arg FROM=$(IMAGE_NAME)-base:latest .
 	docker tag $(IMAGE_NAME):$(TAG) $(IMAGE_NAME):dev
 
 docker_push: docker


### PR DESCRIPTION
Based on #1976.

* use a `Dockerfile-base` containing the common code of `Dockerfile{,-dev}`
* `Dockerfile{,-dev}` depends on a new build arg, `FROM`, describing where to get the base image
* add phony Makefile target `docker-base` which ensure that the base image is build