### PR TITLE
Waiting for proof

### DIFF
--- a/external/js/cothority/spec/personhood/credentials-instance.spec.ts
+++ b/external/js/cothority/spec/personhood/credentials-instance.spec.ts
@@ -21,7 +21,7 @@ async function createInstance(rpc: ByzCoinRPC, signers: Signer[], darc: Darc, cr
 
     await rpc.sendTransactionAndWait(ctx);
 
-    return CredentialsInstance.fromByzcoin(rpc, ctx.instructions[0].deriveId());
+    return CredentialsInstance.fromByzcoin(rpc, ctx.instructions[0].deriveId(), 1);
 }
 
 describe("CredentialsInstance Tests", () => {

--- a/external/js/cothority/spec/personhood/ro-pa-sci-instance.spec.ts
+++ b/external/js/cothority/spec/personhood/ro-pa-sci-instance.spec.ts
@@ -52,7 +52,7 @@ async function createInstance(
     await rpc.sendTransactionAndWait(ctx);
 
     const iid = ctx.instructions[1].deriveId();
-    const instance = await RoPaSciInstance.fromByzcoin(rpc, iid);
+    const instance = await RoPaSciInstance.fromByzcoin(rpc, iid, 1);
     instance.setChoice(1, fillup);
 
     return instance;

--- a/external/js/cothority/src/byzcoin/contracts/coin-instance.ts
+++ b/external/js/cothority/src/byzcoin/contracts/coin-instance.ts
@@ -59,7 +59,7 @@ export default class CoinInstance extends Instance {
 
         await bc.sendTransactionAndWait(ctx, 10);
 
-        return CoinInstance.fromByzcoin(bc, ctx.instructions[0].deriveId());
+        return CoinInstance.fromByzcoin(bc, ctx.instructions[0].deriveId(), 1);
     }
 
     /**

--- a/external/js/cothority/src/byzcoin/contracts/value-instance.ts
+++ b/external/js/cothority/src/byzcoin/contracts/value-instance.ts
@@ -35,7 +35,7 @@ export default class ValueInstance extends Instance {
 
         await bc.sendTransactionAndWait(ctx, 10);
 
-        return ValueInstance.fromByzcoin(bc, ctx.instructions[0].deriveId());
+        return ValueInstance.fromByzcoin(bc, ctx.instructions[0].deriveId(), 1);
     }
 
     /**

--- a/external/js/cothority/src/calypso/calypso-instance.ts
+++ b/external/js/cothority/src/calypso/calypso-instance.ts
@@ -41,7 +41,7 @@ export class OnChainSecretInstance extends Instance {
 
         await bc.sendTransactionAndWait(ctx, 10);
 
-        return OnChainSecretInstance.fromByzcoin(bc, ctx.instructions[0].deriveId());
+        return OnChainSecretInstance.fromByzcoin(bc, ctx.instructions[0].deriveId(), 1);
     }
 
     /**
@@ -96,7 +96,7 @@ export class CalypsoWriteInstance extends Instance {
         await ctx.updateCountersAndSign(bc, [signers]);
         await bc.sendTransactionAndWait(ctx, 10);
 
-        return CalypsoWriteInstance.fromByzcoin(bc, ctx.instructions[0].deriveId());
+        return CalypsoWriteInstance.fromByzcoin(bc, ctx.instructions[0].deriveId(), 1);
     }
 
     /**
@@ -160,7 +160,7 @@ export class CalypsoReadInstance extends Instance {
         await ctx.updateCountersAndSign(bc, ctxSigners);
         await bc.sendTransactionAndWait(ctx);
 
-        return CalypsoReadInstance.fromByzcoin(bc, ctx.instructions[ctx.instructions.length - 1].deriveId());
+        return CalypsoReadInstance.fromByzcoin(bc, ctx.instructions[ctx.instructions.length - 1].deriveId(), 1);
     }
 
     /**
@@ -169,8 +169,9 @@ export class CalypsoReadInstance extends Instance {
      * @param iid   The instance ID
      * @returns a promise that resolves with the coin instance
      */
-    static async fromByzcoin(bc: ByzCoinRPC, iid: InstanceID): Promise<CalypsoReadInstance> {
-        return new CalypsoReadInstance(bc, await Instance.fromByzcoin(bc, iid));
+    static async fromByzcoin(bc: ByzCoinRPC, iid: InstanceID, waitMatch: number = 0, interval: number = 1000):
+        Promise<CalypsoReadInstance> {
+        return new CalypsoReadInstance(bc, await Instance.fromByzcoin(bc, iid, waitMatch, interval));
     }
     read: Read;
 

--- a/external/js/cothority/src/calypso/calypso-rpc.ts
+++ b/external/js/cothority/src/calypso/calypso-rpc.ts
@@ -41,7 +41,7 @@ export class OnChainSecretRPC {
         await ctx.updateCountersAndSign(this.bc, [signers]);
         await this.bc.sendTransactionAndWait(ctx);
         // Ask for the full proof which is easier to verify.
-        const p = await this.bc.getProof(ctx.instructions[0].deriveId());
+        const p = await this.bc.getProof(ctx.instructions[0].deriveId(), 1);
 
         return new WebSocketConnection(r.list[0].getWebSocketAddress(), OnChainSecretRPC.serviceID)
             .send(new CreateLTS({proof: p}), CreateLTSReply);

--- a/external/js/cothority/src/log.ts
+++ b/external/js/cothority/src/log.ts
@@ -135,7 +135,7 @@ export class Logger {
             errMsg = e.message;
         }
         if (e instanceof Error) {
-            for (let i = 1; i < e.stack.split("\n").length; i++) {
+            for (let i = this.stackFrameOffset; i < e.stack.split("\n").length - this.stackFrameOffset; i++) {
                 this.out("C : " + this.printCaller(e, i) + " -> " + this.joinArgs(args));
             }
         } else {

--- a/external/js/cothority/src/personhood/credentials-instance.ts
+++ b/external/js/cothority/src/personhood/credentials-instance.ts
@@ -66,7 +66,7 @@ export default class CredentialsInstance extends Instance {
 
         await bc.sendTransactionAndWait(ctx, 10);
 
-        return CredentialsInstance.fromByzcoin(bc, ctx.instructions[0].deriveId());
+        return CredentialsInstance.fromByzcoin(bc, ctx.instructions[0].deriveId(), 1);
     }
 
     /**
@@ -368,6 +368,11 @@ export class Credential extends Message<Credential> {
             this.attributes = [];
         }
         this.attributes = this.attributes.slice();
+    }
+
+    toString(): string {
+        return `${this.name}= ` +
+            this.attributes.map((a) => `${a.name}=${a.value.toString("hex")}`).join(" - ");
     }
 }
 

--- a/external/js/cothority/src/personhood/spawner-instance.ts
+++ b/external/js/cothority/src/personhood/spawner-instance.ts
@@ -71,10 +71,9 @@ export default class SpawnerInstance extends Instance {
         const inst = Instruction.createSpawn(darcID, this.contractID, args);
         const ctx = ClientTransaction.make(bc.getProtocolVersion(), inst);
         await ctx.updateCountersAndSign(bc, [signers]);
-
         await bc.sendTransactionAndWait(ctx);
 
-        return this.fromByzcoin(bc, ctx.instructions[0].deriveId());
+        return this.fromByzcoin(bc, ctx.instructions[0].deriveId(), 1);
     }
 
     /**

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/urfave/cli v1.22.0
 	go.dedis.ch/kyber/v3 v3.0.11
-	go.dedis.ch/onet/v3 v3.0.30
+	go.dedis.ch/onet/v3 v3.0.31
 	go.dedis.ch/protobuf v1.0.11
 	go.etcd.io/bbolt v1.3.3
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45


### PR DESCRIPTION
When getting a proof for a transaction without waiting, it is important
to try again, in case the transaction has been sent to node A, and
the proof is asked from node B which doesn't have the block yet.

Also includes a small fix to the `Log` module to respect the stack-depth.

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%v` verb.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
