### PR TITLE
Check chain

### DIFF
--- a/byzcoin/bcadmin/README.md
+++ b/byzcoin/bcadmin/README.md
@@ -222,13 +222,14 @@ Bcadmin can also work on the database - either a separate, or a database from
 - `db catchup` fetches new blocks from the network
 - `db replay` applies the blocks from the database to the global state
 - `db status` returns simple status' about the internal database
+- `db check` goes through the whole chain and reports on bad blocks
 
 Before a release of a new version, the following commands should be run 
 and return success:
 
 ```bash
-bcadmin db catchup cache.db _bcID_ _url_
-bcadmin db replay cache.db _bcID_ --continue
+bcadmin db catchup cached.db _bcID_ _url_
+bcadmin db replay cached.db _bcID_ --continue
 ```
 
 The `_bcID_` has to be replaced by the hexadecimal representation of the 
@@ -257,7 +258,10 @@ If no other node in the system has all nodes stored, then you can `merge` a
 db with all nodes:
 ```bash
 # First stop the node
-bcadmin db merge path/to/conode.db _bcID_ cached.db
+bcadmin db merge --overwrite path/to/conode.db _bcID_ cached.db
 ```
+
+The `--overwrite` is necessary to store all blocks from the `cached.db` file 
+to the existing database.
 
 A `cached.db` is available at https://conode.c4dt.org/files/cached.db

--- a/byzcoin/bcadmin/README.md
+++ b/byzcoin/bcadmin/README.md
@@ -212,3 +212,52 @@ $ bcadmin debug block --bc bc-xxx.cfg --index 0 --txDetails
 
 This command will show the genesis-block of the chain defined in `bc-xxx.cfg`
  of all nodes, and also show the transactions contained in that block.
+
+## DataBase Methods
+
+Bcadmin can also work on the database - either a separate, or a database from
+ a conode. The following commands are available:
+ 
+- `db merge` copies the skipblocks from one database to another
+- `db catchup` fetches new blocks from the network
+- `db replay` applies the blocks from the database to the global state
+- `db status` returns simple status' about the internal database
+
+Before a release of a new version, the following commands should be run 
+and return success:
+
+```bash
+bcadmin db catchup cache.db _bcID_ _url_
+bcadmin db replay cache.db _bcID_ --continue
+```
+
+The `_bcID_` has to be replaced by the hexadecimal representation of the 
+chain to be tested (for the DEDIS chain: 
+`9cc36071ccb902a1de7e0d21a2c176d73894b1cf88ae4cc2ba4c95cd76f474f3`) and the 
+`_url_` can be any node in the network who has the needed blocks available, 
+e.g., `https://conode.dedis.ch`.
+
+### Creating a full node out of a caught-up node
+
+If a node is stuck, sometimes the only way to continue is to delete its 
+database and restart it. This works fine, but the node then only has the 
+minimal set of needed blocks and can not participate in catching-up for 
+replays.
+
+Suppose a node has been restarted with an empty database, and has caught up, 
+then you can use the following to store all blocks in the node again:
+
+```bash
+# First you need to stop the node, else the db cannot be modified
+bcadmin db catchup path/to/conode.db _bcID_ _url_
+# Then start the node again
+```
+
+If no other node in the system has all nodes stored, then you can `merge` a 
+db with all nodes:
+```bash
+# First stop the node
+bcadmin db merge path/to/conode.db _bcID_ cached.db
+```
+
+A `cached.db` is available at https://conode.c4dt.org/files/cached.db

--- a/byzcoin/bcadmin/cmd_db.go
+++ b/byzcoin/bcadmin/cmd_db.go
@@ -1,0 +1,434 @@
+package main
+
+import (
+	"encoding/hex"
+	"errors"
+	"flag"
+	"github.com/urfave/cli"
+	"go.dedis.ch/cothority/v3"
+	"go.dedis.ch/cothority/v3/byzcoin"
+	"go.dedis.ch/cothority/v3/skipchain"
+	"go.dedis.ch/onet/v3"
+	"go.dedis.ch/onet/v3/log"
+	"go.dedis.ch/onet/v3/network"
+	"go.etcd.io/bbolt"
+	"golang.org/x/xerrors"
+	"strings"
+)
+
+// dbStatus returns the last block in the db - useful for the integration tests.
+func dbStatus(c *cli.Context) error {
+	fb, err := newFetchBlocks(c)
+	if err != nil {
+		return xerrors.Errorf("couldn't create fetchBlock: %+v", err)
+	}
+
+	last, err := fb.db.GetLatest(fb.genesis)
+	if err != nil {
+		return xerrors.Errorf("couldn't get latest block: %+v", err)
+	}
+	log.Infof("Last block is: %d / %x", last.Index, last.Hash)
+	return nil
+}
+
+// dbCatchup uses the live byzcoin chain to update to the latest blocks
+func dbCatchup(c *cli.Context) error {
+	if c.NArg() < 3 {
+		return errors.New("please give the following arguments: " +
+			"conode.db byzCoinID url")
+	}
+	fb, err := newFetchBlocks(c)
+	if err != nil {
+		return xerrors.Errorf("couldn't create fetchBlock: %+v", err)
+	}
+	err = fb.addURL(c.Args().Get(2))
+	if err != nil {
+		return xerrors.Errorf("couldn't add URL connection: %+v", err)
+	}
+
+	log.Info("Search for latest block")
+	latestID := *fb.bcID
+	for next := fb.db.GetByID(latestID); next != nil && len(next.ForwardLink) > 0; next = fb.db.GetByID(latestID) {
+		latestID = next.ForwardLink[0].To
+		if next.Index%1000 == 0 {
+			log.Info("Found block", next.Index)
+		}
+	}
+
+	for {
+		sb, err := fb.gbMulti(latestID)
+		if err != nil {
+			return xerrors.Errorf("couldn't get blocks from network: %+v", err)
+		}
+		if len(sb.ForwardLink) == 0 {
+			break
+		}
+		latestID = sb.ForwardLink[0].To
+	}
+
+	return nil
+}
+
+// dbReplay re-applies all the contracts to the new blocks available.
+func dbReplay(c *cli.Context) error {
+	fb, err := newFetchBlocks(c)
+	if err != nil {
+		return errors.New("couldn't initialize fetchBlocks: " + err.Error())
+	}
+
+	log.Info("Preparing db")
+	start := *fb.bcID
+	err = fb.boltDB.Update(func(tx *bbolt.Tx) error {
+		if !fb.flagReplayCont {
+			if tx.Bucket(fb.bucketName) != nil {
+				err := tx.DeleteBucket(fb.bucketName)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		_, err := tx.CreateBucketIfNotExists(fb.bucketName)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return xerrors.Errorf("couldn't add bucket: %+v", err)
+	}
+
+	if !fb.flagReplayCont {
+		_, err = fb.service.ReplayStateDB(fb.boltDB, fb.bucketName, fb.genesis)
+		if err != nil {
+			return xerrors.Errorf("couldn't create stateDB: %+v", err)
+		}
+	} else {
+		index, err := fb.service.ReplayStateDB(fb.boltDB, fb.bucketName, nil)
+		if err != nil {
+			return xerrors.Errorf("couldn't replay blocks: %+v", err)
+		}
+
+		log.Info("Searching for block with index", index+1)
+		sb := fb.db.GetByID(start)
+		for sb != nil && sb.Index < index+1 {
+			if len(sb.ForwardLink) == 0 {
+				break
+			}
+			sb = fb.db.GetByID(sb.ForwardLink[0].To)
+			start = sb.Hash
+		}
+		if sb.Index <= index {
+			log.Info("No new blocks available")
+			return nil
+		}
+	}
+
+	log.Info("Replaying blocks")
+	_, err = fb.service.ReplayStateCont(start, fb.blockFetcher)
+	if err != nil {
+		return xerrors.Errorf("couldn't replay blocks: %+v", err)
+	}
+	log.Info("Successfully checked and replayed all blocks.")
+
+	return nil
+}
+
+// dbMerge takes new blocks from a conode-db and applies them to the replay-db.
+func dbMerge(c *cli.Context) error {
+	if c.NArg() < 3 {
+		return errors.New("please give the following arguments: " +
+			"conode.db byzCoinID conode2.db")
+	}
+
+	fb, err := newFetchBlocks(c)
+	if err != nil {
+		return xerrors.Errorf("couldn't create fetchBlock: %+v", err)
+	}
+
+	dbBack, _, err := fb.openDB(c.Args().Get(2))
+	if err != nil {
+		return xerrors.Errorf("couldn't open DB: %+v", err)
+	}
+	sb := dbBack.GetByID(*fb.bcID)
+	if sb != nil {
+		sbLatest, err := fb.db.GetLatest(sb)
+		if err != nil {
+			log.Warn("Couldn't get latest block:", err)
+		} else {
+			sb = dbBack.GetByID(sbLatest.Hash)
+		}
+	}
+	var latest int
+	var blocks int
+	if c.Bool("overwrite") {
+		err = fb.db.RemoveSkipchain(*fb.bcID)
+		if err != nil {
+			return xerrors.Errorf("couldn't remove skipchain: %+v", err)
+		}
+		sb = dbBack.GetByID(*fb.bcID)
+		for sb != nil {
+			blocks++
+			latest = sb.Index
+			if blocks%100 == 0{
+				log.Infof("Stored %d blocks so far", blocks)
+			}
+			fb.db.Store(sb)
+			if len(sb.ForwardLink) > 0 {
+				sb = dbBack.GetByID(sb.ForwardLink[0].To)
+			} else {
+				break
+			}
+		}
+	} else {
+		for sb != nil {
+			latest = sb.Index
+			blocks++
+			fb.db.Store(sb)
+			if len(sb.ForwardLink) > 0 {
+				sb = dbBack.GetByID(sb.ForwardLink[0].To)
+			} else {
+				break
+			}
+			if blocks%100 == 0 {
+				log.Infof("Stored %d blocks - latest block-index is: %d",
+					blocks, latest)
+			}
+		}
+	}
+	log.Infof("Found %d blocks in backup. Latest index: %d", blocks,
+		latest)
+	return nil
+}
+
+// fetchBlocks is used by all db-related bcadmin commands.
+type fetchBlocks struct {
+	cl               *skipchain.Client
+	service          *byzcoin.Service
+	bcID             *skipchain.SkipBlockID
+	local            *onet.LocalTest
+	roster           *onet.Roster
+	genesis          *skipchain.SkipBlock
+	latest           *skipchain.SkipBlock
+	single           int
+	index            int
+	boltDB           *bbolt.DB
+	db               *skipchain.SkipBlockDB
+	bucketName       []byte
+	flagCatchupBatch int
+	flagReplayBlocks int
+	flagReplayCont   bool
+}
+
+func newFetchBlocks(c *cli.Context) (*fetchBlocks,
+	error) {
+	if c.NArg() < 1 {
+		return nil, errors.New("please give the following arguments: " +
+			"conode.db [byzCoinID]")
+	}
+
+	fb := &fetchBlocks{
+		local:            onet.NewLocalTest(cothority.Suite),
+		bucketName:       []byte("replayStateBucket"),
+		flagCatchupBatch: c.Int("batch"),
+		flagReplayBlocks: c.Int("blocks"),
+		flagReplayCont:   c.Bool("continue"),
+	}
+
+	var err error
+	servers := fb.local.GenServers(1)
+	fb.service = servers[0].Service(byzcoin.ServiceName).(*byzcoin.Service)
+
+	fb.db, fb.boltDB, err = fb.openDB(c.Args().First())
+	if err != nil {
+		return nil, xerrors.Errorf("couldn't open DB: %+v", err)
+	}
+
+	if c.NArg() >= 2 {
+		var bi skipchain.SkipBlockID
+		bi, err = hex.DecodeString(c.Args().Get(1))
+		fb.bcID = &bi
+		fb.genesis = fb.db.GetByID(*fb.bcID)
+	}
+
+	if c.Command.Name != "catchup" {
+		err := fb.needBcID()
+		if err != nil {
+			return nil, xerrors.Errorf("couldn't check bcID: %+v", err)
+		}
+	}
+	return fb, nil
+}
+
+func (fb *fetchBlocks) needBcID() error {
+	if fb.bcID != nil {
+		return nil
+	}
+	var scIDs []string
+	sbs, err := fb.db.GetSkipchains()
+	if err != nil {
+		return xerrors.Errorf("couldn't list all blocks: %+v", err)
+	}
+	for _, sb := range sbs {
+		if sb.Index == 0 {
+			scIDs = append(scIDs, hex.EncodeToString(sb.SkipChainID()))
+		}
+	}
+	log.Info("The following chains are available in your db:",
+		strings.Join(scIDs, "\n"))
+	return errors.New("need byzCoinID in arguments")
+}
+
+func (fb *fetchBlocks) addURL(url string) error {
+	if url == "" {
+		return errors.New("cannot use empty url")
+	}
+
+	if fb.bcID == nil {
+		fs := &flag.FlagSet{}
+		if err := fs.Parse([]string{url}); err != nil {
+			return xerrors.Errorf("couldn't parse url: %+v", err)
+		}
+		c := cli.NewContext(nil, fs, nil)
+		err := debugList(c)
+		if err != nil {
+			return err
+		}
+
+		log.Info("Please provide one of the following byzcoin ID as the second argument")
+		return nil
+	}
+
+	fb.cl = skipchain.NewClient()
+	fb.roster = onet.NewRoster([]*network.ServerIdentity{{
+		Address: network.NewAddress(network.TLS, url),
+		URL:     url,
+		// valid server identity must have a public so we create a fake one
+		// as we are only interested in the URL.
+		Public: cothority.Suite.Point().Base(),
+	}})
+	updateChain, err := fb.cl.GetUpdateChain(fb.roster, *fb.bcID)
+	if err != nil {
+		return xerrors.Errorf("couldn't get latest block: %+v", err)
+	}
+	fb.roster.List = []*network.ServerIdentity{}
+	for _, sb := range updateChain.Update {
+		for _, id := range sb.Roster.List {
+			if i, _ := fb.roster.Search(id.ID); i < 0 {
+				fb.roster.List = append(fb.roster.List, id)
+			}
+		}
+	}
+	fb.genesis = updateChain.Update[0]
+	fb.latest = updateChain.Update[len(updateChain.Update)-1]
+	fb.cl.UseNode(0)
+	return nil
+}
+
+func (fb *fetchBlocks) blockFetcher(sib skipchain.SkipBlockID) (*skipchain.SkipBlock, error) {
+	fb.flagReplayBlocks--
+	if fb.flagReplayBlocks == 0 {
+		log.Info("reached end of task")
+		return nil, nil
+	}
+	sb := fb.db.GetByID(sib)
+	if sb == nil {
+		return nil, nil
+	}
+	return sb, nil
+}
+
+func (fb *fetchBlocks) openDB(name string) (*skipchain.SkipBlockDB,
+	*bbolt.DB, error) {
+	db, err := bbolt.Open(name, 0600, nil)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("couldn't open db: %+v", err)
+	}
+	bucketName := []byte("Skipchain_skipblocks")
+	err = db.Update(func(tx *bbolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(bucketName)
+		return err
+	})
+	if err != nil {
+		return nil, nil, xerrors.Errorf("couldn't create bucket: %+v", err)
+	}
+	return skipchain.NewSkipBlockDB(db, bucketName), db, nil
+}
+
+func (fb *fetchBlocks) nextNode() {
+	fb.index = (fb.index + 1) % len(fb.roster.List)
+	fb.cl.UseNode(fb.index)
+}
+
+func (fb *fetchBlocks) gbMulti(startID skipchain.SkipBlockID) (
+	*skipchain.SkipBlock, error) {
+	for range fb.roster.List {
+		blocks, err := fb.cl.GetUpdateChainLevel(fb.roster, startID,
+			1, fb.flagCatchupBatch)
+		log.Lvl2("got", len(blocks), "blocks")
+		ok := false
+		if err != nil {
+			log.Warn("Got error while fetching blocks:", err)
+		} else {
+			ok = true
+			start := blocks[0]
+			for i, sb := range blocks {
+				if sb.Index != start.Index+i {
+					log.Warn("Blocks out of order", sb.Index, i,
+						start.Index)
+					ok = false
+					break
+				}
+			}
+		}
+
+		if !ok {
+			fb.nextNode()
+			continue
+		}
+
+		_, err = fb.db.StoreBlocks(blocks)
+		if err != nil {
+			return nil, xerrors.Errorf("couldn't store blocks: %+v", err)
+		}
+
+		url := fb.roster.List[fb.index].URL
+		if url == "" {
+			url = fb.roster.List[fb.index].Address.String()
+		}
+		log.Infof("Got %d blocks from %s, starting at index %d",
+			len(blocks), fb.roster.List[fb.index].Address, blocks[0].Index)
+		return blocks[len(blocks)-1], nil
+	}
+	return fb.gbSingle(startID)
+}
+
+func (fb *fetchBlocks) gbSingle(blockID skipchain.SkipBlockID) (
+	*skipchain.SkipBlock, error) {
+	var sb *skipchain.SkipBlock
+	for i := 0; i < fb.flagCatchupBatch; i++ {
+		for range fb.roster.List {
+			log.Infof("Getting single block %x from %d",
+				blockID, fb.index)
+			var err error
+			sb, err = fb.cl.GetSingleBlock(fb.roster, blockID)
+			if err != nil {
+				fb.nextNode()
+				continue
+			}
+			_, err = fb.db.StoreBlocks([]*skipchain.SkipBlock{sb})
+			if err != nil {
+				return nil, xerrors.Errorf("couldn't store blocks: %+v", err)
+			}
+			if len(sb.ForwardLink) == 0 {
+				return sb, nil
+			}
+			break
+		}
+		if sb != nil && !sb.ForwardLink[0].To.Equal(blockID) {
+			blockID = sb.ForwardLink[0].To
+		} else {
+			return sb, errors.New("couldn't fetch next block")
+		}
+	}
+	return sb, nil
+}

--- a/byzcoin/bcadmin/cmd_db.go
+++ b/byzcoin/bcadmin/cmd_db.go
@@ -260,8 +260,8 @@ func dbCheck(c *cli.Context) error {
 					continue
 				}
 				if len(previous.ForwardLink) <= i {
-					log.Warnf("%s points to block with less forward"+
-						"-links to point to itself", errStrBl)
+					log.Warnf("%s points to block with not enough forward"+
+						"-links", errStrBl)
 					continue
 				}
 				if previous.ForwardLink[i].IsEmpty() {

--- a/byzcoin/bcadmin/commands.go
+++ b/byzcoin/bcadmin/commands.go
@@ -80,16 +80,65 @@ var cmds = cli.Commands{
 	},
 
 	{
+		Name:      "db",
+		Usage:     "interact with byzcoin for debugging",
+		Aliases:   []string{"d"},
+		ArgsUsage: "conode.db [byzCoinID]",
+		Subcommands: cli.Commands{
+			{
+				Name:   "status",
+				Usage:  "returns the status of the db",
+				Action: dbStatus,
+			},
+			{
+				Name:      "catchup",
+				Usage:     "Fetch new blocks from an active chain",
+				Action:    dbCatchup,
+				ArgsUsage: "URL",
+				Flags: []cli.Flag{
+					cli.IntFlag{
+						Name: "batch",
+						Usage: "how many blocks will be fetched with each" +
+							" request",
+						Value: 100,
+					},
+				},
+			},
+			{
+				Name:   "replay",
+				Usage:  "Replay a chain and check the global state is consistent",
+				Action: dbReplay,
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "continue, cont",
+						Usage: "continue an aborted replay",
+					},
+					cli.IntFlag{
+						Name:  "blocks",
+						Usage: "how many blocks to apply",
+					},
+				},
+			},
+			{
+				Name:      "merge",
+				Usage:     "Copy the blocks of another db-file into this one",
+				Action:    dbMerge,
+				ArgsUsage: "conode2.db",
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "overwrite",
+						Usage: "replace whole blocks if they are duplicate",
+					},
+				},
+			},
+		},
+	},
+
+	{
 		Name:    "debug",
 		Usage:   "interact with byzcoin for debugging",
 		Aliases: []string{"d"},
 		Subcommands: cli.Commands{
-			{
-				Name:      "replay",
-				Usage:     "Replay a chain and check the global state is consistent",
-				Action:    debugReplay,
-				ArgsUsage: "URL",
-			},
 			{
 				Name:   "block",
 				Usage:  "Read a block given by an id or an index",

--- a/byzcoin/bcadmin/commands.go
+++ b/byzcoin/bcadmin/commands.go
@@ -135,6 +135,27 @@ var cmds = cli.Commands{
 					},
 				},
 			},
+			{
+				Name: "check",
+				Usage: "Check that the chain is in a correct state with" +
+					" regard to hashes, forward-, and backward-links",
+				Action: dbCheck,
+				Flags: []cli.Flag{
+					cli.IntFlag{
+						Name:  "blocks",
+						Usage: "maximum number of blocks to check",
+					},
+					cli.IntFlag{
+						Name:  "start",
+						Usage: "index of block to start verifications",
+					},
+					cli.IntFlag{
+						Name:  "process",
+						Usage: "show process indicator every n blocks",
+						Value: 100,
+					},
+				},
+			},
 		},
 	},
 

--- a/byzcoin/bcadmin/commands.go
+++ b/byzcoin/bcadmin/commands.go
@@ -125,6 +125,10 @@ var cmds = cli.Commands{
 				Action:    dbMerge,
 				ArgsUsage: "conode2.db",
 				Flags: []cli.Flag{
+					cli.IntFlag{
+						Name:  "blocks",
+						Usage: "maximum number of blocks to merge",
+					},
 					cli.BoolFlag{
 						Name:  "overwrite",
 						Usage: "replace whole blocks if they are duplicate",

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -1010,10 +1010,10 @@ func debugBlock(c *cli.Context) error {
 			flinks = append(flinks, fmt.Sprintf("\t\tTo: %x - NewRoster: %t",
 				l.To, l.NewRoster != nil))
 		}
-		out := fmt.Sprintf("\tBlock #%d from %s\n"+
+		out := fmt.Sprintf("\tBlock %x (index %d) from %s\n"+
 			"\tNode-list: %s\n"+
 			"\tForward-links:\n%s\n",
-			sb.Index, t.String(),
+			sb.Hash, sb.Index, t.String(),
 			sb.Roster.List,
 			strings.Join(flinks, "\n"))
 		if c.Bool("txDetails") {

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -1005,6 +1005,10 @@ func debugBlock(c *cli.Context) error {
 			return xerrors.Errorf("couldn't decode data: %+v", err)
 		}
 		t := time.Unix(dHead.Timestamp/1e9, 0)
+		var blinks []string
+		for _, l := range sb.BackLinkIDs {
+			blinks = append(blinks, fmt.Sprintf("\t\tTo: %x", l))
+		}
 		var flinks []string
 		for _, l := range sb.ForwardLink {
 			flinks = append(flinks, fmt.Sprintf("\t\tTo: %x - NewRoster: %t",
@@ -1012,9 +1016,11 @@ func debugBlock(c *cli.Context) error {
 		}
 		out := fmt.Sprintf("\tBlock %x (index %d) from %s\n"+
 			"\tNode-list: %s\n"+
+			"\tBack-links:\n%s\n"+
 			"\tForward-links:\n%s\n",
 			sb.Hash, sb.Index, t.String(),
 			sb.Roster.List,
+			strings.Join(blinks, "\n"),
 			strings.Join(flinks, "\n"))
 		if c.Bool("txDetails") {
 			var txs []string

--- a/byzcoin/contracts/coins.go
+++ b/byzcoin/contracts/coins.go
@@ -163,7 +163,7 @@ func (c *contractCoin) Invoke(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instru
 		if err != nil {
 			return nil, nil, errors.New("couldn't marshal target account: " + err.Error())
 		}
-		log.Lvlf1("transferring %d to %x", coinsArg, target)
+		log.Lvlf2("transferring %d to %x", coinsArg, target)
 		sc = append(sc, byzcoin.NewStateChange(byzcoin.Update, byzcoin.NewInstanceID(target),
 			ContractCoinID, targetBuf, did))
 	case "fetch":

--- a/conode/conode_linux.go
+++ b/conode/conode_linux.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,cgo
 
 package main
 

--- a/external/js/cothority/spec/skipchain/skipchain-rpc.spec.ts
+++ b/external/js/cothority/spec/skipchain/skipchain-rpc.spec.ts
@@ -79,7 +79,7 @@ describe("SkipchainRPC Tests", () => {
             .toBeRejected();
         await expectAsync(rejectContains(rpc.getSkipBlock(Buffer.from([1, 2, 3])), "No such block"))
             .toBeResolved();
-        await expectAsync(rejectContains(rpc.getLatestBlock(Buffer.from([1, 2, 3])), "Couldn't find latest skipblock"))
+        await expectAsync(rejectContains(rpc.getLatestBlock(Buffer.from([1, 2, 3])), "couldn't find latest skipblock"))
             .toBeResolved();
     });
 

--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,7 @@ require (
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/ethereum/go-ethereum v1.8.27
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/prataprc/goparsec v0.0.0-20180806094145-2600a2a4a410

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,10 @@ require (
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/ethereum/go-ethereum v1.8.27
+	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/prataprc/goparsec v0.0.0-20180806094145-2600a2a4a410

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,8 @@ github.com/xtaci/kcp-go v5.4.5+incompatible/go.mod h1:bN6vIwHQbfHaHtFpEssmWsN45a
 github.com/xtaci/lossyconn v0.0.0-20190602105132-8df528c0c9ae/go.mod h1:gXtu8J62kEgmN++bm9BVICuT/e8yiLI2KFobd/TRFsE=
 go.dedis.ch/fixbuf v1.0.3 h1:hGcV9Cd/znUxlusJ64eAlExS+5cJDIyTyEG+otu5wQs=
 go.dedis.ch/fixbuf v1.0.3/go.mod h1:yzJMt34Wa5xD37V5RTdmp38cz3QhMagdGoem9anUalw=
+go.dedis.ch/kyber/v3 v3.0.0-pre2/go.mod h1:OzvaEnPvKlyrWyp3kGXlFdp7ap1VC6RkZDTaPikqhsQ=
+go.dedis.ch/kyber/v3 v3.0.3/go.mod h1:OzvaEnPvKlyrWyp3kGXlFdp7ap1VC6RkZDTaPikqhsQ=
 go.dedis.ch/kyber/v3 v3.0.4 h1:FDuC/S3STkvwxZ0ooo3gcp56QkUKsN7Jy7cpzBxL+vQ=
 go.dedis.ch/kyber/v3 v3.0.4/go.mod h1:OzvaEnPvKlyrWyp3kGXlFdp7ap1VC6RkZDTaPikqhsQ=
 go.dedis.ch/kyber/v3 v3.0.5 h1:BpjX6vY1R3b7TnJ0mUnCFRVXEJThSAj1zQzmNh4v+70=
@@ -189,10 +191,12 @@ go.dedis.ch/kyber/v3 v3.0.5/go.mod h1:V1z0JihG9+dUEUCKLI9j9tjnlIflBw3wx8UOg0g3Pn
 go.dedis.ch/onet/v3 v3.0.24 h1:DjPcMDgQgQdxi6Z6vHt3BSuKtZioDUHpIUEC9wQ9NmI=
 go.dedis.ch/onet/v3 v3.0.24/go.mod h1:JhOZn9nJgpvxQWiY7Uebjj1AdXTW0ksQyq8RocRhwPk=
 go.dedis.ch/protobuf v1.0.5/go.mod h1:eIV4wicvi6JK0q/QnfIEGeSFNG0ZeB24kzut5+HaRLo=
+go.dedis.ch/protobuf v1.0.6/go.mod h1:YHYXW6dQ9p2iJ3f+2fxKnOpjGx0MvL4cwpg1RVNXaV8=
 go.dedis.ch/protobuf v1.0.7 h1:wRUEiq3u0/vBhLjcw9CmAVrol+BnDyq2M0XLukdphyI=
 go.dedis.ch/protobuf v1.0.7/go.mod h1:pv5ysfkDX/EawiPqcW3ikOxsL5t+BqnV6xHSmE79KI4=
 go.dedis.ch/protobuf v1.0.8 h1:lmyHigYqVxoTN1V0adoGPvqSdjycAMK0XmTFjP893mA=
 go.dedis.ch/protobuf v1.0.8/go.mod h1:pv5ysfkDX/EawiPqcW3ikOxsL5t+BqnV6xHSmE79KI4=
+go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/libtest.sh
+++ b/libtest.sh
@@ -501,4 +501,4 @@ for i in "$@"; do
 done
 buildDir
 
-export CONODE_SERVICE_PATH=build/service_storage
+export CONODE_SERVICE_PATH=service_storage

--- a/skipchain/api.go
+++ b/skipchain/api.go
@@ -272,7 +272,7 @@ func (c *Client) GetUpdateChainLevel(roster *onet.Roster, latest SkipBlockID,
 		_, err = c.SendProtobufParallel(roster.List, &GetUpdateChain{
 			LatestID:  latest,
 			MaxHeight: maxLevel,
-			MaxBlocks: maxBlocks,
+			MaxBlocks: maxBlocks - len(update),
 		}, r2, c.options)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't get update chain; last error: %v", err)
@@ -323,6 +323,9 @@ func (c *Client) GetUpdateChainLevel(roster *onet.Roster, latest SkipBlockID,
 				}
 			}
 			update = append(update, b)
+			if len(update) == maxBlocks {
+				return update, nil
+			}
 		}
 
 		last := update[len(update)-1]

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -492,7 +492,7 @@ func (s *Service) OptimizeProof(req *OptimizeProofRequest) (*OptimizeProofReply,
 func (s *Service) GetUpdateChain(guc *GetUpdateChain) (*GetUpdateChainReply, error) {
 	block := s.db.GetByID(guc.LatestID)
 	if block == nil {
-		return nil, errors.New("Couldn't find latest skipblock")
+		return nil, errors.New("couldn't find latest skipblock")
 	}
 
 	blocks := []*SkipBlock{block.Copy()}

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -1258,6 +1258,14 @@ func (db *SkipBlockDB) RemoveSkipchain(scid SkipBlockID) error {
 	})
 }
 
+// RemoveBlock removes the given block from the database.
+func (db *SkipBlockDB) RemoveBlock(blockID SkipBlockID) error {
+	return db.Update(func(tx *bbolt.Tx) error {
+		b := tx.Bucket([]byte(db.bucketName))
+		return b.Delete(blockID)
+	})
+}
+
 // storeToTx stores the skipblock into the database.
 // An error is returned on failure.
 // The caller must ensure that this function is called from within a valid transaction.


### PR DESCRIPTION
**What this PR does**

Bcadmin can now also work on the database - either a separate, or a database from
 a conode. The following commands are available:
 
- `db merge` copies the skipblocks from one database to another
- `db catchup` fetches new blocks from the network
- `db replay` applies the blocks from the database to the global state
- `db status` returns simple status' about the internal database

Before a release of a new version, the following commands should be run 
and return success:

```bash
bcadmin db catchup cache.db 9cc36071ccb902a1de7e0d21a2c176d73894b1cf88ae4cc2ba4c95cd76f474f3 https://conode.dedis.ch
bcadmin db replay cache.db 9cc36071ccb902a1de7e0d21a2c176d73894b1cf88ae4cc2ba4c95cd76f474f3 --continue
```

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped, following the `[failed to | couldn't do] ACTION THAT FAILED: " + err.Error()` format.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
