### PR TITLE
Allow darcs with spawn:calypsoRead

### DIFF
--- a/personhood/contract_spawner.go
+++ b/personhood/contract_spawner.go
@@ -101,10 +101,18 @@ func (c *ContractSpawner) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Inst
 		if err != nil {
 			return nil, nil, errors.New("couldn't decode darc: " + err.Error())
 		}
-		// Whitelist allowed darc rules - there is no spawn allowed, and all
+
+		// Allowing unlimited rules while spawning darcs could give attackers
+		// a way break the system.
+		//
+		// So, we whitelist allowed darc rules - there is no spawn allowed, and all
 		// invokes need to be in this list. Just to be sure that there is
 		// no command in the future that will allow to spawn things as an
 		// invoke.
+		//
+		// When using the spawner-instance, darcs with spawn:calypsoRead
+		// can be allowed, as they can only be used as instructions to a
+		// calypsoWrite instance that will check if coins are needed or not.
 		allowed := regexp.MustCompile("^(_sign|invoke:(" +
 			"darc\\.evolve|" +
 			"spawner\\.update|" +

--- a/personhood/contract_spawner.go
+++ b/personhood/contract_spawner.go
@@ -111,8 +111,9 @@ func (c *ContractSpawner) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Inst
 			"coin\\.(fetch|store|transfer)|" +
 			"credential\\.(update|recover)|" +
 			"popParty\\.(barrier|finalize|mine|addParty)|" +
-			"ropasci\\.(second|confirm)" +
-			"value\\.update))$")
+			"ropasci\\.(second|confirm)|" +
+			"value\\.update)|" +
+			"spawn:(calypsoRead))$")
 		for _, rule := range d.Rules.List {
 			if !allowed.MatchString(string(rule.Action)) {
 				return nil, nil, errors.New("cannot spawn darc with rule: " +


### PR DESCRIPTION
**What this PR does**

When using the spawner-instance, darcs with spawn:calypsoRead should
be allowed, as they can only be used as instructions to a calypsoWrite
instance that will check if coins are needed or not.

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped, following the `[failed to | couldn't do] ACTION THAT FAILED: " + err.Error()` format.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
