### PR TITLE
Remove duplicate transactions

### DIFF
--- a/byzcoin/contract_name_test.go
+++ b/byzcoin/contract_name_test.go
@@ -66,7 +66,7 @@ func TestService_Naming(t *testing.T) {
 						},
 						{
 							Name:  "name",
-							Value: []byte("my genesis darc"),
+							Value: []byte("my genesis darc with bad signature"),
 						},
 					},
 				},
@@ -79,7 +79,7 @@ func TestService_Naming(t *testing.T) {
 	_, err = cl.AddTransactionAndWait(namingTx, 10)
 	require.Error(t, err)
 
-	// FAIL - use a use an instance that does not exist
+	// FAIL - use an instance that does not exist
 	namingTx = ClientTransaction{
 		Instructions: Instructions{
 			{

--- a/byzcoin/contracts/contract_deferred_test.go
+++ b/byzcoin/contracts/contract_deferred_test.go
@@ -2449,6 +2449,9 @@ func TestDeferred_ScenarioMultipleSigners(t *testing.T) {
 			Invoke: &byzcoin.Invoke{
 				ContractID: byzcoin.ContractDeferredID,
 				Command:    "execProposedTx",
+				// As the same transaction will be done again later, need to make sure that the
+				// double-transaction-remover accepts the correct transaction later.
+				Args: byzcoin.Arguments{{Name: "dummy", Value: nil}},
 			},
 			SignerCounter: []uint64{4},
 		}},

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -1384,7 +1384,7 @@ func (s *Service) updateTrieCallback(sbID skipchain.SkipBlockID) error {
 		return errors.New("couldn't unmarshal body")
 	}
 
-	log.Lvlf2("%s Updating transactions for %x on index %v", s.ServerIdentity(), sb.SkipChainID(), sb.Index)
+	log.Lvlf2("%s Updating %d transactions for %x on index %v", s.ServerIdentity(), len(body.TxResults), sb.SkipChainID(), sb.Index)
 	_, _, scs, _ := s.createStateChanges(st.MakeStagingStateTrie(), sb.SkipChainID(), body.TxResults, noTimeout)
 
 	log.Lvlf3("%s Storing index %d with %d state changes %v", s.ServerIdentity(), sb.Index, len(scs), scs.ShortStrings())

--- a/byzcoin/struct.go
+++ b/byzcoin/struct.go
@@ -657,7 +657,7 @@ func (c ChainConfig) checkNewRoster(newRoster onet.Roster) error {
 		return errors.New("new leader must be in previous roster")
 	}
 
-	// Check we don't change more than one one
+	// Check we don't change more than one node
 	added := 0
 	oldList := onet.NewRoster(c.Roster.List)
 	for _, si := range newRoster.List {

--- a/byzcoin/tx_pipeline.go
+++ b/byzcoin/tx_pipeline.go
@@ -339,13 +339,14 @@ func (p *txPipeline) processTxs(txChan <-chan ClientTransaction, initialState *t
 					log.Lvl3("stopping txs processor")
 					return
 				}
+				txh := tx.Instructions.Hash()
 				for _, txHash := range txHashes {
-					if bytes.Compare(txHash, tx.Instructions.Hash()) == 0 {
+					if bytes.Compare(txHash, txh) == 0 {
 						log.Lvl2("Got a duplicate transaction, ignoring it")
 						continue leaderLoop
 					}
 				}
-				txHashes = append(txHashes, tx.Instructions.Hash())
+				txHashes = append(txHashes, txh)
 				if len(txHashes) > maxTxHashes {
 					txHashes = txHashes[len(txHashes)-maxTxHashes:]
 				}

--- a/byzcoin/tx_pipeline.go
+++ b/byzcoin/tx_pipeline.go
@@ -1,6 +1,7 @@
 package byzcoin
 
 import (
+	"bytes"
 	"fmt"
 	"sync"
 	"time"
@@ -313,7 +314,9 @@ func (p *txPipeline) collectTx(stopChan chan bool) <-chan ClientTransaction {
 	return outChan
 }
 
-// processTxs consumes transactions and computes the
+var maxTxHashes = 1000
+
+// processTxs consumes transactions and computes the new txResults
 func (p *txPipeline) processTxs(txChan <-chan ClientTransaction, initialState *txProcessorState) {
 	var proposing bool
 	// always use the latest one when adding new
@@ -327,6 +330,8 @@ func (p *txPipeline) processTxs(txChan <-chan ClientTransaction, initialState *t
 		p.wg.Add(1)
 		defer p.wg.Done()
 		intervalChan := getInterval()
+		var txHashes [][]byte
+	leaderLoop:
 		for {
 			select {
 			case tx, ok := <-txChan:
@@ -334,6 +339,17 @@ func (p *txPipeline) processTxs(txChan <-chan ClientTransaction, initialState *t
 					log.Lvl3("stopping txs processor")
 					return
 				}
+				for _, txHash := range txHashes {
+					if bytes.Compare(txHash, tx.Instructions.Hash()) == 0 {
+						log.Lvl2("Got a duplicate transaction, ignoring it")
+						continue leaderLoop
+					}
+				}
+				txHashes = append(txHashes, tx.Instructions.Hash())
+				if len(txHashes) > maxTxHashes {
+					txHashes = txHashes[len(txHashes)-maxTxHashes:]
+				}
+
 				// when processing, we take the latest state
 				// (the last one) and then apply the new transaction to it
 				newStates, err := p.processor.ProcessTx(tx, currentState[len(currentState)-1])

--- a/external/java/src/main/java/ch/epfl/dedis/byzcoin/ByzCoinRPC.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzcoin/ByzCoinRPC.java
@@ -141,6 +141,7 @@ public class ByzCoinRPC {
      * @throws CothorityCommunicationException if the transaction has not been included within 'wait' blocks.
      */
     public ClientTransactionId sendTransactionAndWait(ClientTransaction t, int wait) throws CothorityCommunicationException {
+        logger.info("Sending transaction {} with hash {}", t.getInstructions().get(0).action(), t.getId());
         ByzCoinProto.AddTxRequest.Builder request =
                 ByzCoinProto.AddTxRequest.newBuilder();
         request.setVersion(currentVersion);

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/ByzCoinRPCTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/ByzCoinRPCTest.java
@@ -428,7 +428,9 @@ public class ByzCoinRPCTest {
         assertThrows(CothorityCommunicationException.class, () -> bc.setRoster(newRoster2, admins, counters.getCounters(), 10));
 
         // Too many changes
-        final Roster newRoster3 = new Roster(testInstanceController.getIdentities().subList(0, 6));
+        newList.subList(0, 3).addAll(testInstanceController.getIdentities().subList(4, 6));
+        logger.info(newList.toString());
+        final Roster newRoster3 = new Roster(newList);
         assertThrows(CothorityCommunicationException.class, () -> bc.setRoster(newRoster3, admins, counters.getCounters(), 10));
 
         // And finally some real update of the roster
@@ -456,6 +458,8 @@ public class ByzCoinRPCTest {
             bc.setMaxBlockSize(1000 * 1000, admins, counters.getCounters(), 20);
             counters.increment();
 
+            List<SkipBlock> updates = bc.getSkipchain().getUpdateChain();
+            int latest = updates.get(updates.size() - 1).getIndex();
             logger.info("shutting down two nodes and it should still run");
             try {
                 // here we kill only the 4th conode to avoid killing a subleader because we use a
@@ -472,8 +476,8 @@ public class ByzCoinRPCTest {
             assertEquals(7, bc.getRoster().getNodes().size());
 
             // Check that we can update to the latest block using the skipchain API after roster change.
-            List<SkipBlock> updates = bc.getSkipchain().getUpdateChain();
-            assertEquals(9, updates.get(updates.size() - 1).getIndex());
+            updates = bc.getSkipchain().getUpdateChain();
+            assertEquals(1, updates.get(updates.size() - 1).getIndex() - latest);
 
         } finally {
             logger.info("stopping conode for next tests");

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/NamingTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/NamingTest.java
@@ -51,14 +51,17 @@ public class NamingTest {
         // add the _name rule
         Darc newGenesis = bc.getGenesisDarc().partialCopy();
         newGenesis.setRule("_name:darc", newGenesis.getExpression("spawn:darc"));
+        logger.info("evolving darc");
         bc.getGenesisDarcInstance().evolveDarcAndWait(newGenesis, admin, counters.head(), 10);
 
         // create the naming instance
         counters.increment();
+        logger.info("new naming");
         NamingInstance namingInst = new NamingInstance(bc, genesisDarc.getId(), Collections.singletonList(admin), counters.getCounters());
 
         // set a name for the genesis darc
         counters.increment();
+        logger.info("name for genesis");
         namingInst.setAndWait("my genesis darc",
                 new InstanceId(bc.getGenesisDarc().getBaseId().getId()),
                 Collections.singletonList(admin),
@@ -71,6 +74,7 @@ public class NamingTest {
 
         // set it again and it should fail
         counters.increment();
+        logger.info("name again");
         assertThrows(CothorityException.class,
                 () -> namingInst.setAndWait("my genesis darc",
                         new InstanceId(bc.getGenesisDarc().getBaseId().getId()),
@@ -78,7 +82,21 @@ public class NamingTest {
                         counters.getCounters(),
                         10));
 
-        // remove the name (no need to increment because it failed previously)
+        // Because the current hashing of the ClientTransaction does not include the command,
+        // the removeAndWait will be interpreted as the same instruction as before and rejected.
+        // Insert a dummy instruction here.
+        //
+        // No need to increment because it failed previously)
+        logger.info("dummy name");
+        namingInst.setAndWait("my genesis darc 2",
+                new InstanceId(bc.getGenesisDarc().getBaseId().getId()),
+                Collections.singletonList(admin),
+                counters.getCounters(),
+                10);
+
+        // remove the name
+        logger.info("remove name");
+        counters.increment();
         namingInst.removeAndWait("my genesis darc",
                 new InstanceId(bc.getGenesisDarc().getBaseId().getId()),
                 Collections.singletonList(admin),
@@ -87,6 +105,7 @@ public class NamingTest {
 
         // remove the key again and it should fail
         counters.increment();
+        logger.info("remove key");
         assertThrows(CothorityException.class, () -> namingInst.removeAndWait("my genesis darc",
                 new InstanceId(bc.getGenesisDarc().getBaseId().getId()),
                 Collections.singletonList(admin),
@@ -94,6 +113,7 @@ public class NamingTest {
                 10));
 
         // try to get the name and it should fail
+        logger.info("get name");
         assertThrows(CothorityCommunicationException.class,
                 () -> bc.resolveInstanceID(bc.getGenesisDarc().getBaseId(), "my genesis darc"));
     }

--- a/external/java/src/test/java/ch/epfl/dedis/calypso/CalypsoTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/calypso/CalypsoTest.java
@@ -336,6 +336,9 @@ class CalypsoTest {
         readerDarc.addIdentity(Darc.RuleSignature, reader2.getIdentity(), Rules.OR);
         rd.evolveDarcAndWait(readerDarc, publisher, 2L, 10);
 
+        // Create a new ephemeral pair, so that the instruction will be different and not caught by
+        // the duplicate instruction handler.
+        ephemeralPair = new Ed25519Pair();
         ReadInstance ri = new ReadInstance(calypso, wi, Arrays.asList(reader2), Collections.singletonList(1L), ephemeralPair.point);
         byte[] keyMaterial = ri.decryptKeyMaterial(ephemeralPair.scalar);
         assertArrayEquals(doc.getKeyMaterial(), keyMaterial);


### PR DESCRIPTION
With the new use of the Client-calls, where the same
instruction is sent in parallel to more than one node,
it can happen that the same transaction is proposed
twice in the same block. This removes duplicate transactions
in same and directly following blocks.

Closes #1987 