### PR TITLE
Adds "bcadmin instance get"

### DIFF
--- a/byzcoin/bcadmin/commands.go
+++ b/byzcoin/bcadmin/commands.go
@@ -8,291 +8,22 @@ import (
 	"go.dedis.ch/cothority/v4/byzcoin/bcadmin/clicontracts"
 )
 
+// PLEASE READ THIS
+//
+// In order to keep a consistant formatting please keep the following
+// conventions:
+//
+// - Keep commands SORTED BY NAME
+// - Use the following order for the arguments: Name, Usage, ArgsUsage, Action, Flags
+// - "Flags" should always be the last argument
+
 var cmds = cli.Commands{
-	{
-		Name:      "create",
-		Usage:     "create a ledger",
-		Aliases:   []string{"c"},
-		ArgsUsage: "[roster.toml]",
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  "roster, r",
-				Usage: "the roster of the cothority that will host the ledger",
-			},
-			cli.DurationFlag{
-				Name:  "interval, i",
-				Usage: "the block interval for this ledger",
-				Value: 5 * time.Second,
-			},
-		},
-		Action: create,
-	},
-
-	{
-		Name:        "link",
-		Usage:       "create a BC config file that sets the specified roster, darc and identity. If only the first argument is provided it just prints the byzcoin-ids.",
-		Description: "If no identity is provided, it will use an empty one. Same for the darc param. This allows one that has no private key to perform basic operations that do not require authentication.",
-		Aliases:     []string{"login"},
-		ArgsUsage:   "roster.toml [byzcoin id]",
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  "darc",
-				Usage: "the darc id to be saved. If not provided, it will use the genesis darc.",
-			},
-			cli.StringFlag{
-				Name:  "identity, id",
-				Usage: "the identity to be saved (defaults to an empty identity)",
-			},
-			cli.BoolFlag{
-				Name:  "force, f",
-				Usage: "if set, it will overwrite the config file if already present",
-			},
-		},
-		Action: link,
-	},
-
-	{
-		Name:      "latest",
-		Usage:     "show the latest block in the chain",
-		Aliases:   []string{"s"},
-		ArgsUsage: "[bc.cfg]",
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:   "bc",
-				EnvVar: "BC",
-				Usage:  "the ByzCoin config to use",
-			},
-			cli.IntFlag{
-				Name:  "server",
-				Usage: "which server number from the roster to contact (default: -1 = random)",
-				Value: -1,
-			},
-			cli.BoolFlag{
-				Name:  "update",
-				Usage: "update the ByzCoin config file with the fetched roster",
-			},
-			cli.BoolFlag{
-				Name:  "roster",
-				Usage: "display the latest block's roster",
-			},
-			cli.BoolFlag{
-				Name:  "header",
-				Usage: "display the latest header",
-			},
-		},
-		Action: latest,
-	},
-
-	{
-		Name:      "db",
-		Usage:     "interact with byzcoin for debugging",
-		Aliases:   []string{"d"},
-		ArgsUsage: "conode.db [byzCoinID]",
-		Subcommands: cli.Commands{
-			{
-				Name:   "status",
-				Usage:  "returns the status of the db",
-				Action: dbStatus,
-			},
-			{
-				Name:      "catchup",
-				Usage:     "Fetch new blocks from an active chain",
-				Action:    dbCatchup,
-				ArgsUsage: "URL",
-				Flags: []cli.Flag{
-					cli.IntFlag{
-						Name: "batch",
-						Usage: "how many blocks will be fetched with each" +
-							" request",
-						Value: 100,
-					},
-				},
-			},
-			{
-				Name:   "replay",
-				Usage:  "Replay a chain and check the global state is consistent",
-				Action: dbReplay,
-				Flags: []cli.Flag{
-					cli.BoolFlag{
-						Name:  "continue, cont",
-						Usage: "continue an aborted replay",
-					},
-					cli.IntFlag{
-						Name:  "blocks",
-						Usage: "how many blocks to apply",
-					},
-				},
-			},
-			{
-				Name:      "merge",
-				Usage:     "Copy the blocks of another db-file into this one",
-				Action:    dbMerge,
-				ArgsUsage: "conode2.db",
-				Flags: []cli.Flag{
-					cli.IntFlag{
-						Name:  "blocks",
-						Usage: "maximum number of blocks to merge",
-					},
-					cli.BoolFlag{
-						Name:  "overwrite",
-						Usage: "replace whole blocks if they are duplicate",
-					},
-				},
-			},
-			{
-				Name:      "resetBlock",
-				Usage:     "Clean latest block of dangling forward-links",
-				Action:    dbReset,
-				ArgsUsage: "conode2.db",
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:  "bcID",
-						Usage: "blockchain ID",
-					},
-				},
-			},
-			{
-				Name: "check",
-				Usage: "Check that the chain is in a correct state with" +
-					" regard to hashes, forward-, and backward-links",
-				Action: dbCheck,
-				Flags: []cli.Flag{
-					cli.IntFlag{
-						Name:  "blocks",
-						Usage: "maximum number of blocks to check",
-					},
-					cli.IntFlag{
-						Name:  "start",
-						Usage: "index of block to start verifications",
-					},
-					cli.IntFlag{
-						Name:  "process",
-						Usage: "show process indicator every n blocks",
-						Value: 100,
-					},
-				},
-			},
-		},
-	},
-
-	{
-		Name:    "debug",
-		Usage:   "interact with byzcoin for debugging",
-		Aliases: []string{"d"},
-		Subcommands: cli.Commands{
-			{
-				Name:   "block",
-				Usage:  "Read a block given by an id or an index",
-				Action: debugBlock,
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name: "bcCfg, bc",
-						Usage: "pass a byzcoin-config to define the bcID and" +
-							" the roster",
-					},
-					cli.StringFlag{
-						Name:  "url",
-						Usage: "pass a url to indicate the node to contact",
-					},
-					cli.StringFlag{
-						Name:  "bcID",
-						Usage: "give byzcoin-ID to search for",
-					},
-					cli.BoolFlag{
-						Name:  "all",
-						Usage: "show block in all nodes",
-					},
-					cli.IntFlag{
-						Name:  "blockIndex, index",
-						Value: -1,
-						Usage: "give this block-index",
-					},
-					cli.StringFlag{
-						Name:  "blockID, id",
-						Usage: "give block-id to show",
-					},
-					cli.BoolFlag{
-						Name:  "txDetails, txd",
-						Usage: "prints all transactions",
-					},
-				},
-			},
-			{
-				Name:   "list",
-				Usage:  "Lists all byzcoin instances",
-				Action: debugList,
-				Flags: []cli.Flag{
-					cli.BoolFlag{
-						Name:  "verbose, v",
-						Usage: "print more information of the instances",
-					},
-				},
-				ArgsUsage: "(ip:port | group.toml)",
-			},
-			{
-				Name:  "dump",
-				Usage: "dumps a given byzcoin instance",
-				Flags: []cli.Flag{
-					cli.BoolFlag{
-						Name:  "verbose, v",
-						Usage: "print more information of the instances",
-					},
-				},
-				Action:    debugDump,
-				ArgsUsage: "ip:port byzcoin-id",
-			},
-			{
-				Name:      "remove",
-				Usage:     "removes a given byzcoin instance",
-				Action:    debugRemove,
-				ArgsUsage: "private.toml byzcoin-id",
-			},
-			{
-				Name:      "counters",
-				Usage:     "shows the counter-state in all nodes",
-				Action:    debugCounters,
-				ArgsUsage: "bc.cfg key-file",
-			},
-		},
-	},
-
-	{
-		Name:      "mint",
-		Usage:     "mint coins on account",
-		ArgsUsage: "bc-xxx.cfg key-xxx.cfg public-key #coins",
-		Action:    mint,
-	},
-
-	{
-		Name:    "roster",
-		Usage:   "change the roster of the ByzCoin",
-		Aliases: []string{"r"},
-		Subcommands: cli.Commands{
-			{
-				Name:      "add",
-				ArgsUsage: "bc-xxx.cfg key-xxx.cfg public.toml",
-				Usage:     "Add a new node to the roster",
-				Action:    rosterAdd,
-			},
-			{
-				Name:      "del",
-				ArgsUsage: "bc-xxx.cfg key-xxx.cfg public.toml",
-				Usage:     "Remove a node from the roster",
-				Action:    rosterDel,
-			},
-			{
-				Name:      "leader",
-				ArgsUsage: "bc-xxx.cfg key-xxx.cfg public.toml",
-				Usage:     "Set a specific node to be the leader",
-				Action:    rosterLeader,
-			},
-		},
-	},
 
 	{
 		Name:      "config",
 		Usage:     "update the config",
 		ArgsUsage: "bc-xxx.cfg key-xxx.cfg",
+		Action:    config,
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "interval",
@@ -303,227 +34,6 @@ var cmds = cli.Commands{
 				Usage: "adjust the maximum block size",
 			},
 		},
-		Action: config,
-	},
-
-	{
-		Name:    "key",
-		Usage:   "generates a new keypair and prints the public key in the stdout",
-		Aliases: []string{"k"},
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  "save",
-				Usage: "file in which the user wants to save the public key instead of printing it",
-			},
-			cli.StringFlag{
-				Name:  "print",
-				Usage: "print the private and public key",
-			},
-		},
-		Action: key,
-	},
-
-	{
-		Name:    "darc",
-		Usage:   "tool used to manage darcs",
-		Aliases: []string{"d"},
-		Subcommands: cli.Commands{
-			{
-				Name:   "show",
-				Usage:  "Show a DARC",
-				Action: darcShow,
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:   "bc",
-						EnvVar: "BC",
-						Usage:  "the ByzCoin config to use (required)",
-					},
-					cli.StringFlag{
-						Name:  "darc",
-						Usage: "the darc to show (admin darc by default)",
-					},
-				},
-			},
-			{
-				Name:   "cdesc",
-				Usage:  "Edit the description of a DARC",
-				Action: darcCdesc,
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:   "bc",
-						EnvVar: "BC",
-						Usage:  "the ByzCoin config to use (required)",
-					},
-					cli.StringFlag{
-						Name:  "darc",
-						Usage: "the id of the darc to edit (config admin darc by default)",
-					},
-					cli.StringFlag{
-						Name:  "sign, signer",
-						Usage: "public key which will sign the request (default: the ledger admin identity)",
-					},
-					cli.StringFlag{
-						Name:  "desc",
-						Usage: "the new description of the darc (required)",
-					},
-				},
-			},
-			{
-				Name:   "add",
-				Usage:  "Add a new DARC with default rules.",
-				Action: darcAdd,
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:   "bc",
-						EnvVar: "BC",
-						Usage:  "the ByzCoin config to use (required)",
-					},
-					cli.StringFlag{
-						Name:  "sign, signer",
-						Usage: "public key which will sign the DARC spawn request (default: the ledger admin identity)",
-					},
-					cli.StringFlag{
-						Name:  "darc",
-						Usage: "DARC with the right to create a new DARC (default is the admin DARC)",
-					},
-					cli.StringSliceFlag{
-						Name:  "identity, id",
-						Usage: "an identity, multiple use of this param is allowed. If empty it will create a new identity. Each provided identity is checked by the evaluation parser.",
-					},
-					cli.BoolFlag{
-						Name:  "unrestricted",
-						Usage: "add the invoke:evolve_unrestricted rule",
-					},
-					cli.BoolFlag{
-						Name:  "deferred",
-						Usage: "adds rules related to deferred contract: spawn:deferred, invoke:deferred.addProof, invoke:deferred.execProposedTx",
-					},
-					cli.StringFlag{
-						Name:  "out_id",
-						Usage: "output file for the darc id (optional)",
-					},
-					cli.StringFlag{
-						Name:  "out_key",
-						Usage: "output file for the darc key (optional)",
-					},
-					cli.StringFlag{
-						Name:  "desc",
-						Usage: "the description for the new DARC (default: random)",
-					},
-				},
-			},
-			{
-				Name:   "prule",
-				Usage:  "print rule. Will print the rule given identities and a minimum to have M out of N rule",
-				Action: darcPrintRule,
-				Flags: []cli.Flag{
-					cli.StringSliceFlag{
-						Name:  "identity, id",
-						Usage: "an identity, multiple use of this param is allowed. If empty it will create a new identity. Each provided identity is checked by the evaluation parser.",
-					},
-					cli.UintFlag{
-						Name:  "minimum, M",
-						Usage: "if this flag is set, the rule is computed to be \"M out of N\" identities. Otherwise it uses ANDs",
-					},
-				},
-			},
-			{
-				Name:   "rule",
-				Usage:  "Edit DARC rules.",
-				Action: darcRule,
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:   "bc",
-						EnvVar: "BC",
-						Usage:  "the ByzCoin config to use (required)",
-					},
-					cli.StringFlag{
-						Name:  "darc",
-						Usage: "the DARC to update (default is the admin DARC)",
-					},
-					cli.StringFlag{
-						Name:  "sign",
-						Usage: "public key of the signing entity (default is the admin public key)",
-					},
-					cli.StringFlag{
-						Name:  "rule",
-						Usage: "the rule to be added, updated or deleted",
-					},
-					cli.StringSliceFlag{
-						Name:  "identity, id",
-						Usage: "the identity of the signer who will be allowed to use the rule. Multiple use of this param is allowed. Each identity is checked by the evaluation parser.",
-					},
-					cli.UintFlag{
-						Name:  "minimum, M",
-						Usage: "if this flag is set, the rule is computed to be \"M out of N\" identities. Otherwise it uses ANDs",
-					},
-					cli.BoolFlag{
-						Name:  "replace",
-						Usage: "if this rule already exists, replace it with this new one",
-					},
-					cli.BoolFlag{
-						Name:  "delete",
-						Usage: "delete the rule",
-					},
-					cli.BoolFlag{
-						Name:  "restricted, r",
-						Usage: "evolves the darc in a restricted mode, ie. NOT using the invoke:darc.evolve_unrestricted command",
-					},
-				},
-			},
-		},
-	},
-
-	{
-		Name:    "qr",
-		Usage:   "generates a QRCode containing the description of the BC Config",
-		Aliases: []string{"qrcode"},
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:   "bc",
-				EnvVar: "BC",
-				Usage:  "the ByzCoin config to use (required)",
-			},
-			cli.BoolFlag{
-				Name:  "admin",
-				Usage: "If specified, the QR Code will contain the admin keypair",
-			},
-		},
-		Action: qrcode,
-	},
-
-	{
-		Name:  "info",
-		Usage: "displays infos about the BC config",
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:   "bc",
-				EnvVar: "BC",
-				Usage:  "the ByzCoin config to use (required)",
-			},
-		},
-		Action: getInfo,
-	},
-
-	{
-		Name:  "resolveiid",
-		Usage: "Resolves an instance id given a name and a darc id (using the ResolveInstanceID API call)",
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:   "bc",
-				EnvVar: "BC",
-				Usage:  "the ByzCoin config to use (required)",
-			},
-			cli.StringFlag{
-				Name:  "namingDarc",
-				Usage: "the DARC ID that 'guards' the instance (default is the admin darc)",
-			},
-			cli.StringFlag{
-				Name:  "name",
-				Usage: "the name that was used to store the instance id (required)",
-			},
-		},
-		Action: resolveiid,
 	},
 
 	{
@@ -938,6 +448,533 @@ var cmds = cli.Commands{
 						},
 					},
 				},
+			},
+		},
+	},
+
+	{
+		Name:      "create",
+		Usage:     "create a ledger",
+		Aliases:   []string{"c"},
+		ArgsUsage: "[roster.toml]",
+		Action:    create,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "roster, r",
+				Usage: "the roster of the cothority that will host the ledger",
+			},
+			cli.DurationFlag{
+				Name:  "interval, i",
+				Usage: "the block interval for this ledger",
+				Value: 5 * time.Second,
+			},
+		},
+	},
+
+	{
+		Name:    "darc",
+		Usage:   "tool used to manage darcs",
+		Aliases: []string{"d"},
+		Subcommands: cli.Commands{
+			{
+				Name:   "show",
+				Usage:  "Show a DARC",
+				Action: darcShow,
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:   "bc",
+						EnvVar: "BC",
+						Usage:  "the ByzCoin config to use (required)",
+					},
+					cli.StringFlag{
+						Name:  "darc",
+						Usage: "the darc to show (admin darc by default)",
+					},
+				},
+			},
+			{
+				Name:   "cdesc",
+				Usage:  "Edit the description of a DARC",
+				Action: darcCdesc,
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:   "bc",
+						EnvVar: "BC",
+						Usage:  "the ByzCoin config to use (required)",
+					},
+					cli.StringFlag{
+						Name:  "darc",
+						Usage: "the id of the darc to edit (config admin darc by default)",
+					},
+					cli.StringFlag{
+						Name:  "sign, signer",
+						Usage: "public key which will sign the request (default: the ledger admin identity)",
+					},
+					cli.StringFlag{
+						Name:  "desc",
+						Usage: "the new description of the darc (required)",
+					},
+				},
+			},
+			{
+				Name:   "add",
+				Usage:  "Add a new DARC with default rules.",
+				Action: darcAdd,
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:   "bc",
+						EnvVar: "BC",
+						Usage:  "the ByzCoin config to use (required)",
+					},
+					cli.StringFlag{
+						Name:  "sign, signer",
+						Usage: "public key which will sign the DARC spawn request (default: the ledger admin identity)",
+					},
+					cli.StringFlag{
+						Name:  "darc",
+						Usage: "DARC with the right to create a new DARC (default is the admin DARC)",
+					},
+					cli.StringSliceFlag{
+						Name:  "identity, id",
+						Usage: "an identity, multiple use of this param is allowed. If empty it will create a new identity. Each provided identity is checked by the evaluation parser.",
+					},
+					cli.BoolFlag{
+						Name:  "unrestricted",
+						Usage: "add the invoke:evolve_unrestricted rule",
+					},
+					cli.BoolFlag{
+						Name:  "deferred",
+						Usage: "adds rules related to deferred contract: spawn:deferred, invoke:deferred.addProof, invoke:deferred.execProposedTx",
+					},
+					cli.StringFlag{
+						Name:  "out_id",
+						Usage: "output file for the darc id (optional)",
+					},
+					cli.StringFlag{
+						Name:  "out_key",
+						Usage: "output file for the darc key (optional)",
+					},
+					cli.StringFlag{
+						Name:  "desc",
+						Usage: "the description for the new DARC (default: random)",
+					},
+				},
+			},
+			{
+				Name:   "prule",
+				Usage:  "print rule. Will print the rule given identities and a minimum to have M out of N rule",
+				Action: darcPrintRule,
+				Flags: []cli.Flag{
+					cli.StringSliceFlag{
+						Name:  "identity, id",
+						Usage: "an identity, multiple use of this param is allowed. If empty it will create a new identity. Each provided identity is checked by the evaluation parser.",
+					},
+					cli.UintFlag{
+						Name:  "minimum, M",
+						Usage: "if this flag is set, the rule is computed to be \"M out of N\" identities. Otherwise it uses ANDs",
+					},
+				},
+			},
+			{
+				Name:   "rule",
+				Usage:  "Edit DARC rules.",
+				Action: darcRule,
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:   "bc",
+						EnvVar: "BC",
+						Usage:  "the ByzCoin config to use (required)",
+					},
+					cli.StringFlag{
+						Name:  "darc",
+						Usage: "the DARC to update (default is the admin DARC)",
+					},
+					cli.StringFlag{
+						Name:  "sign",
+						Usage: "public key of the signing entity (default is the admin public key)",
+					},
+					cli.StringFlag{
+						Name:  "rule",
+						Usage: "the rule to be added, updated or deleted",
+					},
+					cli.StringSliceFlag{
+						Name:  "identity, id",
+						Usage: "the identity of the signer who will be allowed to use the rule. Multiple use of this param is allowed. Each identity is checked by the evaluation parser.",
+					},
+					cli.UintFlag{
+						Name:  "minimum, M",
+						Usage: "if this flag is set, the rule is computed to be \"M out of N\" identities. Otherwise it uses ANDs",
+					},
+					cli.BoolFlag{
+						Name:  "replace",
+						Usage: "if this rule already exists, replace it with this new one",
+					},
+					cli.BoolFlag{
+						Name:  "delete",
+						Usage: "delete the rule",
+					},
+					cli.BoolFlag{
+						Name:  "restricted, r",
+						Usage: "evolves the darc in a restricted mode, ie. NOT using the invoke:darc.evolve_unrestricted command",
+					},
+				},
+			},
+		},
+	},
+
+	{
+		Name:      "db",
+		Usage:     "interact with byzcoin for debugging",
+		Aliases:   []string{"d"},
+		ArgsUsage: "conode.db [byzCoinID]",
+		Subcommands: cli.Commands{
+			{
+				Name:   "status",
+				Usage:  "returns the status of the db",
+				Action: dbStatus,
+			},
+			{
+				Name:      "catchup",
+				Usage:     "Fetch new blocks from an active chain",
+				ArgsUsage: "URL",
+				Action:    dbCatchup,
+				Flags: []cli.Flag{
+					cli.IntFlag{
+						Name: "batch",
+						Usage: "how many blocks will be fetched with each" +
+							" request",
+						Value: 100,
+					},
+				},
+			},
+			{
+				Name:   "replay",
+				Usage:  "Replay a chain and check the global state is consistent",
+				Action: dbReplay,
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "continue, cont",
+						Usage: "continue an aborted replay",
+					},
+					cli.IntFlag{
+						Name:  "blocks",
+						Usage: "how many blocks to apply",
+					},
+				},
+			},
+			{
+				Name:      "merge",
+				Usage:     "Copy the blocks of another db-file into this one",
+				ArgsUsage: "conode2.db",
+				Action:    dbMerge,
+				Flags: []cli.Flag{
+					cli.IntFlag{
+						Name:  "blocks",
+						Usage: "maximum number of blocks to merge",
+					},
+					cli.BoolFlag{
+						Name:  "overwrite",
+						Usage: "replace whole blocks if they are duplicate",
+					},
+				},
+			},
+			{
+				Name:      "resetBlock",
+				Usage:     "Clean latest block of dangling forward-links",
+				ArgsUsage: "conode2.db",
+				Action:    dbReset,
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "bcID",
+						Usage: "blockchain ID",
+					},
+				},
+			},
+			{
+				Name: "check",
+				Usage: "Check that the chain is in a correct state with" +
+					" regard to hashes, forward-, and backward-links",
+				Action: dbCheck,
+				Flags: []cli.Flag{
+					cli.IntFlag{
+						Name:  "blocks",
+						Usage: "maximum number of blocks to check",
+					},
+					cli.IntFlag{
+						Name:  "start",
+						Usage: "index of block to start verifications",
+					},
+					cli.IntFlag{
+						Name:  "process",
+						Usage: "show process indicator every n blocks",
+						Value: 100,
+					},
+				},
+			},
+		},
+	},
+
+	{
+		Name:    "debug",
+		Usage:   "interact with byzcoin for debugging",
+		Aliases: []string{"d"},
+		Subcommands: cli.Commands{
+			{
+				Name:   "block",
+				Usage:  "Read a block given by an id or an index",
+				Action: debugBlock,
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name: "bcCfg, bc",
+						Usage: "pass a byzcoin-config to define the bcID and" +
+							" the roster",
+					},
+					cli.StringFlag{
+						Name:  "url",
+						Usage: "pass a url to indicate the node to contact",
+					},
+					cli.StringFlag{
+						Name:  "bcID",
+						Usage: "give byzcoin-ID to search for",
+					},
+					cli.BoolFlag{
+						Name:  "all",
+						Usage: "show block in all nodes",
+					},
+					cli.IntFlag{
+						Name:  "blockIndex, index",
+						Value: -1,
+						Usage: "give this block-index",
+					},
+					cli.StringFlag{
+						Name:  "blockID, id",
+						Usage: "give block-id to show",
+					},
+					cli.BoolFlag{
+						Name:  "txDetails, txd",
+						Usage: "prints all transactions",
+					},
+				},
+			},
+			{
+				Name:   "list",
+				Usage:  "Lists all byzcoin instances",
+				Action: debugList,
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "verbose, v",
+						Usage: "print more information of the instances",
+					},
+				},
+				ArgsUsage: "(ip:port | group.toml)",
+			},
+			{
+				Name:      "dump",
+				Usage:     "dumps a given byzcoin instance",
+				ArgsUsage: "ip:port byzcoin-id",
+				Action:    debugDump,
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "verbose, v",
+						Usage: "print more information of the instances",
+					},
+				},
+			},
+			{
+				Name:      "remove",
+				Usage:     "removes a given byzcoin instance",
+				ArgsUsage: "private.toml byzcoin-id",
+				Action:    debugRemove,
+			},
+			{
+				Name:      "counters",
+				Usage:     "shows the counter-state in all nodes",
+				ArgsUsage: "bc.cfg key-file",
+				Action:    debugCounters,
+			},
+		},
+	},
+
+	{
+		Name:   "info",
+		Usage:  "displays infos about the BC config",
+		Action: getInfo,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:   "bc",
+				EnvVar: "BC",
+				Usage:  "the ByzCoin config to use (required)",
+			},
+		},
+	},
+
+	{
+		Name:  "instance",
+		Usage: "displays infos about an instance",
+		Subcommands: cli.Commands{
+			{
+				Name:   "get",
+				Usage:  "Display the content of an instance",
+				Action: getInstance,
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:   "bc",
+						EnvVar: "BC",
+						Usage:  "the ByzCoin config to use (required)",
+					},
+					cli.StringFlag{
+						Name:  "instid, i",
+						Usage: "the instance id (required)",
+					},
+					cli.BoolFlag{
+						Name:  "hex",
+						Usage: "if set, the data of the instance is hex encoded",
+					},
+				},
+			},
+		},
+	},
+
+	{
+		Name:    "key",
+		Usage:   "generates a new keypair and prints the public key in the stdout",
+		Aliases: []string{"k"},
+		Action:  key,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "save",
+				Usage: "file in which the user wants to save the public key instead of printing it",
+			},
+			cli.StringFlag{
+				Name:  "print",
+				Usage: "print the private and public key",
+			},
+		},
+	},
+
+	{
+		Name:      "latest",
+		Usage:     "show the latest block in the chain",
+		Aliases:   []string{"s"},
+		ArgsUsage: "[bc.cfg]",
+		Action:    latest,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:   "bc",
+				EnvVar: "BC",
+				Usage:  "the ByzCoin config to use",
+			},
+			cli.IntFlag{
+				Name:  "server",
+				Usage: "which server number from the roster to contact (default: -1 = random)",
+				Value: -1,
+			},
+			cli.BoolFlag{
+				Name:  "update",
+				Usage: "update the ByzCoin config file with the fetched roster",
+			},
+			cli.BoolFlag{
+				Name:  "roster",
+				Usage: "display the latest block's roster",
+			},
+			cli.BoolFlag{
+				Name:  "header",
+				Usage: "display the latest header",
+			},
+		},
+	},
+
+	{
+		Name:        "link",
+		Usage:       "create a BC config file that sets the specified roster, darc and identity. If only the first argument is provided it just prints the byzcoin-ids.",
+		Description: "If no identity is provided, it will use an empty one. Same for the darc param. This allows one that has no private key to perform basic operations that do not require authentication.",
+		Aliases:     []string{"login"},
+		ArgsUsage:   "roster.toml [byzcoin id]",
+		Action:      link,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "darc",
+				Usage: "the darc id to be saved. If not provided, it will use the genesis darc.",
+			},
+			cli.StringFlag{
+				Name:  "identity, id",
+				Usage: "the identity to be saved (defaults to an empty identity)",
+			},
+			cli.BoolFlag{
+				Name:  "force, f",
+				Usage: "if set, it will overwrite the config file if already present",
+			},
+		},
+	},
+
+	{
+		Name:      "mint",
+		Usage:     "mint coins on account",
+		ArgsUsage: "bc-xxx.cfg key-xxx.cfg public-key #coins",
+		Action:    mint,
+	},
+
+	{
+		Name:    "qr",
+		Usage:   "generates a QRCode containing the description of the BC Config",
+		Aliases: []string{"qrcode"},
+		Action:  qrcode,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:   "bc",
+				EnvVar: "BC",
+				Usage:  "the ByzCoin config to use (required)",
+			},
+			cli.BoolFlag{
+				Name:  "admin",
+				Usage: "If specified, the QR Code will contain the admin keypair",
+			},
+		},
+	},
+
+	{
+		Name:   "resolveiid",
+		Usage:  "Resolves an instance id given a name and a darc id (using the ResolveInstanceID API call)",
+		Action: resolveiid,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:   "bc",
+				EnvVar: "BC",
+				Usage:  "the ByzCoin config to use (required)",
+			},
+			cli.StringFlag{
+				Name:  "namingDarc",
+				Usage: "the DARC ID that 'guards' the instance (default is the admin darc)",
+			},
+			cli.StringFlag{
+				Name:  "name",
+				Usage: "the name that was used to store the instance id (required)",
+			},
+		},
+	},
+
+	{
+		Name:    "roster",
+		Usage:   "change the roster of the ByzCoin",
+		Aliases: []string{"r"},
+		Subcommands: cli.Commands{
+			{
+				Name:      "add",
+				ArgsUsage: "bc-xxx.cfg key-xxx.cfg public.toml",
+				Usage:     "Add a new node to the roster",
+				Action:    rosterAdd,
+			},
+			{
+				Name:      "del",
+				ArgsUsage: "bc-xxx.cfg key-xxx.cfg public.toml",
+				Usage:     "Remove a node from the roster",
+				Action:    rosterDel,
+			},
+			{
+				Name:      "leader",
+				ArgsUsage: "bc-xxx.cfg key-xxx.cfg public.toml",
+				Usage:     "Set a specific node to be the leader",
+				Action:    rosterLeader,
 			},
 		},
 	},

--- a/byzcoin/bcadmin/test.sh
+++ b/byzcoin/bcadmin/test.sh
@@ -48,6 +48,7 @@ main(){
     run testQR
     run testUpdateDarcDesc
     run testResolveiid
+    run testInstructionGet
     run testContractValue
     run testContractDeferred
     run testContractConfig
@@ -543,6 +544,17 @@ $VALUE_INSTANCE_ID"
   # Let's get the content of the value contract
   OUTRES=`runBA0 contract value get --instid "$VALUE_INSTANCE_ID"`
   testGrep "Hello world" echo "$OUTRES"
+}
+
+# In this test we simply get the config instance
+testInstructionGet() {
+  runCoBG 1 2 3
+  runGrepSed "export BC=" "" runBA create --roster public.toml --interval .5s
+  eval $SED
+  [ -z "$BC" ] && exit 1
+
+  testOK runBA0 instance get -i 0000000000000000000000000000000000000000000000000000000000000000
+  testOK runBA0 instance get -i 0000000000000000000000000000000000000000000000000000000000000000 --hex
 }
 
 main


### PR DESCRIPTION
**What this PR does**

This PR adds a new command `bcadmin instance get` that simply prints the content of an instance if found. 

I also took the opportunity to reformat the "commands.go" file in order to have commands alphabetically sorted. I also made some formatting on the "main.go" file for oversized lines.

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%v` verb.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
