### PR TITLE
Leader detects when to upgrade the byzcoin protocol version

### DIFF
--- a/byzcoin/collect_tx.go
+++ b/byzcoin/collect_tx.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"go.dedis.ch/cothority/v3/byzcoinx"
 	"go.dedis.ch/cothority/v3/skipchain"
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
@@ -21,16 +22,17 @@ func init() {
 // CollectTxProtocol is a protocol for collecting pending transactions.
 type CollectTxProtocol struct {
 	*onet.TreeNodeInstance
-	TxsChan      chan []ClientTransaction
-	SkipchainID  skipchain.SkipBlockID
-	LatestID     skipchain.SkipBlockID
-	MaxNumTxs    int
-	requestChan  chan structCollectTxRequest
-	responseChan chan structCollectTxResponse
-	getTxs       getTxsCallback
-	Finish       chan bool
-	closing      chan bool
-	version      int
+	TxsChan           chan []ClientTransaction
+	CommonVersionChan chan Version
+	SkipchainID       skipchain.SkipBlockID
+	LatestID          skipchain.SkipBlockID
+	MaxNumTxs         int
+	requestChan       chan structCollectTxRequest
+	responseChan      chan structCollectTxResponse
+	getTxs            getTxsCallback
+	Finish            chan bool
+	closing           chan bool
+	version           int
 }
 
 // CollectTxRequest is the request message that asks the receiver to send their
@@ -45,7 +47,8 @@ type CollectTxRequest struct {
 // CollectTxResponse is the response message that contains all the pending
 // transactions on the node.
 type CollectTxResponse struct {
-	Txs []ClientTransaction
+	Txs            []ClientTransaction
+	ByzcoinVersion Version
 }
 
 type structCollectTxRequest struct {
@@ -66,12 +69,13 @@ func NewCollectTxProtocol(getTxs getTxsCallback) func(*onet.TreeNodeInstance) (o
 			// If we do not buffer this channel then the protocol
 			// might be blocked from stopping when the receiver
 			// stops reading from this channel.
-			TxsChan:   make(chan []ClientTransaction, len(node.List())),
-			MaxNumTxs: defaultMaxNumTxs,
-			getTxs:    getTxs,
-			Finish:    make(chan bool),
-			closing:   make(chan bool),
-			version:   1,
+			TxsChan:           make(chan []ClientTransaction, len(node.List())),
+			CommonVersionChan: make(chan Version, len(node.List())),
+			MaxNumTxs:         defaultMaxNumTxs,
+			getTxs:            getTxs,
+			Finish:            make(chan bool),
+			closing:           make(chan bool),
+			version:           1,
 		}
 		if err := node.RegisterChannels(&c.requestChan, &c.responseChan); err != nil {
 			return c, err
@@ -136,7 +140,8 @@ func (p *CollectTxProtocol) Dispatch() error {
 
 	// send the result of the callback to the root
 	resp := &CollectTxResponse{
-		Txs: p.getTxs(req.ServerIdentity, p.Roster(), req.SkipchainID, req.LatestID, maxOut),
+		Txs:            p.getTxs(req.ServerIdentity, p.Roster(), req.SkipchainID, req.LatestID, maxOut),
+		ByzcoinVersion: p.getByzcoinVersion(),
 	}
 	log.Lvl3(p.ServerIdentity(), "sends back", len(resp.Txs), "transactions")
 	if p.IsRoot() {
@@ -152,9 +157,16 @@ func (p *CollectTxProtocol) Dispatch() error {
 	// wait for the results to come back and write to the channel
 	defer close(p.TxsChan)
 	if p.IsRoot() {
+		vb := newVersionBuffer(len(p.Children()) + 1)
+
+		leaderVersion := p.getByzcoinVersion()
+		vb.add(p.ServerIdentity(), leaderVersion)
+
 		for range p.List() {
 			select {
 			case resp := <-p.responseChan:
+				vb.add(resp.ServerIdentity, resp.ByzcoinVersion)
+
 				// If more than the limit is sent, we simply drop all of them
 				// as the conode is not behaving correctly.
 				if p.version == 0 || len(resp.Txs) <= p.MaxNumTxs {
@@ -165,6 +177,10 @@ func (p *CollectTxProtocol) Dispatch() error {
 			case <-p.closing:
 				return nil
 			}
+
+			if vb.hasThresholdFor(leaderVersion) {
+				p.CommonVersionChan <- leaderVersion
+			}
 		}
 	}
 	return nil
@@ -174,4 +190,48 @@ func (p *CollectTxProtocol) Dispatch() error {
 func (p *CollectTxProtocol) Shutdown() error {
 	close(p.closing)
 	return nil
+}
+
+func (p *CollectTxProtocol) getByzcoinVersion() Version {
+	srv := p.Host().Service(ServiceName)
+	if srv == nil {
+		panic("Byzcoin should always be available as a service for this protocol")
+	}
+
+	return srv.(*Service).GetProtocolVersion()
+}
+
+type versionBuffer struct {
+	versions   map[Version]int
+	identities map[network.ServerIdentityID]bool
+	threshold  int
+}
+
+func newVersionBuffer(n int) versionBuffer {
+	return versionBuffer{
+		versions:   make(map[Version]int),
+		identities: make(map[network.ServerIdentityID]bool),
+		threshold:  byzcoinx.Threshold(n),
+	}
+}
+
+func (vb versionBuffer) add(si *network.ServerIdentity, v Version) {
+	if vb.identities[si.ID] {
+		// Make sure a malicious conode cannot send multiple version
+		// upgrade request.
+		return
+	}
+	vb.identities[si.ID] = true
+	vb.versions[v]++
+}
+
+func (vb versionBuffer) hasThresholdFor(version Version) bool {
+	sum := 0
+	for k, v := range vb.versions {
+		if k >= version {
+			sum += v
+		}
+	}
+
+	return sum >= vb.threshold
 }

--- a/byzcoin/collect_tx_test.go
+++ b/byzcoin/collect_tx_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/cothority/v3"
 	"go.dedis.ch/cothority/v3/skipchain"
@@ -89,4 +90,28 @@ outer:
 	}
 
 	return txs, nil
+}
+
+func newSI() *network.ServerIdentity {
+	id, _ := uuid.NewV1()
+	return &network.ServerIdentity{
+		ID: network.ServerIdentityID(id),
+	}
+}
+
+// Check the version buffer features.
+func TestCollectTx_VersionBuffer(t *testing.T) {
+	vb := newVersionBuffer(4)
+	require.Equal(t, vb.threshold, 3)
+
+	vb.add(newSI(), 1)
+	vb.add(newSI(), 2)
+	si1 := newSI()
+	vb.add(si1, 3)
+	vb.add(si1, 3)
+	vb.add(si1, 3)
+
+	require.False(t, vb.hasThresholdFor(3))
+	require.False(t, vb.hasThresholdFor(2))
+	require.True(t, vb.hasThresholdFor(1))
 }

--- a/byzcoin/collect_tx_test.go
+++ b/byzcoin/collect_tx_test.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/cothority/v3"
 	"go.dedis.ch/cothority/v3/skipchain"
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/network"
+	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 var testSuite = cothority.Suite
@@ -93,7 +93,7 @@ outer:
 }
 
 func newSI() *network.ServerIdentity {
-	id, _ := uuid.NewV1()
+	id := uuid.NewV1()
 	return &network.ServerIdentity{
 		ID: network.ServerIdentityID(id),
 	}

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -554,7 +554,7 @@ func TestService_AutomaticVersionUpgrade(t *testing.T) {
 
 	time.Sleep(testInterval)
 
-	// Simulate a upgrade of the conodes.
+	// Simulate an upgrade of the conodes.
 	for _, srv := range s.services {
 		srv.defaultVersionLock.Lock()
 		srv.defaultVersion = CurrentVersion

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -511,6 +512,76 @@ func TestService_AddTransactionVersion(t *testing.T) {
 	reply, err := s.service().AddTransaction(atx)
 	require.NoError(t, err)
 	require.Contains(t, reply.Error, "wrong byzcoin version")
+}
+
+func TestService_AutomaticVersionUpgrade(t *testing.T) {
+	// Creates a chain starting with version 0.
+	s := newSerWithVersion(t, 1, testInterval, 4, disableViewChange, 0)
+	defer s.local.CloseAll()
+
+	closing := make(chan bool)
+	wg := sync.WaitGroup{}
+	go func(closeChan chan bool) {
+		wg.Add(1)
+		defer wg.Done()
+
+		c := uint64(1)
+		shutdown := false
+		wait := 0
+		for !shutdown {
+			select {
+			case <-closing:
+				shutdown = true
+				wait = 10
+			default:
+			}
+
+			tx, err := createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, []byte{}, s.signer, c)
+			require.NoError(t, err)
+			atx := &AddTxRequest{
+				Version:       CurrentVersion,
+				SkipchainID:   s.genesis.SkipChainID(),
+				Transaction:   tx,
+				InclusionWait: wait,
+			}
+			_, err = s.service().AddTransaction(atx)
+			require.NoError(t, err)
+
+			c++
+			time.Sleep(50 * time.Millisecond)
+		}
+	}(closing)
+
+	time.Sleep(testInterval)
+
+	// Simulate a upgrade of the conodes.
+	for _, srv := range s.services {
+		srv.defaultVersionLock.Lock()
+		srv.defaultVersion = CurrentVersion
+		srv.defaultVersionLock.Unlock()
+	}
+
+	for i := 0; i < 10; i++ {
+		time.Sleep(testInterval)
+
+		proof, err := s.service().GetProof(&GetProof{
+			Version: CurrentVersion,
+			Key:     NewInstanceID([]byte{}).Slice(),
+			ID:      s.genesis.Hash,
+		})
+		require.NoError(t, err)
+
+		header, err := decodeBlockHeader(&proof.Proof.Latest)
+		if header.Version == CurrentVersion {
+			close(closing)
+			wg.Wait()
+			return
+		}
+	}
+
+	close(closing)
+	wg.Wait()
+	t.Fail()
 }
 
 func TestService_GetProof(t *testing.T) {

--- a/byzcoin/tx_pipeline.go
+++ b/byzcoin/tx_pipeline.go
@@ -12,12 +12,19 @@ import (
 	"go.dedis.ch/protobuf"
 )
 
+// CollectTxResult contains the aggregated response of the conodes to the
+// collectTx protocol.
+type CollectTxResult struct {
+	Txs           []ClientTransaction
+	CommonVersion Version
+}
+
 // txProcessor is the interface that must be implemented. It is used in the
 // stateful pipeline txPipeline that takes transactions and creates blocks.
 type txProcessor interface {
 	// CollectTx implements a blocking function that returns transactions
 	// that should go into new blocks. These transactions are not verified.
-	CollectTx() ([]ClientTransaction, error)
+	CollectTx() (*CollectTxResult, error)
 	// ProcessTx attempts to apply the given tx to the input state and then
 	// produce new state(s). If the new tx is too big to fit inside a new
 	// state, the function will return more states. Where the older states
@@ -30,6 +37,9 @@ type txProcessor interface {
 	// function should only return when a decision has been made regarding
 	// the proposal.
 	ProposeBlock(*txProcessorState) error
+	// ProposeUpgradeBlock should create a barrier block between two Byzcoin
+	// version so that next blocks will use the version in parameter.
+	ProposeUpgradeBlock(Version) error
 	// GetLatestGoodState should return the latest state that the processor
 	// trusts.
 	GetLatestGoodState() *txProcessorState
@@ -89,7 +99,7 @@ type defaultTxProcessor struct {
 	sync.Mutex
 }
 
-func (s *defaultTxProcessor) CollectTx() ([]ClientTransaction, error) {
+func (s *defaultTxProcessor) CollectTx() (*CollectTxResult, error) {
 	// Need to update the config, as in the meantime a new block should have
 	// arrived with a possible new configuration.
 	bcConfig, err := s.LoadConfig(s.scID)
@@ -150,9 +160,14 @@ func (s *defaultTxProcessor) CollectTx() ([]ClientTransaction, error) {
 	protocolTimeout := time.After(bcConfig.BlockInterval / 2)
 
 	var txs []ClientTransaction
+	commonVersion := Version(0)
+
 collectTxLoop:
 	for {
 		select {
+		case commonVersion = <-root.CommonVersionChan:
+			// At this point, we only know if other conodes are running the same
+			// version as the leader, but it can be the current one.
 		case newTxs, more := <-root.TxsChan:
 			if more {
 				for _, ct := range newTxs {
@@ -173,11 +188,11 @@ collectTxLoop:
 		case <-s.stopCollect:
 			log.Lvl2(s.ServerIdentity(), "abort collection of transactions")
 			close(root.Finish)
-			return txs, nil
+			break collectTxLoop
 		}
 	}
 
-	return txs, nil
+	return &CollectTxResult{Txs: txs, CommonVersion: commonVersion}, nil
 }
 
 func (s *defaultTxProcessor) ProcessTx(tx ClientTransaction, inState *txProcessorState) ([]*txProcessorState, error) {
@@ -251,6 +266,11 @@ func (s *defaultTxProcessor) ProposeBlock(state *txProcessorState) error {
 	return err
 }
 
+func (s *defaultTxProcessor) ProposeUpgradeBlock(version Version) error {
+	_, err := s.createUpgradeVersionBlock(s.scID, version)
+	return err
+}
+
 func (s *defaultTxProcessor) GetInterval() time.Duration {
 	bcConfig, err := s.LoadConfig(s.scID)
 	if err != nil {
@@ -290,23 +310,28 @@ func (s *defaultTxProcessor) Stop() {
 }
 
 type txPipeline struct {
-	wg        sync.WaitGroup
-	processor txProcessor
+	ctxChan     chan ClientTransaction
+	needUpgrade chan Version
+	stopCollect chan bool
+	wg          sync.WaitGroup
+	processor   txProcessor
 }
 
 func (p *txPipeline) start(initialState *txProcessorState, stopSignal chan bool) {
-	stopCollect := make(chan bool)
-	ctxChan := p.collectTx(stopCollect)
-	p.processTxs(ctxChan, initialState)
+	p.stopCollect = make(chan bool)
+	p.ctxChan = make(chan ClientTransaction, 200)
+	p.needUpgrade = make(chan Version, 1)
+
+	p.collectTx()
+	p.processTxs(initialState)
 
 	<-stopSignal
-	close(stopCollect)
+	close(p.stopCollect)
 	p.processor.Stop()
 	p.wg.Wait()
 }
 
-func (p *txPipeline) collectTx(stopChan chan bool) <-chan ClientTransaction {
-	outChan := make(chan ClientTransaction, 200)
+func (p *txPipeline) collectTx() {
 	// set the polling interval to half of the block interval
 	go func() {
 		p.wg.Add(1)
@@ -314,18 +339,23 @@ func (p *txPipeline) collectTx(stopChan chan bool) <-chan ClientTransaction {
 		for {
 			interval := p.processor.GetInterval()
 			select {
-			case <-stopChan:
+			case <-p.stopCollect:
 				log.Lvl3("stopping tx collector")
-				close(outChan)
+				close(p.ctxChan)
 				return
 			case <-time.After(interval / 2):
-				txs, err := p.processor.CollectTx()
+				res, err := p.processor.CollectTx()
 				if err != nil {
-					log.Error("failed to collect transactions")
+					log.Error("failed to collect transactions", err)
 				}
-				for _, tx := range txs {
+
+				// If a common version is found, it is sent anyway and the processing
+				// will check if it is necessary to upgrade.
+				p.needUpgrade <- res.CommonVersion
+
+				for _, tx := range res.Txs {
 					select {
-					case outChan <- tx:
+					case p.ctxChan <- tx:
 						// channel not full, do nothing
 					default:
 						log.Warn("dropping transactions because there are too many")
@@ -334,16 +364,16 @@ func (p *txPipeline) collectTx(stopChan chan bool) <-chan ClientTransaction {
 			}
 		}
 	}()
-	return outChan
 }
 
 var maxTxHashes = 1000
 
 // processTxs consumes transactions and computes the new txResults
-func (p *txPipeline) processTxs(txChan <-chan ClientTransaction, initialState *txProcessorState) {
+func (p *txPipeline) processTxs(initialState *txProcessorState) {
 	var proposing bool
 	// always use the latest one when adding new
 	currentState := []*txProcessorState{initialState}
+	currentVersion := p.processor.GetLatestGoodState().sst.GetVersion()
 	proposalResult := make(chan error, 1)
 	getInterval := func() <-chan time.Time {
 		interval := p.processor.GetInterval()
@@ -357,7 +387,33 @@ func (p *txPipeline) processTxs(txChan <-chan ClientTransaction, initialState *t
 	leaderLoop:
 		for {
 			select {
-			case tx, ok := <-txChan:
+			case version := <-p.needUpgrade:
+				if version <= currentVersion {
+					// Prevent multiple upgrade blocks for the same version.
+					break
+				}
+
+				// An upgrade is done synchronously so that other operations
+				// are not performed until the upgrade is done.
+
+				if proposing {
+					// If a block is currently created, it will wait for the
+					// end of the process.
+					select {
+					case err := <-proposalResult:
+						proposalResult <- err
+					}
+				}
+
+				err := p.processor.ProposeUpgradeBlock(version)
+				if err != nil {
+					// Only log the error as it won't prevent normal blocks
+					// to be created.
+					log.Error("failed to upgrade", err)
+				}
+
+				currentVersion = version
+			case tx, ok := <-p.ctxChan:
 				if !ok {
 					log.Lvl3("stopping txs processor")
 					return

--- a/byzcoin/tx_pipeline_test.go
+++ b/byzcoin/tx_pipeline_test.go
@@ -201,20 +201,6 @@ func newSlowCollectMockTxProc(t *testing.T, batch int, txs []ClientTransaction, 
 	return proc
 }
 
-func newDefaultMockTxVersion(t *testing.T, batch int, txs []ClientTransaction, failAt int) mockTxProc {
-	return &defaultMockTxProc{
-		batch:            batch,
-		txs:              txs,
-		done:             make(chan bool, 1),
-		t:                t,
-		failAt:           failAt,
-		proposeDelay:     10 * time.Microsecond,
-		collectDelay:     10 * time.Microsecond,
-		commonVersion:    1,
-		stateTrieVersion: 0,
-	}
-}
-
 func TestTxPipeline(t *testing.T) {
 	testTxPipeline(t, 1, 1, 1, newDefaultMockTxProc)
 	testTxPipeline(t, 4, 1, 4, newDefaultMockTxProc)

--- a/byzcoin/tx_pipeline_test.go
+++ b/byzcoin/tx_pipeline_test.go
@@ -2,6 +2,7 @@ package byzcoin
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"sync"
 
@@ -20,30 +21,35 @@ type mockTxProc interface {
 
 type defaultMockTxProc struct {
 	sync.Mutex
-	batch        int
-	txCtr        int
-	proposed     TxResults
-	failAt       int                 // instructs ProposeBlock to return an error when processing the tx at the failAt index
-	txs          []ClientTransaction // we assume these are unique
-	done         chan bool
-	proposeDelay time.Duration
-	collectDelay time.Duration
-	goodState    *stagingStateTrie
-	t            *testing.T
+	batch            int
+	txCtr            int
+	proposed         TxResults
+	failAt           int                 // instructs ProposeBlock to return an error when processing the tx at the failAt index
+	txs              []ClientTransaction // we assume these are unique
+	commonVersion    Version
+	stateTrieVersion Version
+	done             chan bool
+	proposeDelay     time.Duration
+	collectDelay     time.Duration
+	goodState        *stagingStateTrie
+	t                *testing.T
 }
 
 func txEqual(a, b ClientTransaction) bool {
 	return bytes.Equal(a.Instructions.Hash(), b.Instructions.Hash())
 }
 
-func (p *defaultMockTxProc) CollectTx() ([]ClientTransaction, error) {
+func (p *defaultMockTxProc) CollectTx() (*CollectTxResult, error) {
+	p.Lock()
+	defer p.Unlock()
+
 	time.Sleep(p.collectDelay) // simulate slow network/protocol
 	if p.txCtr+p.batch > len(p.txs) {
-		return nil, nil
+		return &CollectTxResult{}, nil
 	}
 	out := p.txs[p.txCtr : p.txCtr+p.batch]
 	p.txCtr += p.batch
-	return out, nil
+	return &CollectTxResult{Txs: out, CommonVersion: p.commonVersion}, nil
 }
 
 func (p *defaultMockTxProc) ProcessTx(tx ClientTransaction, inState *txProcessorState) ([]*txProcessorState, error) {
@@ -97,6 +103,16 @@ func (p *defaultMockTxProc) ProposeBlock(state *txProcessorState) error {
 	return nil
 }
 
+func (p *defaultMockTxProc) ProposeUpgradeBlock(version Version) error {
+	p.Lock()
+	defer p.Unlock()
+
+	require.True(p.t, p.commonVersion > p.stateTrieVersion)
+	p.stateTrieVersion = p.commonVersion
+	p.goodState = nil
+	return nil
+}
+
 func (p *defaultMockTxProc) GetInterval() time.Duration {
 	return 100 * time.Millisecond
 }
@@ -107,8 +123,15 @@ func (p *defaultMockTxProc) Stop() {
 func (p *defaultMockTxProc) GetLatestGoodState() *txProcessorState {
 	goodState := p.goodState
 	if goodState == nil {
+		p.Lock()
+		defer p.Unlock()
+
 		sst, err := newMemStagingStateTrie([]byte(""))
 		require.NoError(p.t, err)
+
+		versionBuf := make([]byte, 4)
+		binary.LittleEndian.PutUint32(versionBuf, uint32(p.stateTrieVersion))
+		sst.Set([]byte(trieVersionKey), versionBuf)
 		goodState = sst
 	}
 	return &txProcessorState{
@@ -178,6 +201,20 @@ func newSlowCollectMockTxProc(t *testing.T, batch int, txs []ClientTransaction, 
 	return proc
 }
 
+func newDefaultMockTxVersion(t *testing.T, batch int, txs []ClientTransaction, failAt int) mockTxProc {
+	return &defaultMockTxProc{
+		batch:            batch,
+		txs:              txs,
+		done:             make(chan bool, 1),
+		t:                t,
+		failAt:           failAt,
+		proposeDelay:     10 * time.Microsecond,
+		collectDelay:     10 * time.Microsecond,
+		commonVersion:    1,
+		stateTrieVersion: 0,
+	}
+}
+
 func TestTxPipeline(t *testing.T) {
 	testTxPipeline(t, 1, 1, 1, newDefaultMockTxProc)
 	testTxPipeline(t, 4, 1, 4, newDefaultMockTxProc)
@@ -245,6 +282,14 @@ func testTxPipeline(t *testing.T, n, batch, failAt int, mock newMockTxProcFunc) 
 		close(pipelineDone)
 	}()
 
+	mockproc, ok := processor.(*defaultMockTxProc)
+	if ok {
+		<-time.After(mockproc.collectDelay)
+		mockproc.Lock()
+		mockproc.commonVersion = 3
+		mockproc.Unlock()
+	}
+
 	interval := processor.GetInterval()
 
 	if failAt < n {
@@ -264,6 +309,11 @@ func testTxPipeline(t *testing.T, n, batch, failAt int, mock newMockTxProcFunc) 
 		case <-time.After(5 * time.Duration(n/batch) * interval):
 			require.Fail(t, "tx processor did not finish in time")
 		}
+	}
+
+	// Check if the version is up-to-date with the latest.
+	if ok {
+		require.Equal(t, mockproc.commonVersion, mockproc.stateTrieVersion)
 	}
 
 	close(stopChan)

--- a/byzcoin/tx_pipeline_test.go
+++ b/byzcoin/tx_pipeline_test.go
@@ -39,17 +39,17 @@ func txEqual(a, b ClientTransaction) bool {
 	return bytes.Equal(a.Instructions.Hash(), b.Instructions.Hash())
 }
 
-func (p *defaultMockTxProc) CollectTx() (*CollectTxResult, error) {
+func (p *defaultMockTxProc) CollectTx() (*collectTxResult, error) {
 	p.Lock()
 	defer p.Unlock()
 
 	time.Sleep(p.collectDelay) // simulate slow network/protocol
 	if p.txCtr+p.batch > len(p.txs) {
-		return &CollectTxResult{}, nil
+		return &collectTxResult{}, nil
 	}
 	out := p.txs[p.txCtr : p.txCtr+p.batch]
 	p.txCtr += p.batch
-	return &CollectTxResult{Txs: out, CommonVersion: p.commonVersion}, nil
+	return &collectTxResult{Txs: out, CommonVersion: p.commonVersion}, nil
 }
 
 func (p *defaultMockTxProc) ProcessTx(tx ClientTransaction, inState *txProcessorState) ([]*txProcessorState, error) {


### PR DESCRIPTION
This updates the transaction collection to include the version of the
Byzcoin protocol of the conode so that the leader can synchronize an
upgrade.