### PR TITLE
calypso: use xerrors

### DIFF
--- a/calypso/api.go
+++ b/calypso/api.go
@@ -99,7 +99,10 @@ func (c *Client) CreateLTS(ltsRoster *onet.Roster, darcID darc.ID, signers []dar
 // from localhost, except if the COTHORITY_ALLOW_INSECURE_ADMIN is set to 'true'.
 // Deprecated: please use Authorize.
 func (c *Client) Authorise(who *network.ServerIdentity, what skipchain.SkipBlockID) error {
-	return cothority.ErrorOrNil(c.c.SendProtobuf(who, &Authorize{ByzCoinID: what}, nil), "send Authorize message")
+	return cothority.ErrorOrNil(
+		c.c.SendProtobuf(who, &Authorize{ByzCoinID: what}, nil),
+		"send Authorize message",
+	)
 }
 
 // Authorize adds a ByzCoinID to the list of authorized IDs in the server. To

--- a/calypso/api.go
+++ b/calypso/api.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"go.dedis.ch/kyber/v4/sign/schnorr"
+	"golang.org/x/xerrors"
 
 	"go.dedis.ch/cothority/v4"
 	"go.dedis.ch/cothority/v4/byzcoin"
@@ -50,7 +51,7 @@ func (c *Client) CreateLTS(ltsRoster *onet.Roster, darcID darc.ID, signers []dar
 	// Make the transaction and get its proof
 	buf, err := protobuf.Encode(&LtsInstanceInfo{*ltsRoster})
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("encoding roster: %v", err)
 	}
 	inst := byzcoin.Instruction{
 		InstanceID: byzcoin.NewInstanceID(darcID),
@@ -69,18 +70,18 @@ func (c *Client) CreateLTS(ltsRoster *onet.Roster, darcID darc.ID, signers []dar
 		Instructions: []byzcoin.Instruction{inst},
 	}
 	if err := tx.FillSignersAndSignWith(signers...); err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("signing txn: %v", err)
 	}
 
 	atr, err := c.bcClient.AddTransactionAndWait(tx, 10)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("adding transaction: %v", err)
 	}
 
 	id := tx.Instructions[0].DeriveID("").Slice()
 	resp, err := c.bcClient.GetProofAfter(id, true, &atr.Proof.Latest)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("getting txn proof: %v", err)
 	}
 
 	// Start the DKG
@@ -89,7 +90,7 @@ func (c *Client) CreateLTS(ltsRoster *onet.Roster, darcID darc.ID, signers []dar
 		Proof: resp.Proof,
 	}, reply)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("send CreateLTS message: %v", err)
 	}
 	return reply, nil
 }
@@ -98,7 +99,7 @@ func (c *Client) CreateLTS(ltsRoster *onet.Roster, darcID darc.ID, signers []dar
 // from localhost, except if the COTHORITY_ALLOW_INSECURE_ADMIN is set to 'true'.
 // Deprecated: please use Authorize.
 func (c *Client) Authorise(who *network.ServerIdentity, what skipchain.SkipBlockID) error {
-	return c.c.SendProtobuf(who, &Authorize{ByzCoinID: what}, nil)
+	return cothority.ErrorOrNil(c.c.SendProtobuf(who, &Authorize{ByzCoinID: what}, nil), "send Authorize message")
 }
 
 // Authorize adds a ByzCoinID to the list of authorized IDs in the server. To
@@ -117,7 +118,7 @@ func (c *Client) Authorize(who *network.ServerIdentity, what skipchain.SkipBlock
 	binary.LittleEndian.PutUint64(msg[32:], uint64(ts))
 	sig, err := schnorr.Sign(cothority.Suite, who.GetPrivate(), msg)
 	if err != nil {
-		return err
+		return xerrors.Errorf("creating schnorr signature: %v", err)
 	}
 	err = c.c.SendProtobuf(who, &Authorize{
 		ByzCoinID: what,
@@ -125,7 +126,7 @@ func (c *Client) Authorize(who *network.ServerIdentity, what skipchain.SkipBlock
 		Signature: sig,
 	}, reply)
 	if err != nil {
-		return err
+		return xerrors.Errorf("sending Authorize message: %v", err)
 	}
 	return nil
 }
@@ -136,10 +137,7 @@ func (c *Client) Authorize(who *network.ServerIdentity, what skipchain.SkipBlock
 func (c *Client) DecryptKey(dkr *DecryptKey) (reply *DecryptKeyReply, err error) {
 	reply = &DecryptKeyReply{}
 	err = c.c.SendProtobuf(c.bcClient.Roster.List[0], dkr, reply)
-	if err != nil {
-		return nil, err
-	}
-	return reply, nil
+	return reply, cothority.ErrorOrNil(err, "sending DecryptKey message: %v")
 }
 
 // WaitProof calls the byzcoin client's wait proof
@@ -162,12 +160,9 @@ func (c *Client) WaitProof(id byzcoin.InstanceID, interval time.Duration,
 func (c *Client) AddWrite(write *Write, signer darc.Signer, signerCtr uint64,
 	darc darc.Darc, wait int) (reply *WriteReply, err error) {
 	reply = &WriteReply{}
-	if err != nil {
-		return nil, err
-	}
 	writeBuf, err := protobuf.Encode(write)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("encoding Write message: %v", err)
 	}
 	ctx := byzcoin.ClientTransaction{
 		Instructions: byzcoin.Instructions{{
@@ -183,13 +178,13 @@ func (c *Client) AddWrite(write *Write, signer darc.Signer, signerCtr uint64,
 	//Sign the transaction
 	err = ctx.FillSignersAndSignWith(signer)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("signing txn: %v", err)
 	}
 	reply.InstanceID = ctx.Instructions[0].DeriveID("")
 	//Delegate the work to the byzcoin client
 	reply.AddTxResponse, err = c.bcClient.AddTransactionAndWait(ctx, wait)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("adding txn: %v", err)
 	}
 	return reply, err
 }
@@ -215,12 +210,9 @@ func (c *Client) AddRead(proof *byzcoin.Proof, signer darc.Signer, signerCtr uin
 	reply = &ReadReply{}
 	readBuf, err = protobuf.Encode(read)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("encoding Read message: %v", err)
 	}
 
-	if err != nil {
-		return nil, err
-	}
 	ctx := byzcoin.ClientTransaction{
 		Instructions: byzcoin.Instructions{{
 			InstanceID: byzcoin.NewInstanceID(proof.InclusionProof.Key()),
@@ -232,13 +224,14 @@ func (c *Client) AddRead(proof *byzcoin.Proof, signer darc.Signer, signerCtr uin
 		}},
 	}
 	err = ctx.FillSignersAndSignWith(signer)
-	reply.InstanceID = ctx.Instructions[0].DeriveID("")
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("signing txn: %v", err)
 	}
+
+	reply.InstanceID = ctx.Instructions[0].DeriveID("")
 	reply.AddTxResponse, err = c.bcClient.AddTransactionAndWait(ctx, wait)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("adding txn: %v", err)
 	}
 	return reply, nil
 }
@@ -257,13 +250,9 @@ func (c *Client) AddRead(proof *byzcoin.Proof, signer darc.Signer, signerCtr uin
 func (c *Client) SpawnDarc(signer darc.Signer, signerCtr uint64,
 	controlDarc darc.Darc, spawnDarc darc.Darc, wait int) (
 	reply *byzcoin.AddTxResponse, err error) {
-	reply = &byzcoin.AddTxResponse{}
-	if err != nil {
-		return nil, err
-	}
 	darcBuf, err := spawnDarc.ToProto()
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("serializing darc to protobuf: %v", err)
 	}
 
 	ctx := byzcoin.ClientTransaction{
@@ -281,9 +270,11 @@ func (c *Client) SpawnDarc(signer darc.Signer, signerCtr uint64,
 	}
 	err = ctx.FillSignersAndSignWith(signer)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("signing txn: %v", err)
 	}
-	return c.bcClient.AddTransactionAndWait(ctx, wait)
+
+	reply, err = c.bcClient.AddTransactionAndWait(ctx, wait)
+	return reply, cothority.ErrorOrNil(err, "adding txn")
 }
 
 // RecoverKey is used to recover the secret key once it has been
@@ -307,5 +298,8 @@ func (r *DecryptKeyReply) RecoverKey(xc kyber.Scalar) (key []byte, err error) {
 	// Decrypt r.C to keyPointHat
 	XhatInv.Add(r.C, XhatInv)
 	key, err = XhatInv.Data()
+	if err != nil {
+		err = xerrors.Errorf("extracting data from point: %v", err)
+	}
 	return
 }

--- a/calypso/api.go
+++ b/calypso/api.go
@@ -140,7 +140,7 @@ func (c *Client) Authorize(who *network.ServerIdentity, what skipchain.SkipBlock
 func (c *Client) DecryptKey(dkr *DecryptKey) (reply *DecryptKeyReply, err error) {
 	reply = &DecryptKeyReply{}
 	err = c.c.SendProtobuf(c.bcClient.Roster.List[0], dkr, reply)
-	return reply, cothority.ErrorOrNil(err, "sending DecryptKey message: %v")
+	return reply, cothority.ErrorOrNil(err, "sending DecryptKey message")
 }
 
 // WaitProof calls the byzcoin client's wait proof

--- a/calypso/contracts.go
+++ b/calypso/contracts.go
@@ -1,7 +1,6 @@
 package calypso
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -12,6 +11,7 @@ import (
 	"go.dedis.ch/onet/v4/log"
 	"go.dedis.ch/onet/v4/network"
 	"go.dedis.ch/protobuf"
+	"golang.org/x/xerrors"
 )
 
 // ContractWriteID references a write contract system-wide.
@@ -44,10 +44,7 @@ func contractWriteFromBytes(in []byte) (byzcoin.Contract, error) {
 	c := &ContractWrite{}
 
 	err := protobuf.DecodeWithConstructors(in, &c.Write, network.DefaultConstructors(cothority.Suite))
-	if err != nil {
-		return nil, errors.New("couldn't unmarshal write: " + err.Error())
-	}
-	return c, nil
+	return c, cothority.ErrorOrNil(err, "couldn't unmarshal write")
 }
 
 // Spawn is used to create a new write- or read-contract. The read-contract is
@@ -59,6 +56,7 @@ func (c ContractWrite) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instruc
 	var darcID darc.ID
 	_, _, _, darcID, err = rst.GetValues(inst.InstanceID.Slice())
 	if err != nil {
+		err = xerrors.Errorf("getting values: %v", err)
 		return
 	}
 
@@ -66,19 +64,19 @@ func (c ContractWrite) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instruc
 	case ContractWriteID:
 		w := inst.Spawn.Args.Search("write")
 		if w == nil || len(w) == 0 {
-			err = errors.New("need a write request in 'write' argument")
+			err = xerrors.New("need a write request in 'write' argument")
 			return
 		}
 		err = protobuf.DecodeWithConstructors(w, &c.Write, network.DefaultConstructors(cothority.Suite))
 		if err != nil {
-			err = errors.New("couldn't unmarshal write: " + err.Error())
+			err = xerrors.New("couldn't unmarshal write: " + err.Error())
 			return
 		}
 		if d := inst.Spawn.Args.Search("darcID"); d != nil {
 			darcID = d
 		}
 		if err = c.Write.CheckProof(cothority.Suite, darcID); err != nil {
-			err = errors.New("proof of write failed: " + err.Error())
+			err = xerrors.Errorf("proof of write failed: %v", err)
 			return
 		}
 		instID := inst.DeriveID("")
@@ -88,21 +86,21 @@ func (c ContractWrite) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instruc
 		var rd Read
 		r := inst.Spawn.Args.Search("read")
 		if r == nil || len(r) == 0 {
-			return nil, nil, errors.New("need a read argument")
+			return nil, nil, xerrors.New("need a read argument")
 		}
 		err = protobuf.DecodeWithConstructors(r, &rd, network.DefaultConstructors(cothority.Suite))
 		if err != nil {
-			return nil, nil, errors.New("passed read argument is invalid: " + err.Error())
+			return nil, nil, xerrors.Errorf("passed read argument is invalid: %v", err)
 		}
 		if !rd.Write.Equal(inst.InstanceID) {
-			return nil, nil, errors.New("the read request doesn't reference this write-instance")
+			return nil, nil, xerrors.New("the read request doesn't reference this write-instance")
 		}
 		if c.Cost.Value > 0 {
 			for i, coin := range cout {
 				if coin.Name.Equal(c.Cost.Name) {
 					err := coin.SafeSub(c.Cost.Value)
 					if err != nil {
-						return nil, nil, errors.New("couldn't pay for read request:" + err.Error())
+						return nil, nil, xerrors.Errorf("couldn't pay for read request: %v", err)
 					}
 					cout[i] = coin
 					break
@@ -111,7 +109,7 @@ func (c ContractWrite) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instruc
 		}
 		sc = byzcoin.StateChanges{byzcoin.NewStateChange(byzcoin.Create, inst.DeriveID(""), ContractReadID, r, darcID)}
 	default:
-		err = errors.New("can only spawn writes and reads")
+		err = xerrors.New("can only spawn writes and reads")
 	}
 	return
 }
@@ -126,7 +124,7 @@ type ContractRead struct {
 }
 
 func contractReadFromBytes(in []byte) (byzcoin.Contract, error) {
-	return nil, errors.New("calypso read instances are never instantiated")
+	return nil, xerrors.New("calypso read instances are never instantiated")
 }
 
 // ContractLongTermSecretID is the contract ID for updating the LTS roster.
@@ -141,30 +139,27 @@ func contractLTSFromBytes(in []byte) (byzcoin.Contract, error) {
 	c := &contractLTS{}
 
 	err := protobuf.DecodeWithConstructors(in, &c.LtsInstanceInfo, network.DefaultConstructors(cothority.Suite))
-	if err != nil {
-		return nil, errors.New("couldn't unmarshal LtsInfo: " + err.Error())
-	}
-	return c, nil
+	return c, cothority.ErrorOrNil(err, "couldn't unmarshal LtsInfo")
 }
 
 func (c *contractLTS) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instruction, coins []byzcoin.Coin) ([]byzcoin.StateChange, []byzcoin.Coin, error) {
 	var darcID darc.ID
 	_, _, _, darcID, err := rst.GetValues(inst.InstanceID.Slice())
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, xerrors.Errorf("getting values: %v", err)
 	}
 
 	if inst.Spawn.ContractID != ContractLongTermSecretID {
-		return nil, nil, errors.New("can only spawn long-term-secret instances")
+		return nil, nil, xerrors.New("can only spawn long-term-secret instances")
 	}
 	infoBuf := inst.Spawn.Args.Search("lts_instance_info")
 	if infoBuf == nil || len(infoBuf) == 0 {
-		return nil, nil, errors.New("need a lts_instance_info argument")
+		return nil, nil, xerrors.New("need a lts_instance_info argument")
 	}
 	var info LtsInstanceInfo
 	err = protobuf.DecodeWithConstructors(infoBuf, &info, network.DefaultConstructors(cothority.Suite))
 	if err != nil {
-		return nil, nil, errors.New("passed lts_instance_info argument is invalid: " + err.Error())
+		return nil, nil, xerrors.Errorf("passed lts_instance_info argument is invalid: %v", err)
 	}
 	return byzcoin.StateChanges{byzcoin.NewStateChange(byzcoin.Create, inst.DeriveID(""), ContractLongTermSecretID, infoBuf, darcID)}, coins, nil
 }
@@ -173,25 +168,25 @@ func (c *contractLTS) Invoke(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instruc
 	var darcID darc.ID
 	curBuf, _, _, darcID, err := rst.GetValues(inst.InstanceID.Slice())
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, xerrors.Errorf("getting values: %v", err)
 	}
 
 	if inst.Invoke.Command != "reshare" {
-		return nil, nil, errors.New("can only reshare long-term secrets")
+		return nil, nil, xerrors.New("can only reshare long-term secrets")
 	}
 	infoBuf := inst.Invoke.Args.Search("lts_instance_info")
 	if infoBuf == nil || len(infoBuf) == 0 {
-		return nil, nil, errors.New("need a lts_instance_info argument")
+		return nil, nil, xerrors.New("need a lts_instance_info argument")
 	}
 
 	var curInfo, newInfo LtsInstanceInfo
 	err = protobuf.DecodeWithConstructors(infoBuf, &newInfo, network.DefaultConstructors(cothority.Suite))
 	if err != nil {
-		return nil, nil, errors.New("passed lts_instance_info argument is invalid: " + err.Error())
+		return nil, nil, xerrors.Errorf("passed lts_instance_info argument is invalid: %v", err)
 	}
 	err = protobuf.DecodeWithConstructors(curBuf, &curInfo, network.DefaultConstructors(cothority.Suite))
 	if err != nil {
-		return nil, nil, errors.New("current info is invalid: " + err.Error())
+		return nil, nil, xerrors.Errorf("current info is invalid: %v", err)
 	}
 
 	// Verify the intersection between new roster and the old one. There must be
@@ -200,7 +195,7 @@ func (c *contractLTS) Invoke(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instruc
 	overlap := intersectRosters(&curInfo.Roster, &newInfo.Roster)
 	thr := n - (n-1)/3
 	if overlap < thr {
-		return nil, nil, errors.New("new roster does not overlap enough with current roster")
+		return nil, nil, xerrors.New("new roster does not overlap enough with current roster")
 	}
 
 	return byzcoin.StateChanges{byzcoin.NewStateChange(byzcoin.Update, inst.InstanceID, ContractLongTermSecretID, infoBuf, darcID)}, coins, nil

--- a/calypso/csadmin/clicontracts/write.go
+++ b/calypso/csadmin/clicontracts/write.go
@@ -3,7 +3,6 @@ package clicontracts
 import (
 	"bytes"
 	"encoding/hex"
-	"errors"
 	"io"
 	"io/ioutil"
 	"os"
@@ -36,12 +35,12 @@ import (
 func WriteSpawn(c *cli.Context) error {
 	bcArg := c.String("bc")
 	if bcArg == "" {
-		return errors.New("--bc flag is required")
+		return xerrors.New("--bc flag is required")
 	}
 
 	cfg, cl, err := lib.LoadConfig(bcArg)
 	if err != nil {
-		return err
+		return xerrors.Errorf("loading configuration: %v", err)
 	}
 
 	dstr := c.String("darc")
@@ -56,11 +55,11 @@ func WriteSpawn(c *cli.Context) error {
 	var dataBuf []byte
 	if c.Bool("readData") {
 		if c.Bool("readExtra") {
-			return errors.New("--readData can not be used toghether with --readExtra")
+			return xerrors.New("--readData can not be used toghether with --readExtra")
 		}
 		dataBuf, err = ioutil.ReadAll(os.Stdin)
 		if err != nil {
-			return errors.New("failed to read from stdin: " + err.Error())
+			return xerrors.Errorf("failed to read from stdin: %v", err)
 		}
 	} else {
 		dataBuf = []byte(c.String("data"))
@@ -70,7 +69,7 @@ func WriteSpawn(c *cli.Context) error {
 	if c.Bool("readExtra") {
 		extraDataBuf, err = ioutil.ReadAll(os.Stdin)
 		if err != nil {
-			return errors.New("failed to read from stdin: " + err.Error())
+			return xerrors.Errorf("failed to read from stdin: %v", err)
 		}
 		// We found out that a newline is automatically added when using pipes
 		extraDataBuf = bytes.TrimRight(extraDataBuf, "\n")
@@ -80,34 +79,34 @@ func WriteSpawn(c *cli.Context) error {
 
 	secret := c.String("secret")
 	if secret == "" {
-		return errors.New("please provide secret with --secret")
+		return xerrors.New("please provide secret with --secret")
 	}
 	secretBuf, err := hex.DecodeString(secret)
 	if err != nil {
-		return errors.New("failed to decode secret as hexadecimal: " + err.Error())
+		return xerrors.Errorf("failed to decode secret as hexadecimal: %v", err)
 	}
 
 	instidstr := c.String("instid")
 	if instidstr == "" {
-		return errors.New("please provide the LTS instance ID with --instid")
+		return xerrors.New("please provide the LTS instance ID with --instid")
 	}
 	instidbuf, err := hex.DecodeString(instidstr)
 	if err != nil {
-		return errors.New("failed to decode instance id: " + err.Error())
+		return xerrors.Errorf("failed to decode instance id: %v", err)
 	}
 
 	keyStr := c.String("key")
 	if keyStr == "" {
-		return errors.New("please provide the hex string public key with --key")
+		return xerrors.New("please provide the hex string public key with --key")
 	}
 	keyBuf, err := hex.DecodeString(keyStr)
 	if err != nil {
-		return errors.New("failed to decode hex string key: " + err.Error())
+		return xerrors.Errorf("failed to decode hex string key: %v", err)
 	}
 	p := cothority.Suite.Point()
 	err = p.UnmarshalBinary(keyBuf)
 	if err != nil {
-		return errors.New("failed to unmarshal key: " + err.Error())
+		return xerrors.Errorf("failed to unmarshal key: %v", err)
 	}
 
 	instid := byzcoin.NewInstanceID(instidbuf)
@@ -116,14 +115,14 @@ func WriteSpawn(c *cli.Context) error {
 
 	write := calypso.NewWrite(cothority.Suite, instid, d.GetBaseID(), p, secretBuf)
 	if write == nil {
-		return errors.New("got a nil write, this is due to a key that is " +
+		return xerrors.New("got a nil write, this is due to a key that is " +
 			"too long to be embeded")
 	}
 	write.Data = dataBuf
 	write.ExtraData = extraDataBuf
 	writeBuf, err := protobuf.Encode(write)
 	if err != nil {
-		return errors.New("failed to encode Write struct: " + err.Error())
+		return xerrors.Errorf("failed to encode Write struct: %v", err)
 	}
 
 	var signer *darc.Signer
@@ -135,10 +134,13 @@ func WriteSpawn(c *cli.Context) error {
 		signer, err = lib.LoadKeyFromString(sstr)
 	}
 	if err != nil {
-		return errors.New("failed to parse the signer: " + err.Error())
+		return xerrors.Errorf("failed to parse the signer: %v", err)
 	}
 
 	counters, err := cl.GetSignerCounters(signer.Identity().String())
+	if err != nil {
+		return xerrors.Errorf("getting signer counters: %v", err)
+	}
 
 	ctx := byzcoin.ClientTransaction{
 		Instructions: byzcoin.Instructions{{
@@ -154,18 +156,18 @@ func WriteSpawn(c *cli.Context) error {
 
 	err = ctx.FillSignersAndSignWith(*signer)
 	if err != nil {
-		return errors.New("failed to sign transaction: " + err.Error())
+		return xerrors.Errorf("failed to sign transaction: %v", err)
 	}
 
 	reply.InstanceID = ctx.Instructions[0].DeriveID("")
 	reply.AddTxResponse, err = cl.AddTransactionAndWait(ctx, 10)
 	if err != nil {
-		return errors.New("failed to send transaction: " + err.Error())
+		return xerrors.Errorf("failed to send transaction: %v", err)
 	}
 
 	err = lib.WaitPropagation(c, cl)
 	if err != nil {
-		return err
+		return xerrors.Errorf("waiting for block propagation", err)
 	}
 
 	iidStr := hex.EncodeToString(reply.InstanceID.Slice())
@@ -173,7 +175,7 @@ func WriteSpawn(c *cli.Context) error {
 		reader := bytes.NewReader([]byte(iidStr))
 		_, err = io.Copy(os.Stdout, reader)
 		if err != nil {
-			return errors.New("failed to copy to stdout: " + err.Error())
+			return xerrors.Errorf("failed to copy to stdout: %v", err)
 		}
 		return nil
 	}
@@ -189,46 +191,46 @@ func WriteGet(c *cli.Context) error {
 
 	bcArg := c.String("bc")
 	if bcArg == "" {
-		return errors.New("--bc flag is required")
+		return xerrors.New("--bc flag is required")
 	}
 
 	_, cl, err := lib.LoadConfig(bcArg)
 	if err != nil {
-		return err
+		return xerrors.Errorf("loading configuration: %v", err)
 	}
 
 	instID := c.String("instid")
 	if instID == "" {
-		return errors.New("--instid flag is required")
+		return xerrors.New("--instid flag is required")
 	}
 	instIDBuf, err := hex.DecodeString(instID)
 	if err != nil {
-		return errors.New("failed to decode the instID string")
+		return xerrors.New("failed to decode the instID string")
 	}
 
 	pr, err := cl.GetProofFromLatest(instIDBuf)
 	if err != nil {
-		return errors.New("couldn't get proof: " + err.Error())
+		return xerrors.Errorf("couldn't get proof: %v", err)
 	}
 	proof := pr.Proof
 
 	exist, err := proof.InclusionProof.Exists(instIDBuf)
 	if err != nil {
-		return errors.New("error while checking if proof exist: " + err.Error())
+		return xerrors.Errorf("error while checking if proof exist: %v", err)
 	}
 	if !exist {
-		return errors.New("proof not found")
+		return xerrors.New("proof not found")
 	}
 
 	match := proof.InclusionProof.Match(instIDBuf)
 	if !match {
-		return errors.New("proof does not match")
+		return xerrors.New("proof does not match")
 	}
 
 	var write calypso.Write
 	err = proof.VerifyAndDecode(cothority.Suite, calypso.ContractWriteID, &write)
 	if err != nil {
-		return errors.New("didn't get a write instance: " + err.Error())
+		return xerrors.Errorf("didn't get a write instance: %v", err)
 	}
 
 	if c.Bool("export") {

--- a/calypso/csadmin/clicontracts/write.go
+++ b/calypso/csadmin/clicontracts/write.go
@@ -168,7 +168,7 @@ func WriteSpawn(c *cli.Context) error {
 
 	err = lib.WaitPropagation(c, cl)
 	if err != nil {
-		return xerrors.Errorf("waiting for block propagation", err)
+		return xerrors.Errorf("waiting for block propagation: %v", err)
 	}
 
 	iidStr := hex.EncodeToString(reply.InstanceID.Slice())

--- a/calypso/csadmin/clicontracts/write.go
+++ b/calypso/csadmin/clicontracts/write.go
@@ -55,7 +55,8 @@ func WriteSpawn(c *cli.Context) error {
 	var dataBuf []byte
 	if c.Bool("readData") {
 		if c.Bool("readExtra") {
-			return xerrors.New("--readData can not be used toghether with --readExtra")
+			return xerrors.New("--readData can not be used toghether with" +
+				"--readExtra")
 		}
 		dataBuf, err = ioutil.ReadAll(os.Stdin)
 		if err != nil {

--- a/calypso/csadmin/main.go
+++ b/calypso/csadmin/main.go
@@ -211,7 +211,8 @@ func reencrypt(c *cli.Context) error {
 		}
 		exist, err := proof.InclusionProof.Exists(iid)
 		if err != nil {
-			return nil, xerrors.Errorf("error while checking if proof exist: %v", err)
+			return nil,
+				xerrors.Errorf("error while checking if proof exist: %v", err)
 		}
 		if !exist {
 			return nil, xerrors.New("proof not found")

--- a/calypso/db.go
+++ b/calypso/db.go
@@ -1,14 +1,15 @@
 package calypso
 
 import (
-	"errors"
 	"sync"
 
+	"go.dedis.ch/cothority/v4"
 	"go.dedis.ch/cothority/v4/byzcoin"
 	dkgprotocol "go.dedis.ch/cothority/v4/dkg/pedersen"
 	dkg "go.dedis.ch/kyber/v4/share/dkg/pedersen"
 	"go.dedis.ch/onet/v4"
 	"go.dedis.ch/onet/v4/log"
+	"golang.org/x/xerrors"
 )
 
 const dbVersion = 1
@@ -37,7 +38,7 @@ func (s *Service) save() error {
 	err := s.Save(storageKey, s.storage)
 	if err != nil {
 		log.Error("Couldn't save data:", err)
-		return err
+		return xerrors.Errorf("saving data: %v", err)
 	}
 	return nil
 }
@@ -48,7 +49,7 @@ func (s *Service) tryLoad() error {
 	s.storage = &storage{}
 	ver, err := s.LoadVersion()
 	if err != nil {
-		return err
+		return xerrors.Errorf("loading configuration: %v", err)
 	}
 
 	// Make sure we don't have any unallocated maps.
@@ -77,13 +78,13 @@ func (s *Service) tryLoad() error {
 	if ver < dbVersion {
 		// There is no version 0. Save empty storage and update version number.
 		if err = s.save(); err != nil {
-			return err
+			return xerrors.Errorf("saving storage: %v", err)
 		}
-		return s.SaveVersion(dbVersion)
+		return cothority.ErrorOrNil(s.SaveVersion(dbVersion), "saving version")
 	}
 	msg, err := s.Load(storageKey)
 	if err != nil {
-		return err
+		return xerrors.Errorf("loading storage: %v", err)
 	}
 	if msg == nil {
 		return nil
@@ -91,7 +92,7 @@ func (s *Service) tryLoad() error {
 	var ok bool
 	s.storage, ok = msg.(*storage)
 	if !ok {
-		return errors.New("data of wrong type")
+		return xerrors.New("data of wrong type")
 	}
 	return nil
 }

--- a/calypso/protocol/ocs.go
+++ b/calypso/protocol/ocs.go
@@ -7,7 +7,6 @@ paper-draft about onchain-secrets (called BlockMage).
 
 import (
 	"crypto/sha256"
-	"errors"
 	"sync"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	"go.dedis.ch/kyber/v4/share"
 	"go.dedis.ch/onet/v4"
 	"go.dedis.ch/onet/v4/log"
+	"golang.org/x/xerrors"
 )
 
 func init() {
@@ -59,7 +59,7 @@ func NewOCS(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
 
 	err := o.RegisterHandlers(o.reencrypt, o.reencryptReply)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("registring handlers: %v", err)
 	}
 	return o, nil
 }
@@ -69,11 +69,11 @@ func (o *OCS) Start() error {
 	log.Lvl3("Starting Protocol")
 	if o.Shared == nil {
 		o.finish(false)
-		return errors.New("please initialize Shared first")
+		return xerrors.New("please initialize Shared first")
 	}
 	if o.U == nil {
 		o.finish(false)
-		return errors.New("please initialize U first")
+		return xerrors.New("please initialize U first")
 	}
 	rc := &Reencrypt{
 		U:  o.U,
@@ -85,7 +85,7 @@ func (o *OCS) Start() error {
 	if o.Verify != nil {
 		if !o.Verify(rc) {
 			o.finish(false)
-			return errors.New("refused to reencrypt")
+			return xerrors.New("refused to reencrypt")
 		}
 	}
 	o.timeout = time.AfterFunc(1*time.Minute, func() {
@@ -95,7 +95,7 @@ func (o *OCS) Start() error {
 	errs := o.Broadcast(rc)
 	if len(errs) > (len(o.Roster().List)-1)/3 {
 		log.Errorf("Some nodes failed with error(s) %v", errs)
-		return errors.New("too many nodes failed in broadcast")
+		return xerrors.New("too many nodes failed in broadcast")
 	}
 	return nil
 }
@@ -106,15 +106,13 @@ func (o *OCS) reencrypt(r structReencrypt) error {
 	log.Lvl3(o.Name() + ": starting reencrypt")
 	defer o.Done()
 
-	ui, err := o.getUI(r.U, r.Xc)
-	if err != nil {
-		return nil
-	}
+	ui := o.getUI(r.U, r.Xc)
 
 	if o.Verify != nil {
 		if !o.Verify(&r.Reencrypt) {
 			log.Lvl2(o.ServerIdentity(), "refused to reencrypt")
-			return o.SendToParent(&ReencryptReply{})
+			return cothority.ErrorOrNil(o.SendToParent(&ReencryptReply{}),
+				"sending ReencryptReply to parent")
 		}
 	}
 
@@ -128,11 +126,14 @@ func (o *OCS) reencrypt(r structReencrypt) error {
 	hiHat.MarshalTo(hash)
 	ei := cothority.Suite.Scalar().SetBytes(hash.Sum(nil))
 
-	return o.SendToParent(&ReencryptReply{
-		Ui: ui,
-		Ei: ei,
-		Fi: cothority.Suite.Scalar().Add(si, cothority.Suite.Scalar().Mul(ei, o.Shared.V)),
-	})
+	return cothority.ErrorOrNil(
+		o.SendToParent(&ReencryptReply{
+			Ui: ui,
+			Ei: ei,
+			Fi: cothority.Suite.Scalar().Add(si, cothority.Suite.Scalar().Mul(ei, o.Shared.V)),
+		}),
+		"sending ReencryptReply to parent",
+	)
 }
 
 // reencryptReply is the root-node waiting for all replies and generating
@@ -152,11 +153,7 @@ func (o *OCS) reencryptReply(rr structReencryptReply) error {
 	// minus one to exclude the root
 	if len(o.replies) >= int(o.Threshold-1) {
 		o.Uis = make([]*share.PubShare, len(o.List()))
-		var err error
-		o.Uis[0], err = o.getUI(o.U, o.Xc)
-		if err != nil {
-			return err
-		}
+		o.Uis[0] = o.getUI(o.U, o.Xc)
 
 		for _, r := range o.replies {
 			// Verify proofs
@@ -192,13 +189,13 @@ func (o *OCS) reencryptReply(rr structReencryptReply) error {
 	return nil
 }
 
-func (o *OCS) getUI(U, Xc kyber.Point) (*share.PubShare, error) {
+func (o *OCS) getUI(U, Xc kyber.Point) *share.PubShare {
 	v := cothority.Suite.Point().Mul(o.Shared.V, U)
 	v.Add(v, cothority.Suite.Point().Mul(o.Shared.V, Xc))
 	return &share.PubShare{
 		I: o.Shared.Index,
 		V: v,
-	}, nil
+	}
 }
 
 func (o *OCS) finish(result bool) {

--- a/calypso/protocol/ocs_test.go
+++ b/calypso/protocol/ocs_test.go
@@ -1,7 +1,6 @@
 package protocol
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 	"go.dedis.ch/kyber/v4/util/random"
 	"go.dedis.ch/onet/v4"
 	"go.dedis.ch/onet/v4/log"
+	"golang.org/x/xerrors"
 )
 
 var tSuite = cothority.Suite
@@ -165,7 +165,7 @@ func (s *testService) NewProtocol(tn *onet.TreeNodeInstance, conf *onet.GenericC
 	case NameOCS:
 		pi, err := NewOCS(tn)
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("creating new OCS instance: %v", err)
 		}
 		ocs := pi.(*OCS)
 		ocs.Shared = s.Shared
@@ -174,7 +174,7 @@ func (s *testService) NewProtocol(tn *onet.TreeNodeInstance, conf *onet.GenericC
 		}
 		return ocs, nil
 	default:
-		return nil, errors.New("unknown protocol for this service")
+		return nil, xerrors.New("unknown protocol for this service")
 	}
 }
 
@@ -249,7 +249,7 @@ func DecodeKey(suite kyber.Group, X kyber.Point, Cs []kyber.Point, XhatEnc kyber
 		keyPart, err := keyPointHat.Data()
 		log.Lvl3("keyPart:", keyPart)
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("getting data from keypoint: %v", err)
 		}
 		key = append(key, keyPart...)
 	}

--- a/calypso/protocol/onchain_test.go
+++ b/calypso/protocol/onchain_test.go
@@ -133,10 +133,12 @@ func CreateDKGs(suite dkg.Suite, nbrNodes, threshold int) (dkgs []*dkg.DistKeyGe
 					log.Lvl3("Response from-to-peer:", i, j, k)
 					justification, err := p.ProcessResponse(r)
 					if err != nil {
-						return nil, xerrors.Errorf("processing responses: %v", err)
+						return nil,
+							xerrors.Errorf("processing responses: %v", err)
 					}
 					if justification != nil {
-						return nil, xerrors.New("there should be no justification")
+						return nil,
+							xerrors.New("there should be no justification")
 					}
 				}
 			}
@@ -165,7 +167,8 @@ const nonceLen = 12
 func aeadSeal(symKey, data []byte) ([]byte, error) {
 	block, err := aes.NewCipher(symKey)
 	if err != nil {
-		return nil, xerrors.Errorf("creating aes cipher block instance: %v", err)
+		return nil,
+			xerrors.Errorf("creating aes cipher block instance: %v", err)
 	}
 
 	// Never use more than 2^32 random nonces with a given key because of the risk of a repeat.
@@ -187,7 +190,8 @@ func aeadSeal(symKey, data []byte) ([]byte, error) {
 func aeadOpen(key, ciphertext []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, xerrors.Errorf("creating aes cipher block instance: %v", err)
+		return nil,
+			xerrors.Errorf("creating aes cipher block instance: %v", err)
 	}
 
 	aesgcm, err := cipher.NewGCM(block)

--- a/calypso/protocol/onchain_test.go
+++ b/calypso/protocol/onchain_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"errors"
 	"io"
 	"testing"
 
@@ -17,6 +16,7 @@ import (
 	"go.dedis.ch/kyber/v4/util/key"
 	"go.dedis.ch/kyber/v4/util/random"
 	"go.dedis.ch/onet/v4/log"
+	"golang.org/x/xerrors"
 )
 
 var suite = suites.MustFind("Ed25519")
@@ -106,6 +106,7 @@ func CreateDKGs(suite dkg.Suite, nbrNodes, threshold int) (dkgs []*dkg.DistKeyGe
 		dkgs[i], err = dkg.NewDistKeyGenerator(suite,
 			scalars[i], points, threshold)
 		if err != nil {
+			err = xerrors.Errorf("creating new distirbuted key generator: %v", err)
 			return
 		}
 	}
@@ -115,12 +116,12 @@ func CreateDKGs(suite dkg.Suite, nbrNodes, threshold int) (dkgs []*dkg.DistKeyGe
 		responses[i] = make([]*dkg.Response, nbrNodes)
 		deals, err := p.Deals()
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("getting deals: %v", err)
 		}
 		for j, d := range deals {
 			responses[i][j], err = dkgs[j].ProcessDeal(d)
 			if err != nil {
-				return nil, err
+				return nil, xerrors.Errorf("processing deals: %v", err)
 			}
 		}
 	}
@@ -132,10 +133,10 @@ func CreateDKGs(suite dkg.Suite, nbrNodes, threshold int) (dkgs []*dkg.DistKeyGe
 					log.Lvl3("Response from-to-peer:", i, j, k)
 					justification, err := p.ProcessResponse(r)
 					if err != nil {
-						return nil, err
+						return nil, xerrors.Errorf("processing responses: %v", err)
 					}
 					if justification != nil {
-						return nil, errors.New("there should be no justification")
+						return nil, xerrors.New("there should be no justification")
 					}
 				}
 			}
@@ -145,7 +146,7 @@ func CreateDKGs(suite dkg.Suite, nbrNodes, threshold int) (dkgs []*dkg.DistKeyGe
 	// Verify if all is OK
 	for _, p := range dkgs {
 		if !p.Certified() {
-			return nil, errors.New("one of the dkgs is not finished yet")
+			return nil, xerrors.New("one of the dkgs is not finished yet")
 		}
 	}
 	return
@@ -164,19 +165,19 @@ const nonceLen = 12
 func aeadSeal(symKey, data []byte) ([]byte, error) {
 	block, err := aes.NewCipher(symKey)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("creating aes cipher block instance: %v", err)
 	}
 
 	// Never use more than 2^32 random nonces with a given key because of the risk of a repeat.
 	nonce := make([]byte, nonceLen)
 	_, err = io.ReadFull(rand.Reader, nonce)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("reading nonce: %v", err)
 	}
 
 	aesgcm, err := cipher.NewGCM(block)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("creating aesgcm instance: %v", err)
 	}
 	encData := aesgcm.Seal(nil, nonce, data, nil)
 	encData = append(encData, nonce...)
@@ -186,19 +187,19 @@ func aeadSeal(symKey, data []byte) ([]byte, error) {
 func aeadOpen(key, ciphertext []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("creating aes cipher block instance: %v", err)
 	}
 
 	aesgcm, err := cipher.NewGCM(block)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("creating aesgcm instance: %v", err)
 	}
 	log.ErrFatal(err)
 
 	if len(ciphertext) < 12 {
-		return nil, errors.New("ciphertext too short")
+		return nil, xerrors.New("ciphertext too short")
 	}
 	nonce := ciphertext[len(ciphertext)-nonceLen:]
 	out, err := aesgcm.Open(nil, nonce, ciphertext[0:len(ciphertext)-nonceLen], nil)
-	return out, err
+	return out, cothority.ErrorOrNil(err, "decrypting ciphertext")
 }

--- a/calypso/service.go
+++ b/calypso/service.go
@@ -29,7 +29,6 @@ package calypso
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"math"
 	"net"
@@ -39,6 +38,7 @@ import (
 	"time"
 
 	"go.dedis.ch/kyber/v4/sign/schnorr"
+	"golang.org/x/xerrors"
 
 	"go.dedis.ch/cothority/v4"
 	"go.dedis.ch/cothority/v4/byzcoin"
@@ -136,12 +136,12 @@ func (s *Service) ProcessClientRequest(req *http.Request, path string, buf []byt
 		h, _, err := net.SplitHostPort(req.RemoteAddr)
 
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, xerrors.Errorf("splitting host port: %v", err)
 		}
 		ip := net.ParseIP(h)
 		if !ip.IsLoopback() {
 
-			return nil, nil, errors.New("authorise is only allowed on loopback")
+			return nil, nil, xerrors.New("authorise is only allowed on loopback")
 		}
 	}
 	return s.ServiceProcessor.ProcessClientRequest(req, path, buf)
@@ -152,21 +152,21 @@ func (s *Service) ProcessClientRequest(req *http.Request, path string, buf []byt
 // Deprecated: please use Authorize.
 func (s *Service) Authorise(req *Authorise) (*AuthoriseReply, error) {
 	if len(req.ByzCoinID) == 0 {
-		return nil, errors.New("empty ByzCoin ID")
+		return nil, xerrors.New("empty ByzCoin ID")
 	}
 
 	s.storage.Lock()
 	bcID := string(req.ByzCoinID)
 	if _, ok := s.storage.AuthorisedByzCoinIDs[bcID]; ok {
 		s.storage.Unlock()
-		return nil, errors.New("ByzCoinID already authorised")
+		return nil, xerrors.New("ByzCoinID already authorised")
 	}
 	s.storage.AuthorisedByzCoinIDs[bcID] = true
 	s.storage.Unlock()
 
 	err := s.save()
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("saving data: %v", err)
 	}
 	log.Lvl1("Stored ByzCoinID")
 	return &AuthoriseReply{}, err
@@ -181,21 +181,21 @@ func (s *Service) Authorise(req *Authorise) (*AuthoriseReply, error) {
 // skipped.
 func (s *Service) Authorize(req *Authorize) (*AuthorizeReply, error) {
 	if len(req.ByzCoinID) == 0 {
-		return nil, errors.New("empty ByzCoin ID")
+		return nil, xerrors.New("empty ByzCoin ID")
 	}
 
 	if !allowInsecureAdmin {
 		if len(req.Signature) == 0 {
-			return nil, errors.New("no signature provided")
+			return nil, xerrors.New("no signature provided")
 		}
 		if math.Abs(time.Now().Sub(time.Unix(req.Timestamp, 0)).Seconds()) > 60 {
-			return nil, errors.New("signature is too old")
+			return nil, xerrors.New("signature is too old")
 		}
 		msg := append(req.ByzCoinID, make([]byte, 8)...)
 		binary.LittleEndian.PutUint64(msg[32:], uint64(req.Timestamp))
 		err := schnorr.Verify(cothority.Suite, s.ServerIdentity().Public, msg, req.Signature)
 		if err != nil {
-			return nil, errors.New("signature verification failed: " + err.Error())
+			return nil, xerrors.New("signature verification failed: " + err.Error())
 		}
 	}
 
@@ -205,14 +205,14 @@ func (s *Service) Authorize(req *Authorize) (*AuthorizeReply, error) {
 		s.storage.Unlock()
 		// This error string is tested against in `external/js/cothority/src/calypso/calypso-rpc.ts, so
 		// if you change the error-message here, all apps depending on the @dedis/cothority npm-package will fail.
-		return nil, errors.New("ByzCoinID already authorised")
+		return nil, xerrors.New("ByzCoinID already authorised")
 	}
 	s.storage.AuthorisedByzCoinIDs[bcID] = true
 	s.storage.Unlock()
 
 	err := s.save()
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("saving data: %v", err)
 	}
 	log.Lvl1("Stored ByzCoinID")
 	return &AuthorizeReply{}, nil
@@ -223,41 +223,41 @@ func (s *Service) Authorize(req *Authorize) (*AuthorizeReply, error) {
 // decryption requests. The LTSID should be the InstanceID.
 func (s *Service) CreateLTS(req *CreateLTS) (reply *CreateLTSReply, err error) {
 	if err := s.verifyProof(&req.Proof); err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("verifying proof: %v", err)
 	}
 
 	roster, instID, err := s.getLtsRoster(&req.Proof)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("get roster: %v", err)
 	}
 
 	// NOTE: the roster stored in ByzCoin must have myself.
 	tree := roster.GenerateNaryTreeWithRoot(len(roster.List), s.ServerIdentity())
 	if tree == nil {
 		log.Error("cannot create tree with roster", roster.List)
-		return nil, errors.New("error while generating tree")
+		return nil, xerrors.New("error while generating tree")
 	}
 	cfg := newLtsConfig{
 		req.Proof,
 	}
 	cfgBuf, err := protobuf.Encode(&cfg)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("serializing configuration, %v", err)
 	}
 	pi, err := s.CreateProtocol(dkgprotocol.Name, tree)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("creating dkg protocol: %v", err)
 	}
 	setupDKG := pi.(*dkgprotocol.Setup)
 	setupDKG.Wait = true
 	err = setupDKG.SetConfig(&onet.GenericConfig{Data: cfgBuf})
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("set dkg config: %v", err)
 	}
 	setupDKG.KeyPair = s.getKeyPair()
 
 	if err := pi.Start(); err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("starting dkg protocol: %v", err)
 	}
 
 	log.Lvl3("Started DKG-protocol - waiting for done", len(roster.List))
@@ -265,7 +265,7 @@ func (s *Service) CreateLTS(req *CreateLTS) (reply *CreateLTSReply, err error) {
 	case <-setupDKG.Finished:
 		shared, dks, err := setupDKG.SharedSecret()
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("get aggregate public key: %v", err)
 		}
 		reply = &CreateLTSReply{
 			ByzCoinID:  req.Proof.Latest.SkipChainID(),
@@ -281,11 +281,11 @@ func (s *Service) CreateLTS(req *CreateLTS) (reply *CreateLTSReply, err error) {
 		s.storage.Unlock()
 		err = s.save()
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("save dkg state: %v", err)
 		}
 		log.Lvlf2("%v Created LTS with ID: %v, pk %v", s.ServerIdentity(), instID, reply.X)
 	case <-time.After(propagationTimeout):
-		return nil, errors.New("new-dkg didn't finish in time")
+		return nil, xerrors.New("new-dkg didn't finish in time")
 	}
 	return
 }
@@ -297,10 +297,10 @@ func (s *Service) ReshareLTS(req *ReshareLTS) (*ReshareLTSReply, error) {
 	// Verify the request
 	roster, id, err := s.getLtsRoster(&req.Proof)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("get roster: %v", err)
 	}
 	if err := s.verifyProof(&req.Proof); err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("verifying proof: %v", err)
 	}
 
 	// Initialise the protocol
@@ -310,7 +310,7 @@ func (s *Service) ReshareLTS(req *ReshareLTS) (*ReshareLTSReply, error) {
 
 		// Check that we know the shared secret, otherwise don't do re-sharing
 		if s.storage.Shared[id] == nil || s.storage.DKS[id] == nil {
-			return nil, errors.New("cannot start resharing without an LTS")
+			return nil, xerrors.New("cannot start resharing without an LTS")
 		}
 
 		// NOTE: the roster stored in ByzCoin must have myself.
@@ -324,18 +324,18 @@ func (s *Service) ReshareLTS(req *ReshareLTS) (*ReshareLTSReply, error) {
 		}
 		cfgBuf, err := protobuf.Encode(&cfg)
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("serializing configuration: %v", err)
 		}
 		pi, err := s.CreateProtocol(calypsoReshareProto, tree)
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("creating reshare protocol: %v", err)
 		}
 		setupDKG := pi.(*dkgprotocol.Setup)
 		setupDKG.Wait = true
 		setupDKG.KeyPair = s.getKeyPair()
 		err = setupDKG.SetConfig(&onet.GenericConfig{Data: cfgBuf})
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("setting dkg configuration: %v", err)
 		}
 
 		// Because we are the node starting the resharing protocol, by
@@ -354,15 +354,15 @@ func (s *Service) ReshareLTS(req *ReshareLTS) (*ReshareLTSReply, error) {
 		}
 		setupDKG.NewDKG = func() (*dkg.DistKeyGenerator, error) {
 			d, err := dkg.NewDistKeyHandler(c)
-			return d, err
+			return d, cothority.ErrorOrNil(err, "creating new distributed key generator")
 		}
 		return setupDKG, nil
 	}()
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("initializing dkg: %v", err)
 	}
 	if err := setupDKG.Start(); err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("starting dkg: %v", err)
 	}
 	log.Lvl3(s.ServerIdentity(), "Started resharing DKG-protocol - waiting for done")
 
@@ -371,19 +371,19 @@ func (s *Service) ReshareLTS(req *ReshareLTS) (*ReshareLTSReply, error) {
 	case <-setupDKG.Finished:
 		shared, dks, err := setupDKG.SharedSecret()
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("getting shared secret: %v", err)
 		}
 		pk = shared.X
 		s.storage.Lock()
 		// Check the secret shares are different
 		if shared.V.Equal(s.storage.Shared[id].V) {
 			s.storage.Unlock()
-			return nil, errors.New("the reshared secret is the same")
+			return nil, xerrors.New("the reshared secret is the same")
 		}
 		// Check the public key remains the same
 		if !shared.X.Equal(s.storage.Shared[id].X) {
 			s.storage.Unlock()
-			return nil, errors.New("the reshared public point is different")
+			return nil, xerrors.New("the reshared public point is different")
 		}
 		s.storage.Shared[id] = shared
 		s.storage.Polys[id] = &pubPoly{s.Suite().Point().Base(), dks.Commits}
@@ -392,13 +392,13 @@ func (s *Service) ReshareLTS(req *ReshareLTS) (*ReshareLTSReply, error) {
 		s.storage.Unlock()
 		err = s.save()
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("saving dkg state: %v", err)
 		}
 		if s.afterReshare != nil {
 			s.afterReshare()
 		}
 	case <-time.After(propagationTimeout):
-		return nil, errors.New("resharing-dkg didn't finish in time")
+		return nil, xerrors.New("resharing-dkg didn't finish in time")
 	}
 
 	log.Lvl2(s.ServerIdentity(), "resharing protocol finished")
@@ -411,15 +411,15 @@ func (s *Service) verifyProof(proof *byzcoin.Proof) error {
 	s.storage.Lock()
 	defer s.storage.Unlock()
 	if _, ok := s.storage.AuthorisedByzCoinIDs[string(scID)]; !ok {
-		return errors.New("this ByzCoin ID is not authorised")
+		return xerrors.New("this ByzCoin ID is not authorised")
 	}
 
 	sb, err := s.fetchGenesisBlock(scID, proof.Links[0].NewRoster)
 	if err != nil {
-		return err
+		return xerrors.Errorf("fetching genesis block: %v", err)
 	}
 
-	return proof.VerifyFromBlock(sb)
+	return cothority.ErrorOrNil(proof.VerifyFromBlock(sb), "verifying proof from block")
 }
 
 func (s *Service) fetchGenesisBlock(scID skipchain.SkipBlockID, roster *onet.Roster) (*skipchain.SkipBlock, error) {
@@ -433,7 +433,7 @@ func (s *Service) fetchGenesisBlock(scID skipchain.SkipBlockID, roster *onet.Ros
 	cl := skipchain.NewClient()
 	sb, err := cl.GetSingleBlock(roster, scID)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.Errorf("getting single block: %v", err)
 	}
 
 	// Genesis block can be reused later on.
@@ -445,13 +445,14 @@ func (s *Service) fetchGenesisBlock(scID skipchain.SkipBlockID, roster *onet.Ros
 func (s *Service) getLtsRoster(proof *byzcoin.Proof) (*onet.Roster, byzcoin.InstanceID, error) {
 	instanceID, buf, _, _, err := proof.KeyValue()
 	if err != nil {
-		return nil, byzcoin.InstanceID{}, err
+		return nil, byzcoin.InstanceID{},
+			xerrors.Errorf("getting keys and values in the proof: %v", err)
 	}
 
 	var info LtsInstanceInfo
 	err = protobuf.DecodeWithConstructors(buf, &info, network.DefaultConstructors(cothority.Suite))
 	if err != nil {
-		return nil, byzcoin.InstanceID{}, err
+		return nil, byzcoin.InstanceID{}, xerrors.Errorf("decoding roster: %v", err)
 	}
 	return &info.Roster, byzcoin.NewInstanceID(instanceID), nil
 }
@@ -468,30 +469,30 @@ func (s *Service) DecryptKey(dkr *DecryptKey) (reply *DecryptKeyReply, err error
 
 	var read Read
 	if err := dkr.Read.VerifyAndDecode(cothority.Suite, ContractReadID, &read); err != nil {
-		return nil, errors.New("didn't get a read instance: " + err.Error())
+		return nil, xerrors.New("didn't get a read instance: " + err.Error())
 	}
 
 	var write Write
 	if err := dkr.Write.VerifyAndDecode(cothority.Suite, ContractWriteID, &write); err != nil {
-		return nil, errors.New("didn't get a write instance: " + err.Error())
+		return nil, xerrors.New("didn't get a write instance: " + err.Error())
 	}
 	if !read.Write.Equal(byzcoin.NewInstanceID(dkr.Write.InclusionProof.Key())) {
-		return nil, errors.New("read doesn't point to passed write")
+		return nil, xerrors.New("read doesn't point to passed write")
 	}
 	s.storage.Lock()
 	id := write.LTSID
 	roster := s.storage.Rosters[id]
 	if roster == nil {
 		s.storage.Unlock()
-		return nil, fmt.Errorf("don't know the LTSID '%v' stored in write", id)
+		return nil, xerrors.Errorf("don't know the LTSID '%v' stored in write", id)
 	}
 	s.storage.Unlock()
 
 	if err = s.verifyProof(&dkr.Read); err != nil {
-		return nil, errors.New("read proof cannot be verified to come from scID: " + err.Error())
+		return nil, xerrors.Errorf("read proof cannot be verified to come from scID: %v", err)
 	}
 	if err = s.verifyProof(&dkr.Write); err != nil {
-		return nil, errors.New("write proof cannot be verified to come from scID: " + err.Error())
+		return nil, xerrors.Errorf("write proof cannot be verified to come from scID: %v", err)
 	}
 
 	// Start ocs-protocol to re-encrypt the file's symmetric key under the
@@ -501,7 +502,7 @@ func (s *Service) DecryptKey(dkr *DecryptKey) (reply *DecryptKeyReply, err error
 	tree := roster.GenerateNaryTreeWithRoot(nodes, s.ServerIdentity())
 	pi, err := s.CreateProtocol(protocol.NameOCS, tree)
 	if err != nil {
-		return nil, errors.New("failed to create ocs-protocol: " + err.Error())
+		return nil, xerrors.Errorf("failed to create ocs-protocol: %v", err)
 	}
 	ocsProto := pi.(*protocol.OCS)
 	ocsProto.U = write.U
@@ -512,7 +513,7 @@ func (s *Service) DecryptKey(dkr *DecryptKey) (reply *DecryptKeyReply, err error
 	log.Lvlf2("%v Public key is: %s", s.ServerIdentity(), ocsProto.Xc)
 	ocsProto.VerificationData, err = protobuf.Encode(verificationData)
 	if err != nil {
-		return nil, errors.New("couldn't marshal verification data: " + err.Error())
+		return nil, xerrors.Errorf("couldn't marshal verification data: %v", err)
 	}
 
 	// Make sure everything used from the s.Storage structure is copied, so
@@ -531,20 +532,20 @@ func (s *Service) DecryptKey(dkr *DecryptKey) (reply *DecryptKeyReply, err error
 	log.Lvl3("Starting reencryption protocol")
 	err = ocsProto.SetConfig(&onet.GenericConfig{Data: id.Slice()})
 	if err != nil {
-		return nil, errors.New("failed to set config for ocs-protocol: " + err.Error())
+		return nil, xerrors.Errorf("failed to set config for ocs-protocol: %v", err)
 	}
 	err = ocsProto.Start()
 	if err != nil {
-		return nil, errors.New("failed to start ocs-protocol: " + err.Error())
+		return nil, xerrors.Errorf("failed to start ocs-protocol: %v", err)
 	}
 	if !<-ocsProto.Reencrypted {
-		return nil, errors.New("reencryption got refused")
+		return nil, xerrors.New("reencryption got refused")
 	}
 	log.Lvl3("Reencryption protocol is done.")
 	reply.XhatEnc, err = share.RecoverCommit(cothority.Suite, ocsProto.Uis,
 		threshold, nodes)
 	if err != nil {
-		return nil, errors.New("failed to recover commit: " + err.Error())
+		return nil, xerrors.Errorf("failed to recover commit: %v", err)
 	}
 	reply.C = write.C
 	log.Lvl3("Successfully reencrypted the key")
@@ -558,7 +559,7 @@ func (s *Service) GetLTSReply(req *GetLTSReply) (*CreateLTSReply, error) {
 	defer s.storage.Unlock()
 	reply, ok := s.storage.Replies[req.LTSID]
 	if !ok {
-		return nil, fmt.Errorf("didn't find this LTS: %v", req.LTSID)
+		return nil, xerrors.Errorf("didn't find this LTS: %v", req.LTSID)
 	}
 	return &CreateLTSReply{
 		ByzCoinID:  append([]byte{}, reply.ByzCoinID...),
@@ -581,20 +582,20 @@ func (s *Service) NewProtocol(tn *onet.TreeNodeInstance, conf *onet.GenericConfi
 	case dkgprotocol.Name:
 		var cfg newLtsConfig
 		if err := protobuf.DecodeWithConstructors(conf.Data, &cfg, network.DefaultConstructors(cothority.Suite)); err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("decoding LTS config: %v", err)
 		}
 		if err := s.verifyProof(&cfg.Proof); err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("verifying proof: %v", err)
 		}
 		inst, _, _, _, err := cfg.KeyValue()
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("getting key value from proof: %v", err)
 		}
 		instID := byzcoin.NewInstanceID(inst)
 
 		pi, err := dkgprotocol.NewSetup(tn)
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("error setting up dkg: %v", err)
 		}
 		setupDKG := pi.(*dkgprotocol.Setup)
 		setupDKG.KeyPair = s.getKeyPair()
@@ -628,10 +629,10 @@ func (s *Service) NewProtocol(tn *onet.TreeNodeInstance, conf *onet.GenericConfi
 		// Decode and verify config
 		var cfg reshareLtsConfig
 		if err := protobuf.DecodeWithConstructors(conf.Data, &cfg, network.DefaultConstructors(cothority.Suite)); err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("decoding config: %v", err)
 		}
 		if err := s.verifyProof(&cfg.Proof); err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("verifying proof: %v", err)
 		}
 
 		_, id, err := s.getLtsRoster(&cfg.Proof)
@@ -639,7 +640,7 @@ func (s *Service) NewProtocol(tn *onet.TreeNodeInstance, conf *onet.GenericConfi
 		// Set up the protocol
 		pi, err := dkgprotocol.NewSetup(tn)
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("setting up dkg protocol: %v", err)
 		}
 		setupDKG := pi.(*dkgprotocol.Setup)
 		setupDKG.KeyPair = s.getKeyPair()
@@ -667,11 +668,7 @@ func (s *Service) NewProtocol(tn *onet.TreeNodeInstance, conf *onet.GenericConfi
 
 		setupDKG.NewDKG = func() (*dkg.DistKeyGenerator, error) {
 			d, err := dkg.NewDistKeyHandler(c)
-			return d, err
-		}
-
-		if err != nil {
-			return nil, err
+			return d, cothority.ErrorOrNil(err, "creating new distributed key generator")
 		}
 
 		// Wait for DKG in reshare mode to end
@@ -723,7 +720,7 @@ func (s *Service) NewProtocol(tn *onet.TreeNodeInstance, conf *onet.GenericConfi
 		}
 		pi, err := protocol.NewOCS(tn)
 		if err != nil {
-			return nil, err
+			return nil, xerrors.Errorf("creating OCS protocol instance: %v", err)
 		}
 		ocs := pi.(*protocol.OCS)
 		ocs.Shared = shared
@@ -748,25 +745,25 @@ func (s *Service) verifyReencryption(rc *protocol.Reencrypt) bool {
 		var verificationData vData
 		err := protobuf.DecodeWithConstructors(*rc.VerificationData, &verificationData, network.DefaultConstructors(cothority.Suite))
 		if err != nil {
-			return err
+			return xerrors.Errorf("decoding verification data: %v", err)
 		}
 		_, v0, contractID, _, err := verificationData.Proof.KeyValue()
 		if err != nil {
-			return errors.New("proof cannot return values: " + err.Error())
+			return xerrors.Errorf("proof cannot return values: %v", err)
 		}
 		if contractID != ContractReadID {
-			return errors.New("proof doesn't point to read instance")
+			return xerrors.New("proof doesn't point to read instance")
 		}
 		var r Read
 		err = protobuf.DecodeWithConstructors(v0, &r, network.DefaultConstructors(cothority.Suite))
 		if err != nil {
-			return errors.New("couldn't decode read data: " + err.Error())
+			return xerrors.Errorf("couldn't decode read data: %v", err)
 		}
 		if verificationData.Ephemeral != nil {
-			return errors.New("ephemeral keys not supported yet")
+			return xerrors.New("ephemeral keys not supported yet")
 		}
 		if !r.Xc.Equal(rc.Xc) {
-			return errors.New("wrong reader")
+			return xerrors.New("wrong reader")
 		}
 		return nil
 	}()
@@ -787,11 +784,11 @@ func newService(c *onet.Context) (onet.Service, error) {
 	}
 	if err := s.RegisterHandlers(s.CreateLTS, s.ReshareLTS, s.DecryptKey,
 		s.GetLTSReply, s.Authorise, s.Authorize); err != nil {
-		return nil, errors.New("couldn't register messages")
+		return nil, xerrors.New("couldn't register messages")
 	}
 	if err := s.tryLoad(); err != nil {
 		log.Error(err)
-		return nil, err
+		return nil, xerrors.Errorf("loading configuration: %v", err)
 	}
 	return s, nil
 }


### PR DESCRIPTION
**What this PR does**
Wraps errors using the xerrors package


---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%v` verb.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
