### PR TITLE
Limit viewchange timeout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/ethereum/go-ethereum v1.8.27
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect


### PR DESCRIPTION
The viewchange timeout was not handled correctly in case of very big
numbers. `time.Duration(float64(1e100))*time.Second == 0s`! So the
verification `if duration < 0` was never `true`, and the viewchange
was reset to `0s`!

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%v` verb.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
