### PR TITLE
Adding ClientTransaction.Hash

### DIFF
--- a/byzcoin/contract_name_test.go
+++ b/byzcoin/contract_name_test.go
@@ -66,7 +66,7 @@ func TestService_Naming(t *testing.T) {
 						},
 						{
 							Name:  "name",
-							Value: []byte("my genesis darc with bad signature"),
+							Value: []byte("my genesis darc"),
 						},
 					},
 				},

--- a/byzcoin/contracts/contract_deferred_test.go
+++ b/byzcoin/contracts/contract_deferred_test.go
@@ -2449,9 +2449,6 @@ func TestDeferred_ScenarioMultipleSigners(t *testing.T) {
 			Invoke: &byzcoin.Invoke{
 				ContractID: byzcoin.ContractDeferredID,
 				Command:    "execProposedTx",
-				// As the same transaction will be done again later, need to make sure that the
-				// double-transaction-remover accepts the correct transaction later.
-				Args: byzcoin.Arguments{{Name: "dummy", Value: nil}},
 			},
 			SignerCounter: []uint64{4},
 		}},

--- a/byzcoin/transaction.go
+++ b/byzcoin/transaction.go
@@ -90,6 +90,20 @@ func (args Arguments) Names() []string {
 	return names
 }
 
+// Hash calculates the hash over all instructions and their signatures.
+// This creates a unique hash with regard to two sets of instructions
+// that only differ with their signature.
+func (ctx *ClientTransaction) Hash() []byte {
+	h := sha256.New()
+	for _, inst := range ctx.Instructions {
+		h.Write(inst.Hash())
+		for _, sig := range inst.Signatures {
+			h.Write(sig)
+		}
+	}
+	return h.Sum(nil)
+}
+
 // FillSignersAndSignWith fills the SignerIdentities field with the identities of the signers and then signs all the
 // instructions using the same set of  signers. If some instructions need to be signed by different sets of signers,
 // then use the SignWith method of Instruction.

--- a/byzcoin/transaction.go
+++ b/byzcoin/transaction.go
@@ -90,20 +90,6 @@ func (args Arguments) Names() []string {
 	return names
 }
 
-// Hash calculates the hash over all instructions and their signatures.
-// This creates a unique hash with regard to two sets of instructions
-// that only differ with their signature.
-func (ctx *ClientTransaction) Hash() []byte {
-	h := sha256.New()
-	for _, inst := range ctx.Instructions {
-		h.Write(inst.Hash())
-		for _, sig := range inst.Signatures {
-			h.Write(sig)
-		}
-	}
-	return h.Sum(nil)
-}
-
 // FillSignersAndSignWith fills the SignerIdentities field with the identities of the signers and then signs all the
 // instructions using the same set of  signers. If some instructions need to be signed by different sets of signers,
 // then use the SignWith method of Instruction.
@@ -419,6 +405,20 @@ func (instrs Instructions) Hash() []byte {
 	h := sha256.New()
 	for _, instr := range instrs {
 		h.Write(instr.Hash())
+	}
+	return h.Sum(nil)
+}
+
+// HashWithSignatures calculates the hash over all instructions and their signatures.
+// This creates a unique hash with regard to two sets of instructions
+// that only differ with their signature.
+func (instrs Instructions) HashWithSignatures() []byte {
+	h := sha256.New()
+	for _, inst := range instrs {
+		h.Write(inst.Hash())
+		for _, sig := range inst.Signatures {
+			h.Write(sig)
+		}
 	}
 	return h.Sum(nil)
 }

--- a/byzcoin/tx_pipeline.go
+++ b/byzcoin/tx_pipeline.go
@@ -340,7 +340,7 @@ func (p *txPipeline) processTxs(txChan <-chan ClientTransaction, initialState *t
 					log.Lvl3("stopping txs processor")
 					return
 				}
-				txh := tx.Hash()
+				txh := tx.Instructions.HashWithSignatures()
 				for _, txHash := range txHashes {
 					if bytes.Compare(txHash, txh) == 0 {
 						log.Lvl2("Got a duplicate transaction, ignoring it")

--- a/byzcoin/tx_pipeline.go
+++ b/byzcoin/tx_pipeline.go
@@ -340,7 +340,7 @@ func (p *txPipeline) processTxs(txChan <-chan ClientTransaction, initialState *t
 					log.Lvl3("stopping txs processor")
 					return
 				}
-				txh := tx.Instructions.Hash()
+				txh := tx.Hash()
 				for _, txHash := range txHashes {
 					if bytes.Compare(txHash, txh) == 0 {
 						log.Lvl2("Got a duplicate transaction, ignoring it")

--- a/external/java/src/main/java/ch/epfl/dedis/byzcoin/ByzCoinRPC.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzcoin/ByzCoinRPC.java
@@ -141,7 +141,6 @@ public class ByzCoinRPC {
      * @throws CothorityCommunicationException if the transaction has not been included within 'wait' blocks.
      */
     public ClientTransactionId sendTransactionAndWait(ClientTransaction t, int wait) throws CothorityCommunicationException {
-        logger.info("Sending transaction {} with hash {}", t.getInstructions().get(0).action(), t.getId());
         ByzCoinProto.AddTxRequest.Builder request =
                 ByzCoinProto.AddTxRequest.newBuilder();
         request.setVersion(currentVersion);

--- a/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/NamingTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/byzcoin/contracts/NamingTest.java
@@ -82,21 +82,9 @@ public class NamingTest {
                         counters.getCounters(),
                         10));
 
-        // Because the current hashing of the ClientTransaction does not include the command,
-        // the removeAndWait will be interpreted as the same instruction as before and rejected.
-        // Insert a dummy instruction here.
-        //
-        // No need to increment because it failed previously)
-        logger.info("dummy name");
-        namingInst.setAndWait("my genesis darc 2",
-                new InstanceId(bc.getGenesisDarc().getBaseId().getId()),
-                Collections.singletonList(admin),
-                counters.getCounters(),
-                10);
-
         // remove the name
+        // No need to increment because it failed previously)
         logger.info("remove name");
-        counters.increment();
         namingInst.removeAndWait("my genesis darc",
                 new InstanceId(bc.getGenesisDarc().getBaseId().getId()),
                 Collections.singletonList(admin),

--- a/external/java/src/test/java/ch/epfl/dedis/calypso/CalypsoTest.java
+++ b/external/java/src/test/java/ch/epfl/dedis/calypso/CalypsoTest.java
@@ -336,9 +336,6 @@ class CalypsoTest {
         readerDarc.addIdentity(Darc.RuleSignature, reader2.getIdentity(), Rules.OR);
         rd.evolveDarcAndWait(readerDarc, publisher, 2L, 10);
 
-        // Create a new ephemeral pair, so that the instruction will be different and not caught by
-        // the duplicate instruction handler.
-        ephemeralPair = new Ed25519Pair();
         ReadInstance ri = new ReadInstance(calypso, wi, Arrays.asList(reader2), Collections.singletonList(1L), ephemeralPair.point);
         byte[] keyMaterial = ri.decryptKeyMaterial(ephemeralPair.scalar);
         assertArrayEquals(doc.getKeyMaterial(), keyMaterial);


### PR DESCRIPTION
The detection of duplicate transactions makes it difficult to test
in the case where you want to prove that
1. the transaction doesn't go through
2. something changes (darc gets updated)
3. the same transaction as in 1 goes through

Using ClientTransaction.Hash, the same transaction can be re-submitted
after a new signature.

Also reverts patches to tests that didn't work with the old duplicate transaction detection.

This _should_ be backwards-compatible, as the test is only done in the leader. So if different version of conodes are available, it might be that sometimes given transactions are rejected as being doubles, and sometimes not...