### PR TITLE
external/kyber: test for BN256 add/mul consistency

### DIFF
--- a/external/js/kyber/spec/pairing/point.spec.ts
+++ b/external/js/kyber/spec/pairing/point.spec.ts
@@ -26,6 +26,26 @@ describe("BN256 Point Tests", () => {
         expect(prop).toHold();
     });
 
+    it("should yield the same point by addition and multiplication", () => {
+        const prop = jsc.forall(jsc.uint8, (target) => {
+            const base = new BN256G1Point().base();
+            const scalarUnit = new BN256Scalar().one()
+            const pointUnit = new BN256G1Point().mul(scalarUnit, base)
+
+            const scalarAdder = new BN256Scalar();
+            const pointAdder = new BN256G1Point();
+            for (let i = 0; i < target; i++) {
+                scalarAdder.add(scalarAdder, scalarUnit)
+                pointAdder.add(pointAdder, pointUnit);
+            }
+
+            return pointAdder.equals(new BN256G1Point().mul(scalarAdder, base));
+        });
+
+        // @ts-ignore
+        expect(prop).toHold();
+    });
+
     it("should add and multiply g1 points", () => {
         const prop = jsc.forall(jsc.array(jsc.uint8), (a) => {
             const p1 = new BN256G1Point(a);


### PR DESCRIPTION
PR failing on purpose (for now).
Disclaimer: I don't know much about crypto, I might be completely wrong.

__Multiplication is not consistent with addition on BN256G1 in typescript, ie `s*P != P + P + P + ...`.__ I'm adding a small test showing it, which is really close to the [golang one](https://github.com/dedis/kyber/pull/410). From what I gather, it's the addition which is wrongly implemented.

Now, I don't know how to fix it, so some help from a cryptographer would be nice :)