### PR TITLE
Fixes personhood contracts

### DIFF
--- a/external/java/src/main/java/ch/epfl/dedis/byzcoin/ByzCoinRPC.java
+++ b/external/java/src/main/java/ch/epfl/dedis/byzcoin/ByzCoinRPC.java
@@ -51,7 +51,7 @@ public class ByzCoinRPC {
     private SkipchainRPC skipchain;
 
     private Subscription subscription;
-    public static final int currentVersion = 1;
+    public static final int currentVersion = 2;
     final String[] darcContractIDs = new String[]{"darc"};
 
     private static final Logger logger = LoggerFactory.getLogger(ByzCoinRPC.class);

--- a/external/js/cothority/src/byzcoin/byzcoin-rpc.ts
+++ b/external/js/cothority/src/byzcoin/byzcoin-rpc.ts
@@ -25,7 +25,7 @@ import {
     GetSignerCountersResponse,
 } from "./proto/requests";
 
-export const currentVersion = 1;
+export const currentVersion = 2;
 
 const CONFIG_INSTANCE_ID = Buffer.alloc(32, 0);
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/ethereum/go-ethereum v1.8.27
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/prataprc/goparsec v0.0.0-20180806094145-2600a2a4a410

--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,7 @@ require (
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/ethereum/go-ethereum v1.8.27
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/prataprc/goparsec v0.0.0-20180806094145-2600a2a4a410

--- a/personhood/contract_ropasci_test.go
+++ b/personhood/contract_ropasci_test.go
@@ -182,7 +182,7 @@ func (sr *testRPS) newCalypsoRPS(move int, coinID byzcoin.InstanceID, stake uint
 	ropasci := RoPaSciStruct{
 		Description:        "test",
 		FirstPlayerHash:    moveHash[:],
-		FirstPlayerAccount: sr.coin1.id,
+		FirstPlayerAccount: &sr.coin1.id,
 	}
 	ropasciBuf, err := protobuf.Encode(&ropasci)
 	require.NoError(sr.t, err)

--- a/personhood/contract_test.go
+++ b/personhood/contract_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestContractSpawner(t *testing.T) {
-	iid := byzcoin.InstanceID{}
+	iid := byzcoin.NewInstanceID([]byte("some coin"))
 	s := newRstSimul()
 	s.values[string(iid.Slice())] = byzcoin.StateChangeBody{}
 	cs := &ContractSpawner{}

--- a/personhood/proto.go
+++ b/personhood/proto.go
@@ -72,12 +72,12 @@ type RoPaSciStruct struct {
 	Description         string
 	Stake               byzcoin.Coin
 	FirstPlayerHash     []byte
-	FirstPlayer         int                `protobuf:"opt"`
-	SecondPlayer        int                `protobuf:"opt"`
-	SecondPlayerAccount byzcoin.InstanceID `protobuf:"opt"`
-	FirstPlayerAccount  byzcoin.InstanceID `protobuf:"opt"`
-	CalypsoWrite        byzcoin.InstanceID `protobuf:"opt"`
-	CalypsoRead         byzcoin.InstanceID `protobuf:"opt"`
+	FirstPlayer         int                 `protobuf:"opt"`
+	SecondPlayer        int                 `protobuf:"opt"`
+	SecondPlayerAccount byzcoin.InstanceID  `protobuf:"opt"`
+	FirstPlayerAccount  *byzcoin.InstanceID `protobuf:"opt"`
+	CalypsoWrite        *byzcoin.InstanceID `protobuf:"opt"`
+	CalypsoRead         *byzcoin.InstanceID `protobuf:"opt"`
 }
 
 // CredentialStruct holds a slice of credentials.


### PR DESCRIPTION
**What this PR does**

When testing the new personhood contracts with bcadmin replay, it showed that they
were not backwards-compatible. This PR fixes the contracts such that all blocks can
be successfully applied to get the current global state.

This increases the `Version` to `2`, so that the spawner-contract can behave correctly in the future.

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped, following the `[failed to | couldn't do] ACTION THAT FAILED: " + err.Error()` format.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
