### PR TITLE
speed up counter handling in byzcoin

### DIFF
--- a/external/js/cothority/spec/byzcoin/client-transaction.spec.ts
+++ b/external/js/cothority/spec/byzcoin/client-transaction.spec.ts
@@ -8,6 +8,13 @@ const updater = new class {
     getSignerCounters(signers: IIdentity[], increment: number): Promise<Long[]> {
         return Promise.resolve(signers.map(() => Long.fromNumber(increment)));
     }
+    updateCachedCounters(signers: IIdentity[]): Promise<Long[]> {
+        return this.getSignerCounters(signers, 1);
+    }
+    getNextCounter(signer: IIdentity): Long {
+        return Long.fromNumber(1);
+    }
+
 }();
 
 describe("ClientTransaction Tests", () => {

--- a/external/js/cothority/src/byzcoin/byzcoin-rpc.ts
+++ b/external/js/cothority/src/byzcoin/byzcoin-rpc.ts
@@ -31,10 +31,6 @@ const CONFIG_INSTANCE_ID = Buffer.alloc(32, 0);
 
 export default class ByzCoinRPC implements ICounterUpdater {
 
-    get genesisID(): InstanceID {
-        return this.genesis.computeHash();
-    }
-
     static staticCounters: Map<string, Map<string, Long>> = new Map<string, Map<string, Long>>();
 
     /**
@@ -123,6 +119,14 @@ export default class ByzCoinRPC implements ICounterUpdater {
     private conn: IConnection;
 
     protected constructor() {
+    }
+
+    get genesisID(): InstanceID {
+        return this.genesis.computeHash();
+    }
+
+    get latest(): SkipBlock {
+        return new SkipBlock(this._latest);
     }
 
     /**

--- a/external/js/cothority/src/byzcoin/byzcoin-rpc.ts
+++ b/external/js/cothority/src/byzcoin/byzcoin-rpc.ts
@@ -30,6 +30,13 @@ export const currentVersion = 2;
 const CONFIG_INSTANCE_ID = Buffer.alloc(32, 0);
 
 export default class ByzCoinRPC implements ICounterUpdater {
+
+    get genesisID(): InstanceID {
+        return this.genesis.computeHash();
+    }
+
+    static staticCounters: Map<string, Map<string, Long>> = new Map<string, Map<string, Long>>();
+
     /**
      * Helper to create a genesis darc
      * @param signers       Authorized signers
@@ -60,21 +67,23 @@ export default class ByzCoinRPC implements ICounterUpdater {
      * @param skipchainID   The genesis block identifier
      * @param waitMatch how many times to wait for a match - useful if its called just after an addTransactionAndWait.
      * @param interval how long to wait between two attempts in waitMatch.
+     * @param latest if given, use this to prove the current state of the blockchain. Needs to be trusted!
      * @returns a promise that resolves with the initialized ByzCoin instance
      */
-    static async fromByzcoin(roster: Roster, skipchainID: Buffer, waitMatch: number = 0, interval: number = 1000):
+    static async fromByzcoin(roster: Roster, skipchainID: Buffer, waitMatch: number = 0, interval: number = 1000,
+                             latest: SkipBlock = null):
         Promise<ByzCoinRPC> {
         const rpc = new ByzCoinRPC();
         rpc.conn = new RosterWSConnection(roster, "ByzCoin");
 
         const skipchain = new SkipchainRPC(roster);
         rpc.genesis = await skipchain.getSkipBlock(skipchainID);
-        rpc.latest = rpc.genesis;
+        rpc._latest = latest ? latest : rpc.genesis;
 
-        const ccProof = await rpc.getProof(CONFIG_INSTANCE_ID, waitMatch, interval);
+        const ccProof = await rpc.getProofFromLatest(CONFIG_INSTANCE_ID, waitMatch, interval);
         rpc.config = ChainConfig.fromProof(ccProof);
-
         const di = await DarcInstance.fromByzcoin(rpc, ccProof.stateChangeBody.darcID, waitMatch, interval);
+
         rpc.genesisDarc = di.darc;
 
         return rpc;
@@ -102,22 +111,18 @@ export default class ByzCoinRPC implements ICounterUpdater {
 
         const ret = await rpc.conn.send<CreateGenesisBlockResponse>(req, CreateGenesisBlockResponse);
         rpc.genesis = ret.skipblock;
-        rpc.latest = ret.skipblock;
+        rpc._latest = ret.skipblock;
         await rpc.updateConfig();
 
         return rpc;
     }
-
+    private _latest: SkipBlock;
     private genesisDarc: Darc;
     private config: ChainConfig;
     private genesis: SkipBlock;
-    private latest: SkipBlock;
     private conn: IConnection;
 
-    protected constructor() {}
-
-    get genesisID(): InstanceID {
-        return this.genesis.computeHash();
+    protected constructor() {
     }
 
     /**
@@ -149,7 +154,7 @@ export default class ByzCoinRPC implements ICounterUpdater {
      * latest block known by the RPC client.
      */
     getProtocolVersion(): number {
-        const header = DataHeader.decode(this.latest.data);
+        const header = DataHeader.decode(this._latest.data);
 
         return header.version;
     }
@@ -172,9 +177,21 @@ export default class ByzCoinRPC implements ICounterUpdater {
             transaction,
             version: currentVersion,
         });
+        const counters = this.counters();
 
         // The error might be in the response, so we look for it and then reject the promise.
         const resp = await this.conn.send(req, AddTxResponse) as AddTxResponse;
+        // If the transaction has been successful, we update all cached counters. If the transaction
+        // failed, all involved counters are reset and will have to be fetched again.
+        transaction.instructions.forEach((instruction) => {
+            instruction.signerIdentities.forEach((signer, i) => {
+                if (resp.error.length === 0) {
+                    counters.set(signer.toString(), instruction.signerCounter[i]);
+                } else {
+                    counters.delete(signer.toString());
+                }
+            });
+        });
         if (resp.error.length === 0) {
             return Promise.resolve(resp);
         }
@@ -225,11 +242,11 @@ export default class ByzCoinRPC implements ICounterUpdater {
      * @return a promise that resolves with the proof, rejecting otherwise
      */
     async getProofFromLatest(id: Buffer, waitMatch: number = 0, interval: number = 1000): Promise<Proof> {
-        if (!this.latest) {
+        if (!this._latest) {
             throw new Error("no latest block found");
         }
 
-        return this.getProofFrom(this.latest, id, waitMatch, interval);
+        return this.getProofFrom(this._latest, id, waitMatch, interval);
     }
 
     /**
@@ -265,7 +282,7 @@ export default class ByzCoinRPC implements ICounterUpdater {
             throw err;
         }
 
-        this.latest = reply.proof.latest;
+        this._latest = reply.proof.latest;
 
         return reply.proof;
     }
@@ -284,7 +301,47 @@ export default class ByzCoinRPC implements ICounterUpdater {
         });
 
         const rep = await this.conn.send<GetSignerCountersResponse>(req, GetSignerCountersResponse);
+        const counters = this.counters();
+        ids.forEach((counter, i) => counters.set(counter.toString(), rep.counters[i]));
         return rep.counters.map((c) => c.add(add));
+    }
+
+    /**
+     * This keeps track of the know counters, thus speeding up signing with known keys. It
+     * also solves the problem of counters sometimes being out of synch with the chain.
+     * After the call returns, all signers are in ClientTransaction.counters.
+     *
+     * @param rpc should allow updates for counters
+     * @param signers the signers needed
+     */
+    async updateCachedCounters(signers: IIdentity[]): Promise<Long[]> {
+        const counters = this.counters();
+        const newSigners = signers.filter((signer) => {
+            return counters.has(signer.toString()) === false;
+        });
+        if (newSigners.length > 0) {
+            await this.getSignerCounters(newSigners, 0);
+        }
+        return signers.map((signer) => {
+            return counters.get(signer.toString());
+        });
+    }
+
+    /**
+     * Clears the counters, in case of an error.
+     */
+    clearCounters() {
+        this.counters().clear();
+    }
+
+    /**
+     * Returns the next value for the counter and updates the cache.
+     */
+    getNextCounter(signer: IIdentity): Long {
+        const counters = this.counters();
+        const c = counters.get(signer.toString()).add(1);
+        counters.set(signer.toString(), c);
+        return c;
     }
 
     /**
@@ -309,5 +366,13 @@ export default class ByzCoinRPC implements ICounterUpdater {
 
         const reply = await this.conn.send<CheckAuthorizationResponse>(req, CheckAuthorizationResponse);
         return reply.actions;
+    }
+
+    private counters(): Map<string, Long> {
+        const idStr = this.genesisID.toString("hex");
+        if (!ByzCoinRPC.staticCounters.has(idStr)) {
+            ByzCoinRPC.staticCounters.set(idStr, new Map<string, Long>());
+        }
+        return ByzCoinRPC.staticCounters.get(idStr);
     }
 }


### PR DESCRIPTION
**What this PR does**

Adds a local cache for the counters that is invalidated if a transaction
fails. This speeds up transactions a lot, because after a short set-up
phase, the counters don't have to be updated anymore.

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%+v` verb.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
