### PR TITLE
Use "matchOK" in favour of "testGrep"

### DIFF
--- a/byzcoin/bcadmin/clicontracts/config.go
+++ b/byzcoin/bcadmin/clicontracts/config.go
@@ -164,7 +164,7 @@ func ConfigInvokeUpdateConfig(c *cli.Context) error {
 
 	newInstID := ctx.Instructions[0].DeriveID("").Slice()
 	log.Infof("Config contract updated! (instance ID is %x)", newInstID)
-	log.Infof("Here is the config data: \n%s", contractConfig)
+	log.Infof("Here is the config data:\n%s", contractConfig)
 
 	return nil
 }
@@ -198,7 +198,7 @@ func ConfigGet(c *cli.Context) error {
 		return errors.New("couldn't decode chainConfig: " + err.Error())
 	}
 
-	log.Infof("Here is the config data: \n%s", config)
+	log.Infof("Here is the config data:\n%s", config)
 
 	return nil
 }

--- a/byzcoin/bcadmin/clicontracts/config_test.sh
+++ b/byzcoin/bcadmin/clicontracts/config_test.sh
@@ -18,14 +18,14 @@ testContractConfigInvoke() {
     # config.
     OUTRES=`runBA0 contract config invoke updateConfig`
 
-    testGrep "Config contract updated! \(instance ID is [a-f0-9]+\)" echo "$OUTRES"
-    testGrep "Here is the config data:" echo "$OUTRES"
-    testGrep "ChainConfig" echo "$OUTRES"
-    testGrep "\- BlockInterval: [a-z0-9]+" echo "$OUTRES"
-    testGrep "\- Roster: \{.*\}" echo "$OUTRES"
-    testGrep "\- MaxBlockSize: [0-9]+" echo "$OUTRES"
-    testGrep "\- DarcContractIDs:" echo "$OUTRES"
-    testGrep "\-\- darc contract ID 0: darc" echo "$OUTRES"
+    matchOK "$OUTRES" "^Config contract updated! \(instance ID is [a-f0-9]{64}\)
+Here is the config data:
+- ChainConfig:
+-- BlockInterval: [a-z0-9]+
+-- Roster: \{.*\}
+-- MaxBlockSize: [0-9]+
+-- DarcContractIDs:
+--- darc contract ID 0: darc$"
 
     # Update all the arguments. We check if the return corresponds.
     OUTRES=`runBA0 contract config invoke updateConfig\
@@ -33,16 +33,17 @@ testContractConfigInvoke() {
                 --maxBlockSize 5000000\
                 --darcContractIDs darc,darc2,darc3`
     
-    testGrep "Config contract updated! \(instance ID is [a-f0-9]+\)" echo "$OUTRES"
-    testGrep "Here is the config data:" echo "$OUTRES"
-    testGrep "ChainConfig" echo "$OUTRES"
-    testGrep "\- BlockInterval: 7s" echo "$OUTRES"
-    testGrep "\- Roster: \{.*\}" echo "$OUTRES"
-    testGrep "\- MaxBlockSize: 5000000" echo "$OUTRES"
-    testGrep "\- DarcContractIDs:" echo "$OUTRES"
-    testGrep "\-\- darc contract ID 0: darc" echo "$OUTRES"
-    testGrep "\-\- darc contract ID 1: darc2" echo "$OUTRES"
-    testGrep "\-\- darc contract ID 2: darc3" echo "$OUTRES"
+    matchOK "$OUTRES" "^Config contract updated! \(instance ID is [a-f0-9]{64}\)
+Here is the config data:
+- ChainConfig:
+-- BlockInterval: 7s
+-- Roster: \{.*\}
+-- MaxBlockSize: 5000000
+-- DarcContractIDs:
+--- darc contract ID 0: darc
+--- darc contract ID 1: darc2
+--- darc contract ID 2: darc3$"
+
 }
 
 # In this test we simply get the config contract and check the result.
@@ -55,12 +56,11 @@ testContractConfigGet() {
     # Get the config instance
     OUTRES=`runBA0 contract config get`
 
-    # Check the result
-    testGrep "Here is the config data:" echo "$OUTRES"
-    testGrep "ChainConfig" echo "$OUTRES"
-    testGrep "\- BlockInterval: [a-z0-9]+" echo "$OUTRES"
-    testGrep "\- Roster: \{.*\}" echo "$OUTRES"
-    testGrep "\- MaxBlockSize: [0-9]+" echo "$OUTRES"
-    testGrep "\- DarcContractIDs:" echo "$OUTRES"
-    testGrep "\-\- darc contract ID 0: darc" echo "$OUTRES"
+    matchOK "$OUTRES" "^Here is the config data:
+- ChainConfig:
+-- BlockInterval: [a-z0-9]+
+-- Roster: \{.*\}
+-- MaxBlockSize: [0-9]+
+-- DarcContractIDs:
+--- darc contract ID 0: darc$"
 }

--- a/byzcoin/bcadmin/clicontracts/deferred.go
+++ b/byzcoin/bcadmin/clicontracts/deferred.go
@@ -110,7 +110,7 @@ func DeferredSpawn(c *cli.Context) error {
 	}
 
 	instID := ctx.Instructions[0].DeriveID("").Slice()
-	log.Infof("Spawned new deferred contract, its instance id is: \n%x", instID)
+	log.Infof("Spawned a new deferred contract. Its instance id is:\n%x", instID)
 
 	// ---
 	// 3.
@@ -131,7 +131,7 @@ func DeferredSpawn(c *cli.Context) error {
 		return errors.New("couldn't decode the result: " + err.Error())
 	}
 
-	log.Infof("Here is the deferred data: \n%s", result)
+	log.Infof("Here is the deferred data:\n%s", result)
 
 	return lib.WaitPropagation(c, cl)
 }

--- a/byzcoin/bcadmin/clicontracts/value.go
+++ b/byzcoin/bcadmin/clicontracts/value.go
@@ -90,7 +90,7 @@ func ValueSpawn(c *cli.Context) error {
 	}
 
 	instID := ctx.Instructions[0].DeriveID("").Slice()
-	log.Infof("Spawned new value contract. Instance id is:\n%x", instID)
+	log.Infof("Spawned a new value contract. Its instance id is:\n%x", instID)
 
 	return lib.WaitPropagation(c, cl)
 }

--- a/byzcoin/bcadmin/clicontracts/value_test.sh
+++ b/byzcoin/bcadmin/clicontracts/value_test.sh
@@ -26,10 +26,12 @@ testValueSpawn() {
     OUTRES=`runBA0 contract value spawn --value "myValue" --darc "$ID" --sign "$KEY"`
 
     # Check if we got the expected output
-    testGrep "Spawned new value contract. Instance id is:" echo "$OUTRES"
+    matchOK "$OUTRES" "^Spawned a new value contract. Its instance id is:
+[0-9a-f]{64}$"
 
     # Extract the instance ID of the newly created value instance
-    VALUE_INSTANCE_ID=$( echo "$OUTRES" | grep -A 1 "Instance id" | sed -n 2p )
+    VALUE_INSTANCE_ID=$( echo "$OUTRES" | grep -A 1 "instance id" | sed -n 2p )
+    matchOK "$VALUE_INSTANCE_ID" ^[0-9a-f]{64}$
 
     # Update the value instance based on the instance ID
     testOK runBA contract value invoke update --value "newValue" --instid $VALUE_INSTANCE_ID --darc "$ID" --sign "$KEY"
@@ -119,10 +121,12 @@ testValueGet() {
     OUTRES=`runBA0 contract value spawn --value "myValue" --darc "$ID" --sign "$KEY"`
 
     # Check if we got the expected output
-    testGrep "Spawned new value contract. Instance id is:" echo "$OUTRES"
+    matchOK "$OUTRES" "^Spawned a new value contract. Its instance id is:
+[0-9a-f]{64}$"
 
     # Extract the instance ID of the newly created value instance
-    VALUE_INSTANCE_ID=$( echo "$OUTRES" | grep -A 1 "Instance id" | sed -n 2p )
+    VALUE_INSTANCE_ID=$( echo "$OUTRES" | grep -A 1 "instance id" | sed -n 2p )
+    matchOK "$VALUE_INSTANCE_ID" ^[0-9a-f]{64}$
 
     # Use the "get" function and save the output to the OUTPUT variable
     OUTRES=`runBA0 contract value get --instid "$VALUE_INSTANCE_ID"`
@@ -160,10 +164,12 @@ testValueDel() {
     OUTRES=`runBA0 contract value spawn --value "myValue" --darc "$ID" --sign "$KEY"`
 
     # Check if we got the expected output
-    testGrep "Spawned new value contract. Instance id is:" echo "$OUTRES"
+    matchOK "$OUTRES" "^Spawned a new value contract. Its instance id is:
+[0-9a-f]{64}$"
 
     # Extract the instance ID of the newly created value instance
-    VALUE_INSTANCE_ID=$( echo "$OUTRES" | grep -A 1 "Instance id" | sed -n 2p )
+    VALUE_INSTANCE_ID=$( echo "$OUTRES" | grep -A 1 "instance id" | sed -n 2p )
+    matchOK "$VALUE_INSTANCE_ID" ^[0-9a-f]{64}$
 
     # Use the "get" function to retrieve the contract. It should pass.
     testOK runBA contract value get --instid "$VALUE_INSTANCE_ID"

--- a/byzcoin/contract_deferred.go
+++ b/byzcoin/contract_deferred.go
@@ -59,7 +59,7 @@ func (dd DeferredData) String() string {
 		out.WriteString(eachLine.ReplaceAllString(inst.String(), "--$1"))
 	}
 	fmt.Fprintf(out, "- Expire Block Index: %d\n", dd.ExpireBlockIndex)
-	fmt.Fprint(out, "- Instruction hashes: \n")
+	fmt.Fprint(out, "- Instruction hashes:\n")
 	for i, hash := range dd.InstructionHashes {
 		fmt.Fprintf(out, "-- hash %d:\n", i)
 		fmt.Fprintf(out, "--- %x\n", hash)

--- a/calypso/csadmin/clicontracts/lts_test.sh
+++ b/calypso/csadmin/clicontracts/lts_test.sh
@@ -14,8 +14,9 @@ testContractLTSInvoke() {
     eval $SED
     [ -z "$BC" ] && exit 1
 
-    testGrep "Spawned a new LTS contract. Its instance id is:
-[0-9a-f]{64}$" runCA contract lts spawn
+    OUTRES=`runCA0 contract lts spawn`
+    matchOK "$OUTRES" "^Spawned a new LTS contract. Its instance id is:
+[0-9a-f]{64}$" 
 
     # Create a DARC
     testOK runBA darc add -out_id ./darc_id.txt -out_key ./darc_key.txt -unrestricted
@@ -39,9 +40,11 @@ testContractLTSInvoke() {
     testOK runBA darc rule -rule "spawn:longTermSecret" --identity "$KEY" --darc "$ID" --sign "$KEY"
     testOK runCA contract lts spawn --darc "$ID" --sign "$KEY"
 
-    testGrep "Spawned a new LTS contract. Its instance id is:
-[0-9a-f]{64}$" runCA contract lts spawn --darc "$ID" --sign "$KEY"
+    OUTRES=`runCA0 contract lts spawn --darc "$ID" --sign "$KEY"`
+    matchOK "$OUTRES" "^Spawned a new LTS contract. Its instance id is:
+[0-9a-f]{64}$" 
 
     # Check the export option
-    testGrep "[0-9a-f]{64}" runCA contract lts spawn --darc "$ID" --sign "$KEY" -x
+    runCA0 contract lts spawn --darc "$ID" --sign "$KEY" -x > iid.txt
+    matchOK "`cat iid.txt`" ^[0-9a-f]{64}$
 }

--- a/calypso/csadmin/clicontracts/read_test.sh
+++ b/calypso/csadmin/clicontracts/read_test.sh
@@ -49,8 +49,8 @@ testContractReadInvoke() {
 
     OUTRES=`runCA0 contract read spawn --sign $KEY --instid $WRITE_ID`
 
-    matchOK "$OUTRES" "Spawned a new read instance. Its instance id is:
-[0-9a-f]{32}"
+    matchOK "$OUTRES" "^Spawned a new read instance. Its instance id is:
+[0-9a-f]{64}$"
 
     # Check the export option
     runCA0 contract read spawn --sign $KEY --instid $WRITE_ID -x > iid.txt

--- a/calypso/csadmin/clicontracts/write_test.sh
+++ b/calypso/csadmin/clicontracts/write_test.sh
@@ -44,8 +44,8 @@ testContractWriteInvoke() {
     
     OUTRES=`runCA0 contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY"`
 
-    matchOK "$OUTRES" "Spawned a new write instance. Its instance id is:
-[0-9a-f]{32}"
+    matchOK "$OUTRES" "^Spawned a new write instance. Its instance id is:
+[0-9a-f]{64}$"
 
     # We check only that commands exits correctly. The content should be checked
     # by a `csadmin contract write get` function.


### PR DESCRIPTION
Using `matchOK` performs an exact match contrary to `testGrep`. It should improves the robustness of the tests.
Fixes #2015 