### PR TITLE
external/kyber: test for BN256 add/sub/neg/mul immutability

### DIFF
--- a/external/js/kyber/spec/pairing/point.spec.ts
+++ b/external/js/kyber/spec/pairing/point.spec.ts
@@ -46,6 +46,25 @@ describe("BN256 Point Tests", () => {
         expect(prop).toHold();
     });
 
+    it("should not modify params with add/sub/neg/mul", () => {
+        const prop = jsc.forall(jsc.uint8, (target) => {
+            const pointRef = new BN256G1Point(target);
+            const scalarRef = new BN256Scalar(target);
+            const point = pointRef.clone();
+            const scalar = scalarRef.clone()
+
+            point.clone().add(point, point);
+            point.clone().sub(point, point);
+            point.clone().neg(point);
+            point.clone().mul(scalar, point);
+
+            return pointRef.equals(point) && scalarRef.equals(scalar);
+        });
+
+        // @ts-ignore
+        expect(prop).toHold();
+    });
+
     it("should add and multiply g1 points", () => {
         const prop = jsc.forall(jsc.array(jsc.uint8), (a) => {
             const p1 = new BN256G1Point(a);

--- a/external/js/kyber/src/pairing/point.ts
+++ b/external/js/kyber/src/pairing/point.ts
@@ -92,7 +92,7 @@ export class BN256G1Point implements Point {
 
     /** @inheritdoc */
     sub(a: BN256G1Point, b: BN256G1Point): BN256G1Point {
-        return this.add(a, b.neg(b));
+        return this.add(a, b.clone().neg(b));
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
Found another mutability issue, very close to dedis/cothority#2172; adding a test triggering it (spoiler, it's `sub`).

And the fix is simply to `clone` the point before modifiying it.