### PR TITLE
Java: Use the pool for TwistPoint

### DIFF
--- a/external/java/src/main/java/ch/epfl/dedis/lib/crypto/bn256/OptAte.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/crypto/bn256/OptAte.java
@@ -190,10 +190,10 @@ class OptAte {
     private static byte[] sixuPlus2NAF = new byte[]{0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, -1, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, -1, 0, 1, 0, 0, 0, 1, 0, -1, 0, 0, 0, -1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 1};
 
     private static GFp12 miller(TwistPoint q, CurvePoint p) {
-        GFp12 ret = new GFp12();
+        GFp12 ret = new GFp12(); // return
         ret.setOne();
 
-        TwistPoint aAffine = new TwistPoint();
+        TwistPoint aAffine = new TwistPoint(GFpPool.getInstance());
         aAffine.set(q);
         aAffine.makeAffine();
 
@@ -201,10 +201,10 @@ class OptAte {
         bAffine.set(p);
         bAffine.makeAffine();
 
-        TwistPoint minusA = new TwistPoint();
+        TwistPoint minusA = new TwistPoint(GFpPool.getInstance());
         minusA.negative(aAffine);
 
-        TwistPoint r = new TwistPoint();
+        TwistPoint r = new TwistPoint(GFpPool.getInstance());
         r.set(aAffine);
 
         GFp2 r2 = GFpPool.getInstance().get2();
@@ -243,7 +243,7 @@ class OptAte {
             r = newR;
         }
 
-        TwistPoint q1 = new TwistPoint();
+        TwistPoint q1 = new TwistPoint(GFpPool.getInstance());
         q1.x.conjugate(aAffine.x);
         q1.x.mul(q1.x, Constants.xiToPMinus1Over3);
         q1.y.conjugate(aAffine.y);
@@ -251,7 +251,7 @@ class OptAte {
         q1.z.setOne();
         q1.t.setOne();
 
-        TwistPoint minusQ2 = new TwistPoint();
+        TwistPoint minusQ2 = new TwistPoint(GFpPool.getInstance());
         minusQ2.x.mulScalar(aAffine.x, Constants.xiToPSquaredMinus1Over3);
         minusQ2.y.set(aAffine.y);
         minusQ2.z.setOne();
@@ -276,6 +276,13 @@ class OptAte {
         newR = res2.rOut;
         mulLine(ret, a, b, c);
         r = newR;
+
+        // Free at the end as GFps are passed around.
+        aAffine.free(GFpPool.getInstance());
+        minusA.free(GFpPool.getInstance());
+        r.free(GFpPool.getInstance());
+        q1.free(GFpPool.getInstance());
+        minusQ2.free(GFpPool.getInstance());
 
         return ret;
     }

--- a/external/java/src/main/java/ch/epfl/dedis/lib/crypto/bn256/TwistPoint.java
+++ b/external/java/src/main/java/ch/epfl/dedis/lib/crypto/bn256/TwistPoint.java
@@ -43,6 +43,13 @@ class TwistPoint {
         this.t = new GFp2(p.t);
     }
 
+    TwistPoint(GFpPool pool) {
+        x = pool.get2();
+        y = pool.get2();
+        z = pool.get2();
+        t = pool.get2();
+    }
+
     private TwistPoint(GFp2 x, GFp2 y, GFp2 z, GFp2 t) {
         this.x = x;
         this.y = y;
@@ -237,5 +244,14 @@ class TwistPoint {
         this.y.sub(this.y, a.y);
         this.z.set(a.z);
         this.t.setZero();
+    }
+
+    void free(GFpPool pool) {
+        pool.put2(x, y, z, t);
+        // Make sure any use of the object will fail.
+        x = null;
+        y = null;
+        z = null;
+        t = null;
     }
 }


### PR DESCRIPTION
**What this PR does**

This makes sure that the pool is also used in the pairing operation
when TwistPoints are instantiated.

Fixes #1945

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behavior is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped, following the `[failed to | counldn't do] ACTION THAT FAILED: " + err.Error()` format.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
