### PR TITLE
Use new darc-rule only in version 3

### DIFF
--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/qantik/qrgo"
 	"github.com/urfave/cli"
 	"go.dedis.ch/cothority/v3"
+	_ "go.dedis.ch/cothority/v3/bevm"
 	"go.dedis.ch/cothority/v3/byzcoin"
 	"go.dedis.ch/cothority/v3/byzcoin/bcadmin/lib"
 	"go.dedis.ch/cothority/v3/byzcoin/contracts"

--- a/byzcoin/messages.go
+++ b/byzcoin/messages.go
@@ -24,4 +24,4 @@ func init() {
 type Version int
 
 // CurrentVersion is what we're running now
-const CurrentVersion Version = 2
+const CurrentVersion Version = 3

--- a/personhood/contract_popparty.go
+++ b/personhood/contract_popparty.go
@@ -98,7 +98,7 @@ func (c ContractPopParty) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Inst
 		return nil, nil, errors.New("couldn't get darc: " + err.Error())
 	}
 	var expr expression.Expr
-	if rst.GetVersion() < 2 {
+	if rst.GetVersion() < 3 {
 		expr = d.Rules.Get("invoke:finalize")
 	} else {
 		expr = d.Rules.Get("invoke:popParty.finalize")


### PR DESCRIPTION
There has been a mismatch with the release of the nodes and the spawning of contracts. To keep the chain in a consistent state, the version needs to be updated to version 3, and only then the new darc rule needs to be used.

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%v` verb.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
