### PR TITLE
Resolve name from the naming instance

### DIFF
--- a/external/java/src/main/java/ch/epfl/dedis/byzcoin/contracts/NamingInstance.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzcoin/contracts/NamingInstance.java
@@ -126,6 +126,18 @@ public class NamingInstance {
         bc.sendTransactionAndWait(makeRemoveTx(instanceName, iID, signers, signerCtrs), wait);
     }
 
+    /**
+     * Resolves a previously named instance ID from a darc ID and a name.
+     *
+     * @param dID  is the darc ID that guards the instance.
+     * @param name is the name given to the instance when it was named.
+     * @return the instance ID.
+     * @throws CothorityCommunicationException if the name does not exist or other failures.
+     */
+    public InstanceId resolve(DarcId dID, String name) throws CothorityCommunicationException {
+        return bc.resolveInstanceID(dID, name);
+    }
+
     private NamingInstance(ByzCoinRPC bc, Instance instance) throws CothorityNotFoundException {
         if (!instance.getContractId().equals(ContractId)) {
             logger.error("wrong contractId: {}", instance.getContractId());

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/NamingTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/NamingTest.java
@@ -44,7 +44,7 @@ public class NamingTest {
      * Name resolution tests only contains functional tests, more rigorous testing is in the go side.
      */
     @Test
-    void resolveInstanceID() throws Exception {
+    void nameResolution() throws Exception {
         SignerCounters counters = bc.getSignerCounters(Collections.singletonList(admin.getIdentity().toString()));
         counters.increment();
 
@@ -66,8 +66,8 @@ public class NamingTest {
                 10);
 
         // try to get the name back
-        InstanceId iID = bc.resolveInstanceID(bc.getGenesisDarc().getBaseId(), "my genesis darc");
-        assertTrue(iID.equals(new InstanceId(bc.getGenesisDarc().getBaseId().getId())));
+        InstanceId iID = namingInst.resolve(bc.getGenesisDarc().getBaseId(), "my genesis darc");
+        assertEquals(iID, new InstanceId(bc.getGenesisDarc().getBaseId().getId()));
 
         // set it again and it should fail
         counters.increment();
@@ -95,7 +95,7 @@ public class NamingTest {
 
         // try to get the name and it should fail
         assertThrows(CothorityCommunicationException.class,
-                () -> bc.resolveInstanceID(bc.getGenesisDarc().getBaseId(), "my genesis darc"));
+                () -> namingInst.resolve(bc.getGenesisDarc().getBaseId(), "my genesis darc"));
     }
 
 }


### PR DESCRIPTION
It's more convenient to have the set and the resolution in the same
class. This is also consistent with EventLogInstance.