### PR TITLE
Fix issue with isSecureContext with local content

### DIFF
--- a/external/js/cothority/package-lock.json
+++ b/external/js/cothority/package-lock.json
@@ -1100,9 +1100,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+      "version": "12.7.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
+      "integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
     },
     "@types/shuffle-array": {
       "version": "0.0.28",
@@ -3072,8 +3072,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3094,14 +3093,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3116,20 +3113,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3246,8 +3240,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3259,7 +3252,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3274,7 +3266,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3282,14 +3273,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3308,7 +3297,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3389,8 +3377,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3402,7 +3389,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3488,8 +3474,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3525,7 +3510,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3545,7 +3529,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3589,14 +3572,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6267,6 +6248,13 @@
         "@types/long": "^4.0.0",
         "@types/node": "^10.1.0",
         "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.14.21",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.21.tgz",
+          "integrity": "sha512-nuFlRdBiqbF+PJIEVxm2jLFcQWN7q7iWEJGsBV4n7v1dbI9qXB8im2pMMKMCUZe092sQb5SQft2DHfuQGK5hqQ=="
+        }
       }
     },
     "prr": {
@@ -7362,9 +7350,9 @@
       }
     },
     "typescript": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
-      "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
       "dev": true
     },
     "uglify-js": {

--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -34,7 +34,7 @@
     "@dedis/kyber": "^3.0.9",
     "@stablelib/blake2xs": "^0.10.4",
     "@types/crypto-js": "^3.1.43",
-    "@types/node": "^10.12.18",
+    "@types/node": "^12.7.12",
     "@types/sprintf-js": "^1.1.1",
     "@types/url-parse": "^1.4.3",
     "buffer": "^5.2.1",
@@ -76,7 +76,7 @@
     "ts-node": "^8.0.1",
     "tslint": "^5.12.1",
     "typedoc": "^0.15.0",
-    "typescript": "^3.1.6",
+    "typescript": "^3.6.4",
     "webpack": "^4.29.1",
     "webpack-cli": "^3.2.3"
   },

--- a/external/js/cothority/spec/helpers/global-this.ts
+++ b/external/js/cothority/spec/helpers/global-this.ts
@@ -1,4 +1,9 @@
 
+// globalThis in NodeJS appeared since 12.0.0 which means we need to declare the
+// global for the LTS. As it is simply a reference to the global object (_window_
+// for the browser and _global_ for NodeJS), we can assign it.
+// This routine is run only for the tests as the production code should check for
+// existance until we drop version above 12.0.0.
 beforeAll(() => {
     // @ts-ignore
     global.globalThis = global;

--- a/external/js/cothority/spec/helpers/global-this.ts
+++ b/external/js/cothority/spec/helpers/global-this.ts
@@ -1,0 +1,5 @@
+
+beforeAll(() => {
+    // @ts-ignore
+    global.globalThis = global;
+});

--- a/external/js/cothority/spec/network/connection.spec.ts
+++ b/external/js/cothority/spec/network/connection.spec.ts
@@ -10,6 +10,11 @@ class UnregisteredMessage extends Message<UnregisteredMessage> {}
 describe("WebSocketAdapter Tests", () => {
     afterAll(() => {
         setFactory((path: string) => new BrowserWebSocketAdapter(path));
+
+        globalThis.location = {
+            ...globalThis.location,
+            protocol: "",
+        };
     });
 
     it("should send and receive data", async () => {
@@ -104,5 +109,18 @@ describe("WebSocketAdapter Tests", () => {
         expect(conn.getURL()).toBe("ws://a:1235");
 
         expect(() => new LeaderConnection(new Roster(), "")).toThrow();
+    });
+
+    it("should switch to wss in https context", async () => {
+        const conn = new WebSocketConnection("ws://a:1234", "");
+        expect(conn.getURL()).toBe("ws://a:1234");
+
+        globalThis.location = {
+            ...globalThis.location,
+            protocol: "https:",
+        };
+
+        const conn2 = new WebSocketConnection("ws://a:1234", "");
+        expect(conn2.getURL()).toBe("wss://a:1234");
     });
 });

--- a/external/js/cothority/src/network/connection.ts
+++ b/external/js/cothority/src/network/connection.ts
@@ -61,8 +61,10 @@ export class WebSocketConnection {
      */
     constructor(addr: string, service: string) {
         const url = new URL(addr, {});
-        if (typeof window !== "undefined" && window.isSecureContext === true) {
-            url.set("protocol", "wss");
+        if (typeof globalThis !== "undefined" && typeof globalThis.location !== "undefined") {
+            if (globalThis.location.protocol === "https:") {
+                url.set("protocol", "wss");
+            }
         }
         this.url = url.href;
 


### PR DESCRIPTION
This changes the logic to instead check the current protocol so that
browser context with a location using HTTPS will always use WSS.

Fixes #2104

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%v` verb.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
