### PR TITLE
protobufjs/light and export Log

### DIFF
--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@dedis/cothority",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "A typescript implementation of the cothority",
   "main": "index.js",
   "browser": "bundle.min.js",

--- a/external/js/cothority/spec/network/connection.spec.ts
+++ b/external/js/cothority/spec/network/connection.spec.ts
@@ -1,4 +1,4 @@
-import { Message } from "protobufjs";
+import { Message } from "protobufjs/light";
 import { BrowserWebSocketAdapter } from "../../src/network";
 import { LeaderConnection, RosterWSConnection, setFactory, WebSocketConnection } from "../../src/network/connection";
 import { Roster, ServerIdentity } from "../../src/network/proto";

--- a/external/js/cothority/src/byzcoin/instance.ts
+++ b/external/js/cothority/src/byzcoin/instance.ts
@@ -1,4 +1,4 @@
-import { Properties } from "protobufjs";
+import { Properties } from "protobufjs/light";
 import ByzCoinRPC from "./byzcoin-rpc";
 import Proof from "./proof";
 

--- a/external/js/cothority/src/calypso/calypso-rpc.ts
+++ b/external/js/cothority/src/calypso/calypso-rpc.ts
@@ -1,5 +1,5 @@
 import { Point, PointFactory, Scalar } from "@dedis/kyber";
-import { Message, Properties } from "protobufjs";
+import { Message, Properties } from "protobufjs/light";
 import { Argument, ClientTransaction, InstanceID, Instruction, Proof } from "../byzcoin";
 import ByzCoinRPC from "../byzcoin/byzcoin-rpc";
 import { Signer } from "../darc";

--- a/external/js/cothority/src/index.ts
+++ b/external/js/cothority/src/index.ts
@@ -2,6 +2,7 @@ import * as byzcoin from "./byzcoin";
 import * as contracts from "./byzcoin/contracts";
 import * as calypso from "./calypso";
 import * as darc from "./darc";
+import Log, { Logger } from "./log";
 import * as network from "./network";
 import * as skipchain from "./skipchain";
 import * as status from "./status";
@@ -14,4 +15,6 @@ export {
     network,
     skipchain,
     status,
+    Log,
+    Logger,
 };


### PR DESCRIPTION
Some of the files still imported 'protobufjs' instead of the
light version.

index.ts exports now Log and Logger.

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%v` verb.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
