### PR TITLE
Remove the link for the deploy stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,10 +113,8 @@ jobs:
           branch: master
         provider: script
         script: >-
-          cd external/js/kyber && npm ci && npm run link && cd ../../.. &&
           cd external/js/cothority &&
           npm ci &&
-          npm link @dedis/kyber &&
           npm version prerelease --preid=p`date +%y%m.%d%H.%M%S` &&
           ./publish.sh --tag dev
 


### PR DESCRIPTION
Kyber and Cothority JS should not be linked together during a deployment
as it should use existing dependency. Kyber should be upgraded first and
then Cothority can use the new version.

Fixes #2124 

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%v` verb.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
