### PR TITLE
Add LTS info

### DIFF
--- a/calypso/csadmin/README.md
+++ b/calypso/csadmin/README.md
@@ -47,12 +47,14 @@ $ csadmin authorize <private.toml> <byzcoin id>
 
 **2) Create an instance of LTS**
 
-Spawn a new instance of the LTS contract:
+Spawn a new instance of the LTS contract and show the information about the
+contract as read from byzcoin:
 
 ```bash
 $ csadmin contract lts spawn # uses the default admin darc and key
 > Spawned new LTS contract. Its instance id is: 
 > <lts instance id>
+$ csadmin dkg info --bc bc-*.cfg --instid <lts instance id>
 ```
 
 **3) Start a new DKG**

--- a/calypso/csadmin/commands.go
+++ b/calypso/csadmin/commands.go
@@ -37,6 +37,22 @@ var cmds = cli.Commands{
 					},
 				},
 			},
+			{
+				Name:   "info",
+				Usage:  "prints info about an lts instance",
+				Action: dkgInfo,
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:   "bc",
+						EnvVar: "BC",
+						Usage:  "the ByzCoin config to use (required)",
+					},
+					cli.StringFlag{
+						Name:  "instid, i",
+						Usage: "the instance id of the spawned LTS contract",
+					},
+				},
+			},
 		},
 	},
 	{

--- a/calypso/csadmin/test.sh
+++ b/calypso/csadmin/test.sh
@@ -26,6 +26,7 @@ main(){
     startTest
     buildConode go.dedis.ch/cothority/v4/calypso
     build $APPDIR/../../byzcoin/bcadmin
+    run testInfo
     run testAuth
     run testContractLTS
     run testDkgStart
@@ -34,6 +35,17 @@ main(){
     run testReencrypt
     run testDecrypt
     stopTest
+}
+
+testInfo(){
+    rm -f config/*
+    runCoBG 1 2 3
+    runBA create public.toml --interval .5s
+    bcID=$( ls config/bc-* | sed -e "s/.*bc-\(.*\).cfg/\1/" )
+    OUTRES=`runCA0 contract lts spawn --bc config/bc-*`
+    LTS_ID=`echo "$OUTRES" | sed -n '2p'`
+    testGrep "tls://localhost:2002" runCA dkg info --bc config/bc-* \
+         --instid $LTS_ID
 }
 
 testAuth(){

--- a/conode/run_nodes.sh
+++ b/conode/run_nodes.sh
@@ -14,7 +14,7 @@ show_all="true"
 show_time="false"
 single=""
 
-while getopts "h?v:n:p:i:d:qftsc" opt; do
+while getopts "h?v:n:p:i:d:qftsca" opt; do
     case "$opt" in
     h|\?)
         echo "Allowed arguments:
@@ -29,7 +29,8 @@ while getopts "h?v:n:p:i:d:qftsc" opt; do
         -d data dir to store private keys, databases and logs (.)
         -q quiet all non-leader nodes
         -s don't start failing nodes again
-        -f flush databases and start from scratch"
+        -f flush databases and start from scratch
+        -a allow insecure lts creations"
         exit 0
         ;;
     v)  verbose=$OPTARG
@@ -52,6 +53,8 @@ while getopts "h?v:n:p:i:d:qftsc" opt; do
     s)  single="true"
         ;;
     c)  export DEBUG_COLOR=true
+        ;;
+    a)  export COTHORITY_ALLOW_INSECURE_ADMIN=1
         ;;
     esac
 done


### PR DESCRIPTION
Adds the `csadmin dkg info` command to print the roster of an lts-instance.
Also adds the `run_nodes.sh -a` option to allow insecure lts creations.

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%v` verb.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
