### PR TITLE
KyberJS: fix curve point double stability

### DIFF
--- a/external/js/kyber/spec/pairing/point.spec.ts
+++ b/external/js/kyber/spec/pairing/point.spec.ts
@@ -26,6 +26,26 @@ describe("BN256 Point Tests", () => {
         expect(prop).toHold();
     });
 
+    it("should yield the same point by addition and mul", () => {
+        const prop = jsc.forall(jsc.uint8, (target) => {
+            const base = new BN256G1Point().base();
+            const scalarUnit = new BN256Scalar().one();
+            const pointUnit = new BN256G1Point().mul(scalarUnit, base);
+
+            const scalarAdder = new BN256Scalar();
+            const pointAdder = new BN256G1Point();
+            for (let i = 0; i < target; i++) {
+                scalarAdder.add(scalarAdder, scalarUnit);
+                pointAdder.add(pointAdder, pointUnit);
+            }
+
+            return pointAdder.equals(new BN256G1Point().mul(scalarAdder, base));
+        });
+
+        // @ts-ignore
+        expect(prop).toHold();
+    });
+
     it("should add and multiply g1 points", () => {
         const prop = jsc.forall(jsc.array(jsc.uint8), (a) => {
             const p1 = new BN256G1Point(a);

--- a/external/js/kyber/src/pairing/curve-point.ts
+++ b/external/js/kyber/src/pairing/curve-point.ts
@@ -172,7 +172,10 @@ export default class CurvePoint {
         const B = a.y.sqr().mod(p);
         const C = B.sqr().mod(p);
 
-        let t = a.x.add(B);
+        let t = a.y.mul(a.z).mod(p);
+        this.z = t.add(t).mod(p);
+
+        t = a.x.add(B);
         let t2 = t.sqr().mod(p);
         t = t2.sub(A);
         t2 = t.sub(C);
@@ -190,9 +193,6 @@ export default class CurvePoint {
         this.y = d.sub(this.x);
         t2 = e.mul(this.y).mod(p);
         this.y = t2.sub(t).mod(p);
-
-        t = a.y.mul(a.z).mod(p);
-        this.z = t.add(t).mod(p);
     }
 
     /**


### PR DESCRIPTION
This allows a and this to be the same object and still get a correct
result.

Closes #2172 

---

🙅‍ Friendly checklist:

- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
