### PR TITLE
Fix message races

### DIFF
--- a/byzcoin/api_test.go
+++ b/byzcoin/api_test.go
@@ -307,6 +307,7 @@ func TestClient_NoPhantomSkipchain(t *testing.T) {
 	gac, err = c.GetAllByzCoinIDs(roster.List[0])
 	require.NoError(t, err)
 	require.Equal(t, 1, len(gac.IDs))
+	require.NoError(t, l.WaitDone(time.Second))
 }
 
 // Insure that the decoder will return an error if the reply

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -2567,7 +2567,6 @@ func (s *Service) TestRestart() error {
 }
 
 func (s *Service) cleanupGoroutines() {
-	log.Lvl1(s.ServerIdentity(), "closing go-routines 1")
 	s.heartbeats.closeAll()
 	s.closeLeaderMonitorChan <- true
 	s.viewChangeMan.closeAll()
@@ -2579,9 +2578,7 @@ func (s *Service) cleanupGoroutines() {
 		delete(s.pollChan, k)
 	}
 	s.pollChanMut.Unlock()
-	log.Lvl1(s.ServerIdentity(), "closing go-routines 2")
 	s.pollChanWG.Wait()
-	log.Lvl1(s.ServerIdentity(), "closing go-routines 3")
 }
 
 func (s *Service) monitorLeaderFailure() {

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -15,6 +15,8 @@ import (
 	"sync"
 	"time"
 
+	uuid "gopkg.in/satori/go.uuid.v1"
+
 	"go.dedis.ch/cothority/v3"
 	"go.dedis.ch/cothority/v3/blscosi/protocol"
 	"go.dedis.ch/cothority/v3/byzcoin/trie"
@@ -31,7 +33,6 @@ import (
 	"go.dedis.ch/protobuf"
 	"go.etcd.io/bbolt"
 	"golang.org/x/xerrors"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 var pairingSuite = suites.MustFind("bn256.adapter").(*pairing.SuiteBn256)
@@ -2492,8 +2493,7 @@ func (s *Service) getTxs(leader *network.ServerIdentity, roster *onet.Roster, sc
 
 	// First we check if we are up-to-date with this chain and catch up
 	// if necessary.
-	_, doCatchUp := s.skService().WaitBlock(scID, latestID)
-	if doCatchUp {
+	if !s.skService().ChainHasBlock(scID, latestID) {
 		// The function will prevent multiple request to catch up so we can securely call it here
 		err := s.catchupFromID(roster, scID, latestID)
 		if err != nil {
@@ -2547,6 +2547,7 @@ func loadNonceFromTxs(txs TxResults) ([]byte, error) {
 func (s *Service) TestClose() {
 	s.closedMutex.Lock()
 	if !s.closed {
+		s.skService().TestClose()
 		s.closed = true
 		s.closedMutex.Unlock()
 		s.cleanupGoroutines()
@@ -2556,8 +2557,17 @@ func (s *Service) TestClose() {
 	}
 }
 
+// TestRestart activates a test that has been closed using TestClose. This
+// allows to simulate restarting of nodes in the tests.
+func (s *Service) TestRestart() error {
+	if err := s.startAllChains(); err != nil {
+		return err
+	}
+	return s.skService().TestRestart()
+}
+
 func (s *Service) cleanupGoroutines() {
-	log.Lvl1(s.ServerIdentity(), "closing go-routines")
+	log.Lvl1(s.ServerIdentity(), "closing go-routines 1")
 	s.heartbeats.closeAll()
 	s.closeLeaderMonitorChan <- true
 	s.viewChangeMan.closeAll()
@@ -2569,7 +2579,9 @@ func (s *Service) cleanupGoroutines() {
 		delete(s.pollChan, k)
 	}
 	s.pollChanMut.Unlock()
+	log.Lvl1(s.ServerIdentity(), "closing go-routines 2")
 	s.pollChanWG.Wait()
+	log.Lvl1(s.ServerIdentity(), "closing go-routines 3")
 }
 
 func (s *Service) monitorLeaderFailure() {

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -2711,7 +2711,7 @@ func (s *ser) testDarcEvolution(t *testing.T, d2 darc.Darc, fail bool) (pr *Proo
 
 func (s *ser) deleteDBs(t *testing.T, index int) {
 	bc := s.services[index]
-	log.Lvl1("Deleting DB of node", index, bc.ServerIdentity())
+	log.Lvlf1("%s: Deleting DB of node %d", bc.ServerIdentity(), index)
 	bc.TestClose()
 	for scid := range bc.stateTries {
 		require.NoError(t, deleteDB(bc.ServiceProcessor, []byte(scid)))

--- a/byzcoin/tx_pipeline.go
+++ b/byzcoin/tx_pipeline.go
@@ -111,8 +111,8 @@ func (s *defaultTxProcessor) CollectTx() (*collectTxResult, error) {
 	}
 
 	if s.skService().ChainIsProcessing(s.scID) {
-		// When a block is processed, wait for the block to be done
-		time.Sleep(bcConfig.BlockInterval / 2)
+		// When a block is processed,
+		// return immediately without processing any tx from the nodes.
 		return &collectTxResult{Txs: nil, CommonVersion: CurrentVersion - 1}, nil
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/allegro/bigcache v1.2.1 // indirect
 	github.com/aristanetworks/goarista v0.0.0-20191023202215-f096da5361bb // indirect
 	github.com/bford/golang-x-crypto v0.0.0-20160518072526-27db609c9d03
-	github.com/btcsuite/btcd v0.20.0-beta // indirect
+	github.com/btcsuite/btcd v0.20.1-beta // indirect
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/deckarep/golang-set v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/bford/golang-x-crypto v0.0.0-20160518072526-27db609c9d03 h1:xx2iF0Ijs
 github.com/bford/golang-x-crypto v0.0.0-20160518072526-27db609c9d03/go.mod h1:EJtJlqu+jyMBrhodO8x5R91nQFv4nsWZP4USkxx3itk=
 github.com/btcsuite/btcd v0.20.0-beta h1:PamBMopnHxO2nEIsU89ibVVnqnXR2yFTgGNc+PdG68o=
 github.com/btcsuite/btcd v0.20.0-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
+github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
+github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bford/golang-x-crypto v0.0.0-20160518072526-27db609c9d03 h1:xx2iF0IjsICKj3dAv5xK+qiiL2XxgUqNVn442P6Eu+k=
 github.com/bford/golang-x-crypto v0.0.0-20160518072526-27db609c9d03/go.mod h1:EJtJlqu+jyMBrhodO8x5R91nQFv4nsWZP4USkxx3itk=
-github.com/btcsuite/btcd v0.20.0-beta h1:PamBMopnHxO2nEIsU89ibVVnqnXR2yFTgGNc+PdG68o=
-github.com/btcsuite/btcd v0.20.0-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -974,7 +974,8 @@ func (s *Service) ChainIsProcessing(sid SkipBlockID) bool {
 // WaitBlock returns a block by its ID instantly if already stored in the DB
 // or check if the block is inside the buffer. If the block is known, false will
 // be returned because a catch up is not necessary, true otherwise.
-// DEPRECATED
+// DEPRECATED - mixes checking for available block and waiting for it.
+// Use ChainHasBlock and ChainIsProcessing instead.
 func (s *Service) WaitBlock(sid SkipBlockID, id SkipBlockID) (*SkipBlock, bool) {
 	sb := s.db.GetByID(id)
 	if sb != nil {

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -20,6 +20,8 @@ import (
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
+	"golang.org/x/xerrors"
+
 	bbolt "go.etcd.io/bbolt"
 	uuid "gopkg.in/satori/go.uuid.v1"
 )
@@ -774,6 +776,9 @@ func (db *SkipBlockDB) GetStatus() *onet.Status {
 // GetByID returns a new copy of the skip-block or nil if it doesn't exist
 func (db *SkipBlockDB) GetByID(sbID SkipBlockID) *SkipBlock {
 	var result *SkipBlock
+	if sbID == nil {
+		return nil
+	}
 	err := db.View(func(tx *bbolt.Tx) error {
 		sb, err := db.getFromTx(tx, sbID)
 		if err != nil {
@@ -1284,7 +1289,11 @@ func (db *SkipBlockDB) storeToTx(tx *bbolt.Tx, sb *SkipBlock) error {
 // An error is thrown if marshalling fails.
 // The caller must ensure that this function is called from within a valid transaction.
 func (db *SkipBlockDB) getFromTx(tx *bbolt.Tx, sbID SkipBlockID) (*SkipBlock, error) {
-	val := tx.Bucket([]byte(db.bucketName)).Get(sbID)
+	if sbID == nil {
+		return nil, xerrors.New("cannot look up skipblock with ID == nil")
+	}
+
+	val := tx.Bucket(db.bucketName).Get(sbID)
 	if val == nil {
 		return nil, nil
 	}

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -139,6 +140,8 @@ func TestSkipBlock_InvalidForwardLinks(t *testing.T) {
 	// Try to store a new block with too many forward-links
 	s.db.Store(gb2)
 	require.Contains(t, log.GetStdErr(), "found 1 forward-links for a height of 0")
+
+	require.NoError(t, local.WaitDone(time.Second))
 }
 
 func TestSkipBlock_WrongSignatures(t *testing.T) {


### PR DESCRIPTION
Divers races have been fixed:
- between closing down byzcoin/skipchain and calling propagateForwardLinks
- between resetting byzcoin and calling propagateForwardLinks
- added some `local.WaitDone(time.Second)` to the end of some tests to make sure all messages are passed before closing the services

Plus a proposed change to the ill-named skipchain::Service.WaitBlock

Closes #2129

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%v` verb.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
