### PR TITLE
Observable ByzCoin

### DIFF
--- a/external/js/cothority/package-lock.json
+++ b/external/js/cothority/package-lock.json
@@ -6593,6 +6593,14 @@
         "aproba": "^1.1.1"
       }
     },
+    "rxjs": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",

--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -49,6 +49,7 @@
     "os": "^0.1.1",
     "protobufjs": "^6.8.8",
     "pure-uuid": "^1.5.5",
+    "rxjs": "^6.5.4",
     "shuffle-array": "^1.0.1",
     "sprintf-js": "^1.1.2",
     "toml": "^2.3.5",

--- a/external/js/cothority/spec/byzcoin/byzcoin-rpc.spec.ts
+++ b/external/js/cothority/spec/byzcoin/byzcoin-rpc.spec.ts
@@ -68,7 +68,7 @@ describe("ByzCoinRPC Tests", () => {
             history.push(`${d.version}-${d.description.toString()}`);
         });
         expect(history[0]).toBe("0-initial");
-
+// Evolving the Darc we observe, we expect the history to be updated
         const di = await DarcInstance.fromByzcoin(rpc, darc.getBaseID());
         const newDI = new Darc({
             ...darc.evolve(),

--- a/external/js/cothority/spec/byzcoin/byzcoin-rpc.spec.ts
+++ b/external/js/cothority/spec/byzcoin/byzcoin-rpc.spec.ts
@@ -61,7 +61,7 @@ describe("ByzCoinRPC Tests", () => {
         const darc = ByzCoinRPC.makeGenesisDarc([SIGNER], roster, "initial");
         const rpc = await ByzCoinRPC.newByzCoinRPC(roster, darc, BLOCK_INTERVAL, cache);
 
-        const instUpdate = await rpc.proofObservable(darc.getBaseID());
+        const instUpdate = await rpc.instanceObservable(darc.getBaseID());
         const history: string[] = [];
         instUpdate.subscribe((inst) => {
             const d = Darc.decode(inst.value);
@@ -93,7 +93,7 @@ describe("ByzCoinRPC Tests", () => {
             await wait100ms();
         }
 // Getting a new proofObservable on the previously updated Darc should return the latest version of the Darc
-        const latestProof = (await rpc.proofObservable(darc.getBaseID())).getValue();
+        const latestProof = (await rpc.instanceObservable(darc.getBaseID())).getValue();
         expect(latestProof.stateChangeBody.version.equals(Long.fromNumber(1)))
             .toBeTruthy();
 

--- a/external/js/cothority/spec/byzcoin/byzcoin-rpc.spec.ts
+++ b/external/js/cothority/spec/byzcoin/byzcoin-rpc.spec.ts
@@ -92,7 +92,7 @@ describe("ByzCoinRPC Tests", () => {
             expect(history.length).toBe(2);
             await wait100ms();
         }
-
+// Getting a new proofObservable on the previously updated Darc should return the latest version of the Darc
         const latestProof = (await rpc.proofObservable(darc.getBaseID())).getValue();
         expect(latestProof.stateChangeBody.version.equals(Long.fromNumber(1)))
             .toBeTruthy();

--- a/external/js/cothority/spec/byzcoin/byzcoin-rpc.spec.ts
+++ b/external/js/cothority/spec/byzcoin/byzcoin-rpc.spec.ts
@@ -1,6 +1,10 @@
+import Long from "long";
+import { Log } from "../../src";
 import { ByzCoinRPC } from "../../src/byzcoin";
+import { LocalCache } from "../../src/byzcoin/byzcoin-rpc";
 import DarcInstance from "../../src/byzcoin/contracts/darc-instance";
 import Instance from "../../src/byzcoin/instance";
+import { Darc } from "../../src/darc";
 import { BLOCK_INTERVAL, ROSTER, SIGNER, startConodes } from "../support/conondes";
 
 describe("ByzCoinRPC Tests", () => {
@@ -51,4 +55,52 @@ describe("ByzCoinRPC Tests", () => {
             .toBeRejectedWith(new Error("key not in proof: 010203"));
         await expectAsync(DarcInstance.fromByzcoin(rpc, Buffer.alloc(32, 0))).toBeRejected();
     });
+
+    it("should get updated when an instance is updated", async () => {
+        const cache = new LocalCache();
+        const darc = ByzCoinRPC.makeGenesisDarc([SIGNER], roster, "initial");
+        const rpc = await ByzCoinRPC.newByzCoinRPC(roster, darc, BLOCK_INTERVAL, cache);
+
+        const instUpdate = await rpc.proofObservable(darc.getBaseID());
+        const history: string[] = [];
+        instUpdate.subscribe((inst) => {
+            const d = Darc.decode(inst.value);
+            history.push(`${d.version}-${d.description.toString()}`);
+        });
+        expect(history[0]).toBe("0-initial");
+
+        const di = await DarcInstance.fromByzcoin(rpc, darc.getBaseID());
+        const newDI = new Darc({
+            ...darc.evolve(),
+            description: Buffer.from("new"),
+        });
+        await di.evolveDarcAndWait(newDI, [SIGNER], 10);
+
+        for (let i = 0; i < 5; i++) {
+            if (history.length === 2) {
+                break;
+            }
+            await wait100ms();
+        }
+        expect(history.length).toBe(2);
+        expect(history[1]).toBe("1-new");
+
+        const newDarc = Darc.createBasic([SIGNER], [SIGNER],
+            Buffer.from("darc 2"));
+        await di.spawnDarcAndWait(newDarc, [SIGNER], 2);
+        for (let i = 0; i < 5; i++) {
+            expect(history.length).toBe(2);
+            await wait100ms();
+        }
+
+        const latestProof = (await rpc.proofObservable(darc.getBaseID())).getValue();
+        expect(latestProof.stateChangeBody.version.equals(Long.fromNumber(1)))
+            .toBeTruthy();
+
+        rpc.closeNewBlocks();
+    });
 });
+
+async function wait100ms(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 100));
+}

--- a/external/js/cothority/spec/byzcoin/byzcoin-rpc.spec.ts
+++ b/external/js/cothority/spec/byzcoin/byzcoin-rpc.spec.ts
@@ -84,7 +84,7 @@ describe("ByzCoinRPC Tests", () => {
         }
         expect(history.length).toBe(2);
         expect(history[1]).toBe("1-new");
-
+// Creating a new Darc, this should not update the history
         const newDarc = Darc.createBasic([SIGNER], [SIGNER],
             Buffer.from("darc 2"));
         await di.spawnDarcAndWait(newDarc, [SIGNER], 2);

--- a/external/js/cothority/src/byzcoin/byzcoin-rpc.ts
+++ b/external/js/cothority/src/byzcoin/byzcoin-rpc.ts
@@ -1,9 +1,17 @@
 import Long from "long";
+import { BehaviorSubject } from "rxjs";
+import { tap } from "rxjs/internal/operators/tap";
+import { distinctUntilChanged, filter, map, mergeMap } from "rxjs/operators";
 import { Rule } from "../darc";
 import Darc from "../darc/darc";
 import IdentityEd25519 from "../darc/identity-ed25519";
 import IdentityWrapper, { IIdentity } from "../darc/identity-wrapper";
-import { IConnection, LeaderConnection, RosterWSConnection } from "../network/connection";
+import { WebSocketAdapter } from "../network";
+import {
+    IConnection,
+    LeaderConnection,
+    RosterWSConnection,
+} from "../network/connection";
 import { Roster } from "../network/proto";
 import { SkipBlock } from "../skipchain/skipblock";
 import SkipchainRPC from "../skipchain/skipchain-rpc";
@@ -24,6 +32,7 @@ import {
     GetSignerCounters,
     GetSignerCountersResponse,
 } from "./proto/requests";
+import { StreamingRequest, StreamingResponse } from "./proto/stream";
 
 export const currentVersion = 2;
 
@@ -39,13 +48,14 @@ const CONFIG_INSTANCE_ID = Buffer.alloc(32, 0);
  */
 export default class ByzCoinRPC implements ICounterUpdater {
 
+    get genesisID(): InstanceID {
+        return this.genesis.computeHash();
+    }
+
     get latest(): SkipBlock {
         return new SkipBlock(this._latest);
     }
 
-    get genesisID(): InstanceID {
-        return this.genesis.computeHash();
-    }
     static readonly serviceName = "ByzCoin";
 
     /**
@@ -79,10 +89,12 @@ export default class ByzCoinRPC implements ICounterUpdater {
      * @param waitMatch how many times to wait for a match - useful if its called just after an addTransactionAndWait.
      * @param interval how long to wait between two attempts in waitMatch.
      * @param latest if given, use this to prove the current state of the blockchain. Needs to be trusted!
+     * @param storage to be used to store instance caches
      * @returns a promise that resolves with the initialized ByzCoin instance
      */
     static async fromByzcoin(nodes: Roster | IConnection, skipchainID: Buffer, waitMatch: number = 0,
-                             interval: number = 1000, latest?: SkipBlock):
+                             interval: number = 1000, latest?: SkipBlock,
+                             storage?: IStorage):
         Promise<ByzCoinRPC> {
         const rpc = new ByzCoinRPC();
         if (nodes instanceof Roster) {
@@ -100,6 +112,7 @@ export default class ByzCoinRPC implements ICounterUpdater {
         const di = await DarcInstance.fromByzcoin(rpc, ccProof.stateChangeBody.darcID, waitMatch, interval);
 
         rpc.genesisDarc = di.darc;
+        rpc.db = storage;
 
         return rpc;
     }
@@ -109,8 +122,10 @@ export default class ByzCoinRPC implements ICounterUpdater {
      * @param roster        The roster to use to create the genesis block
      * @param darc          The genesis darc
      * @param blockInterval The interval of block creation in nanoseconds
+     * @param storage       To be used to store instance caches
      */
-    static async newByzCoinRPC(roster: Roster, darc: Darc, blockInterval: Long): Promise<ByzCoinRPC> {
+    static async newByzCoinRPC(roster: Roster, darc: Darc, blockInterval: Long,
+                               storage?: IStorage): Promise<ByzCoinRPC> {
         const leader = new LeaderConnection(roster, ByzCoinRPC.serviceName);
         const req = new CreateGenesisBlock({
             blockInterval,
@@ -121,13 +136,18 @@ export default class ByzCoinRPC implements ICounterUpdater {
         });
 
         const ret = await leader.send<CreateGenesisBlockResponse>(req, CreateGenesisBlockResponse);
-        return ByzCoinRPC.fromByzcoin(roster, ret.skipblock.hash);
+        return ByzCoinRPC.fromByzcoin(roster, ret.skipblock.hash,
+            undefined, undefined, undefined, storage);
     }
     private static staticCounters = new Map<string, Map<string, Long>>();
+    private newBlockWS: WebSocketAdapter;
     private genesisDarc: Darc;
+    private newBlock: BehaviorSubject<SkipBlock>;
     private config: ChainConfig;
     private genesis: SkipBlock;
     private conn: IConnection;
+    private db: IStorage;
+    private cache = new Map<InstanceID, BehaviorSubject<Proof>>();
 
     private _latest: SkipBlock;
 
@@ -166,6 +186,70 @@ export default class ByzCoinRPC implements ICounterUpdater {
         const header = DataHeader.decode(this._latest.data);
 
         return header.version;
+    }
+
+    /**
+     * Returns an observable proof for an instance that will be
+     * automatically updated whenever the instance is changed.
+     * It returns a BehaviorSubject, which is a special observable that
+     * keeps the current value.
+     * It also caches all requests, so if there are two requests for the
+     * same id, no new observable will be created.
+     * It connects to `getNewBlocks` to be informed whenever a new block is
+     * created.
+     * @param id of the instance to return
+     * @throws an error if the instance does not exist
+     */
+    async proofObservable(id: InstanceID): Promise<BehaviorSubject<Proof>> {
+        const bs = this.cache.get(id);
+        if (bs !== undefined) {
+            return bs;
+        }
+
+        // Check if the db already has a version, which might be outdated,
+        // but still better than to wait for the network.
+        // might be old, but be informed as soon as the correct values arrive.
+        // This makes it possible to have a quick display of values that
+        const idStr = id.toString("hex");
+        const proofBuf = await this.db.get(idStr);
+        let dbProof: Proof;
+        if (proofBuf === undefined) {
+            dbProof = await this.getProofFromLatest(id);
+        } else {
+            dbProof = Proof.decode(proofBuf);
+        }
+        if (!dbProof.exists(id)) {
+            throw new Error("this instance does not exist");
+        }
+
+        // Create a new BehaviorSubject with the proof, which might not be
+        // current, but a best guess from the db of a previous session.
+        const bsNew = new BehaviorSubject(dbProof);
+        this.cache.set(id, bsNew);
+
+        // Set up a pipe from the block to fetch new versions if a new block
+        // arrives.
+        // Start with an observable that emits each new block as it arrives.
+        (await this.getNewBlocks())
+            .pipe(
+                // Make sure only newer blocks than the proof are taken into
+                // account
+                filter((block) => block.index > dbProof.latest.index),
+                // Get a new proof of the instance
+                mergeMap(() => this.getProofFromLatest(id)),
+                // Don't emit proofs that are already known
+                distinctUntilChanged((a, b) =>
+                    a.stateChangeBody.version.equals(b.stateChangeBody.version)),
+                // Store new proofs in the db for later use
+                tap((proof) =>
+                    this.db.set(idStr, Buffer.from(Proof.encode(proof).finish()))),
+                // Link to the BehaviorSubject
+            ).subscribe(bsNew);
+
+        // Return the BehaviorSubject - the pipe will continue to run in the
+        // background and check if the proof changed on the emission of
+        // every new block.
+        return bsNew;
     }
 
     /**
@@ -386,11 +470,71 @@ export default class ByzCoinRPC implements ICounterUpdater {
         return reply.actions;
     }
 
+    /**
+     * The returned BehaviorSubject replays all new blocks to all listeners.
+     * The streaming is attached to the first node of the connectionlist.
+     */
+    async getNewBlocks(): Promise<BehaviorSubject<SkipBlock>> {
+        if (this.newBlock !== undefined) {
+            return this.newBlock;
+        }
+        if (this._latest === undefined) {
+            await this.getProofFromLatest(CONFIG_INSTANCE_ID);
+        }
+        this.newBlock = new BehaviorSubject(this._latest);
+        const msgBlock = new StreamingRequest({
+            id: this.genesisID,
+        });
+        this.conn.sendStream<StreamingResponse>(msgBlock,
+            StreamingResponse).pipe(map(([sr, ws]) => {
+            this.newBlockWS = ws;
+            return sr.block;
+        })).subscribe(this.newBlock);
+        return this.newBlock;
+    }
+
+    /**
+     * Closes an eventual newBlock websocket. All connected BehaviorSubjects
+     * will get a 'completed' message.
+     */
+    closeNewBlocks() {
+        if (this.newBlock) {
+            this.newBlockWS.close(1000);
+            this.newBlock = undefined;
+        }
+    }
+
     private counters(): Map<string, Long> {
         const idStr = this.genesisID.toString("hex");
         if (!ByzCoinRPC.staticCounters.has(idStr)) {
             ByzCoinRPC.staticCounters.set(idStr, new Map<string, Long>());
         }
         return ByzCoinRPC.staticCounters.get(idStr);
+    }
+
+}
+
+/**
+ * IStorage represents a storage backend - either a local cache, or a db
+ * that stays around between sessions.
+ */
+export interface IStorage {
+    get(key: string): Promise<Buffer | undefined>;
+
+    set(key: string, value: Buffer): Promise<void>;
+}
+
+/**
+ * LocalCache wraps a Map<string, Buffer> to be used by the Marshaller.
+ */
+export class LocalCache implements IStorage {
+    private cache = new Map<string, Buffer>();
+
+    async get(key: string): Promise<Buffer | undefined> {
+        return this.cache.get(key);
+    }
+
+    async set(key: string, value: Buffer): Promise<void> {
+        this.cache.set(key, value);
     }
 }

--- a/external/js/cothority/src/byzcoin/byzcoin-rpc.ts
+++ b/external/js/cothority/src/byzcoin/byzcoin-rpc.ts
@@ -200,7 +200,7 @@ export default class ByzCoinRPC implements ICounterUpdater {
      * @param id of the instance to return
      * @throws an error if the instance does not exist
      */
-    async proofObservable(id: InstanceID): Promise<BehaviorSubject<Proof>> {
+    async instanceObservable(id: InstanceID): Promise<BehaviorSubject<Proof>> {
         const bs = this.cache.get(id);
         if (bs !== undefined) {
             return bs;

--- a/external/js/cothority/src/byzcoin/contracts/darc-instance.ts
+++ b/external/js/cothority/src/byzcoin/contracts/darc-instance.ts
@@ -175,7 +175,7 @@ export default class DarcInstance extends Instance {
         ];
 
         await this.spawnInstanceAndWait(DarcInstance.contractID, args, signers, wait);
-        return DarcInstance.fromByzcoin(this.rpc, d.getBaseID());
+        return DarcInstance.fromByzcoin(this.rpc, d.getBaseID(), wait);
     }
 
     /**


### PR DESCRIPTION
Bringing the wonderful world of rxjs to cothority/byzcoin:
- connection:sendString - uses Observable instead of callbacks
- ByzCoinRPC.getNewBlocks - returns a BehaviorSubject
- ByzCoinRPC.proofObservable - returns a BehaviorSubject of a proof

**It breaks API compatibility for the new WebSocketAdapter.sendStream**

If that is a problem, it's quite straightforward to do the following:
- change `sendStream` to `sendStreamObservable`
- add `sendStream` that behaves like before, but calls `sendStreamObservable`

Readmes:
https://rxjs.dev/guide/observable
https://gist.github.com/staltz/868e7e9bc2a7b8c1f754