### PR TITLE
Makefile: auto-get Coding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ external/java/.project
 .vscode
 *.db
 *.cfg
+
+# cloned
+/Coding

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ _: &language_js
   language: node_js
   node_js: "lts/*"
 
-_: &get_coding
-  b=github.com/dedis/Coding; git clone https://$b.git $GOPATH/src/$b
 _: &gen_link_kyber
   pushd external/js/kyber && npm ci && npm run link && popd
 _: &get_go
@@ -19,7 +17,6 @@ _: &get_go
   - . $HOME/.gimme/envs/go1.12.4.env
 
 _: &stage_lint_go
-  before_script: *get_coding
   script:
     - make -C conode verify
     - GO111MODULE=on make test_{fmt,lint}
@@ -29,7 +26,6 @@ _: &stage_build_go
     - GO111MODULE=on go get ./...
     - GO111MODULE=on go build ./...
 _: &stage_test_go
-  before_script: *get_coding
   script: GO111MODULE=on make test_goveralls
 _: &stage_deploy_npm
   <<: *language_js
@@ -50,7 +46,6 @@ jobs:
     - stage: lint
       name: "protobuf"
       language: minimal
-      before_script: *get_coding
       script: make test_proto
     - <<: *stage_lint_go
       <<: *language_go_1_11
@@ -86,7 +81,6 @@ jobs:
     - name: "java"
       language: java
       install: *get_go
-      before_script: *get_coding
       script: make test_java
     - name: "js > kyber"
       <<: *language_js
@@ -98,7 +92,6 @@ jobs:
       <<: *language_js
       install: *get_go
       before_script:
-        - *get_coding
         - make docker
         - *gen_link_kyber
       script:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 all: test
 
-include $(shell go env GOPATH)/src/github.com/dedis/Coding/bin/Makefile.base
-EXCLUDE_LINT = "should be.*UI|_test.go"
+Coding/bin/Makefile.base:
+	git clone https://github.com/dedis/Coding
+include Coding/bin/Makefile.base
+EXCLUDE_LINT = should be.*UI|_test.go
 
 # You can use `test_playground` to run any test or part of cothority
 # for more than once in Travis. Change `make test` in .travis.yml


### PR DESCRIPTION
# has to be merged after https://github.com/dedis/Coding/pull/2

**Auto clone dedis/Coding**

To avoid having to explicitly clone Coding before `make`-ing cothority, the `Makefile` now does it by itself.

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped, following the `[failed to | couldn't do] ACTION THAT FAILED: " + err.Error()` format.
- [x] 5. Hard limit of 80 chars is always respected.
- [ ] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.