### PR TITLE
external/kyber/bn256: mod after neg

### DIFF
--- a/external/js/kyber/spec/pairing/point.spec.ts
+++ b/external/js/kyber/spec/pairing/point.spec.ts
@@ -67,6 +67,17 @@ describe("BN256 Point Tests", () => {
         expect(prop).toHold();
     });
 
+    it("should yield the same point by negation and multiplication, for -1", () => {
+        const base = new BN256G1Point().base();
+        const scalarOne = new BN256Scalar().one();
+        const pointOne = new BN256G1Point().mul(scalarOne, base);
+
+        scalarOne.neg(scalarOne);
+        pointOne.neg(pointOne);
+
+        expect(pointOne.equals(new BN256G1Point().mul(scalarOne, base))).toBeTruthy();
+    });
+
     it("should not modify params with add/sub/neg/mul", () => {
         const prop = jsc.forall(jsc.uint8, (target) => {
             const pointRef = new BN256G1Point(target);

--- a/external/js/kyber/src/pairing/curve-point.ts
+++ b/external/js/kyber/src/pairing/curve-point.ts
@@ -240,7 +240,7 @@ export default class CurvePoint {
      */
     negative(a: CurvePoint): void {
         this.x = a.x;
-        this.y = a.y.negate();
+        this.y = a.y.negate().mod(p);
         this.z = a.z;
     }
 


### PR DESCRIPTION
-1 is not encoded the same when using `neg` rather than `mul`. Adding a small test for it and a fix (yet, I'm no cryptographer, I don't know if it's correct at all).

I'm using `p` here, as throughout the typescript codebase, see dedis/kyber#412 if you find it weird.