### PR TITLE
Nicer replay output

### DIFF
--- a/byzcoin/bcadmin/cmd_db.go
+++ b/byzcoin/bcadmin/cmd_db.go
@@ -134,7 +134,7 @@ func dbReplay(c *cli.Context) error {
 
 	log.Info("Replaying blocks")
 	_, err = fb.service.ReplayStateContLog(start,
-		&sumFetcher{sum: c.Int("summarize"), bff: fb.blockFetcher})
+		&sumFetcher{summarizeBlocks: c.Int("summarize"), bff: fb.blockFetcher})
 	if err != nil {
 		return xerrors.Errorf("couldn't replay blocks: %+v", err)
 	}
@@ -144,25 +144,25 @@ func dbReplay(c *cli.Context) error {
 }
 
 type sumFetcher struct {
-	sum            int
-	bff            byzcoin.BlockFetcherFunc
-	txs            int
-	accepted       int
-	blocks         int
-	timeLastBlock  int64
-	timeLastSum    int64
-	maxTPS         float64
-	maxBlockSize   int
-	totalBlockSize int
+	summarizeBlocks int
+	bff             byzcoin.BlockFetcherFunc
+	totalTXs        int
+	accepted        int
+	seenBlocks      int
+	timeLastBlock   int64
+	timeLastSum     int64
+	maxTPS          float64
+	maxBlockSize    int
+	totalBlockSize  int
 }
 
-func (sf sumFetcher) BlockFetcherFunc(sib skipchain.SkipBlockID) (*skipchain.
+func (sf sumFetcher) BlockFetcherFunc(sid skipchain.SkipBlockID) (*skipchain.
 	SkipBlock, error) {
-	return sf.bff(sib)
+	return sf.bff(sid)
 }
 
 func (sf sumFetcher) LogNewBlock(sb *skipchain.SkipBlock) {
-	if sf.sum == 1 {
+	if sf.summarizeBlocks == 1 {
 		log.Infof("Replaying block at index %d", sb.Index)
 	}
 }
@@ -180,21 +180,22 @@ func (sf *sumFetcher) LogAppliedBlock(sb *skipchain.SkipBlock,
 		}
 	}
 	buf, err := protobuf.Encode(sb)
-	if err == nil && sf.sum > 1 {
+	log.ErrFatal(err, "while encoding block")
+	if sf.summarizeBlocks > 1 {
 		sf.totalBlockSize += len(buf)
 		if len(buf) > sf.maxBlockSize {
 			sf.maxBlockSize = len(buf)
 		}
 	}
-	sf.txs += len(body.TxResults)
-	sf.blocks++
+	sf.totalTXs += len(body.TxResults)
+	sf.seenBlocks++
 	if sf.timeLastBlock == 0 {
 		sf.timeLastBlock = head.Timestamp
 		sf.timeLastSum = head.Timestamp
 		sf.maxTPS = 0
 	}
 
-	if sf.sum > 1 && head.Timestamp != sf.timeLastBlock {
+	if sf.summarizeBlocks > 1 && head.Timestamp != sf.timeLastBlock {
 		tpsBlock := float64(len(body.TxResults)) /
 			float64((head.Timestamp-sf.timeLastBlock)/1e9)
 		if tpsBlock > sf.maxTPS {
@@ -203,27 +204,27 @@ func (sf *sumFetcher) LogAppliedBlock(sb *skipchain.SkipBlock,
 		sf.timeLastBlock = head.Timestamp
 	}
 
-	if sb.Index%sf.sum == (sf.sum - 1) {
+	if sb.Index%sf.summarizeBlocks == (sf.summarizeBlocks - 1) {
 		tStr := time.Unix(head.Timestamp/1e9, 0).String()
-		tpsMean := float64(sf.txs) /
+		tpsMean := float64(sf.totalTXs) /
 			float64((head.Timestamp-sf.timeLastSum)/1e9)
-		if sf.sum > 1 {
+		if sf.summarizeBlocks > 1 {
 			log.Infof("Processed blocks %d.."+
 				"%d [%s]: Txs total/accepted = %d/%d - "+
 				"tps max/mean: %.1f/%.1f\n"+
 				"\troster-size: %d, max/mean block size: %d/%d",
-				sb.Index-sf.blocks+1, sb.Index, tStr,
-				sf.txs, sf.accepted, sf.maxTPS, tpsMean,
+				sb.Index-sf.seenBlocks+1, sb.Index, tStr,
+				sf.totalTXs, sf.accepted, sf.maxTPS, tpsMean,
 				len(sb.Roster.List),
-				sf.maxBlockSize, sf.totalBlockSize/sf.sum)
+				sf.maxBlockSize, sf.totalBlockSize/sf.summarizeBlocks)
 		} else {
 			log.Infof("Got correct block from %s with %d txs, "+
 				"out of which %d txs got accepted. Tps: %.1f",
-				tStr, sf.txs, sf.accepted, tpsMean)
+				tStr, sf.totalTXs, sf.accepted, tpsMean)
 		}
-		sf.txs = 0
+		sf.totalTXs = 0
 		sf.accepted = 0
-		sf.blocks = 0
+		sf.seenBlocks = 0
 		sf.timeLastBlock = head.Timestamp
 		sf.timeLastSum = head.Timestamp
 		sf.maxTPS = 0.0

--- a/byzcoin/bcadmin/commands.go
+++ b/byzcoin/bcadmin/commands.go
@@ -660,6 +660,11 @@ var cmds = cli.Commands{
 						Name:  "blocks",
 						Usage: "how many blocks to apply",
 					},
+					cli.IntFlag{
+						Name:  "summarize, sum",
+						Usage: "summarize this many blocks in output",
+						Value: 1,
+					},
 				},
 			},
 			{

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -2257,7 +2257,7 @@ func (s *Service) processOneTx(sst *stagingStateTrie, tx ClientTransaction,
 		cin = cout
 	}
 	if len(cin) != 0 {
-		log.Warn(s.ServerIdentity(), "Leftover coins detected, discarding.")
+		log.Lvl2(s.ServerIdentity(), "Leftover coins detected, discarding.")
 	}
 
 	return statesTemp, sst, nil

--- a/byzcoin/statereplay.go
+++ b/byzcoin/statereplay.go
@@ -24,7 +24,7 @@ type BlockFetcherFunc func(sib skipchain.SkipBlockID) (*skipchain.SkipBlock, err
 // BlockFetcher is an interface that can be passed to ReplayStateLog so that
 // the output of the replay can be adapted to what the user wants.
 type BlockFetcher interface {
-	BlockFetcherFunc(sib skipchain.SkipBlockID) (*skipchain.SkipBlock, error)
+	BlockFetcherFunc(sid skipchain.SkipBlockID) (*skipchain.SkipBlock, error)
 	LogNewBlock(sb *skipchain.SkipBlock)
 	LogAppliedBlock(sb *skipchain.SkipBlock, head DataHeader, body DataBody)
 	LogWarn(sb *skipchain.SkipBlock, msg, dump string)
@@ -221,7 +221,8 @@ func (s *Service) ReplayStateContLog(id skipchain.SkipBlockID,
 
 // ReplayStateCont is a wrapper over ReplayStateContLog and outputs every
 // block to the std-output.
-func (s *Service) ReplayStateCont(id skipchain.SkipBlockID, cb BlockFetcherFunc) (ReadOnlyStateTrie, error) {
+func (s *Service) ReplayStateCont(id skipchain.SkipBlockID,
+	cb BlockFetcherFunc) (ReadOnlyStateTrie, error) {
 	return s.ReplayStateContLog(id, stdFetcher{cb})
 }
 

--- a/personhood/contract_spawner.go
+++ b/personhood/contract_spawner.go
@@ -317,7 +317,6 @@ func (ss *SpawnerStruct) parseArgs(args byzcoin.Arguments, v byzcoin.Version) er
 				return fmt.Errorf("couldn't decode coin %s: %s", cost.name, err)
 			}
 		} else {
-			log.Print(v)
 			if v > 1 {
 				cost.coin.Name = contracts.CoinName
 				cost.coin.Value = 100
@@ -334,6 +333,5 @@ func (ss *SpawnerStruct) parseArgs(args byzcoin.Arguments, v byzcoin.Version) er
 	if args.Search("costValue") == nil {
 		ss.CostValue = nil
 	}
-	log.Printf("%+v", ss.CostCWrite)
 	return nil
 }


### PR DESCRIPTION
In order to run the 'bcadmin db replay' command on travis with ~30k blocks,
this PR adds a '--summarize' flag that takes as an argument the number of
blocks to summarize before printing statistics about the blocks.

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%v` verb.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
