### PR TITLE
external/js/kyber: add @types/elliptic for users

### DIFF
--- a/external/js/cothority/package-lock.json
+++ b/external/js/cothority/package-lock.json
@@ -1061,15 +1061,6 @@
         "@types/node": "*"
       }
     },
-    "@types/elliptic": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.2.tgz",
-      "integrity": "sha512-aIhX07nKFHKTw8z5mZcsgbXjTD9pOXVbqtcNUbdhd3YhH5pC94+plnSglrPFhbHgeL2dCTobnb4kn6gtf7UC3A==",
-      "dev": true,
-      "requires": {
-        "@types/bn.js": "*"
-      }
-    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -3072,7 +3063,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3093,12 +3085,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3113,17 +3107,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3240,7 +3237,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3252,6 +3250,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3266,6 +3265,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3273,12 +3273,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3297,6 +3299,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3377,7 +3380,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3389,6 +3393,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3474,7 +3479,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3510,6 +3516,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3529,6 +3536,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3572,12 +3580,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -60,7 +60,6 @@
     "@babel/preset-env": "^7.3.1",
     "@types/bn.js": "^4.11.4",
     "@types/dockerode": "^2.5.11",
-    "@types/elliptic": "^6.4.2",
     "@types/jasmine": "^3.3.5",
     "@types/lodash": "^4.14.139",
     "@types/long": "^4.0.0",

--- a/external/js/kyber/package-lock.json
+++ b/external/js/kyber/package-lock.json
@@ -193,7 +193,6 @@
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.2.tgz",
       "integrity": "sha512-aIhX07nKFHKTw8z5mZcsgbXjTD9pOXVbqtcNUbdhd3YhH5pC94+plnSglrPFhbHgeL2dCTobnb4kn6gtf7UC3A==",
-      "dev": true,
       "requires": {
         "@types/bn.js": "*"
       }
@@ -207,7 +206,8 @@
     "@types/lodash": {
       "version": "4.14.139",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.139.tgz",
-      "integrity": "sha512-Z6pbDYaWpluqcF8+6qgv6STPEl0jIlyQmpYGwTrzhgwqok8ltBh/p7GAmYnz81wUhxQRhEr8MBpQrB4fQ/hwIA=="
+      "integrity": "sha512-Z6pbDYaWpluqcF8+6qgv6STPEl0jIlyQmpYGwTrzhgwqok8ltBh/p7GAmYnz81wUhxQRhEr8MBpQrB4fQ/hwIA==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -457,7 +457,8 @@
     "ajv-keywords": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
+      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "3.1.0",
@@ -5157,7 +5158,7 @@
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },

--- a/external/js/kyber/package.json
+++ b/external/js/kyber/package.json
@@ -31,12 +31,12 @@
   "dependencies": {
     "@stablelib/blake2xs": "^0.10.4",
     "@types/bn.js": "^4.11.5",
+    "@types/elliptic": "^6.4.1",
     "bn.js": "^4.11.8",
     "elliptic": "^6.4.1",
     "hash.js": "^1.1.3"
   },
   "devDependencies": {
-    "@types/elliptic": "^6.4.2",
     "@types/jasmine": "^3.3.5",
     "@types/node": "^9.6.6",
     "@types/lodash": "^4.14.139",


### PR DESCRIPTION
**Allow @dedis/{kyber, cothority} to be imported in typescript land without adding extra deps**

This PR moves `@types/elliptic` from dev deps to user deps, thus allowing theses project to use it with typescript direclty, without having to add its own version of the typing lib. It's also removing the now dangling deps of @dedis/cothority.

When building a project using @dedis/cothority or @dedis/kyber, `tsc` yield:
```
node_modules/@dedis/kyber/curve/edwards25519/curve.d.ts:2:23 - error TS7016: Could not find a declaration file for module 'elliptic'. '/home/tharvik/c4dt/service-drynx/library/node_modules/elliptic/lib/elliptic.js' implicitly has an 'any' type.
  Try `npm install @types/elliptic` if it exists or add a new declaration (.d.ts) file containing `declare module 'elliptic';`

2 import { curve } from "elliptic";
                        ~~~~~~~~~~

node_modules/@dedis/kyber/curve/nist/curve.d.ts:1:22 - error TS7016: Could not find a declaration file for module 'elliptic'. '/home/tharvik/c4dt/service-drynx/library/node_modules/elliptic/lib/elliptic.js' implicitly has an 'any' type.
  Try `npm install @types/elliptic` if it exists or add a new declaration (.d.ts) file containing `declare module 'elliptic';`

1 import elliptic from "elliptic";
```