### PR TITLE
Csadmin update

### DIFF
--- a/byzcoin/contract_darc.go
+++ b/byzcoin/contract_darc.go
@@ -100,7 +100,7 @@ func (c *contractSecureDarc) Spawn(rst ReadOnlyStateTrie, inst Instruction, coin
 	// into the trie.
 	c2, err := cfact(nil)
 	if err != nil {
-		return nil, nil, fmt.Errorf("coult not spawn new zero instance: %v", err)
+		return nil, nil, fmt.Errorf("could not spawn new zero instance: %v", err)
 	}
 	if cwr, ok := c2.(ContractWithRegistry); ok {
 		cwr.SetRegistry(c.contracts)

--- a/calypso/csadmin/README.md
+++ b/calypso/csadmin/README.md
@@ -78,22 +78,23 @@ spawn the write instance:
 
 ```bash
 $ csadmin contract write spawn --instid <lts instance id>\
-        --secret "Hello, world." --key <lts public key>\
+        --secret "aef123" --key <lts public key>\
         --darc <doc darc> --sign <writer id>
 > spawned a new write instance. Its instance id is:
 > <write instance id>
 ```
 
-Note: Data stored with `--secret` will be encrypted using a `kyber.Point`.
-Depending on the suite used, this has a limitation on the size. For the default
-suite used (ed25519), this limitation is 29 bits. Therefore, it is possible to
-store additional data in two fields: 'data' and 'extra data'. The 'data' field
-should contain data encrypted with a symetric key stored in the secret, while
-the 'extra data' field should contain any public information. 'data' can be set
-with the `--data` option or directly from STDIN using the `--readData` option.
-'extra data' can be set with the `--extraData` option or directly from STDIN
-using the `--readExtra` option. Note that `--readData` and `--readExtra` can NOT
-be used both at the same time.
+Note: Data stored with `--secret` will be encrypted using a `kyber.Point` and it
+must be provided as a hexadecimal string. Depending on the suite used, this has
+a limitation on the size. For the default suite used (ed25519), this limitation
+is 29 bytes, which means no more than 58 hexadecimal chars. Therefore, it is
+possible to store additional data in two fields: 'data' and 'extra data'. The
+'data' field should contain data encrypted with a symetric key stored in the
+secret, while the 'extra data' field should contain any public information.
+'data' can be set with the `--data` option or directly from STDIN using the
+`--readData` option. 'extra data' can be set with the `--extraData` option or
+directly from STDIN using the `--readExtra` option. Note that `--readData` and
+`--readExtra` can NOT be used both at the same time.
 
 **5) Spawn a read instance**
 
@@ -141,8 +142,8 @@ the re-encrypted secret:
 
 ```bash
 $ csadmin decrypt < reply.bin
-> key decrypted:
-> Hello, world.
+> Key decrypted:
+> aef123
 ```
 
 Alternatively, the path to a private key file can be provided:

--- a/calypso/csadmin/clicontracts/read_test.sh
+++ b/calypso/csadmin/clicontracts/read_test.sh
@@ -1,14 +1,14 @@
 # This method should be called from the calypso/csadmin/test.sh script
 
 testContractRead() {
-    run testContractReadInvoke
+    run testContractReadSpawn
 }
 
 # rely on:
 # - csadmin contract lts spawn
 # - csadmin authorize
 # - csadmin contract write spawn
-testContractReadInvoke() {
+testContractReadSpawn() {
     rm -f config/*
     runCoBG 1 2 3
     runGrepSed "export BC=" "" runBA create --roster public.toml --interval .5s
@@ -38,7 +38,7 @@ testContractReadInvoke() {
     # Add the Calypso rule "spawn:calypsoWrite"
     testOK runBA darc rule -rule spawn:calypsoWrite -darc $ID -sign $KEY -identity $KEY
     
-    OUTRES=`runCA0 contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY"`
+    OUTRES=`runCA0 contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "aabbccddeeff0011" --key "$PUB_KEY"`
     WRITE_ID=`echo "$OUTRES" | sed -n '2p'` # must be at the second line
 
     # Should fail because we miss the "spawn:calypsoRead" rule

--- a/calypso/csadmin/clicontracts/write.go
+++ b/calypso/csadmin/clicontracts/write.go
@@ -81,6 +81,10 @@ func WriteSpawn(c *cli.Context) error {
 	if secret == "" {
 		return errors.New("please provide secret with --secret")
 	}
+	secretBuf, err := hex.DecodeString(secret)
+	if err != nil {
+		return errors.New("failed to decode secret as hexadecimal: " + err.Error())
+	}
 
 	instidstr := c.String("instid")
 	if instidstr == "" {
@@ -109,8 +113,7 @@ func WriteSpawn(c *cli.Context) error {
 
 	reply := &calypso.WriteReply{}
 
-	write := calypso.NewWrite(cothority.Suite, instid, d.GetBaseID(), p,
-		[]byte(secret))
+	write := calypso.NewWrite(cothority.Suite, instid, d.GetBaseID(), p, secretBuf)
 	if write == nil {
 		return errors.New("got a nil write, this is due to a key that is " +
 			"too long to be embeded")

--- a/calypso/csadmin/clicontracts/write_test.sh
+++ b/calypso/csadmin/clicontracts/write_test.sh
@@ -1,14 +1,14 @@
 # This method should be called from the calypso/csadmin/test.sh script
 
 testContractWrite() {
-    run testContractWriteInvoke
+    run testContractWriteSpawn
     run testContractWriteGet
 }
 
 # rely on:
 # - csadmin contract lts spawn
 # - csadmin authorize
-testContractWriteInvoke() {
+testContractWriteSpawn() {
     rm -f config/*
     runCoBG 1 2 3
     runGrepSed "export BC=" "" runBA create --roster public.toml --interval .5s
@@ -37,12 +37,12 @@ testContractWriteInvoke() {
     matchOK $PUB_KEY ^[0-9a-f]{64}$
 
     # Fail because the Calypso rule "spawn:calypsoWrite" has not been added
-    testFail runCA contract write spawn --darc $ID --sign $KEY --instid $LTS_ID --secret "Hello world." --key $PUB_KEY
+    testFail runCA contract write spawn --darc $ID --sign $KEY --instid $LTS_ID --secret "aabbccdd" --key $PUB_KEY
 
     # Add the missing Calypso rule
     testOK runBA darc rule -rule spawn:calypsoWrite -darc $ID -sign $KEY -identity $KEY
     
-    OUTRES=`runCA0 contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY"`
+    OUTRES=`runCA0 contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "aabbccdd" --key "$PUB_KEY"`
 
     matchOK "$OUTRES" "^Spawned a new write instance. Its instance id is:
 [0-9a-f]{64}$"
@@ -50,31 +50,38 @@ testContractWriteInvoke() {
     # We check only that commands exits correctly. The content should be checked
     # by a `csadmin contract write get` function.
 
+    # Check the --secret option
+    # Not hexadecimal encoded
+    testFail runCA0 contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY"
+    testFail runCA0 contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "aabbccd" --key "$PUB_KEY"
+    testFail runCA0 contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "aabbccdx" --key "$PUB_KEY"
+    testOK runCA0 contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "aabbccdd" --key "$PUB_KEY"
+
     # Check the export option
-    runCA0 contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" -x > iid.txt
+    runCA0 contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "aabbccddeeff0011" --key "$PUB_KEY" -x > iid.txt
     matchOK "`cat iid.txt`" ^[0-9a-f]{64}$
 
     # Check the --data option
-    testOK runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --data "This should be encrypted data"
+    testOK runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "aabbccddeeff0011" --key "$PUB_KEY" --data "This should be encrypted data"
 
     # Check the --readData option
-    testOK echo "This should be encrypted data" | runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --readData
+    testOK echo "This should be encrypted data" | runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "aabbccddeeff0011" --key "$PUB_KEY" --readData
 
     # Check the --readData option with --data
-    testOK echo "This should be encrypted data" | runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --readData --data "not used"
+    testOK echo "This should be encrypted data" | runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "aabbccddeeff0011" --key "$PUB_KEY" --readData --data "not used"
 
     # Check the --extraData option
-    testOK runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --extraData "This is some cleartext data"
+    testOK runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "aabbccddeeff0011" --key "$PUB_KEY" --extraData "This is some cleartext data"
 
     # Check the --readExtra option
-    testOK echo "This is some cleartext data" | runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --readExtra
+    testOK echo "This is some cleartext data" | runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "aabbccddeeff0011" --key "$PUB_KEY" --readExtra
 
     # Check the --readExtra option with --extraData
-    testOK echo "This is some cleartext data" | runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --readExtra --extraData "not used"
+    testOK echo "This is some cleartext data" | runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "aabbccddeeff0011" --key "$PUB_KEY" --readExtra --extraData "not used"
 
     # Using --readData and --readExtra should not be permitted
-    testFail runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --readExtra --readData
-    testFail runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY" --readExtra --readData --extraData "extra" --data "data"
+    testFail runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "aabbccddeeff0011" --key "$PUB_KEY" --readExtra --readData
+    testFail runCA contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID" --secret "aabbccddeeff0011" --key "$PUB_KEY" --readExtra --readData --extraData "extra" --data "data"
 }
 
 # rely on:
@@ -111,8 +118,13 @@ testContractWriteGet() {
     # Add the missing Calypso rule
     testOK runBA darc rule -rule spawn:calypsoWrite -darc $ID -sign $KEY -identity $KEY
     
+    # Using a non hex encoded secret should fail
+    testOK runCA0 contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
+                        --secret "aabbccddeeff0011" --key "$PUB_KEY"\
+                        --data "Should be encrypted"
+
     runCA0 contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
-                    --secret "Hello world." --key "$PUB_KEY"\
+                    --secret "aabbccddeeff0011" --key "$PUB_KEY"\
                     --data "Should be encrypted" -x > writeid.txt
     WRITE_ID=`cat writeid.txt`
     matchOK $WRITE_ID ^[0-9a-f]{64}$
@@ -134,7 +146,7 @@ testContractWriteGet() {
     # Use the --readin option
     echo -n "Should be encrypted - from STDIN" | runCA0 contract write spawn\
                     --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
-                    --secret "Hello world." --key "$PUB_KEY"\
+                    --secret "aabbccddeeff0011" --key "$PUB_KEY"\
                     --readData -x > writeid.txt
     WRITE_ID=`cat writeid.txt`
     matchOK $WRITE_ID ^[0-9a-f]{64}$
@@ -155,7 +167,7 @@ testContractWriteGet() {
 
     # Provide no data
     runCA0 contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
-                    --secret "Hello world." --key "$PUB_KEY" -x > writeid.txt
+                    --secret "aabbccddeeff0011" --key "$PUB_KEY" -x > writeid.txt
     WRITE_ID=`cat writeid.txt`
     matchOK $WRITE_ID ^[0-9a-f]{64}$
 
@@ -176,7 +188,7 @@ testContractWriteGet() {
     # Provide both --data and --readin. --readin should be used.
     echo -n "Should be encrypted - from STDIN" | runCA0 contract write spawn\
                     --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
-                    --secret "Hello world." --key "$PUB_KEY"\
+                    --secret "aabbccddeeff0011" --key "$PUB_KEY"\
                     --readData --data "Hello there." -x > writeid.txt
     WRITE_ID=`cat writeid.txt`
     matchOK $WRITE_ID ^[0-9a-f]{64}$
@@ -195,9 +207,15 @@ testContractWriteGet() {
 -- LTSID: [0-9a-f]{64}
 -- Cost: .*$"
 
+
+    # Let's try with the --export option
+    OUTRES=`runCA0 contract write get --instid $WRITE_ID --export`
+
+    testGrep "Should be encrypted - from STDIN" echo "$OUTRES"
+    
     # Provide both --data and --extraData.
     runCA0 contract write spawn --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
-                    --secret "Hello world." --key "$PUB_KEY"\
+                    --secret "aabbccddeeff0011" --key "$PUB_KEY"\
                     --data "Should be encrypted"\
                     --extraData "Public infos" -x > writeid.txt
     WRITE_ID=`cat writeid.txt`
@@ -220,7 +238,7 @@ testContractWriteGet() {
     # Provide both --extraData and --readExtra. --readExtra should be used.
     echo -n "Extra data - from STDIN" | runCA0 contract write spawn\
                     --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
-                    --secret "Hello world." --key "$PUB_KEY"\
+                    --secret "aabbccddeeff0011" --key "$PUB_KEY"\
                     --readExtra --extraData "Hello there." -x > writeid.txt
     WRITE_ID=`cat writeid.txt`
     matchOK $WRITE_ID ^[0-9a-f]{64}$
@@ -242,7 +260,7 @@ testContractWriteGet() {
     # Provide both --data and --readExtra.
     echo -n "Extra data - from STDIN" | runCA0 contract write spawn\
                     --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
-                    --secret "Hello world." --key "$PUB_KEY"\
+                    --secret "aabbccddeeff0011" --key "$PUB_KEY"\
                     --readExtra --data "Hello there." -x > writeid.txt
     WRITE_ID=`cat writeid.txt`
     matchOK $WRITE_ID ^[0-9a-f]{64}$
@@ -264,7 +282,7 @@ testContractWriteGet() {
     # Provide both --extraData and --readData.
     echo -n "Should be encrypted - from STDIN" | runCA0 contract write spawn\
                     --darc "$ID" --sign "$KEY" --instid "$LTS_ID"\
-                    --secret "Hello world." --key "$PUB_KEY"\
+                    --secret "aabbccddeeff0011" --key "$PUB_KEY"\
                     --readData --extraData "Hello there." -x > writeid.txt
     WRITE_ID=`cat writeid.txt`
     matchOK $WRITE_ID ^[0-9a-f]{64}$

--- a/calypso/csadmin/commands.go
+++ b/calypso/csadmin/commands.go
@@ -145,7 +145,7 @@ var cmds = cli.Commands{
 							},
 							cli.StringFlag{
 								Name:  "secret",
-								Usage: "data to be encrypted, has limited space regarding the kyber.Suite used (29 bits for ed25519)",
+								Usage: "data to be encrypted, encoded as hexadecimal, has limited space regarding the kyber.Suite used (29 bytes for ed25519)",
 							},
 							cli.StringFlag{
 								Name:  "data, d",

--- a/calypso/csadmin/main.go
+++ b/calypso/csadmin/main.go
@@ -311,9 +311,8 @@ func decrypt(c *cli.Context) error {
 		return errors.New("failed to recover the key: " + err.Error())
 	}
 
-	dataStr := string(key)
 	if c.Bool("export") {
-		reader := bytes.NewReader([]byte(dataStr))
+		reader := bytes.NewReader(key)
 		_, err = io.Copy(os.Stdout, reader)
 		if err != nil {
 			return errors.New("failed to copy to stdout: " + err.Error())
@@ -321,7 +320,7 @@ func decrypt(c *cli.Context) error {
 		return nil
 	}
 
-	log.Infof("Key decrypted:\n%s", dataStr)
+	log.Infof("Key decrypted:\n%x", key)
 
 	return nil
 }

--- a/calypso/csadmin/test.sh
+++ b/calypso/csadmin/test.sh
@@ -146,7 +146,7 @@ testReencrypt(){
     
     # Spawn write
     OUTRES=`runCA0 contract write spawn --darc "$ID" --sign "$KEY"\
-                    --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY"`
+                    --instid "$LTS_ID" --secret "aabbccddeeff0011" --key "$PUB_KEY"`
     WRITE_ID=`echo "$OUTRES" | sed -n '2p'` # must be at the second line
     matchOK $WRITE_ID ^[0-9a-f]{64}$
 
@@ -214,7 +214,7 @@ testDecrypt(){
     
     # Spawn write
     OUTRES=`runCA0 contract write spawn --darc "$ID" --sign "$KEY" \
-                    --instid "$LTS_ID" --secret "Hello world." --key "$PUB_KEY"`
+                    --instid "$LTS_ID" --secret "aabbccddeeff0011" --key "$PUB_KEY"`
     WRITE_ID=`echo "$OUTRES" | sed -n '2p'` # must be at the second line
     matchOK $WRITE_ID ^[0-9a-f]{64}$
 
@@ -229,16 +229,17 @@ testDecrypt(){
     # should fail since it will use the default key, the admin one, and this is
     # not the key that was set for the read request
     OUTRES=`runCA decrypt < reply.bin`
-    testNGrep "Hello world" echo "$OUTRES"
+    testNGrep "aabbccddeeff0011" echo "$OUTRES"
 
     # should pass with the correct --key
     OUTRES=`runCA0 decrypt --key config/key-$KEY.cfg < reply.bin`
     matchOK "$OUTRES" "Key decrypted:
-Hello world."
+aabbccddeeff0011"
 
     # Check the export option
-    runCA0 decrypt --key config/key-$KEY.cfg -x < reply.bin > data.txt
-    matchOK "`cat data.txt`" "Hello world."
+    # We can not assert the content because the export option saves the data as
+    # raw bytes, where we input the secrect as hexadecimal converted to bytes.
+    testOK runCA0 decrypt --key config/key-$KEY.cfg -x < reply.bin > data.txt
 
     #
     # Now let's try to generate a new key and use this one to encrypt the data:
@@ -268,15 +269,15 @@ Hello world."
 
     # should fail with the default key
     OUTRES=`runCA decrypt < reply.bin`
-    testNGrep "Hello world" echo "$OUTRES"
+    testNGrep "aabbccddeeff0011" echo "$OUTRES"
     # should fail with the key used to sign
     OUTRES=`runCA decrypt --key config/key-$KEY.cfg < reply.bin`
-    testNGrep "Hello world" echo "$OUTRES"
+    testNGrep "aabbccddeeff0011" echo "$OUTRES"
     
     # should now work with the newly created key
     OUTRES=`runCA0 decrypt --key config/key-$NEW_KEY.cfg < reply.bin`
     matchOK "$OUTRES" "Key decrypted:
-Hello world."
+aabbccddeeff0011"
 }
 
 runCA(){


### PR DESCRIPTION
**What this PR does**

This PR updates the `--secret` argument to accept hexadecimal encoded string instead of plain string. It is easier to manipulate hexadecimal string via the command line since it does not have special chars that can be accidentally interpreted by the command line, and it makes it easier to reason in term of bytes (in this case a secret must not exceed 29 bytes).

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behavior is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped, following the `[failed to | counldn't do] ACTION THAT FAILED: " + err.Error()` format.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
