### PR TITLE
Fix consistency issue if any

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -30,7 +30,7 @@ import (
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/protobuf"
-	bbolt "go.etcd.io/bbolt"
+	"go.etcd.io/bbolt"
 	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
@@ -2501,7 +2501,7 @@ func (s *Service) repairStateTrie(from *skipchain.SkipBlock, st *stateTrie) erro
 		_, _, scs, _ := s.createStateChanges(st.MakeStagingStateTrie(), from.SkipChainID(), body.TxResults, noTimeout)
 
 		// Update our global state using all state changes.
-		if st.GetIndex() + 1 != from.Index {
+		if st.GetIndex()+1 != from.Index {
 			return errors.New("unexpected index")
 		}
 		if err := st.VerifiedStoreAll(scs, from.Index, header.TrieRoot); err != nil {

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"go.dedis.ch/cothority/v3/byzcoin/trie"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/cothority/v3"
+	"go.dedis.ch/cothority/v3/byzcoin/trie"
 	"go.dedis.ch/cothority/v3/darc"
 	"go.dedis.ch/cothority/v3/darc/expression"
 	"go.dedis.ch/cothority/v3/skipchain"
@@ -2229,7 +2229,7 @@ func TestService_Repair(t *testing.T) {
 			require.NoError(t, err)
 
 			intermediateStateTrie = &stateTrie{*intermediateTrie}
-		} else if i == n - 1 {
+		} else if i == n-1 {
 			tmpTrie, err := s.service().getStateTrie(s.genesis.SkipChainID())
 			require.NoError(t, err)
 			finalRoot = tmpTrie.GetRoot()

--- a/byzcoin/statereplay.go
+++ b/byzcoin/statereplay.go
@@ -69,7 +69,7 @@ func (s *Service) ReplayState(id skipchain.SkipBlockID, ro *onet.Roster, cb Bloc
 			}
 
 			if sb.Index == 0 {
-				nonce, err := s.loadNonceFromTxs(dBody.TxResults)
+				nonce, err := loadNonceFromTxs(dBody.TxResults)
 				if err != nil {
 					return nil, replayError(sb, err.Error())
 				}

--- a/byzcoin/statetrie.go
+++ b/byzcoin/statetrie.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-
 	"go.dedis.ch/cothority/v3/byzcoin/trie"
 	"go.dedis.ch/cothority/v3/darc"
-	bbolt "go.etcd.io/bbolt"
+	"go.etcd.io/bbolt"
 )
 
 var errKeyNotSet = errors.New("key not set")


### PR DESCRIPTION
This commit implements a workaround for #1982. Instead of doing
transactions atomically, we detect consistency issues on startup and fix
it if possible.