### PR TITLE
Fixes some race conditions

### DIFF
--- a/byzcoin/bcadmin/commands.go
+++ b/byzcoin/bcadmin/commands.go
@@ -533,7 +533,7 @@ var cmds = cli.Commands{
                                       [--darc <darc id>] 
                                       [--sign <pub key>]     
                              }
-   CONTRAT   {value,deferred,config}`),
+   CONTRACT   {value,deferred,config}`),
 		Subcommands: cli.Commands{
 			{
 				Name:  "value",

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -87,7 +87,7 @@ func main() {
 	rand.Seed(time.Now().Unix())
 	err := cliApp.Run(os.Args)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("error: %+v", err)
 	}
 	return
 }
@@ -446,6 +446,8 @@ func getBcKey(c *cli.Context) (cfg lib.Config, cl *byzcoin.Client, signer *darc.
 		err = errors.New("couldn't decode chainConfig: " + err.Error())
 		return
 	}
+	cl.Roster = chainCfg.Roster
+
 	return
 }
 

--- a/byzcoin/bcadmin/test.sh
+++ b/byzcoin/bcadmin/test.sh
@@ -5,7 +5,7 @@
 # Options:
 #   -b   re-builds bcadmin package
 
-DBG_TEST=1
+DBG_TEST=2
 DBG_SRV=1
 DBG_BCADMIN=2
 


### PR DESCRIPTION
**What this PR does**

Correct `WaitPropagation` to correctly wait for all nodes to be in the same state.

Also `xerrors.Errorf` changes while searching the bug.
Also more error-handling where `err` was not checked.

Closes #2083 

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%+v` verb.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
