### PR TITLE
Clean the block-cache correctly

### DIFF
--- a/byzcoin/viewchange.go
+++ b/byzcoin/viewchange.go
@@ -354,8 +354,8 @@ func (s *Service) verifyViewChange(msg []byte, data []byte) bool {
 	}()
 	f := s.getFaultThreshold(sb.Hash)
 	if uniqueSigners <= 2*f {
-		log.Errorf("%s: not enough proofs: %v <= %v",
-			s.ServerIdentity(), uniqueSigners, 2*f)
+		log.Errorf("%s: not enough proofs: %v < %v",
+			s.ServerIdentity(), uniqueSigners, 2*f+1)
 		return false
 	}
 	if uniqueViews != 1 {


### PR DESCRIPTION
If the block cache is cleaned before the block is stored in the db,
byzcoin might think that the block is missing, when in fact it is
available.

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%v` verb.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
