### PR TITLE
external/kyber/bn256: fix order for scalar

### DIFF
--- a/external/js/kyber/spec/pairing/point.spec.ts
+++ b/external/js/kyber/spec/pairing/point.spec.ts
@@ -46,6 +46,27 @@ describe("BN256 Point Tests", () => {
         expect(prop).toHold();
     });
 
+    it("should yield the same point by negative addition and multiplication", () => {
+        const prop = jsc.forall(jsc.uint8, (target) => {
+            const base = new BN256G1Point().base();
+            const scalarNegUnit = new BN256Scalar().one();
+            scalarNegUnit.neg(scalarNegUnit);
+            const pointNegUnit = new BN256G1Point().mul(scalarNegUnit, base);
+
+            const scalarSuber = new BN256Scalar().zero();
+            const pointSuber = new BN256G1Point().null();
+            for (let i = 0; i < target; i++) {
+                scalarSuber.add(scalarSuber, scalarNegUnit);
+                pointSuber.add(pointSuber, pointNegUnit);
+            }
+
+            return pointSuber.equals(new BN256G1Point().mul(scalarSuber, base));
+        });
+
+        // @ts-ignore
+        expect(prop).toHold();
+    });
+
     it("should not modify params with add/sub/neg/mul", () => {
         const prop = jsc.forall(jsc.uint8, (target) => {
             const pointRef = new BN256G1Point(target);

--- a/external/js/kyber/spec/pairing/scalar.spec.ts
+++ b/external/js/kyber/spec/pairing/scalar.spec.ts
@@ -1,6 +1,6 @@
 import BN from "bn.js";
 import jsc from "jsverify";
-import { p } from "../../src/pairing/constants";
+import { order } from "../../src/pairing/constants";
 import BN256Scalar from "../../src/pairing/scalar";
 
 describe("BN256 Scalar Tests", () => {
@@ -12,7 +12,7 @@ describe("BN256 Scalar Tests", () => {
             sum.add(sA, sB);
             sum.add(sum, new BN256Scalar().zero());
 
-            return sum.getValue().eq(new BN(a + b).umod(p));
+            return sum.getValue().eq(new BN(a + b).umod(order));
         });
 
         // @ts-ignore
@@ -26,7 +26,7 @@ describe("BN256 Scalar Tests", () => {
             const res = new BN256Scalar();
             res.sub(sA, sB);
 
-            return res.getValue().eq(new BN(a - b).umod(p));
+            return res.getValue().eq(new BN(a - b).umod(order));
         });
 
         // @ts-ignore
@@ -40,7 +40,7 @@ describe("BN256 Scalar Tests", () => {
             const res = new BN256Scalar();
             res.mul(sA, sB);
 
-            return res.getValue().eq(new BN(a * b).umod(p));
+            return res.getValue().eq(new BN(a * b).umod(order));
         });
 
         // @ts-ignore
@@ -54,7 +54,7 @@ describe("BN256 Scalar Tests", () => {
             const res = new BN256Scalar();
             res.div(sA, sB);
 
-            return res.getValue().eq(new BN(a).umod(p));
+            return res.getValue().eq(new BN(a).umod(order));
         });
 
         // @ts-ignore

--- a/external/js/kyber/src/pairing/curve-point.ts
+++ b/external/js/kyber/src/pairing/curve-point.ts
@@ -202,15 +202,11 @@ export default class CurvePoint {
      */
     mul(a: CurvePoint, scalar: BN): void {
         const sum = new CurvePoint();
-        sum.setInfinity();
-        const t = new CurvePoint();
 
-        for (let i = scalar.bitLength(); i >= 0; i--) {
-            t.dbl(sum);
+        for (let i = scalar.bitLength() - 1; i >= 0; i--) {
+            sum.dbl(sum);
             if (scalar.testn(i)) {
-                sum.add(t, a);
-            } else {
-                sum.copy(t);
+                sum.add(sum, a);
             }
         }
 

--- a/external/js/kyber/src/pairing/scalar.ts
+++ b/external/js/kyber/src/pairing/scalar.ts
@@ -2,7 +2,7 @@ import BN from "bn.js";
 import { randomBytes } from "crypto-browserify";
 import { Scalar } from "../index";
 import { int } from "../random";
-import { p } from "./constants";
+import { order } from "./constants";
 
 export type BNType = number | string | number[] | Buffer | BN;
 
@@ -13,7 +13,7 @@ export default class BN256Scalar implements Scalar {
     private v: BN;
 
     constructor(value?: BNType) {
-        this.v = new BN(value).umod(p);
+        this.v = new BN(value).umod(order);
     }
 
     /**
@@ -44,37 +44,37 @@ export default class BN256Scalar implements Scalar {
 
     /** @inheritdoc */
     add(a: BN256Scalar, b: BN256Scalar): BN256Scalar {
-        this.v = a.v.add(b.v).umod(p);
+        this.v = a.v.add(b.v).umod(order);
         return this;
     }
 
     /** @inheritdoc */
     sub(a: BN256Scalar, b: BN256Scalar): BN256Scalar {
-        this.v = a.v.sub(b.v).umod(p);
+        this.v = a.v.sub(b.v).umod(order);
         return this;
     }
 
     /** @inheritdoc */
     neg(a: BN256Scalar): BN256Scalar {
-        this.v = a.v.neg().umod(p);
+        this.v = a.v.neg().umod(order);
         return this;
     }
 
     /** @inheritdoc */
     div(a: BN256Scalar, b: BN256Scalar): BN256Scalar {
-        this.v = a.v.div(b.v).umod(p);
+        this.v = a.v.div(b.v).umod(order);
         return this;
     }
 
     /** @inheritdoc */
     mul(s1: BN256Scalar, b: BN256Scalar): BN256Scalar {
-        this.v = s1.v.mul(b.v).umod(p);
+        this.v = s1.v.mul(b.v).umod(order);
         return this;
     }
 
     /** @inheritdoc */
     inv(a: BN256Scalar): BN256Scalar {
-        this.v = a.v.invm(p);
+        this.v = a.v.invm(order);
         return this;
     }
 
@@ -82,7 +82,7 @@ export default class BN256Scalar implements Scalar {
     pick(callback?: (length: number) => Buffer): BN256Scalar {
         callback = callback || randomBytes;
 
-        const bytes = int(p, callback);
+        const bytes = int(order, callback);
         this.setBytes(bytes);
         return this;
     }


### PR DESCRIPTION
**The modulo for bn256' scalar in typescript is wrong.**

By looking at the [golang implementation of bn256' scalar](https://github.com/dedis/kyber/blob/master/pairing/bn256/group.go#L69), we see that it uses the order (the number of element of a ring) as modulus. In the typescript, it actually uses `p`, not `group`, which gives that addition is not consistent with multiplication when using negatives.

This PR adds a test triggering the issue, and the fix. It also contain a simplification of multiplication for bn256 (which is unrelated, just easier to understand).

Kudos to @ineiti for helping me debug :)