### PR TITLE
gofmt -simplify

### DIFF
--- a/byzcoin/api_test.go
+++ b/byzcoin/api_test.go
@@ -59,7 +59,7 @@ func TestClient_NewLedgerCorrupted(t *testing.T) {
 
 	data := &DataBody{
 		TxResults: []TxResult{
-			TxResult{ClientTransaction: ClientTransaction{Instructions: []Instruction{Instruction{}}}},
+			{ClientTransaction: ClientTransaction{Instructions: []Instruction{{}}}},
 		},
 	}
 	sb.Payload, err = protobuf.Encode(data)
@@ -71,7 +71,7 @@ func TestClient_NewLedgerCorrupted(t *testing.T) {
 
 	data.TxResults[0].ClientTransaction.Instructions[0].Spawn = &Spawn{
 		Args: []Argument{
-			Argument{
+			{
 				Name:  "darc",
 				Value: []byte{1, 2, 3},
 			},
@@ -87,7 +87,7 @@ func TestClient_NewLedgerCorrupted(t *testing.T) {
 	darcBytes, _ := protobuf.Encode(&darc.Darc{})
 	data.TxResults[0].ClientTransaction.Instructions[0].Spawn = &Spawn{
 		Args: []Argument{
-			Argument{
+			{
 				Name:  "darc",
 				Value: darcBytes,
 			},
@@ -187,7 +187,7 @@ func TestClient_GetProofCorrupted(t *testing.T) {
 	service.GetProofResponse = &GetProofResponse{
 		Proof: Proof{
 			Latest: *sb,
-			Links:  []skipchain.ForwardLink{skipchain.ForwardLink{To: c.ID}},
+			Links:  []skipchain.ForwardLink{{To: c.ID}},
 		},
 	}
 

--- a/byzcoin/collect_tx_test.go
+++ b/byzcoin/collect_tx_test.go
@@ -46,7 +46,7 @@ func testRunCollectionTxProtocol(n, max, version int) ([]ClientTransaction, erro
 
 	getTx := func(leader *network.ServerIdentity, roster *onet.Roster, scID skipchain.SkipBlockID, latestID skipchain.SkipBlockID, max int) []ClientTransaction {
 		tx := ClientTransaction{
-			Instructions: []Instruction{Instruction{}},
+			Instructions: []Instruction{{}},
 		}
 		return []ClientTransaction{tx}
 	}

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -1147,7 +1147,7 @@ func TestService_StateChange(t *testing.T) {
 			}
 			binary.PutVarint(zeroBuf, 0)
 			return []StateChange{
-				StateChange{
+				{
 					StateAction: Create,
 					InstanceID:  inst.DeriveID("add").Slice(),
 					ContractID:  cid,
@@ -1166,7 +1166,7 @@ func TestService_StateChange(t *testing.T) {
 			vBuf := make([]byte, 8)
 			binary.PutVarint(vBuf, v)
 			return []StateChange{
-				StateChange{
+				{
 					StateAction: Update,
 					InstanceID:  inst.InstanceID.Slice(),
 					ContractID:  cid,
@@ -1249,19 +1249,19 @@ func TestService_StateChangeVerification(t *testing.T) {
 		}
 
 		return []StateChange{
-			StateChange{
+			{
 				StateAction: Create,
 				InstanceID:  inst.DeriveID("").Slice(),
 				ContractID:  cid,
 				Value:       zeroBuf,
 			},
-			StateChange{
+			{
 				StateAction: Update,
 				InstanceID:  inst.DeriveID("").Slice(),
 				ContractID:  cid,
 				Value:       zeroBuf,
 			},
-			StateChange{
+			{
 				StateAction: sa,
 				InstanceID:  iid2.Slice(),
 				ContractID:  cid,
@@ -1355,7 +1355,7 @@ func TestService_DarcEvolutionFail(t *testing.T) {
 			// Because field ContractID is missing, this Invoke should fail.
 			Command: cmdDarcEvolve,
 			Args: []Argument{
-				Argument{
+				{
 					Name:  "darc",
 					Value: d2Buf,
 				},
@@ -2569,7 +2569,7 @@ func darcToTx(t *testing.T, d2 darc.Darc, signer darc.Signer, ctr uint64) Client
 		ContractID: ContractDarcID,
 		Command:    cmdDarcEvolve,
 		Args: []Argument{
-			Argument{
+			{
 				Name:  "darc",
 				Value: d2Buf,
 			},

--- a/byzcoin/statereplay_test.go
+++ b/byzcoin/statereplay_test.go
@@ -89,7 +89,7 @@ func TestService_StateReplayFailures(t *testing.T) {
 		sb := skipchain.NewSkipBlock()
 		sb.Roster = s.roster
 		sb.Payload = []byte{1, 1, 1, 1, 1}
-		sb.ForwardLink = []*skipchain.ForwardLink{&skipchain.ForwardLink{}}
+		sb.ForwardLink = []*skipchain.ForwardLink{{}}
 		return sb, nil
 	}
 	tryReplay(t, s, cb, "Error while decoding field")
@@ -100,7 +100,7 @@ func TestService_StateReplayFailures(t *testing.T) {
 		sb.Roster = s.roster
 		sb.Payload = []byte{}
 		sb.Data = []byte{1, 1, 1, 1, 1}
-		sb.ForwardLink = []*skipchain.ForwardLink{&skipchain.ForwardLink{}}
+		sb.ForwardLink = []*skipchain.ForwardLink{{}}
 		return sb, nil
 	}
 	tryReplay(t, s, cb, "Error while decoding field")
@@ -109,7 +109,7 @@ func TestService_StateReplayFailures(t *testing.T) {
 	cb = func(sib skipchain.SkipBlockID) (*skipchain.SkipBlock, error) {
 		sb := skipchain.NewSkipBlock()
 		sb.Payload = []byte{}
-		sb.ForwardLink = []*skipchain.ForwardLink{&skipchain.ForwardLink{}}
+		sb.ForwardLink = []*skipchain.ForwardLink{{}}
 		return sb, nil
 	}
 	tryReplay(t, s, cb, "client transaction hash does not match")

--- a/byzcoin/viewchange.go
+++ b/byzcoin/viewchange.go
@@ -444,7 +444,7 @@ func (s *Service) createViewChangeBlock(req viewchange.NewViewReq, multisig []by
 		return xerrors.Errorf("signing tx: %v", err)
 	}
 
-	_, err = s.createNewBlock(req.GetGen(), rotateRoster(sb.Roster, req.GetView().LeaderIndex), []TxResult{TxResult{ctx, false}})
+	_, err = s.createNewBlock(req.GetGen(), rotateRoster(sb.Roster, req.GetView().LeaderIndex), []TxResult{{ctx, false}})
 	return cothority.ErrorOrNil(err, "creating block")
 }
 

--- a/darc/darc_test.go
+++ b/darc/darc_test.go
@@ -177,13 +177,13 @@ func TestDarc_EvolveMoreOnline(t *testing.T) {
 	// create darcs that do not have the full path, i.e. we set VerificationDarcs to nil
 	lightDarc1 := darcs[len(darcs)-1].Copy()
 	lightDarc1.VerificationDarcs = nil
-	lightDarc1.Signatures = []Signature{Signature{
+	lightDarc1.Signatures = []Signature{{
 		Signature: copyBytes(darcs[len(darcs)-1].Signatures[0].Signature),
 		Signer:    darcs[len(darcs)-1].Signatures[0].Signer,
 	}}
 	lightDarc2 := darcs[len(darcs)-2].Copy()
 	lightDarc2.VerificationDarcs = nil
-	lightDarc2.Signatures = []Signature{Signature{
+	lightDarc2.Signatures = []Signature{{
 		Signature: copyBytes(darcs[len(darcs)-2].Signatures[0].Signature),
 		Signer:    darcs[len(darcs)-2].Signatures[0].Signer,
 	}}

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -769,7 +769,7 @@ func TestService_ForgedPropagationMessage(t *testing.T) {
 	forgedBlock := NewSkipBlock()
 	forgedBlock.BackLinkIDs = []SkipBlockID{p1[3].Hash}
 	forgedBlock.updateHash()
-	p1[3].ForwardLink = []*ForwardLink{&ForwardLink{From: p1[3].Hash, To: forgedBlock.Hash}}
+	p1[3].ForwardLink = []*ForwardLink{{From: p1[3].Hash, To: forgedBlock.Hash}}
 	err = service.propagateProofHandler(&PropagateProof{Proof(append(p1, forgedBlock))})
 	require.NotNil(t, err)
 }

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -379,11 +379,11 @@ func TestSkipBlockDB_GetProof(t *testing.T) {
 	sb2.GenesisID = root.Hash
 	sb2.BackLinkIDs = []SkipBlockID{sb1.Hash}
 	sb2.updateHash()
-	sb1.ForwardLink = []*ForwardLink{&ForwardLink{From: sb1.Hash, To: sb2.Hash}}
+	sb1.ForwardLink = []*ForwardLink{{From: sb1.Hash, To: sb2.Hash}}
 	require.NoError(t, sb1.ForwardLink[0].sign(ro))
 	root.ForwardLink = []*ForwardLink{
-		&ForwardLink{From: root.Hash, To: sb1.Hash},
-		&ForwardLink{From: root.Hash, To: sb2.Hash},
+		{From: root.Hash, To: sb1.Hash},
+		{From: root.Hash, To: sb2.Hash},
 	}
 	require.NoError(t, root.ForwardLink[0].sign(ro))
 	require.NoError(t, root.ForwardLink[1].sign(ro))


### PR DESCRIPTION
I recently found the `-s` flag to `gofmt`, which simplify code. Running it here gave me some small changes, mostly in tests.