### PR TITLE
Updates write spawn to include the extraData field

### DIFF
--- a/calypso/csadmin/README.md
+++ b/calypso/csadmin/README.md
@@ -87,8 +87,13 @@ $ csadmin contract write spawn --instid <lts instance id>\
 Note: Data stored with `--secret` will be encrypted using a `kyber.Point`.
 Depending on the suite used, this has a limitation on the size. For the default
 suite used (ed25519), this limitation is 29 bits. Therefore, it is possible to
-store additional but unencrypted data with the `--data` option, or directly from
-STDIN using the `--readin` option.
+store additional data in two fields: 'data' and 'extra data'. The 'data' field
+should contain data encrypted with a symetric key stored in the secret, while
+the 'extra data' field should contain any public information. 'data' can be set
+with the `--data` option or directly from STDIN using the `--readData` option.
+'extra data' can be set with the `--extraData` option or directly from STDIN
+using the `--readExtra` option. Note that `--readData` and `--readExtra` can NOT
+be used both at the same time.
 
 **5) Spawn a read instance**
 

--- a/calypso/csadmin/clicontracts/write.go
+++ b/calypso/csadmin/clicontracts/write.go
@@ -24,11 +24,14 @@ import (
 // by the DKG. The secret that will be encrypted under the collective public key
 // is provided as a string with --secret and then converted as a slice of bytes.
 // This secret has a maximum size depending on the suite used (29 bits for
-// ed25519). Another field, filled with --data or from STDIN with the --readin
+// ed25519). Another field, filled with --data or from STDIN with the --readData
 // option, can contain unlimited sized data. The data however won't be
-// automatically encrypted. If everything goes well, it prints the instance id
-// of the newly spawned Write instance. With the --export option, the instance
-// id is sent to STDOUT.
+// automatically encrypted. An additional field 'extra data' can be set, which
+// is useful to store cleartext data, where --data should be used to store
+// encrypted data. The 'extra data' field can be filled with either --extraData
+// or --readExtra. Both --readExtra and --readData can NOT be used at the same
+// time. If everything goes well, it prints the instance id of the newly spawned
+// Write instance. With the --export option, the instance id is sent to STDOUT.
 func WriteSpawn(c *cli.Context) error {
 	bcArg := c.String("bc")
 	if bcArg == "" {
@@ -50,7 +53,10 @@ func WriteSpawn(c *cli.Context) error {
 	}
 
 	var dataBuf []byte
-	if c.Bool("readin") {
+	if c.Bool("readData") {
+		if c.Bool("readExtra") {
+			return errors.New("--readData can not be used toghether with --readExtra")
+		}
 		dataBuf, err = ioutil.ReadAll(os.Stdin)
 		if err != nil {
 			return errors.New("failed to read from stdin: " + err.Error())
@@ -59,6 +65,18 @@ func WriteSpawn(c *cli.Context) error {
 		dataBuf = bytes.TrimRight(dataBuf, "\n")
 	} else {
 		dataBuf = []byte(c.String("data"))
+	}
+
+	var extraDataBuf []byte
+	if c.Bool("readExtra") {
+		extraDataBuf, err = ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return errors.New("failed to read from stdin: " + err.Error())
+		}
+		// We found out that a newline is automatically added when using pipes
+		extraDataBuf = bytes.TrimRight(extraDataBuf, "\n")
+	} else {
+		extraDataBuf = []byte(c.String("extraData"))
 	}
 
 	secret := c.String("secret")
@@ -100,6 +118,7 @@ func WriteSpawn(c *cli.Context) error {
 			"too long to be embeded")
 	}
 	write.Data = dataBuf
+	write.ExtraData = extraDataBuf
 	writeBuf, err := protobuf.Encode(write)
 	if err != nil {
 		return errors.New("failed to encode Write struct: " + err.Error())

--- a/calypso/csadmin/clicontracts/write.go
+++ b/calypso/csadmin/clicontracts/write.go
@@ -61,8 +61,6 @@ func WriteSpawn(c *cli.Context) error {
 		if err != nil {
 			return errors.New("failed to read from stdin: " + err.Error())
 		}
-		// We found out that a newline is automatically added when using pipes
-		dataBuf = bytes.TrimRight(dataBuf, "\n")
 	} else {
 		dataBuf = []byte(c.String("data"))
 	}

--- a/calypso/csadmin/clicontracts/write_test.sh
+++ b/calypso/csadmin/clicontracts/write_test.sh
@@ -131,8 +131,8 @@ testContractWriteGet() {
 -- LTSID: [0-9a-f]{64}
 -- Cost: .*$"
 
-    # Use the --readData option
-    echo "Should be encrypted - from STDIN" | runCA0 contract write spawn\
+    # Use the --readin option
+    echo -n "Should be encrypted - from STDIN" | runCA0 contract write spawn\
                     --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
                     --secret "Hello world." --key "$PUB_KEY"\
                     --readData -x > writeid.txt
@@ -173,8 +173,8 @@ testContractWriteGet() {
 -- LTSID: [0-9a-f]{64}
 -- Cost: .*$"
 
-    # Provide both --data and --readData. --readData should be used.
-    echo "Should be encrypted - from STDIN" | runCA0 contract write spawn\
+    # Provide both --data and --readin. --readin should be used.
+    echo -n "Should be encrypted - from STDIN" | runCA0 contract write spawn\
                     --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
                     --secret "Hello world." --key "$PUB_KEY"\
                     --readData --data "Hello there." -x > writeid.txt
@@ -218,7 +218,7 @@ testContractWriteGet() {
 -- Cost: .*$"
 
     # Provide both --extraData and --readExtra. --readExtra should be used.
-    echo "Extra data - from STDIN" | runCA0 contract write spawn\
+    echo -n "Extra data - from STDIN" | runCA0 contract write spawn\
                     --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
                     --secret "Hello world." --key "$PUB_KEY"\
                     --readExtra --extraData "Hello there." -x > writeid.txt
@@ -240,7 +240,7 @@ testContractWriteGet() {
 -- Cost: .*$"
 
     # Provide both --data and --readExtra.
-    echo "Extra data - from STDIN" | runCA0 contract write spawn\
+    echo -n "Extra data - from STDIN" | runCA0 contract write spawn\
                     --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
                     --secret "Hello world." --key "$PUB_KEY"\
                     --readExtra --data "Hello there." -x > writeid.txt
@@ -262,7 +262,7 @@ testContractWriteGet() {
 -- Cost: .*$"
 
     # Provide both --extraData and --readData.
-    echo "Should be encrypted - from STDIN" | runCA0 contract write spawn\
+    echo -n "Should be encrypted - from STDIN" | runCA0 contract write spawn\
                     --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
                     --secret "Hello world." --key "$PUB_KEY"\
                     --readData --extraData "Hello there." -x > writeid.txt

--- a/calypso/csadmin/clicontracts/write_test.sh
+++ b/calypso/csadmin/clicontracts/write_test.sh
@@ -55,13 +55,26 @@ testContractWriteInvoke() {
     matchOK "`cat iid.txt`" ^[0-9a-f]{64}$
 
     # Check the --data option
-    testOK runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --data "This is some cleartext data"
+    testOK runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --data "This should be encrypted data"
 
-    # Check the --readin option
-    testOK echo "This is some cleartext data" | runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --readin
+    # Check the --readData option
+    testOK echo "This should be encrypted data" | runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --readData
 
-    # Check the --readin option with --data
-    testOK echo "This is some cleartext data" | runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --readin --data "not used"
+    # Check the --readData option with --data
+    testOK echo "This should be encrypted data" | runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --readData --data "not used"
+
+    # Check the --extraData option
+    testOK runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --extraData "This is some cleartext data"
+
+    # Check the --readExtra option
+    testOK echo "This is some cleartext data" | runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --readExtra
+
+    # Check the --readExtra option with --extraData
+    testOK echo "This is some cleartext data" | runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --readExtra --extraData "not used"
+
+    # Using --readData and --readExtra should not be permitted
+    testFail runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --readExtra --readData
+    testFail runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --readExtra --readData --extraData "extra" --data "data"
 }
 
 # rely on:
@@ -100,7 +113,7 @@ testContractWriteGet() {
     
     runCA0 contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
                     --secret "Hello world." --key "$PUB_KEY"\
-                    --data "Not secret" -x > writeid.txt
+                    --data "Should be encrypted" -x > writeid.txt
     WRITE_ID=`cat writeid.txt`
     matchOK $WRITE_ID ^[0-9a-f]{64}$
 
@@ -108,7 +121,7 @@ testContractWriteGet() {
     OUTRES=`runCA0 contract write get --instid $WRITE_ID`
 
     matchOK "$OUTRES" "^- Write:
--- Data: Not secret
+-- Data: Should be encrypted
 -- U: [0-9a-f]{64}
 -- Ubar: [0-9a-f]{64}
 -- E: [0-9a-f]{64}
@@ -118,11 +131,11 @@ testContractWriteGet() {
 -- LTSID: [0-9a-f]{64}
 -- Cost: .*$"
 
-    # Use the --readin option
-    echo "No secret from STDIN" | runCA0 contract write spawn\
+    # Use the --readData option
+    echo "Should be encrypted - from STDIN" | runCA0 contract write spawn\
                     --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
                     --secret "Hello world." --key "$PUB_KEY"\
-                    --readin -x > writeid.txt
+                    --readData -x > writeid.txt
     WRITE_ID=`cat writeid.txt`
     matchOK $WRITE_ID ^[0-9a-f]{64}$
 
@@ -130,7 +143,7 @@ testContractWriteGet() {
     OUTRES=`runCA0 contract write get --instid $WRITE_ID`
 
     matchOK "$OUTRES" "^- Write:
--- Data: No secret from STDIN
+-- Data: Should be encrypted - from STDIN
 -- U: [0-9a-f]{64}
 -- Ubar: [0-9a-f]{64}
 -- E: [0-9a-f]{64}
@@ -160,11 +173,11 @@ testContractWriteGet() {
 -- LTSID: [0-9a-f]{64}
 -- Cost: .*$"
 
-    # Provide both --data and --readin. --readin should be used.
-    echo "No secret from STDIN" | runCA0 contract write spawn\
+    # Provide both --data and --readData. --readData should be used.
+    echo "Should be encrypted - from STDIN" | runCA0 contract write spawn\
                     --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
                     --secret "Hello world." --key "$PUB_KEY"\
-                    --readin --data "Hello there." -x > writeid.txt
+                    --readData --data "Hello there." -x > writeid.txt
     WRITE_ID=`cat writeid.txt`
     matchOK $WRITE_ID ^[0-9a-f]{64}$
 
@@ -172,13 +185,101 @@ testContractWriteGet() {
     OUTRES=`runCA0 contract write get --instid $WRITE_ID`
 
     matchOK "$OUTRES" "^- Write:
--- Data: No secret from STDIN
+-- Data: Should be encrypted - from STDIN
 -- U: [0-9a-f]{64}
 -- Ubar: [0-9a-f]{64}
 -- E: [0-9a-f]{64}
 -- F: [0-9a-f]{64}
 -- C: [0-9a-f]{64}
 -- ExtraData: 
+-- LTSID: [0-9a-f]{64}
+-- Cost: .*$"
+
+    # Provide both --data and --extraData.
+    runCA0 contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
+                    --secret "Hello world." --key "$PUB_KEY"\
+                    --data "Should be encrypted"\
+                    --extraData "Public infos" -x > writeid.txt
+    WRITE_ID=`cat writeid.txt`
+    matchOK $WRITE_ID ^[0-9a-f]{64}$
+
+    # Lets now check the result
+    OUTRES=`runCA0 contract write get --instid $WRITE_ID`
+
+    matchOK "$OUTRES" "^- Write:
+-- Data: Should be encrypted
+-- U: [0-9a-f]{64}
+-- Ubar: [0-9a-f]{64}
+-- E: [0-9a-f]{64}
+-- F: [0-9a-f]{64}
+-- C: [0-9a-f]{64}
+-- ExtraData: Public infos
+-- LTSID: [0-9a-f]{64}
+-- Cost: .*$"
+
+    # Provide both --extraData and --readExtra. --readExtra should be used.
+    echo "Extra data - from STDIN" | runCA0 contract write spawn\
+                    --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
+                    --secret "Hello world." --key "$PUB_KEY"\
+                    --readExtra --extraData "Hello there." -x > writeid.txt
+    WRITE_ID=`cat writeid.txt`
+    matchOK $WRITE_ID ^[0-9a-f]{64}$
+
+    # Lets now check the result
+    OUTRES=`runCA0 contract write get --instid $WRITE_ID`
+
+    matchOK "$OUTRES" "^- Write:
+-- Data: 
+-- U: [0-9a-f]{64}
+-- Ubar: [0-9a-f]{64}
+-- E: [0-9a-f]{64}
+-- F: [0-9a-f]{64}
+-- C: [0-9a-f]{64}
+-- ExtraData: Extra data - from STDIN
+-- LTSID: [0-9a-f]{64}
+-- Cost: .*$"
+
+    # Provide both --data and --readExtra.
+    echo "Extra data - from STDIN" | runCA0 contract write spawn\
+                    --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
+                    --secret "Hello world." --key "$PUB_KEY"\
+                    --readExtra --data "Hello there." -x > writeid.txt
+    WRITE_ID=`cat writeid.txt`
+    matchOK $WRITE_ID ^[0-9a-f]{64}$
+
+    # Lets now check the result
+    OUTRES=`runCA0 contract write get --instid $WRITE_ID`
+
+    matchOK "$OUTRES" "^- Write:
+-- Data: Hello there.
+-- U: [0-9a-f]{64}
+-- Ubar: [0-9a-f]{64}
+-- E: [0-9a-f]{64}
+-- F: [0-9a-f]{64}
+-- C: [0-9a-f]{64}
+-- ExtraData: Extra data - from STDIN
+-- LTSID: [0-9a-f]{64}
+-- Cost: .*$"
+
+    # Provide both --extraData and --readData.
+    echo "Should be encrypted - from STDIN" | runCA0 contract write spawn\
+                    --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
+                    --secret "Hello world." --key "$PUB_KEY"\
+                    --readData --extraData "Hello there." -x > writeid.txt
+    WRITE_ID=`cat writeid.txt`
+    matchOK $WRITE_ID ^[0-9a-f]{64}$
+
+    # Lets now check the result
+    OUTRES=`runCA0 contract write get --instid $WRITE_ID`
+
+    matchOK "$OUTRES" "^- Write:
+-- Data: Should be encrypted - from STDIN
+-- U: [0-9a-f]{64}
+-- Ubar: [0-9a-f]{64}
+-- E: [0-9a-f]{64}
+-- F: [0-9a-f]{64}
+-- C: [0-9a-f]{64}
+-- ExtraData: Hello there.
 -- LTSID: [0-9a-f]{64}
 -- Cost: .*$"
 }

--- a/calypso/csadmin/commands.go
+++ b/calypso/csadmin/commands.go
@@ -148,12 +148,20 @@ var cmds = cli.Commands{
 								Usage: "data to be encrypted, has limited space regarding the kyber.Suite used (29 bits for ed25519)",
 							},
 							cli.StringFlag{
-								Name:  "data",
-								Usage: "cleartext data that can be stored in the Write contract (optional). Is not used if --readin is provided.",
+								Name:  "data, d",
+								Usage: "data that should be encrypted with the secret. Use --extraData for cleartext data. Not used if --readData is provided.",
 							},
 							cli.BoolFlag{
-								Name:  "readin",
-								Usage: "if provided, the --data flag is not used and the data is read from STDIN",
+								Name:  "readData, rd",
+								Usage: "if provided, the --data flag is not used and the data is read from STDIN. Can NOT be used conjointly with --readExtra.",
+							},
+							cli.StringFlag{
+								Name:  "extraData, ed",
+								Usage: "additional data, for example unencrypted infos. Not used if --readExtra is provided.",
+							},
+							cli.BoolFlag{
+								Name:  "readExtra, re",
+								Usage: "if provided, the --extraData flag is not used and the extra data is read from STDIN. Can NOT be used conjointly with --readData.",
 							},
 							cli.StringFlag{
 								Name:  "key",


### PR DESCRIPTION
I found out that I somehow miss-interpreted the use of the `data` and `extraData` fields of a write instance in Calypso.
This PR updates the cli to include the `extraData` option when spawning a write instance and also update the explanations to make the use of `data` vs `extraData` clear.