### PR TITLE
Makefile: define EXCLUDE_LINT before include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-all: test
+.DEFAULT_GOAL := test
+
+EXCLUDE_LINT := should be.*UI
 
 Coding/bin/Makefile.base:
 	git clone https://github.com/dedis/Coding
 include Coding/bin/Makefile.base
-EXCLUDE_LINT = should be.*UI|_test.go
 
 # You can use `test_playground` to run any test or part of cothority
 # for more than once in Travis. Change `make test` in .travis.yml


### PR DESCRIPTION
**Small changes to Makefile**

This PR is for allowing small changes PR on Coding to not break, see dedis/Coding#3.