### PR TITLE
Changes a log.Lvl2 to log.Lvl3

### DIFF
--- a/byzcoin/collect_tx.go
+++ b/byzcoin/collect_tx.go
@@ -138,7 +138,7 @@ func (p *CollectTxProtocol) Dispatch() error {
 	resp := &CollectTxResponse{
 		Txs: p.getTxs(req.ServerIdentity, p.Roster(), req.SkipchainID, req.LatestID, maxOut),
 	}
-	log.Lvl2(p.ServerIdentity(), "sends back", len(resp.Txs), "transactions")
+	log.Lvl3(p.ServerIdentity(), "sends back", len(resp.Txs), "transactions")
 	if p.IsRoot() {
 		if err := p.SendTo(p.TreeNode(), resp); err != nil {
 			return err


### PR DESCRIPTION
This log prints a lot of information while the client does nothing.
In my opinion log =< 2 should not print anything if the client doesn't interact with the system.

If this log is valuable but there is already too much things printed at log level 3, then we should move some stuff from log level 3 to log level 4.