### PR TITLE
reset forwardlinks of latest block

### DIFF
--- a/byzcoin/bcadmin/commands.go
+++ b/byzcoin/bcadmin/commands.go
@@ -136,6 +136,18 @@ var cmds = cli.Commands{
 				},
 			},
 			{
+				Name:      "resetBlock",
+				Usage:     "Clean latest block of dangling forward-links",
+				Action:    dbReset,
+				ArgsUsage: "conode2.db",
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "bcID",
+						Usage: "blockchain ID",
+					},
+				},
+			},
+			{
 				Name: "check",
 				Usage: "Check that the chain is in a correct state with" +
 					" regard to hashes, forward-, and backward-links",

--- a/byzcoin/bcadmin/test.sh
+++ b/byzcoin/bcadmin/test.sh
@@ -27,6 +27,7 @@ main(){
     startTest
     buildConode go.dedis.ch/cothority/v4/byzcoin go.dedis.ch/cothority/v4/byzcoin/contracts
     [[ ! -x ./bcadmin ]] && exit 1
+    run testReset
     run testDbReplay
     run testDbMerge
     run testDbCatchup
@@ -52,6 +53,19 @@ main(){
     run testContractConfig
     run testContractName
     stopTest
+}
+
+testReset(){
+  rm -f config/* *.db
+  runCoBG 1 2 3
+  runBA create public.toml --interval .5s
+  bc=config/bc*cfg
+  key=config/key*cfg
+  bcID=$( echo $bc | sed -e "s/.*bc-\(.*\).cfg/\1/" )
+  db=service_storage/$( ls service_storage | tail -n 1 )
+  runBA config --blockSize 1000000 $bc $key
+
+  runBA db resetBlock $db $bcID
 }
 
 testDbReplay(){

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/ethereum/go-ethereum v1.8.27
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect


### PR DESCRIPTION
When the chain malfunctions and has a latest block with a dangling forward-link,
bcadmin db resetBlock
can remove that dangling forward-link.

Closes #2118

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%v` verb.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
