### PR TITLE
Implement StoreAllToReplica

### DIFF
--- a/byzcoin/contracts/coins_test.go
+++ b/byzcoin/contracts/coins_test.go
@@ -321,6 +321,10 @@ func (ct cvTest) GetNonce() ([]byte, error) {
 	return nil, errors.New("not implemented")
 }
 
+func (ct cvTest) StoreAllToReplica(scs byzcoin.StateChanges) (byzcoin.ReadOnlyStateTrie, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (ct cvTest) setSignatureCounter(id string, v uint64) {
 	key := sha256.Sum256([]byte("signercounter_" + id))
 	verBuf := make([]byte, 8)

--- a/byzcoin/statetrie.go
+++ b/byzcoin/statetrie.go
@@ -95,10 +95,12 @@ func (t *stagingStateTrie) GetIndex() int {
 	return int(index)
 }
 
+// StoreAllToReplica creates a copy of the read-only trie and applies the state
+// changes to the copy.
 func (t *stagingStateTrie) StoreAllToReplica(scs StateChanges) (ReadOnlyStateTrie, error) {
 	newTrie := t.Clone()
 	if err := newTrie.StoreAll(scs); err != nil {
-		return nil, err
+		return nil, errors.New("replica failed to store state changes: " + err.Error())
 	}
 	return newTrie, nil
 }
@@ -217,6 +219,10 @@ func (t *stateTrie) MakeStagingStateTrie() *stagingStateTrie {
 	}
 }
 
+// StoreAllToReplica is not supported. It cannot be implemented in an immutable
+// way because writing state changes to the replica will change the underlying
+// trie since the receiver is not a stagingStateTrie. Convert it to a
+// stagingStateTrie and then use StoreAllToReplica.
 func (t *stateTrie) StoreAllToReplica(scs StateChanges) (ReadOnlyStateTrie, error) {
 	return nil, errors.New("unsupported operation")
 }

--- a/byzcoin/statetrie.go
+++ b/byzcoin/statetrie.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+
 	"go.dedis.ch/cothority/v3/byzcoin/trie"
 	"go.dedis.ch/cothority/v3/darc"
 	"go.etcd.io/bbolt"
@@ -25,6 +26,10 @@ type ReadOnlyStateTrie interface {
 	// ForEach calls the callback function on every key/value pair in the
 	// trie, which does not include the metadata.
 	ForEach(func(k, v []byte) error) error
+	// StoreAllToReplica creates a copy of the read-only trie and applies
+	// the state changes to the copy. The implementation should make sure
+	// that the original read-only trie is not be modified.
+	StoreAllToReplica(StateChanges) (ReadOnlyStateTrie, error)
 }
 
 // stagingStateTrie is a wrapper around trie.StagingTrie that allows for use in
@@ -88,6 +93,14 @@ func (t *stagingStateTrie) Commit() error {
 func (t *stagingStateTrie) GetIndex() int {
 	index := binary.LittleEndian.Uint32(t.StagingTrie.GetMetadata([]byte(trieIndexKey)))
 	return int(index)
+}
+
+func (t *stagingStateTrie) StoreAllToReplica(scs StateChanges) (ReadOnlyStateTrie, error) {
+	newTrie := t.Clone()
+	if err := newTrie.StoreAll(scs); err != nil {
+		return nil, err
+	}
+	return newTrie, nil
 }
 
 const trieIndexKey = "trieIndexKey"
@@ -202,6 +215,10 @@ func (t *stateTrie) MakeStagingStateTrie() *stagingStateTrie {
 	return &stagingStateTrie{
 		StagingTrie: *t.MakeStagingTrie(),
 	}
+}
+
+func (t *stateTrie) StoreAllToReplica(scs StateChanges) (ReadOnlyStateTrie, error) {
+	return nil, errors.New("unsupported operation")
 }
 
 // newMemStagingStateTrie creates an in-memory StagingStateTrie.

--- a/personhood/contract_test.go
+++ b/personhood/contract_test.go
@@ -168,3 +168,6 @@ func (s *rstSimul) GetNonce() ([]byte, error) {
 func (s *rstSimul) ForEach(func(k, v []byte) error) error {
 	return errors.New("not implemented")
 }
+func (s *rstSimul) StoreAllToReplica(scs byzcoin.StateChanges) (byzcoin.ReadOnlyStateTrie, error) {
+	return nil, errors.New("not implemented")
+}


### PR DESCRIPTION
Doing ForEach in the deferred contract might become expensive when the
state grows big. So we introduce StoreAllToReplica that makes a
"lightweight" copy of the trie and then applies the state changes. It
still makes copies of key/values but only those that are waiting to be
committed to a new block.

Closes #1938