### PR TITLE
add calypso ropascis to personhood

### DIFF
--- a/external/js/cothority/src/personhood/credentials-instance.ts
+++ b/external/js/cothority/src/personhood/credentials-instance.ts
@@ -122,7 +122,8 @@ export default class CredentialsInstance extends Instance {
     /**
      * Update the data of the crendetial instance by fetching the proof
      *
-     * @returns a promise resolving with the instance
+     * @returns a promise resolving with the instance on success, rejecting with
+     * the error otherwise
      */
     async update(): Promise<CredentialsInstance> {
         const inst = await Instance.fromByzcoin(this.rpc, this.id);

--- a/external/js/cothority/src/personhood/credentials-instance.ts
+++ b/external/js/cothority/src/personhood/credentials-instance.ts
@@ -122,8 +122,7 @@ export default class CredentialsInstance extends Instance {
     /**
      * Update the data of the crendetial instance by fetching the proof
      *
-     * @returns a promise resolving with the instance on success, rejecting with
-     * the error otherwise
+     * @returns a promise resolving with the instance on success
      */
     async update(): Promise<CredentialsInstance> {
         const inst = await Instance.fromByzcoin(this.rpc, this.id);

--- a/external/js/cothority/src/personhood/pop-party-instance.ts
+++ b/external/js/cothority/src/personhood/pop-party-instance.ts
@@ -116,7 +116,7 @@ export class PopPartyInstance extends Instance {
     /**
      * Returns a copy of the list of all attendees.
      */
-    getAttendees(): Point[] {
+    getTmpAttendees(): Point[] {
         return this.tmpAttendees.slice();
     }
 

--- a/external/js/cothority/src/personhood/ro-pa-sci-instance.ts
+++ b/external/js/cothority/src/personhood/ro-pa-sci-instance.ts
@@ -107,7 +107,7 @@ export default class RoPaSciInstance extends Instance {
      */
     ourGame(coinID: InstanceID): boolean {
         const player1 = this.struct.firstPlayerAccount;
-        if (player1 && !player1.equals(Buffer.alloc(32))) {
+        if (player1 !== undefined && !player1.equals(Buffer.alloc(32))) {
             return player1.equals(coinID);
         }
         return !!this.getChoice()[1];
@@ -136,7 +136,7 @@ export default class RoPaSciInstance extends Instance {
         const priv = curve25519.scalar().pick();
         const pub = curve25519.point().mul(priv);
         if (this.isCalypso()) {
-            if (!lts) {
+            if (lts !== undefined) {
                 throw new Error("need LTS for calypso-ropascis");
             }
             args.push(new Argument({name: "public", value: pub.marshalBinary()}));
@@ -242,7 +242,7 @@ export class RoPaSciStruct extends Message<RoPaSciStruct> {
     readonly firstPlayer: number;
     readonly secondPlayer: number;
     readonly secondPlayerAccount: Buffer;
-    readonly firstPlayerAccount: Buffer;
+    readonly firstPlayerAccount: Buffer | undefined;
     readonly calypsoWrite: Buffer;
     readonly calypsoRead: Buffer;
 

--- a/external/js/cothority/src/personhood/ro-pa-sci-instance.ts
+++ b/external/js/cothority/src/personhood/ro-pa-sci-instance.ts
@@ -81,7 +81,7 @@ export default class RoPaSciInstance extends Instance {
     /**
      * Returns the firstMove and the fillUp values.
      */
-    getChoice(): [number, Buffer] {
+    getChoice(): [number, Buffer | undefined] {
         return [this.firstMove, this.fillUp ? Buffer.from(this.fillUp) : undefined];
     }
 
@@ -110,7 +110,7 @@ export default class RoPaSciInstance extends Instance {
         if (player1 !== undefined && !player1.equals(Buffer.alloc(32))) {
             return player1.equals(coinID);
         }
-        return !!this.getChoice()[1];
+        return this.getChoice()[1] !== undefined;
     }
 
     /**
@@ -171,7 +171,7 @@ export default class RoPaSciInstance extends Instance {
                 await this.rpc.getProof(this.struct.calypsoRead));
             const preHash = await dreply.decrypt(priv);
             this.firstMove = preHash[0];
-            this.fillUp = Buffer.alloc(31);
+            this.fillUp = Buffer.allocUnsafe(31);
             preHash.slice(1).copy(this.fillUp);
             await this.confirm(coin);
         }

--- a/external/js/cothority/src/personhood/ro-pa-sci-instance.ts
+++ b/external/js/cothority/src/personhood/ro-pa-sci-instance.ts
@@ -1,10 +1,16 @@
 import { Message, Properties } from "protobufjs/light";
+
+import { LongTermSecret } from "../calypso";
+
+import { curve } from "@dedis/kyber";
 import ByzCoinRPC from "../byzcoin/byzcoin-rpc";
 import ClientTransaction, { Argument, Instruction } from "../byzcoin/client-transaction";
 import CoinInstance, { Coin } from "../byzcoin/contracts/coin-instance";
 import Instance, { InstanceID } from "../byzcoin/instance";
 import Signer from "../darc/signer";
 import { EMPTY_BUFFER, registerMessage } from "../protobuf";
+
+const curve25519 = curve.newCurve("edwards25519");
 
 export default class RoPaSciInstance extends Instance {
 
@@ -31,6 +37,7 @@ export default class RoPaSciInstance extends Instance {
     get adversaryChoice(): number {
         return this.struct.secondPlayer;
     }
+
     static readonly contractID = "ropasci";
 
     /**
@@ -47,7 +54,6 @@ export default class RoPaSciInstance extends Instance {
         Promise<RoPaSciInstance> {
         return new RoPaSciInstance(bc, await Instance.fromByzcoin(bc, iid, waitMatch, interval));
     }
-
     struct: RoPaSciStruct;
     private fillUp: Buffer;
     private firstMove: number;
@@ -89,6 +95,25 @@ export default class RoPaSciInstance extends Instance {
     }
 
     /**
+     * returns true if there is a CalypsoWrite instance stored.
+     */
+    isCalypso(): boolean {
+        return !this.struct.calypsoWrite.equals(Buffer.alloc(32));
+    }
+
+    /**
+     * ourGame returns if this game belongs to the given coin.
+     * @param coinID
+     */
+    ourGame(coinID: InstanceID): boolean {
+        const player1 = this.struct.firstPlayerAccount;
+        if (player1 && !player1.equals(Buffer.alloc(32))) {
+            return player1.equals(coinID);
+        }
+        return !!this.getChoice()[1];
+    }
+
+    /**
      * Play the adversary move
      *
      * @param coin      The CoinInstance of the second player
@@ -96,12 +121,25 @@ export default class RoPaSciInstance extends Instance {
      * @param choice    The choice of the second player
      * @returns a promise that resolves on success, or rejects with the error
      */
-    async second(coin: CoinInstance, signer: Signer, choice: number): Promise<void> {
+    async second(coin: CoinInstance, signer: Signer, choice: number, lts?: LongTermSecret): Promise<void> {
         if (!coin.name.equals(this.struct.stake.name)) {
             throw new Error("not correct coin-type for player 2");
         }
         if (coin.value.lessThan(this.struct.stake.value)) {
             throw new Error("don't have enough coins to match stake");
+        }
+
+        const args = [
+            new Argument({name: "account", value: coin.id}),
+            new Argument({name: "choice", value: Buffer.from([choice % 3])}),
+        ];
+        const priv = curve25519.scalar().pick();
+        const pub = curve25519.point().mul(priv);
+        if (this.isCalypso()) {
+            if (!lts) {
+                throw new Error("need LTS for calypso-ropascis");
+            }
+            args.push(new Argument({name: "public", value: pub.marshalBinary()}));
         }
 
         const ctx = ClientTransaction.make(
@@ -121,15 +159,22 @@ export default class RoPaSciInstance extends Instance {
                 this.id,
                 RoPaSciInstance.contractID,
                 "second",
-                [
-                    new Argument({name: "account", value: coin.id}),
-                    new Argument({name: "choice", value: Buffer.from([choice % 3])}),
-                ],
+                args,
             ),
         );
         await ctx.updateCountersAndSign(this.rpc, [[signer], []]);
 
         await this.rpc.sendTransactionAndWait(ctx);
+        await this.update();
+        if (this.isCalypso()) {
+            const dreply = await lts.reencryptKey(await this.rpc.getProof(this.struct.calypsoWrite),
+                await this.rpc.getProof(this.struct.calypsoRead));
+            const preHash = await dreply.decrypt(priv);
+            this.firstMove = preHash[0];
+            this.fillUp = Buffer.alloc(31);
+            preHash.slice(1).copy(this.fillUp);
+            await this.confirm(coin);
+        }
     }
 
     /**
@@ -144,7 +189,7 @@ export default class RoPaSciInstance extends Instance {
             throw new Error("not correct coin-type for player 1");
         }
 
-        const preHash = Buffer.alloc(32, 0);
+        const preHash = Buffer.alloc(this.fillUp.length + 1, 0);
         preHash[0] = this.firstMove % 3;
         this.fillUp.copy(preHash, 1);
         const ctx = ClientTransaction.make(this.rpc.getProtocolVersion(), Instruction.createInvoke(
@@ -183,6 +228,7 @@ export default class RoPaSciInstance extends Instance {
  * Data hold by a rock-paper-scissors instance
  */
 export class RoPaSciStruct extends Message<RoPaSciStruct> {
+
     /**
      * @see README#Message classes
      */
@@ -196,6 +242,9 @@ export class RoPaSciStruct extends Message<RoPaSciStruct> {
     readonly firstPlayer: number;
     readonly secondPlayer: number;
     readonly secondPlayerAccount: Buffer;
+    readonly firstPlayerAccount: Buffer;
+    readonly calypsoWrite: Buffer;
+    readonly calypsoRead: Buffer;
 
     constructor(props?: Properties<RoPaSciStruct>) {
         super(props);
@@ -236,6 +285,33 @@ export class RoPaSciStruct extends Message<RoPaSciStruct> {
             },
             set(value: Buffer) {
                 this.secondPlayerAccount = value;
+            },
+        });
+
+        Object.defineProperty(this, "firstplayeraccount", {
+            get(): Buffer {
+                return this.firstPlayerAccount;
+            },
+            set(value: Buffer) {
+                this.firstPlayerAccount = value;
+            },
+        });
+
+        Object.defineProperty(this, "calypsowrite", {
+            get(): Buffer {
+                return this.calypsoWrite;
+            },
+            set(value: Buffer) {
+                this.calypsoWrite = value;
+            },
+        });
+
+        Object.defineProperty(this, "calypsoread", {
+            get(): Buffer {
+                return this.calypsoRead;
+            },
+            set(value: Buffer) {
+                this.calypsoRead = value;
             },
         });
     }

--- a/external/js/cothority/src/personhood/spawner-instance.ts
+++ b/external/js/cothority/src/personhood/spawner-instance.ts
@@ -358,7 +358,7 @@ export default class SpawnerInstance extends Instance {
         const rps = new RoPaSciStruct({
             description: desc,
             firstPlayer: -1,
-            firstPlayerAccount: calypso ? coin.id : null,
+            firstPlayerAccount: calypso !== undefined ? coin.id : undefined,
             firstPlayerHash: fph.digest(),
             secondPlayer: -1,
             secondPlayerAccount: Buffer.alloc(32),
@@ -366,7 +366,7 @@ export default class SpawnerInstance extends Instance {
         });
 
         const rpsArgs = [new Argument({name: "struct", value: rps.toBytes()})];
-        if (calypso) {
+        if (calypso !== undefined) {
             const wcH = createHash("sha256");
             wcH.update(rps.firstPlayerHash);
             const writeCommit = wcH.digest();

--- a/external/js/cothority/src/personhood/spawner-instance.ts
+++ b/external/js/cothority/src/personhood/spawner-instance.ts
@@ -350,7 +350,7 @@ export default class SpawnerInstance extends Instance {
             throw new Error("account balance not high enough for that stake");
         }
 
-        const preHash = Buffer.alloc(32);
+        const preHash = Buffer.allocUnsafe(32);
         preHash.writeInt8(choice % 3, 0);
         fillup.copy(preHash, 1);
         const fph = createHash("sha256");

--- a/external/js/cothority/src/personhood/spawner-instance.ts
+++ b/external/js/cothority/src/personhood/spawner-instance.ts
@@ -339,7 +339,7 @@ export default class SpawnerInstance extends Instance {
      * @returns a promise that resolves with the new instance
      */
     async spawnRoPaSci(params: ICreateRoPaSci): Promise<RoPaSciInstance> {
-        const {desc, coin, signers, stake, choice, fillup} = params;
+        const {desc, coin, signers, stake, choice, fillup, calypso} = params;
 
         if (fillup.length !== 31) {
             throw new Error("need exactly 31 bytes for fillUp");
@@ -350,18 +350,30 @@ export default class SpawnerInstance extends Instance {
             throw new Error("account balance not high enough for that stake");
         }
 
+        const preHash = Buffer.alloc(32);
+        preHash.writeInt8(choice % 3, 0);
+        fillup.copy(preHash, 1);
         const fph = createHash("sha256");
-        fph.update(Buffer.from([choice % 3]));
-        fph.update(fillup);
+        fph.update(preHash);
         const rps = new RoPaSciStruct({
             description: desc,
             firstPlayer: -1,
+            firstPlayerAccount: calypso ? coin.id : null,
             firstPlayerHash: fph.digest(),
             secondPlayer: -1,
             secondPlayerAccount: Buffer.alloc(32),
             stake: c,
         });
 
+        const rpsArgs = [new Argument({name: "struct", value: rps.toBytes()})];
+        if (calypso) {
+            const wcH = createHash("sha256");
+            wcH.update(rps.firstPlayerHash);
+            const writeCommit = wcH.digest();
+            const w = await Write.createWrite(calypso.id, writeCommit, calypso.X, preHash.slice(0, 28));
+            const writeBuf = Write.encode(w).finish();
+            rpsArgs.push(new Argument({name: "secret", value: Buffer.from(writeBuf)}));
+        }
         const ctx = ClientTransaction.make(
             this.rpc.getProtocolVersion(),
             Instruction.createInvoke(
@@ -373,7 +385,7 @@ export default class SpawnerInstance extends Instance {
             Instruction.createSpawn(
                 this.id,
                 RoPaSciInstance.contractID,
-                [new Argument({name: "struct", value: rps.toBytes()})],
+                rpsArgs,
             ),
         );
         await ctx.updateCountersAndSign(this.rpc, [signers, []]);
@@ -628,6 +640,7 @@ interface ICreateRoPaSci {
     stake: Long;
     choice: number;
     fillup: Buffer;
+    calypso?: LongTermSecret;
 
     [k: string]: any;
 }

--- a/personhood/contract_popparty.go
+++ b/personhood/contract_popparty.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"go.dedis.ch/cothority/v3/darc/expression"
 	"strings"
 
 	"go.dedis.ch/kyber/v3/util/key"
@@ -97,7 +98,12 @@ func (c ContractPopParty) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Inst
 	if err != nil {
 		return nil, nil, errors.New("couldn't get darc: " + err.Error())
 	}
-	expr := d.Rules.Get("invoke:finalize")
+	var expr expression.Expr
+	if rst.GetVersion() < 2 {
+		expr = d.Rules.Get("invoke:finalize")
+	} else {
+		expr = d.Rules.Get("invoke:popParty.finalize")
+	}
 	c.Organizers = len(strings.Split(string(expr), "|"))
 
 	miningRewardBuf := inst.Spawn.Args.Search("miningReward")

--- a/personhood/contract_popparty.go
+++ b/personhood/contract_popparty.go
@@ -6,14 +6,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"go.dedis.ch/cothority/v3/darc/expression"
 	"strings"
-
-	"go.dedis.ch/kyber/v3/util/key"
 
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/kyber/v3/group/edwards25519"
 	"go.dedis.ch/kyber/v3/sign/anon"
+	"go.dedis.ch/kyber/v3/util/key"
 	"go.dedis.ch/kyber/v3/xof/blake2xs"
 	"go.dedis.ch/onet/v3/log"
 
@@ -21,6 +19,7 @@ import (
 	"go.dedis.ch/cothority/v3/byzcoin"
 	"go.dedis.ch/cothority/v3/byzcoin/contracts"
 	"go.dedis.ch/cothority/v3/darc"
+	"go.dedis.ch/cothority/v3/darc/expression"
 	"go.dedis.ch/cothority/v3/skipchain"
 	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/protobuf"


### PR DESCRIPTION
**What this PR does**

The new personhood Rock-Paper-Scissors contract allows to use calypso for
making sure that the 2nd player can finalize the game. This adds the
javascript support for this functionality.

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%+v` verb.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
