### PR TITLE
external/cothority/protobuf: addJSON supports known namespace

### DIFF
--- a/external/js/cothority/src/protobuf/index.ts
+++ b/external/js/cothority/src/protobuf/index.ts
@@ -82,5 +82,14 @@ export function registerMessage(
  * @param json The definition imported from a json file
  */
 export function addJSON(json: INamespace): void {
-    root.addJSON(json.nested);
+    const temp = protobuf.Root.fromJSON(json);
+
+    for (const nested of root.nestedArray) {
+        const ns = temp.lookup(nested.name, protobuf.Namespace);
+        if (ns !== null) {
+            temp.remove(ns);
+        }
+    }
+
+    root.add(temp);
 }


### PR DESCRIPTION
`protobuf.addJSON` doesn't support adding already existing namespaces (such as `network`, `skipchain`, `onet`), which happens when adding a model which uses the cothority's models.