### PR TITLE
Fix race condition in the repair test

### DIFF
--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -2238,12 +2238,16 @@ func TestService_Repair(t *testing.T) {
 
 	// Introduce an artificial corruption and then try to repair it.
 	genesisHex := fmt.Sprintf("%x", s.genesis.SkipChainID())
+	s.service().stateTriesLock.Lock()
 	s.service().stateTries[genesisHex] = intermediateStateTrie
+	s.service().stateTriesLock.Unlock()
 
-	err := s.service().fixInconsistencyIfAny(s.genesis.SkipChainID(), s.service().stateTries[genesisHex])
+	err := s.service().fixInconsistencyIfAny(s.genesis.SkipChainID(), intermediateStateTrie)
 	require.NoError(t, err)
 
+	s.service().stateTriesLock.Lock()
 	newRoot := s.service().stateTries[genesisHex].GetRoot()
+	s.service().stateTriesLock.Unlock()
 	require.Equal(t, finalRoot, newRoot)
 }
 


### PR DESCRIPTION
The race condition is caused by using the internal stateTries map in the
test. Which is fixed by using the appropriate locks in the test.