### PR TITLE
staticcheck tests pass

### DIFF
--- a/authprox/service_test.go
+++ b/authprox/service_test.go
@@ -103,7 +103,7 @@ func Test_EnrollAndSign(t *testing.T) {
 			RandPri:  rp,
 			RandPubs: rPubCommits,
 		}
-		resp, err := s.Signature(req)
+		_, err := s.Signature(req)
 		require.Error(t, err)
 
 		// And now correctly.
@@ -114,7 +114,7 @@ func Test_EnrollAndSign(t *testing.T) {
 			RandPri:  rp,
 			RandPubs: rPubCommits,
 		}
-		resp, err = s.Signature(req)
+		resp, err := s.Signature(req)
 		require.NoError(t, err)
 
 		ps := &dss.PartialSig{

--- a/bevm/bevm_contract_test.go
+++ b/bevm/bevm_contract_test.go
@@ -40,7 +40,7 @@ func Test_Spawn(t *testing.T) {
 
 	// Spawn a new BEvm instance
 	_, err := NewBEvm(bct.cl, bct.signer, bct.gDarc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 // Spawn and delete a BEvm instance
@@ -53,31 +53,31 @@ func Test_SpawnAndDelete(t *testing.T) {
 
 	// Spawn a new BEvm instance
 	instanceID, err := NewBEvm(bct.cl, bct.signer, bct.gDarc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Create a new BEvm client
 	bevmClient, err := NewClient(bct.cl, bct.signer, instanceID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Initialize an account
 	a, err := NewEvmAccount(testPrivateKeys[0])
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Credit the account
 	err = bevmClient.CreditAccount(big.NewInt(5*WeiPerEther), a.Address)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Deploy a Candy contract
 	candySupply := big.NewInt(100)
 	candyContract, err := NewEvmContract(
 		"Candy", getContractData(t, "Candy", "abi"), getContractData(t, "Candy", "bin"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, err = bevmClient.Deploy(txParams.GasLimit, txParams.GasPrice, 0, a, candyContract, candySupply)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Delete the BEvm instance
 	err = bevmClient.Delete()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 // Credit and display three accounts balances
@@ -90,17 +90,17 @@ func Test_InvokeCreditAccounts(t *testing.T) {
 
 	// Spawn a new BEvm instance
 	instanceID, err := NewBEvm(bct.cl, bct.signer, bct.gDarc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Create a new BEvm client
 	bevmClient, err := NewClient(bct.cl, bct.signer, instanceID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Initialize some accounts
 	accounts := []*EvmAccount{}
 	for _, privKey := range testPrivateKeys {
 		account, err := NewEvmAccount(privKey)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		accounts = append(accounts, account)
 	}
 
@@ -109,10 +109,10 @@ func Test_InvokeCreditAccounts(t *testing.T) {
 		amount := big.NewInt(int64((i + 1) * WeiPerEther))
 
 		err = bevmClient.CreditAccount(amount, account.Address)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		balance, err := bevmClient.GetAccountBalance(account.Address)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, amount, balance)
 	}
@@ -127,41 +127,41 @@ func Test_InvokeCandyContract(t *testing.T) {
 
 	// Spawn a new BEvm instance
 	instanceID, err := NewBEvm(bct.cl, bct.signer, bct.gDarc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Create a new BEvm client
 	bevmClient, err := NewClient(bct.cl, bct.signer, instanceID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Initialize an account
 	a, err := NewEvmAccount(testPrivateKeys[0])
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Credit the account
 	err = bevmClient.CreditAccount(big.NewInt(5*WeiPerEther), a.Address)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Deploy a Candy contract
 	candySupply := big.NewInt(100)
 	candyContract, err := NewEvmContract(
 		"Candy", getContractData(t, "Candy", "abi"), getContractData(t, "Candy", "bin"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	candyInstance, err := bevmClient.Deploy(txParams.GasLimit, txParams.GasPrice, 0, a, candyContract, candySupply)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Get initial candy balance
 	candyBalance, err := bevmClient.Call(a, candyInstance, "getRemainingCandies")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, candySupply, candyBalance)
 
 	// Eat 10 candies
 	err = bevmClient.Transaction(txParams.GasLimit, txParams.GasPrice, 0, a, candyInstance, "eatCandy", big.NewInt(10))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Get remaining candies
 	expectedCandyBalance := big.NewInt(90)
 	candyBalance, err = bevmClient.Call(a, candyInstance, "getRemainingCandies")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, expectedCandyBalance, candyBalance)
 }
 
@@ -174,31 +174,31 @@ func Test_Time(t *testing.T) {
 
 	// Spawn a new BEvm instance
 	instanceID, err := NewBEvm(bct.cl, bct.signer, bct.gDarc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Create a new BEvm client
 	bevmClient, err := NewClient(bct.cl, bct.signer, instanceID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Initialize an account
 	a, err := NewEvmAccount(testPrivateKeys[0])
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Credit the account
 	err = bevmClient.CreditAccount(big.NewInt(5*WeiPerEther), a.Address)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Deploy a TimeTest contract
 	contract, err := NewEvmContract(
 		"TimeTest", getContractData(t, "TimeTest", "abi"), getContractData(t, "TimeTest", "bin"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	timeTestInstance, err := bevmClient.Deploy(txParams.GasLimit, txParams.GasPrice, 0, a, contract)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Get current block time
 	expectedTime := big.NewInt(12345) // Currently hardcoded in getContext()
 	time, err := bevmClient.Call(a, timeTestInstance, "getTime")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, expectedTime, time)
 }
 
@@ -211,72 +211,72 @@ func Test_InvokeTokenContract(t *testing.T) {
 
 	// Spawn a new BEvm instance
 	instanceID, err := NewBEvm(bct.cl, bct.signer, bct.gDarc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Create a new BEvm client
 	bevmClient, err := NewClient(bct.cl, bct.signer, instanceID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Initialize two accounts
 	a, err := NewEvmAccount(testPrivateKeys[0])
-	require.Nil(t, err)
+	require.NoError(t, err)
 	b, err := NewEvmAccount(testPrivateKeys[1])
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Credit the accounts
 	err = bevmClient.CreditAccount(big.NewInt(5*WeiPerEther), a.Address)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = bevmClient.CreditAccount(big.NewInt(5*WeiPerEther), b.Address)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Deploy an ERC20 Token contract
 	erc20Contract, err := NewEvmContract(
 		"ERC20Token", getContractData(t, "ERC20Token", "abi"), getContractData(t, "ERC20Token", "bin"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	erc20Instance, err := bevmClient.Deploy(txParams.GasLimit, txParams.GasPrice, 0, a, erc20Contract)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Retrieve the total supply
 	supply, err := bevmClient.Call(a, erc20Instance, "totalSupply")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// A's initial balance should be the total supply, as he is the owner
 	balance, err := bevmClient.Call(a, erc20Instance, "balanceOf", a.Address)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, supply, balance)
 
 	// B's initial balance should be empty
 	balance, err = bevmClient.Call(a, erc20Instance, "balanceOf", b.Address)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assertBigInt0(t, balance.(*big.Int))
 
 	// Transfer 100 tokens from A to B
 	err = bevmClient.Transaction(txParams.GasLimit, txParams.GasPrice, 0, a, erc20Instance, "transfer", b.Address, big.NewInt(100))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Check the new balances
 	newA := new(big.Int).Sub(supply.(*big.Int), big.NewInt(100))
 	newB := big.NewInt(100)
 
 	balance, err = bevmClient.Call(a, erc20Instance, "balanceOf", a.Address)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, newA, balance)
 
 	balance, err = bevmClient.Call(a, erc20Instance, "balanceOf", b.Address)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, newB, balance)
 
 	// Try to transfer 101 tokens from B to A; this should be rejected by the EVM
 	err = bevmClient.Transaction(txParams.GasLimit, txParams.GasPrice, 0, b, erc20Instance, "transfer", a.Address, big.NewInt(101))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Check that the balances have not changed
 	balance, err = bevmClient.Call(a, erc20Instance, "balanceOf", a.Address)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, newA, balance)
 
 	balance, err = bevmClient.Call(a, erc20Instance, "balanceOf", b.Address)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, newB, balance)
 }
 
@@ -288,30 +288,30 @@ func Test_InvokeLoanContract(t *testing.T) {
 
 	// Spawn a new BEvm instance
 	instanceID, err := NewBEvm(bct.cl, bct.signer, bct.gDarc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Create a new BEvm client
 	bevmClient, err := NewClient(bct.cl, bct.signer, instanceID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Initialize two accounts
 	a, err := NewEvmAccount(testPrivateKeys[0])
-	require.Nil(t, err)
+	require.NoError(t, err)
 	b, err := NewEvmAccount(testPrivateKeys[1])
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Credit the accounts
 	err = bevmClient.CreditAccount(big.NewInt(5*WeiPerEther), a.Address)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = bevmClient.CreditAccount(big.NewInt(5*WeiPerEther), b.Address)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Deploy an ERC20 Token contract
 	erc20Contract, err := NewEvmContract(
 		"ERC20Token", getContractData(t, "ERC20Token", "abi"), getContractData(t, "ERC20Token", "bin"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	erc20Instance, err := bevmClient.Deploy(txParams.GasLimit, txParams.GasPrice, 0, a, erc20Contract)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Deploy a Loan contract
 	guarantee := big.NewInt(10000)
@@ -319,7 +319,7 @@ func Test_InvokeLoanContract(t *testing.T) {
 
 	loanContract, err := NewEvmContract(
 		"LoanContract", getContractData(t, "LoanContract", "abi"), getContractData(t, "LoanContract", "bin"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	loanInstance, err := bevmClient.Deploy(txParams.GasLimit, txParams.GasPrice, 0, a, loanContract,
 		loanAmount,            // wantedAmount: the amount in Ether that the borrower wants to borrow
 		big.NewInt(0),         // interest: the amount in Ether that the borrower will pay pack in addition to the borrowed amount
@@ -328,14 +328,14 @@ func Test_InvokeLoanContract(t *testing.T) {
 		erc20Instance.Address, // tokenContractAddress: the address of the ERC20 contract handling the tokens used as guarantee
 		big.NewInt(0),         // length: the duration of the loan, in days
 	)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	getBalances := func(from *EvmAccount, address common.Address) (tokenBalance, balance *big.Int) {
 		result, err := bevmClient.Call(from, erc20Instance, "balanceOf", address)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		tokenBalance = result.(*big.Int)
 		balance, err = bevmClient.GetAccountBalance(address)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		return
 	}
 
@@ -348,7 +348,7 @@ func Test_InvokeLoanContract(t *testing.T) {
 
 	// Transfer tokens from A as a guarantee (A owns all the tokens as he deployed the Token contract)
 	err = bevmClient.Transaction(txParams.GasLimit, txParams.GasPrice, 0, a, erc20Instance, "transfer", loanInstance.Address, guarantee)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	tokBal, _ = getBalances(a, a.Address)
 	expected := new(big.Int).Sub(initTokBalA, guarantee)
@@ -359,13 +359,13 @@ func Test_InvokeLoanContract(t *testing.T) {
 
 	// Check that there are enough tokens
 	err = bevmClient.Transaction(txParams.GasLimit, txParams.GasPrice, 0, a, loanInstance, "checkTokens")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Lend
 	_, initEtherBalA := getBalances(a, a.Address)
 
 	err = bevmClient.Transaction(txParams.GasLimit, txParams.GasPrice, loanAmount.Uint64(), b, loanInstance, "lend")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	_, bal = getBalances(a, a.Address)
 	expected = new(big.Int).Add(initEtherBalA, loanAmount)
@@ -375,7 +375,7 @@ func Test_InvokeLoanContract(t *testing.T) {
 	_, initEtherBalB := getBalances(a, b.Address)
 
 	err = bevmClient.Transaction(txParams.GasLimit, txParams.GasPrice, loanAmount.Uint64(), a, loanInstance, "payback")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	_, bal = getBalances(a, b.Address)
 	expected = new(big.Int).Add(initEtherBalB, loanAmount)
@@ -409,7 +409,7 @@ func newBCTest(t *testing.T) (out *bcTest) {
 	out.gMsg, err = byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, out.roster,
 		[]string{"spawn:bevm", "invoke:bevm.credit", "invoke:bevm.transaction", "delete:bevm"},
 		out.signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	out.gDarc = &out.gMsg.GenesisDarc
 
 	// This BlockInterval is good for testing, but in real world applications this
@@ -417,7 +417,7 @@ func newBCTest(t *testing.T) (out *bcTest) {
 	out.gMsg.BlockInterval = time.Second
 
 	out.cl, _, err = byzcoin.NewLedger(out.gMsg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	out.cl.UseNode(0)
 
@@ -449,12 +449,12 @@ func getContractData(t *testing.T, name string, extension string) string {
 	// <name>_sol_<name>.{abi,bin}
 
 	curDir, err := os.Getwd()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	path := filepath.Join(curDir, "testdata", name, name+"_sol_"+name+"."+extension)
 
 	data, err := ioutil.ReadFile(path)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	return string(data)
 }

--- a/bevm/params_test.go
+++ b/bevm/params_test.go
@@ -37,7 +37,7 @@ func TestTokenContract(t *testing.T) {
 	// Get smart contract abi and bytecode
 	contract, err := NewEvmContract(
 		"ModifiedToken", getContractData(t, "ModifiedToken", "abi"), getContractData(t, "ModifiedToken", "bin"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Create dummy addresses for testing token transfers
 	addressA := common.HexToAddress("a")
@@ -49,30 +49,30 @@ func TestTokenContract(t *testing.T) {
 
 	// Constructor (function create), mints 12 tokens and credits them to public key A
 	create, err := contract.Abi.Pack("create", uint64(12), addressA)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Get balance function to check if tokens where indeed credited
 	get, err := contract.Abi.Pack("getBalance", addressA)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Transfer function, with parameters to transfer from addressA to addressB, one token
 	send, err := contract.Abi.Pack("transfer", addressA, addressB, uint64(1))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Get balance function to check if token was indeed credited
 	getB, err := contract.Abi.Pack("getBalance", addressB)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	// Get balance function to check if token was indeed credited
 	getA, err := contract.Abi.Pack("getBalance", addressA)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Transfer function, with parameters to transfer from addressA to addressB, one more token
 	transferTests, err := contract.Abi.Pack("transfer", addressA, addressB, uint64(1))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Empty general Ethereum state database to instantiate EVM
 	sdb, err := newEvmMemDb()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Context for instantiating EVM
 	ctx := vm.Context{CanTransfer: canTransfer, Transfer: transfer, GetHash: getHash, Origin: addressA, GasPrice: big.NewInt(1), Coinbase: addressA, GasLimit: 10000000000, BlockNumber: big.NewInt(0), Time: big.NewInt(1), Difficulty: big.NewInt(1)}
@@ -82,61 +82,61 @@ func TestTokenContract(t *testing.T) {
 
 	// Contract deployment
 	_, addrContract, leftOverGas, err := bevm.Create(accountRef, contract.Bytecode, 100000000, big.NewInt(0))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Call the methods from the contract we just deployed using the abi helpers function defined above
 	// Constructor (create method) call
 	_, _, err = bevm.Call(accountRef, addrContract, create, leftOverGas, big.NewInt(0))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	var balance uint64
 
 	// Get balance of addressA
 	retBalanceOfAccountA, _, err := bevm.Call(accountRef, addrContract, get, leftOverGas, big.NewInt(0))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = contract.Abi.Unpack(&balance, "getBalance", retBalanceOfAccountA)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	log.Lvl2(addressA.Hex(), "address, token balance :", balance)
 
 	// Send a token from A to B
 	_, _, err = bevm.Call(accountRef, addrContract, send, leftOverGas, big.NewInt(0))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	log.Lvl2("send one token from", addressA.Hex(), " to ", addressB.Hex())
 
 	// Get balance of addressA
 	retBalanceOfAccountA, _, err = bevm.Call(accountRef, addrContract, getA, leftOverGas, big.NewInt(0))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = contract.Abi.Unpack(&balance, "getBalance", retBalanceOfAccountA)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	log.Lvl2(addressA.Hex(), "address, token balance :", balance)
 	require.Equal(t, balance, uint64(11))
 
 	// Check if the other account was updated accordingly
 	retBalanceOfAccountB, _, err := bevm.Call(accountRef, addrContract, getB, leftOverGas, big.NewInt(0))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = contract.Abi.Unpack(&balance, "getBalance", retBalanceOfAccountB)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	log.Lvl2(addressB.Hex(), "address, token balance :", balance)
 	require.Equal(t, balance, uint64(1))
 
 	// Transfer one more token
 	_, _, err = bevm.Call(accountRef, addrContract, transferTests, leftOverGas, big.NewInt(0))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	log.Lvl2("send one token from", addressA.Hex(), " to ", addressB.Hex())
 
 	// Get balance of addressA
 	retBalanceOfAccountA, _, err = bevm.Call(accountRef, addrContract, getA, leftOverGas, big.NewInt(0))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = contract.Abi.Unpack(&balance, "getBalance", retBalanceOfAccountA)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	log.Lvl2(addressA.Hex(), "address, token balance :", balance)
 	require.Equal(t, balance, uint64(10))
 
 	// Get balance of addressB
 	retBalanceOfAccountB, _, err = bevm.Call(accountRef, addrContract, getB, leftOverGas, big.NewInt(0))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = contract.Abi.Unpack(&balance, "getBalance", retBalanceOfAccountB)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	log.Lvl2(addressB.Hex(), "address, token balance :", balance)
 	require.Equal(t, balance, uint64(2))
 }

--- a/bftcosi/bftcosi_test.go
+++ b/bftcosi/bftcosi_test.go
@@ -234,8 +234,7 @@ func runProtocolOnceGo(nbrHosts int, name string, refuseCount int, succeed bool,
 	}
 
 	// Register the function generating the protocol instance
-	var root *ProtocolBFTCoSi
-	root = node.(*ProtocolBFTCoSi)
+	root := node.(*ProtocolBFTCoSi)
 	root.Msg = msg
 	cMux.Lock()
 	counter := &Counter{refuseCount: refuseCount}

--- a/bftcosi/bftcosi_test.go
+++ b/bftcosi/bftcosi_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.dedis.ch/cothority/v3"
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
@@ -55,7 +55,7 @@ func TestBftCoSi(t *testing.T) {
 
 	// Register test protocol using BFTCoSi
 	onet.GlobalProtocolRegister(TestProtocolName, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-		return NewBFTCoSiProtocol(n, verify)
+		return NewBFTCoSiProtocol(n, verify(t))
 	})
 
 	log.Lvl2("Simple count")
@@ -69,7 +69,7 @@ func TestThreshold(t *testing.T) {
 
 	// Register test protocol using BFTCoSi
 	onet.GlobalProtocolRegister(TestProtocolName, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-		return NewBFTCoSiProtocol(n, verify)
+		return NewBFTCoSiProtocol(n, verify(t))
 	})
 
 	tests := []struct{ h, t int }{
@@ -89,9 +89,9 @@ func TestThreshold(t *testing.T) {
 
 		// Start the protocol
 		node, err := local.CreateProtocol(TestProtocolName, tree)
-		log.ErrFatal(err)
+		require.NoError(t, err)
 		bc := node.(*ProtocolBFTCoSi)
-		assert.Equal(t, thr, bc.allowedExceptions, "hosts was %d", hosts)
+		require.Equal(t, thr, bc.allowedExceptions, "hosts was %d", hosts)
 		bc.Done()
 		local.CloseAll()
 	}
@@ -102,7 +102,7 @@ func TestCheckRefuse(t *testing.T) {
 
 	// Register test protocol using BFTCoSi
 	onet.GlobalProtocolRegister(TestProtocolName, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-		return NewBFTCoSiProtocol(n, verifyRefuse)
+		return NewBFTCoSiProtocol(n, verifyRefuse(t))
 	})
 
 	for refuseCount := 1; refuseCount <= 3; refuseCount++ {
@@ -116,7 +116,7 @@ func TestCheckRefuseMore(t *testing.T) {
 
 	// Register test protocol using BFTCoSi
 	onet.GlobalProtocolRegister(TestProtocolName, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-		return NewBFTCoSiProtocol(n, verifyRefuseMore)
+		return NewBFTCoSiProtocol(n, verifyRefuseMore(t))
 	})
 
 	for _, n := range []int{3, 4, 13} {
@@ -134,7 +134,7 @@ func TestCheckRefuseBit(t *testing.T) {
 
 	// Register test protocol using BFTCoSi
 	onet.GlobalProtocolRegister(TestProtocolName, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-		return NewBFTCoSiProtocol(n, verifyRefuseBit)
+		return NewBFTCoSiProtocol(n, verifyRefuseBit(t))
 	})
 
 	wg := sync.WaitGroup{}
@@ -160,7 +160,7 @@ func TestCheckRefuseParallel(t *testing.T) {
 
 	// Register test protocol using BFTCoSi
 	onet.GlobalProtocolRegister(TestProtocolName, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-		return NewBFTCoSiProtocol(n, verifyRefuseBit)
+		return NewBFTCoSiProtocol(n, verifyRefuseBit(t))
 	})
 
 	wg := sync.WaitGroup{}
@@ -188,12 +188,12 @@ func TestNodeFailure(t *testing.T) {
 
 	// Register test protocol using BFTCoSi
 	onet.GlobalProtocolRegister(TestProtocolName, func(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-		return NewBFTCoSiProtocol(n, verify)
+		return NewBFTCoSiProtocol(n, verify(t))
 	})
 
 	nbrHostsArr := []int{5, 7, 10}
 	for _, nbrHosts := range nbrHostsArr {
-		if err := runProtocolOnceGo(nbrHosts, TestProtocolName, 0, true, nbrHosts/3, nbrHosts-1); err != nil {
+		if err := runProtocolOnceGo(t, nbrHosts, TestProtocolName, 0, true, nbrHosts/3, nbrHosts-1); err != nil {
 			t.Fatalf("%d/%s/%d/%t: %s", nbrHosts, TestProtocolName, 0, true, err)
 		}
 	}
@@ -208,12 +208,12 @@ func runProtocol(t *testing.T, name string, refuseCount int) {
 }
 
 func runProtocolOnce(t *testing.T, nbrHosts int, name string, refuseCount int, succeed bool) {
-	if err := runProtocolOnceGo(nbrHosts, name, refuseCount, succeed, 0, nbrHosts-1); err != nil {
+	if err := runProtocolOnceGo(t, nbrHosts, name, refuseCount, succeed, 0, nbrHosts-1); err != nil {
 		t.Fatalf("%d/%s/%d/%t: %s", nbrHosts, name, refuseCount, succeed, err)
 	}
 }
 
-func runProtocolOnceGo(nbrHosts int, name string, refuseCount int, succeed bool, killCount int, bf int) error {
+func runProtocolOnceGo(t *testing.T, nbrHosts int, name string, refuseCount int, succeed bool, killCount int, bf int) error {
 	log.Lvl2("Running BFTCoSi with", nbrHosts, "hosts")
 	local := onet.NewLocalTest(tSuite)
 	local.Check = onet.CheckNone
@@ -242,7 +242,7 @@ func runProtocolOnceGo(nbrHosts int, name string, refuseCount int, succeed bool,
 	root.Data = []byte(strconv.Itoa(counters.size() - 1))
 	log.Lvl3("Added counter", counters.size()-1, refuseCount)
 	cMux.Unlock()
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	// function that will be called when protocol is finished by the root
 	root.RegisterOnDone(func() {
 		done <- true
@@ -286,62 +286,68 @@ func runProtocolOnceGo(nbrHosts int, name string, refuseCount int, succeed bool,
 }
 
 // Verify function that returns true if the length of the data is 1.
-func verify(m []byte, d []byte) bool {
-	c, err := strconv.Atoi(string(d))
-	log.ErrFatal(err)
-	counter := counters.get(c)
-	counter.Lock()
-	counter.veriCount++
-	log.Lvl4("Verification called", counter.veriCount, "times")
-	counter.Unlock()
-	if len(d) == 0 {
-		log.Error("Didn't receive correct data")
-		return false
+func verify(t *testing.T) VerificationFunction {
+	return func(m []byte, d []byte) bool {
+		c, err := strconv.Atoi(string(d))
+		require.NoError(t, err)
+		counter := counters.get(c)
+		counter.Lock()
+		counter.veriCount++
+		log.Lvl4("Verification called", counter.veriCount, "times")
+		counter.Unlock()
+		if len(d) == 0 {
+			log.Error("Didn't receive correct data")
+			return false
+		}
+		return true
 	}
-	return true
 }
 
 // Verify-function that will refuse if we're the `refuseCount`ed call.
-func verifyRefuse(m []byte, d []byte) bool {
-	c, err := strconv.Atoi(string(d))
-	log.ErrFatal(err)
-	counter := counters.get(c)
-	counter.Lock()
-	defer counter.Unlock()
-	counter.veriCount++
-	if counter.veriCount == counter.refuseCount {
-		log.Lvl2("Refusing for count==", counter.refuseCount)
-		return false
+func verifyRefuse(t *testing.T) VerificationFunction {
+	return func(m []byte, d []byte) bool {
+		c, err := strconv.Atoi(string(d))
+		require.NoError(t, err)
+		counter := counters.get(c)
+		counter.Lock()
+		defer counter.Unlock()
+		counter.veriCount++
+		if counter.veriCount == counter.refuseCount {
+			log.Lvl2("Refusing for count==", counter.refuseCount)
+			return false
+		}
+		log.Lvl3("Verification called", counter.veriCount, "times")
+		log.Lvl3("Ignoring message:", string(m))
+		if len(d) == 0 {
+			log.Error("Didn't receive correct data")
+			return false
+		}
+		return true
 	}
-	log.Lvl3("Verification called", counter.veriCount, "times")
-	log.Lvl3("Ignoring message:", string(m))
-	if len(d) == 0 {
-		log.Error("Didn't receive correct data")
-		return false
-	}
-	return true
 }
 
 // Verify-function that will refuse for all calls >= `refuseCount`.
-func verifyRefuseMore(m []byte, d []byte) bool {
-	c, err := strconv.Atoi(string(d))
-	log.ErrFatal(err)
-	counter := counters.get(c)
-	counter.Lock()
-	defer counter.Unlock()
-	counter.veriCount++
-	if counter.veriCount <= counter.refuseCount {
-		log.Lvlf2("Refusing for %d<=%d", counter.veriCount,
-			counter.refuseCount)
-		return false
+func verifyRefuseMore(t *testing.T) VerificationFunction {
+	return func(m []byte, d []byte) bool {
+		c, err := strconv.Atoi(string(d))
+		require.NoError(t, err)
+		counter := counters.get(c)
+		counter.Lock()
+		defer counter.Unlock()
+		counter.veriCount++
+		if counter.veriCount <= counter.refuseCount {
+			log.Lvlf2("Refusing for %d<=%d", counter.veriCount,
+				counter.refuseCount)
+			return false
+		}
+		log.Lvl3("Verification called", counter.veriCount, "times")
+		log.Lvl3("Ignoring message:", string(m))
+		if len(d) == 0 {
+			log.Error("Didn't receive correct data")
+			return false
+		}
+		return true
 	}
-	log.Lvl3("Verification called", counter.veriCount, "times")
-	log.Lvl3("Ignoring message:", string(m))
-	if len(d) == 0 {
-		log.Error("Didn't receive correct data")
-		return false
-	}
-	return true
 }
 
 func bitCount(x int) int {
@@ -354,21 +360,23 @@ func bitCount(x int) int {
 }
 
 // Verify-function that will refuse if the `called` bit is 0.
-func verifyRefuseBit(m []byte, d []byte) bool {
-	c, err := strconv.Atoi(string(d))
-	log.ErrFatal(err)
-	counter := counters.get(c)
-	counter.Lock()
-	defer counter.Unlock()
-	log.Lvl4("Counter", c, counter.refuseCount, counter.veriCount)
-	myBit := uint(counter.veriCount)
-	counter.veriCount++
-	if counter.refuseCount&(1<<myBit) != 0 {
-		log.Lvl2("Refusing for myBit ==", myBit)
-		return false
+func verifyRefuseBit(t *testing.T) VerificationFunction {
+	return func(m []byte, d []byte) bool {
+		c, err := strconv.Atoi(string(d))
+		require.NoError(t, err)
+		counter := counters.get(c)
+		counter.Lock()
+		defer counter.Unlock()
+		log.Lvl4("Counter", c, counter.refuseCount, counter.veriCount)
+		myBit := uint(counter.veriCount)
+		counter.veriCount++
+		if counter.refuseCount&(1<<myBit) != 0 {
+			log.Lvl2("Refusing for myBit ==", myBit)
+			return false
+		}
+		log.Lvl3("Verification called", counter.veriCount, "times")
+		return true
 	}
-	log.Lvl3("Verification called", counter.veriCount, "times")
-	return true
 }
 
 func min(a, b int) int {

--- a/blscosi/protocol/protocol_test.go
+++ b/blscosi/protocol/protocol_test.go
@@ -61,12 +61,12 @@ func TestMain(m *testing.M) {
 // Tests various trees configurations
 func TestProtocol_1_1(t *testing.T) {
 	_, _, err := runProtocol(1, 0, 1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestProtocol_5_1(t *testing.T) {
 	_, _, err := runProtocol(5, 1, 5)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestProtocol_25_1(t *testing.T) {
@@ -75,12 +75,12 @@ func TestProtocol_25_1(t *testing.T) {
 	}
 
 	_, _, err := runProtocol(25, 1, 25)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestProtocol_7_5(t *testing.T) {
 	_, _, err := runProtocol(7, 5, 7)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestProtocol_25_5(t *testing.T) {
@@ -89,7 +89,7 @@ func TestProtocol_25_5(t *testing.T) {
 	}
 
 	_, _, err := runProtocol(25, 5, 25)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func runProtocol(nbrNodes, nbrSubTrees, threshold int) (BlsSignature, *onet.Roster, error) {
@@ -133,13 +133,13 @@ func runProtocol(nbrNodes, nbrSubTrees, threshold int) (BlsSignature, *onet.Rost
 
 func TestQuickAnswerProtocol_2_1(t *testing.T) {
 	mask, err := runQuickAnswerProtocol(2, 1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, mask.CountEnabled())
 }
 
 func TestQuickAnswerProtocol_5_4(t *testing.T) {
 	mask, err := runQuickAnswerProtocol(5, 4)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 2, mask.CountEnabled())
 }
 
@@ -149,7 +149,7 @@ func TestQuickAnswerProtocol_24_5(t *testing.T) {
 	}
 
 	mask, err := runQuickAnswerProtocol(24, 5)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.InEpsilon(t, 14, mask.CountEnabled(), 2)
 }
 
@@ -173,7 +173,7 @@ func runQuickAnswerProtocol(nbrNodes, nbrTrees int) (*sign.Mask, error) {
 
 func TestProtocol_FailingLeaves_5_1(t *testing.T) {
 	err := runProtocolFailingNodes(5, 1, 1, 4)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestProtocol_FailingLeaves_25_9(t *testing.T) {
@@ -182,7 +182,7 @@ func TestProtocol_FailingLeaves_25_9(t *testing.T) {
 	}
 
 	err := runProtocolFailingNodes(25, 3, 2, 23)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func runProtocolFailingNodes(nbrNodes, nbrTrees, nbrFailure, threshold int) error {
@@ -231,7 +231,7 @@ func runProtocolFailingNodes(nbrNodes, nbrTrees, nbrFailure, threshold int) erro
 
 func TestProtocol_FailingSubLeader_5_1(t *testing.T) {
 	err := runProtocolFailingSubLeader(5, 1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestProtocol_FailingSubLeader_25_3(t *testing.T) {
@@ -240,7 +240,7 @@ func TestProtocol_FailingSubLeader_25_3(t *testing.T) {
 	}
 
 	err := runProtocolFailingSubLeader(25, 3)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func runProtocolFailingSubLeader(nbrNodes, nbrTrees int) error {
@@ -331,7 +331,7 @@ func TestProtocol_IntegrityCheck(t *testing.T) {
 
 func TestProtocol_AllFailing_5_1(t *testing.T) {
 	_, err := runProtocolAllFailing(5, 1, 1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	_, err = runProtocolAllFailing(5, 1, 2)
 	require.NotNil(t, err)
@@ -343,7 +343,7 @@ func TestProtocol_AllFailing_25_3(t *testing.T) {
 	}
 
 	_, err := runProtocolAllFailing(25, 3, 1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	_, err = runProtocolAllFailing(25, 3, 2)
 	require.NotNil(t, err)

--- a/byzcoin/api_test.go
+++ b/byzcoin/api_test.go
@@ -121,7 +121,7 @@ func TestClient_CreateTransaction(t *testing.T) {
 func TestClient_GetProof(t *testing.T) {
 	l := onet.NewTCPTest(cothority.Suite)
 	servers, roster, _ := l.GenTree(3, true)
-	registerDummy(servers)
+	registerDummy(t, servers)
 	defer l.CloseAll()
 
 	// Initialise the genesis message and send it to the service.
@@ -201,7 +201,7 @@ func TestClient_GetProofCorrupted(t *testing.T) {
 func TestClient_Streaming(t *testing.T) {
 	l := onet.NewTCPTest(cothority.Suite)
 	servers, roster, _ := l.GenTree(3, true)
-	registerDummy(servers)
+	registerDummy(t, servers)
 	defer l.CloseAll()
 
 	// Initialise the genesis message and send it to the service.
@@ -281,7 +281,7 @@ func TestClient_Streaming(t *testing.T) {
 func TestClient_NoPhantomSkipchain(t *testing.T) {
 	l := onet.NewTCPTest(cothority.Suite)
 	servers, roster, _ := l.GenTree(3, true)
-	registerDummy(servers)
+	registerDummy(t, servers)
 	defer l.CloseAll()
 
 	// Initialise the genesis message and send it to the service.

--- a/byzcoin/api_test.go
+++ b/byzcoin/api_test.go
@@ -29,7 +29,7 @@ func TestClient_NewLedgerCorrupted(t *testing.T) {
 	service := servers[0].Service(testServiceName).(*corruptedService)
 	signer := darc.NewSignerEd25519(nil, nil)
 	msg, err := DefaultGenesisMsg(CurrentVersion, roster, []string{"spawn:dummy"}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	c := &Client{
 		Client: onet.NewClient(cothority.Suite, testServiceName),
 		Roster: *roster,
@@ -128,14 +128,14 @@ func TestClient_GetProof(t *testing.T) {
 	signer := darc.NewSignerEd25519(nil, nil)
 	msg, err := DefaultGenesisMsg(CurrentVersion, roster, []string{"spawn:dummy"}, signer.Identity())
 	msg.BlockInterval = 100 * time.Millisecond
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// The darc inside it should be valid.
 	d := msg.GenesisDarc
 	require.Nil(t, d.Verify(true))
 
 	c, csr, err := NewLedger(msg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	gac, err := c.GetAllByzCoinIDs(roster.List[1])
 	require.NoError(t, err)
@@ -145,9 +145,9 @@ func TestClient_GetProof(t *testing.T) {
 	value := []byte{5, 6, 7, 8}
 	kind := "dummy"
 	tx, err := createOneClientTx(d.GetBaseID(), kind, value, signer)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	atr, err := c.AddTransactionAndWait(tx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// We should have a proof of our transaction in the skipchain.
 	newID := tx.Instructions[0].Hash()
@@ -156,7 +156,7 @@ func TestClient_GetProof(t *testing.T) {
 	require.Nil(t, p.Proof.Verify(csr.Skipblock.SkipChainID()))
 	require.Equal(t, 2, len(p.Proof.Links))
 	k, v0, _, _, err := p.Proof.KeyValue()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, k, newID)
 	require.Equal(t, value, v0)
 
@@ -208,14 +208,14 @@ func TestClient_Streaming(t *testing.T) {
 	signer := darc.NewSignerEd25519(nil, nil)
 	msg, err := DefaultGenesisMsg(CurrentVersion, roster, []string{"spawn:dummy"}, signer.Identity())
 	msg.BlockInterval = time.Second
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// The darc inside it should be valid.
 	d := msg.GenesisDarc
 	require.Nil(t, d.Verify(true))
 
 	c, csr, err := NewLedger(msg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	n := 2
 	go func() {
@@ -268,7 +268,7 @@ func TestClient_Streaming(t *testing.T) {
 
 	go func() {
 		err = c1.StreamTransactions(cb)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}()
 	select {
 	case <-done:

--- a/byzcoin/api_test.go
+++ b/byzcoin/api_test.go
@@ -10,7 +10,6 @@ import (
 	"go.dedis.ch/cothority/v3/darc"
 	"go.dedis.ch/cothority/v3/skipchain"
 	"go.dedis.ch/onet/v3"
-	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/protobuf"
 	"golang.org/x/xerrors"
@@ -226,9 +225,9 @@ func TestClient_Streaming(t *testing.T) {
 			tx, err := createOneClientTxWithCounter(d.GetBaseID(), kind, value, signer, uint64(i)+1)
 			// Need log.ErrFatal here, else it races with the rest of the code that
 			// uses 't'.
-			log.ErrFatal(err)
+			require.NoError(t, err)
 			_, err = c.AddTransaction(tx)
-			log.ErrFatal(err)
+			require.NoError(t, err)
 
 			// sleep for a block interval so we create multiple blocks
 			time.Sleep(msg.BlockInterval)

--- a/byzcoin/collect_tx_test.go
+++ b/byzcoin/collect_tx_test.go
@@ -77,16 +77,8 @@ func testRunCollectionTxProtocol(n, max, version int) ([]ClientTransaction, erro
 	}
 
 	var txs []ClientTransaction
-outer:
-	for {
-		select {
-		case newTxs, more := <-root.TxsChan:
-			if more {
-				txs = append(txs, newTxs...)
-			} else {
-				break outer
-			}
-		}
+	for newTxs := range root.TxsChan {
+		txs = append(txs, newTxs...)
 	}
 
 	return txs, nil

--- a/byzcoin/contract_darc_test.go
+++ b/byzcoin/contract_darc_test.go
@@ -78,6 +78,7 @@ func TestSecureDarc(t *testing.T) {
 	log.Lvl1("spawn a darc with a version > 0 - fail")
 	secDarc.Version = 1
 	secDarcBuf, err = secDarc.ToProto()
+	require.NoError(t, err)
 	ctx, err = cl.CreateTransaction(Instruction{
 		InstanceID: NewInstanceID(gDarc.GetBaseID()),
 		Spawn: &Spawn{
@@ -101,6 +102,7 @@ func TestSecureDarc(t *testing.T) {
 		require.NoError(t, secDarc2.EvolveFrom(secDarc))
 		require.NoError(t, secDarc2.Rules.AddRule("spawn:coin", secDarc.Rules.Get(invokeEvolveUnrestricted)))
 		secDarc2Buf, err := secDarc2.ToProto()
+		require.NoError(t, err)
 		ctx2, err := cl.CreateTransaction(Instruction{
 			InstanceID: NewInstanceID(secDarc.GetBaseID()),
 			Invoke: &Invoke{
@@ -126,6 +128,7 @@ func TestSecureDarc(t *testing.T) {
 		// changing the signer to something else, then it should fail
 		require.NoError(t, secDarc2.Rules.UpdateRule(invokeEvolveUnrestricted, []byte(restrictedSigner.Identity().String())))
 		secDarc2Buf, err := secDarc2.ToProto()
+		require.NoError(t, err)
 		ctx2, err := cl.CreateTransaction(Instruction{
 			InstanceID: NewInstanceID(secDarc.GetBaseID()),
 			Invoke: &Invoke{
@@ -151,6 +154,7 @@ func TestSecureDarc(t *testing.T) {
 		secDarc2 := secDarc.Copy()
 		require.NoError(t, secDarc2.EvolveFrom(secDarc))
 		secDarc2Buf, err := secDarc2.ToProto()
+		require.NoError(t, err)
 		ctx2, err := cl.CreateTransaction(Instruction{
 			InstanceID: NewInstanceID(secDarc.GetBaseID()),
 			Invoke: &Invoke{
@@ -186,6 +190,7 @@ func TestSecureDarc(t *testing.T) {
 		require.NoError(t, myDarc2.EvolveFrom(&myDarc))
 		require.NoError(t, myDarc2.Rules.AddRule("spawn:coin", myDarc.Rules.Get(invokeEvolveUnrestricted)))
 		myDarc2Buf, err := myDarc2.ToProto()
+		require.NoError(t, err)
 		ctx2, err := cl.CreateTransaction(Instruction{
 			InstanceID: NewInstanceID(myDarc.GetBaseID()),
 			Invoke: &Invoke{
@@ -210,6 +215,7 @@ func TestSecureDarc(t *testing.T) {
 		require.NoError(t, myDarc2.EvolveFrom(&myDarc))
 		require.NoError(t, myDarc2.Rules.AddRule("spawn:coin", myDarc2.Rules.Get(invokeEvolveUnrestricted)))
 		myDarc2Buf, err := myDarc2.ToProto()
+		require.NoError(t, err)
 		ctx2, err := cl.CreateTransaction(Instruction{
 			InstanceID: NewInstanceID(myDarc.GetBaseID()),
 			Invoke: &Invoke{

--- a/byzcoin/contract_darc_test.go
+++ b/byzcoin/contract_darc_test.go
@@ -21,11 +21,11 @@ func TestSecureDarc(t *testing.T) {
 	_, roster, _ := local.GenTree(3, true)
 
 	genesisMsg, err := DefaultGenesisMsg(CurrentVersion, roster, []string{}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	gDarc := &genesisMsg.GenesisDarc
 	genesisMsg.BlockInterval = time.Second
 	cl, _, err := NewLedger(genesisMsg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	restrictedSigner := darc.NewSignerEd25519(nil, nil)
 	unrestrictedSigner := darc.NewSignerEd25519(nil, nil)

--- a/byzcoin/contract_name_test.go
+++ b/byzcoin/contract_name_test.go
@@ -22,11 +22,11 @@ func TestService_Naming(t *testing.T) {
 	s := local.GetServices(hosts, ByzCoinID)[0].(*Service)
 
 	genesisMsg, err := DefaultGenesisMsg(CurrentVersion, roster, []string{"_name:" + ContractDarcID}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	gDarc := &genesisMsg.GenesisDarc
 	genesisMsg.BlockInterval = time.Second
 	cl, _, err := NewLedger(genesisMsg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Spawn the naming instance
 	spawnNamingTx, err := cl.CreateTransaction(Instruction{

--- a/byzcoin/contracts/attr_test.go
+++ b/byzcoin/contracts/attr_test.go
@@ -166,7 +166,7 @@ func TestAttrCustomRule(t *testing.T) {
 
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:" + contractAttrValueID}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	gDarc := &genesisMsg.GenesisDarc
 	// We are only allowed to invoke when the value contains a certain prefix and suffix
@@ -175,7 +175,7 @@ func TestAttrCustomRule(t *testing.T) {
 	genesisMsg.BlockInterval = time.Second
 
 	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myvalue := []byte("abcdefgxyz")
 	ctx, err := cl.CreateTransaction(byzcoin.Instruction{
@@ -315,7 +315,7 @@ func TestAttrBlockIndex(t *testing.T) {
 
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:" + contractAttrValueID}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	gDarc := &genesisMsg.GenesisDarc
 	// We are only allowed to invoke when the value contains a certain prefix and suffix
@@ -323,7 +323,7 @@ func TestAttrBlockIndex(t *testing.T) {
 	genesisMsg.BlockInterval = time.Second
 
 	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myvalue := []byte("abcdefgxyz")
 	ctx, err := cl.CreateTransaction(byzcoin.Instruction{

--- a/byzcoin/contracts/attr_test.go
+++ b/byzcoin/contracts/attr_test.go
@@ -36,8 +36,6 @@ type contractAttrValue struct {
 	value []byte
 }
 
-func notImpl(what string) error { return xerrors.Errorf("this contract does not implement %v", what) }
-
 func (c contractAttrValue) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instruction, coins []byzcoin.Coin) (sc []byzcoin.StateChange, cout []byzcoin.Coin, err error) {
 	cout = coins
 

--- a/byzcoin/contracts/coins_test.go
+++ b/byzcoin/contracts/coins_test.go
@@ -58,7 +58,7 @@ func TestCoin_Spawn(t *testing.T) {
 	c, _ := contractCoinFromBytes(nil)
 	sc, co, err := c.Spawn(ct, inst, []byzcoin.Coin{})
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(sc))
 
 	ca := inst.DeriveID("")
@@ -100,7 +100,7 @@ func TestCoin_InvokeMint(t *testing.T) {
 	}
 
 	sc, co, err := ct.getContract(inst.InstanceID).Invoke(ct, inst, []byzcoin.Coin{})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 0, len(co))
 	require.Equal(t, 1, len(sc))
 	require.Equal(t, byzcoin.NewStateChange(byzcoin.Update, coAddr, ContractCoinID, ciOne, gdarc.GetBaseID()),
@@ -112,7 +112,7 @@ func TestCoin_InvokeOverflow(t *testing.T) {
 		Value: ^uint64(0),
 	}
 	ciBuf, err := protobuf.Encode(&ci)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ct := newCT("invoke:mint")
 	ct.setSignatureCounter(gsigner.Identity().String(), 0)
@@ -159,7 +159,7 @@ func TestCoin_InvokeStoreFetch(t *testing.T) {
 	c2 := byzcoin.Coin{Name: notOlCoin, Value: 1}
 
 	sc, co, err := ct.getContract(inst.InstanceID).Invoke(ct, inst, []byzcoin.Coin{c1, c2})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(co))
 	require.Equal(t, co[0].Name, notOlCoin)
 	require.Equal(t, 1, len(sc))
@@ -184,7 +184,7 @@ func TestCoin_InvokeStoreFetch(t *testing.T) {
 	ct.Store(coAddr, ciOne, ContractCoinID, gdarc.GetBaseID())
 
 	sc, co, err = ct.getContract(inst.InstanceID).Invoke(ct, inst, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(co))
 	require.Equal(t, co[0].Name, CoinName)
 	require.Equal(t, uint64(1), co[0].Value)
@@ -237,7 +237,7 @@ func TestCoin_InvokeTransfer(t *testing.T) {
 	}
 
 	sc, co, err := ct.getContract(inst.InstanceID).Invoke(ct, inst, []byzcoin.Coin{})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 0, len(co))
 	require.Equal(t, 2, len(sc))
 	require.Equal(t, byzcoin.NewStateChange(byzcoin.Update, coAddr2, ContractCoinID, ciOne, gdarc.GetBaseID()), sc[0])

--- a/byzcoin/contracts/coins_test.go
+++ b/byzcoin/contracts/coins_test.go
@@ -177,7 +177,7 @@ func TestCoin_InvokeStoreFetch(t *testing.T) {
 	}
 
 	// Try once with not enough coins available.
-	sc, co, err = ct.getContract(inst.InstanceID).Invoke(ct, inst, nil)
+	_, _, err = ct.getContract(inst.InstanceID).Invoke(ct, inst, nil)
 	require.Error(t, err)
 
 	// Apply the changes to the mock trie.
@@ -220,7 +220,7 @@ func TestCoin_InvokeTransfer(t *testing.T) {
 		SignerCounter:    []uint64{1},
 	}
 
-	sc, co, err := ct.getContract(inst.InstanceID).Invoke(ct, inst, []byzcoin.Coin{})
+	_, _, err := ct.getContract(inst.InstanceID).Invoke(ct, inst, []byzcoin.Coin{})
 	require.Error(t, err)
 
 	inst = byzcoin.Instruction{
@@ -236,7 +236,7 @@ func TestCoin_InvokeTransfer(t *testing.T) {
 		SignerCounter:    []uint64{1},
 	}
 
-	sc, co, err = ct.getContract(inst.InstanceID).Invoke(ct, inst, []byzcoin.Coin{})
+	sc, co, err := ct.getContract(inst.InstanceID).Invoke(ct, inst, []byzcoin.Coin{})
 	require.Nil(t, err)
 	require.Equal(t, 0, len(co))
 	require.Equal(t, 2, len(sc))

--- a/byzcoin/contracts/coins_test.go
+++ b/byzcoin/contracts/coins_test.go
@@ -41,7 +41,7 @@ func init() {
 
 func TestCoin_Spawn(t *testing.T) {
 	// Testing spawning of a new coin and checking it has zero coins in it.
-	ct := newCT("spawn:coin")
+	ct := newCT(t, "spawn:coin")
 	ct.setSignatureCounter(gsigner.Identity().String(), 0)
 
 	inst := byzcoin.Instruction{
@@ -69,7 +69,7 @@ func TestCoin_Spawn(t *testing.T) {
 
 func TestCoin_InvokeMint(t *testing.T) {
 	// Test that a coin can be minted
-	ct := newCT("invoke:mint")
+	ct := newCT(t, "invoke:mint")
 	ct.setSignatureCounter(gsigner.Identity().String(), 0)
 
 	coAddr := byzcoin.InstanceID{}
@@ -114,7 +114,7 @@ func TestCoin_InvokeOverflow(t *testing.T) {
 	ciBuf, err := protobuf.Encode(&ci)
 	require.NoError(t, err)
 
-	ct := newCT("invoke:mint")
+	ct := newCT(t, "invoke:mint")
 	ct.setSignatureCounter(gsigner.Identity().String(), 0)
 
 	coAddr := byzcoin.InstanceID{}
@@ -138,7 +138,7 @@ func TestCoin_InvokeOverflow(t *testing.T) {
 }
 
 func TestCoin_InvokeStoreFetch(t *testing.T) {
-	ct := newCT("invoke:store", "invoke:fetch")
+	ct := newCT(t, "invoke:store", "invoke:fetch")
 	ct.setSignatureCounter(gsigner.Identity().String(), 0)
 
 	coAddr := byzcoin.InstanceID{}
@@ -195,7 +195,7 @@ func TestCoin_InvokeStoreFetch(t *testing.T) {
 
 func TestCoin_InvokeTransfer(t *testing.T) {
 	// Test that a coin can be transferred
-	ct := newCT("invoke:transfer")
+	ct := newCT(t, "invoke:transfer")
 	ct.setSignatureCounter(gsigner.Identity().String(), 0)
 
 	coAddr1 := byzcoin.InstanceID{}
@@ -254,7 +254,7 @@ type cvTest struct {
 var gdarc *darc.Darc
 var gsigner darc.Signer
 
-func newCT(rStr ...string) *cvTest {
+func newCT(t *testing.T, rStr ...string) *cvTest {
 	ct := &cvTest{
 		make(map[string][]byte),
 		make(map[string]string),
@@ -269,7 +269,7 @@ func newCT(rStr ...string) *cvTest {
 	}
 	gdarc = darc.NewDarc(rules, []byte{})
 	dBuf, err := gdarc.ToProto()
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	ct.Store(byzcoin.NewInstanceID(gdarc.GetBaseID()), dBuf, "darc", gdarc.GetBaseID())
 	return ct
 }

--- a/byzcoin/contracts/contract_deferred_test.go
+++ b/byzcoin/contracts/contract_deferred_test.go
@@ -42,7 +42,7 @@ func TestDeferred_ScenarioSingleInstruction(t *testing.T) {
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.addProof",
 			"invoke:deferred.execProposedTx"}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	gDarc := &genesisMsg.GenesisDarc
 
 	genesisMsg.BlockInterval = time.Second
@@ -73,7 +73,7 @@ func TestDeferred_ScenarioSingleInstruction(t *testing.T) {
 	expireBlockIndexBuf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(expireBlockIndexBuf, expireBlockIndexInt)
 	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ctx, err := cl.CreateTransaction(byzcoin.Instruction{
 		InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
@@ -96,11 +96,11 @@ func TestDeferred_ScenarioSingleInstruction(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err := cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myID := ctx.Instructions[0].DeriveID("")
 	result, err := cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction, proposedTransaction)
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
@@ -116,10 +116,10 @@ func TestDeferred_ScenarioSingleInstruction(t *testing.T) {
 
 	identity := signer.Identity()
 	identityBuf, err := protobuf.Encode(&identity)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	signature, err := signer.Sign(rootHash[0]) // == index
-	require.Nil(t, err)
+	require.NoError(t, err)
 	// signature[1] = 0xf
 
 	index := uint32(0)
@@ -152,14 +152,14 @@ func TestDeferred_ScenarioSingleInstruction(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	proposedTransaction.Instructions[0].SignerIdentities = append(proposedTransaction.Instructions[0].SignerIdentities, identity)
 	proposedTransaction.Instructions[0].Signatures = append(proposedTransaction.Instructions[0].Signatures, signature)
 	result.ProposedTransaction = proposedTransaction
 
 	result, err = cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction.Instructions.Hash(), proposedTransaction.Instructions.Hash())
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
@@ -191,10 +191,10 @@ func TestDeferred_ScenarioSingleInstruction(t *testing.T) {
 	signer2 := darc.NewSignerEd25519(nil, nil)
 	identity = signer2.Identity()
 	identityBuf, err = protobuf.Encode(&identity)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	signature, err = signer2.Sign(rootHash[0]) // == index
-	require.Nil(t, err)
+	require.NoError(t, err)
 	// signature[1] = 0xf // Simulates a wrong signature
 
 	ctx, err = cl.CreateTransaction(byzcoin.Instruction{
@@ -223,14 +223,14 @@ func TestDeferred_ScenarioSingleInstruction(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	proposedTransaction.Instructions[0].SignerIdentities = append(proposedTransaction.Instructions[0].SignerIdentities, identity)
 	proposedTransaction.Instructions[0].Signatures = append(proposedTransaction.Instructions[0].Signatures, signature)
 	result.ProposedTransaction = proposedTransaction
 
 	result, err = cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction.Instructions.Hash(), proposedTransaction.Instructions.Hash())
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
@@ -275,7 +275,7 @@ func TestDeferred_ScenarioSingleInstruction(t *testing.T) {
 	require.True(t, pr.InclusionProof.Match(result.ExecResult[0]))
 
 	valueRes, _, _, err := pr.Get(result.ExecResult[0])
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Such a miracle to retrieve this value that was set at the begining
 	require.Equal(t, valueRes, rootInstructionValue)
@@ -323,7 +323,7 @@ func TestDeferred_ScenarioMultiInstructions(t *testing.T) {
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.addProof",
 			"invoke:deferred.execProposedTx"}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	gDarc := &genesisMsg.GenesisDarc
 
 	genesisMsg.BlockInterval = time.Second
@@ -367,7 +367,7 @@ func TestDeferred_ScenarioMultiInstructions(t *testing.T) {
 	expireBlockIndexBuf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(expireBlockIndexBuf, expireBlockIndexInt)
 	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ctx, err := cl.CreateTransaction(byzcoin.Instruction{
 		InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
@@ -390,11 +390,11 @@ func TestDeferred_ScenarioMultiInstructions(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err := cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myID := ctx.Instructions[0].DeriveID("")
 	result, err := cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction, proposedTransaction)
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 2)
@@ -410,10 +410,10 @@ func TestDeferred_ScenarioMultiInstructions(t *testing.T) {
 
 	identity := signer.Identity()
 	identityBuf, err := protobuf.Encode(&identity)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	signature, err := signer.Sign(rootHash[0]) // == index
-	require.Nil(t, err)
+	require.NoError(t, err)
 	// signature[1] = 0xf
 
 	index := uint32(0)
@@ -446,12 +446,12 @@ func TestDeferred_ScenarioMultiInstructions(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	proposedTransaction.Instructions[0].SignerIdentities = append(proposedTransaction.Instructions[0].SignerIdentities, identity)
 	proposedTransaction.Instructions[0].Signatures = append(proposedTransaction.Instructions[0].Signatures, signature)
 	result, err = cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction.Instructions.Hash(), proposedTransaction.Instructions.Hash())
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 2)
@@ -475,7 +475,7 @@ func TestDeferred_ScenarioMultiInstructions(t *testing.T) {
 	// ------------------------------------------------------------------------
 
 	signature, err = signer.Sign(rootHash[1]) // == index
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	index = uint32(1)
 	indexBuf = make([]byte, 4)
@@ -510,10 +510,10 @@ func TestDeferred_ScenarioMultiInstructions(t *testing.T) {
 	proposedTransaction.Instructions[1].Signatures = append(proposedTransaction.Instructions[1].Signatures, signature)
 
 	atr, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	result, err = cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction.Instructions.Hash(), proposedTransaction.Instructions.Hash())
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 2)
@@ -553,11 +553,11 @@ func TestDeferred_ScenarioMultiInstructions(t *testing.T) {
 
 	time.Sleep(2 * genesisMsg.BlockInterval)
 	pr, err := cl.WaitProof(byzcoin.NewInstanceID(result.ExecResult[0]), 2*genesisMsg.BlockInterval, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, pr.InclusionProof.Match(result.ExecResult[0]))
 
 	valueRes, _, _, err := pr.Get(result.ExecResult[0])
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Such a miracle to retrieve this value that was set at the begining
 	require.Equal(t, valueRes, rootInstructionValue1)
@@ -590,7 +590,7 @@ func TestDeferred_ScenarioMultiInstructionsDifferentSigners(t *testing.T) {
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.addProof",
 			"invoke:deferred.execProposedTx"}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	gDarc := &genesisMsg.GenesisDarc
 
 	genesisMsg.BlockInterval = time.Second
@@ -634,7 +634,7 @@ func TestDeferred_ScenarioMultiInstructionsDifferentSigners(t *testing.T) {
 	expireBlockIndexBuf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(expireBlockIndexBuf, expireBlockIndexInt)
 	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ctx, err := cl.CreateTransaction(byzcoin.Instruction{
 		InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
@@ -657,11 +657,11 @@ func TestDeferred_ScenarioMultiInstructionsDifferentSigners(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err := cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myID := ctx.Instructions[0].DeriveID("")
 	result, err := cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction, proposedTransaction)
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 2)
@@ -677,10 +677,10 @@ func TestDeferred_ScenarioMultiInstructionsDifferentSigners(t *testing.T) {
 
 	identity := signer.Identity()
 	identityBuf, err := protobuf.Encode(&identity)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	signature, err := signer.Sign(rootHash[0]) // == index
-	require.Nil(t, err)
+	require.NoError(t, err)
 	// signature[1] = 0xf
 
 	index := uint32(0)
@@ -713,13 +713,13 @@ func TestDeferred_ScenarioMultiInstructionsDifferentSigners(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	proposedTransaction.Instructions[0].SignerIdentities = append(proposedTransaction.Instructions[0].SignerIdentities, identity)
 	proposedTransaction.Instructions[0].Signatures = append(proposedTransaction.Instructions[0].Signatures, signature)
 
 	result, err = cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction.Instructions.Hash(), proposedTransaction.Instructions.Hash())
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 2)
@@ -747,10 +747,10 @@ func TestDeferred_ScenarioMultiInstructionsDifferentSigners(t *testing.T) {
 
 	identity = signer2.Identity()
 	identityBuf, err = protobuf.Encode(&identity)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	signature, err = signer2.Sign(rootHash[1]) // == index
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	index = uint32(1)
 	indexBuf = make([]byte, 4)
@@ -782,13 +782,13 @@ func TestDeferred_ScenarioMultiInstructionsDifferentSigners(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	proposedTransaction.Instructions[1].SignerIdentities = append(proposedTransaction.Instructions[1].SignerIdentities, identity)
 	proposedTransaction.Instructions[1].Signatures = append(proposedTransaction.Instructions[1].Signatures, signature)
 
 	result, err = cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction.Instructions.Hash(), proposedTransaction.Instructions.Hash())
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 2)
@@ -843,7 +843,7 @@ func TestDeferred_WrongSignature(t *testing.T) {
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.addProof",
 			"invoke:deferred.execProposedTx"}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	gDarc := &genesisMsg.GenesisDarc
 
 	genesisMsg.BlockInterval = time.Second
@@ -874,7 +874,7 @@ func TestDeferred_WrongSignature(t *testing.T) {
 	expireBlockIndexBuf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(expireBlockIndexBuf, expireBlockIndexInt)
 	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ctx, err := cl.CreateTransaction(byzcoin.Instruction{
 		InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
@@ -897,11 +897,11 @@ func TestDeferred_WrongSignature(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err := cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myID := ctx.Instructions[0].DeriveID("")
 	result, err := cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction, proposedTransaction)
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
@@ -917,10 +917,10 @@ func TestDeferred_WrongSignature(t *testing.T) {
 
 	identity := signer.Identity()
 	identityBuf, err := protobuf.Encode(&identity)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	signature, err := signer.Sign(rootHash[0]) // == index
-	require.Nil(t, err)
+	require.NoError(t, err)
 	signature[1] = 0xf
 
 	index := uint32(0)
@@ -972,13 +972,13 @@ func TestDeferred_DuplicateIdentity(t *testing.T) {
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.addProof",
 			"invoke:deferred.execProposedTx"}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	gDarc := &genesisMsg.GenesisDarc
 
 	genesisMsg.BlockInterval = time.Second
 
 	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// ------------------------------------------------------------------------
 	// 1. Spawn
@@ -1003,7 +1003,7 @@ func TestDeferred_DuplicateIdentity(t *testing.T) {
 	expireBlockIndexBuf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(expireBlockIndexBuf, expireBlockIndexInt)
 	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ctx, err := cl.CreateTransaction(byzcoin.Instruction{
 		InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
@@ -1026,11 +1026,11 @@ func TestDeferred_DuplicateIdentity(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err := cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myID := ctx.Instructions[0].DeriveID("")
 	result, err := cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction, proposedTransaction)
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
@@ -1046,10 +1046,10 @@ func TestDeferred_DuplicateIdentity(t *testing.T) {
 
 	identity := signer.Identity()
 	identityBuf, err := protobuf.Encode(&identity)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	signature, err := signer.Sign(rootHash[0]) // == index
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	index := uint32(0)
 	indexBuf := make([]byte, 4)
@@ -1081,10 +1081,10 @@ func TestDeferred_DuplicateIdentity(t *testing.T) {
 	require.NoError(t, ctx.FillSignersAndSignWith(signer))
 
 	_, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	_, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// ------------------------------------------------------------------------
 	// 3 Invoke a second time the same "addProof"
@@ -1134,7 +1134,7 @@ func TestDeferred_ExpireBlockIndex(t *testing.T) {
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.addProof",
 			"invoke:deferred.execProposedTx"}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	gDarc := &genesisMsg.GenesisDarc
 
 	genesisMsg.BlockInterval = time.Second
@@ -1165,7 +1165,7 @@ func TestDeferred_ExpireBlockIndex(t *testing.T) {
 	expireBlockIndexBuf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(expireBlockIndexBuf, expireBlockIndexInt)
 	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ctx, err := cl.CreateTransaction(byzcoin.Instruction{
 		InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
@@ -1188,11 +1188,11 @@ func TestDeferred_ExpireBlockIndex(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err := cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myID := ctx.Instructions[0].DeriveID("")
 	result, err := cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction, proposedTransaction)
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
@@ -1208,10 +1208,10 @@ func TestDeferred_ExpireBlockIndex(t *testing.T) {
 
 	identity := signer.Identity()
 	identityBuf, err := protobuf.Encode(&identity)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	signature, err := signer.Sign(rootHash[0]) // == index
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	index := uint32(0)
 	indexBuf := make([]byte, 4)
@@ -1243,7 +1243,7 @@ func TestDeferred_ExpireBlockIndex(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	_, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	_, err = cl.WaitProof(byzcoin.NewInstanceID(ctx.Instructions[0].DeriveID("").Slice()), 2*genesisMsg.BlockInterval, nil)
 	require.Error(t, err)
@@ -1265,7 +1265,7 @@ func TestDeferred_ExecWithNoProof(t *testing.T) {
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.addProof",
 			"invoke:deferred.execProposedTx"}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	gDarc := &genesisMsg.GenesisDarc
 
 	genesisMsg.BlockInterval = time.Second
@@ -1296,7 +1296,7 @@ func TestDeferred_ExecWithNoProof(t *testing.T) {
 	expireBlockIndexBuf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(expireBlockIndexBuf, expireBlockIndexInt)
 	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ctx, err := cl.CreateTransaction(byzcoin.Instruction{
 		InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
@@ -1319,11 +1319,11 @@ func TestDeferred_ExecWithNoProof(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err := cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myID := ctx.Instructions[0].DeriveID("")
 	result, err := cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction, proposedTransaction)
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
@@ -1377,7 +1377,7 @@ func TestDeferred_InstructionsDependent(t *testing.T) {
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:value", "delete:value", "spawn:deferred", "invoke:deferred.addProof",
 			"invoke:deferred.execProposedTx", "invoke:value.update"}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	gDarc := &genesisMsg.GenesisDarc
 
 	genesisMsg.BlockInterval = time.Second
@@ -1405,15 +1405,15 @@ func TestDeferred_InstructionsDependent(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	_, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	valueID := ctx.Instructions[0].DeriveID("")
 	pr, err := cl.WaitProof(byzcoin.NewInstanceID(valueID.Slice()), 2*genesisMsg.BlockInterval, myvalue)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, pr.InclusionProof.Match(valueID.Slice()))
 
 	v0, _, _, err := pr.Get(valueID.Slice())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, myvalue, v0)
 
 	// ------------------------------------------------------------------------
@@ -1445,7 +1445,7 @@ func TestDeferred_InstructionsDependent(t *testing.T) {
 	expireBlockIndexBuf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(expireBlockIndexBuf, expireBlockIndexInt)
 	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ctx, err = cl.CreateTransaction(byzcoin.Instruction{
 		InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
@@ -1468,7 +1468,7 @@ func TestDeferred_InstructionsDependent(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err := cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myID := ctx.Instructions[0].DeriveID("")
 	result, err := cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
@@ -1488,10 +1488,10 @@ func TestDeferred_InstructionsDependent(t *testing.T) {
 
 	identity := signer.Identity()
 	identityBuf, err := protobuf.Encode(&identity)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	signature, err := signer.Sign(rootHash[0]) // == index
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	index := uint32(0)
 	indexBuf := make([]byte, 4)
@@ -1523,13 +1523,13 @@ func TestDeferred_InstructionsDependent(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	proposedTransaction.Instructions[0].SignerIdentities = append(proposedTransaction.Instructions[0].SignerIdentities, identity)
 	proposedTransaction.Instructions[0].Signatures = append(proposedTransaction.Instructions[0].Signatures, signature)
 
 	result, err = cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction.Instructions.Hash(), proposedTransaction.Instructions.Hash())
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 2)
@@ -1553,7 +1553,7 @@ func TestDeferred_InstructionsDependent(t *testing.T) {
 	// ------------------------------------------------------------------------
 
 	signature, err = signer.Sign(rootHash[1]) // == index
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	index = uint32(1)
 	indexBuf = make([]byte, 4)
@@ -1585,13 +1585,13 @@ func TestDeferred_InstructionsDependent(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	proposedTransaction.Instructions[1].SignerIdentities = append(proposedTransaction.Instructions[1].SignerIdentities, identity)
 	proposedTransaction.Instructions[1].Signatures = append(proposedTransaction.Instructions[1].Signatures, signature)
 
 	result, err = cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction.Instructions.Hash(), proposedTransaction.Instructions.Hash())
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 2)
@@ -1646,7 +1646,7 @@ func TestDeferred_DefaultExpireBlockIdx(t *testing.T) {
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.addProof",
 			"invoke:deferred.execProposedTx"}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	gDarc := &genesisMsg.GenesisDarc
 
 	genesisMsg.BlockInterval = time.Second
@@ -1676,7 +1676,7 @@ func TestDeferred_DefaultExpireBlockIdx(t *testing.T) {
 	require.NoError(t, err)
 
 	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ctx, err := cl.CreateTransaction(byzcoin.Instruction{
 		InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
@@ -1695,11 +1695,11 @@ func TestDeferred_DefaultExpireBlockIdx(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err := cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myID := ctx.Instructions[0].DeriveID("")
 	result, err := cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction, proposedTransaction)
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
@@ -1728,13 +1728,13 @@ func TestDeferred_ScenarioUpdateConfig(t *testing.T) {
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.addProof",
 			"invoke:deferred.execProposedTx"}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	gDarc := &genesisMsg.GenesisDarc
 
 	genesisMsg.BlockInterval = time.Second
 
 	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// ------------------------------------------------------------------------
 	// 1. Spawn
@@ -1742,20 +1742,20 @@ func TestDeferred_ScenarioUpdateConfig(t *testing.T) {
 
 	// Get the latest chain config
 	prr, err := cl.GetProofFromLatest(byzcoin.ConfigInstanceID.Slice())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	proof := prr.Proof
 
 	_, value, _, _, err := proof.KeyValue()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	config := byzcoin.ChainConfig{}
 	err = protobuf.DecodeWithConstructors(value, &config, network.DefaultConstructors(cothority.Suite))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	config.BlockInterval, err = time.ParseDuration("7s")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	config.MaxBlockSize += 10
 
 	configBuf, err := protobuf.Encode(&config)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	invoke := byzcoin.Invoke{
 		ContractID: byzcoin.ContractConfigID,
@@ -1775,7 +1775,7 @@ func TestDeferred_ScenarioUpdateConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ctx, err := cl.CreateTransaction(byzcoin.Instruction{
 		InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
@@ -1794,11 +1794,11 @@ func TestDeferred_ScenarioUpdateConfig(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err := cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myID := ctx.Instructions[0].DeriveID("")
 	result, err := cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction, proposedTransaction)
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
@@ -1813,10 +1813,10 @@ func TestDeferred_ScenarioUpdateConfig(t *testing.T) {
 
 	identity := signer.Identity()
 	identityBuf, err := protobuf.Encode(&identity)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	signature, err := signer.Sign(rootHash[0]) // == index
-	require.Nil(t, err)
+	require.NoError(t, err)
 	// signature[1] = 0xf
 
 	index := uint32(0)
@@ -1849,13 +1849,13 @@ func TestDeferred_ScenarioUpdateConfig(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	proposedTransaction.Instructions[0].SignerIdentities = append(proposedTransaction.Instructions[0].SignerIdentities, identity)
 	proposedTransaction.Instructions[0].Signatures = append(proposedTransaction.Instructions[0].Signatures, signature)
 
 	result, err = cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction.Instructions.Hash(), proposedTransaction.Instructions.Hash())
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
@@ -1939,7 +1939,7 @@ func TestDeferred_ScenarioMultipleSigners(t *testing.T) {
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:value", "spawn:deferred", "invoke:deferred.execProposedTx"},
 		signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	gDarc := &genesisMsg.GenesisDarc
 	require.NoError(t, gDarc.Rules.AddRule(darc.Action("invoke:value.update"),
 		expression.InitAndExpr(signer.Identity().String(), signer2.Identity().String())))
@@ -1949,7 +1949,7 @@ func TestDeferred_ScenarioMultipleSigners(t *testing.T) {
 	genesisMsg.BlockInterval = time.Second
 
 	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// ------------------------------------------------------------------------
 	// 1. Spawn the value contract
@@ -1973,12 +1973,12 @@ func TestDeferred_ScenarioMultipleSigners(t *testing.T) {
 	valueID := ctx.Instructions[0].DeriveID("")
 
 	_, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	pr, err := cl.WaitProof(byzcoin.NewInstanceID(valueID.Slice()), 2*genesisMsg.BlockInterval, myvalue)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, pr.InclusionProof.Match(valueID.Slice()))
 	v0, _, _, err := pr.Get(valueID.Slice())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, myvalue, v0)
 
 	// ------------------------------------------------------------------------
@@ -2003,7 +2003,7 @@ func TestDeferred_ScenarioMultipleSigners(t *testing.T) {
 	require.NoError(t, err)
 
 	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ctx, err = cl.CreateTransaction(byzcoin.Instruction{
 		InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
@@ -2022,11 +2022,11 @@ func TestDeferred_ScenarioMultipleSigners(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err := cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myID := ctx.Instructions[0].DeriveID("")
 	result, err := cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction, proposedTransaction)
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
@@ -2041,10 +2041,10 @@ func TestDeferred_ScenarioMultipleSigners(t *testing.T) {
 
 	identity := signer.Identity()
 	identityBuf, err := protobuf.Encode(&identity)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	signature, err := signer.Sign(rootHash[0]) // == index
-	require.Nil(t, err)
+	require.NoError(t, err)
 	// signature[1] = 0xf
 
 	index := uint32(0)
@@ -2077,13 +2077,13 @@ func TestDeferred_ScenarioMultipleSigners(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	proposedTransaction.Instructions[0].SignerIdentities = append(proposedTransaction.Instructions[0].SignerIdentities, identity)
 	proposedTransaction.Instructions[0].Signatures = append(proposedTransaction.Instructions[0].Signatures, signature)
 
 	result, err = cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction.Instructions.Hash(), proposedTransaction.Instructions.Hash())
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
@@ -2126,10 +2126,10 @@ func TestDeferred_ScenarioMultipleSigners(t *testing.T) {
 
 	identity = signer2.Identity()
 	identityBuf, err = protobuf.Encode(&identity)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	signature, err = signer2.Sign(rootHash[0]) // == index
-	require.Nil(t, err)
+	require.NoError(t, err)
 	// signature[1] = 0xf // Simulates a wrong signature
 
 	ctx, err = cl.CreateTransaction(byzcoin.Instruction{
@@ -2158,13 +2158,13 @@ func TestDeferred_ScenarioMultipleSigners(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer2))
 
 	atr, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	proposedTransaction.Instructions[0].SignerIdentities = append(proposedTransaction.Instructions[0].SignerIdentities, identity)
 	proposedTransaction.Instructions[0].Signatures = append(proposedTransaction.Instructions[0].Signatures, signature)
 
 	result, err = cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction.Instructions.Hash(), proposedTransaction.Instructions.Hash())
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
@@ -2251,13 +2251,13 @@ func TestDeferred_SimpleDelete(t *testing.T) {
 
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:deferred", "delete:deferred"}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	gDarc := &genesisMsg.GenesisDarc
 
 	genesisMsg.BlockInterval = time.Second
 
 	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// ------------------------------------------------------------------------
 	// 1. Spawn
@@ -2282,7 +2282,7 @@ func TestDeferred_SimpleDelete(t *testing.T) {
 	expireBlockIndexBuf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(expireBlockIndexBuf, expireBlockIndexInt)
 	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ctx, err := cl.CreateTransaction(byzcoin.Instruction{
 		InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
@@ -2305,11 +2305,11 @@ func TestDeferred_SimpleDelete(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err := cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myID := ctx.Instructions[0].DeriveID("")
 	result, err := cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction, proposedTransaction)
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
@@ -2332,12 +2332,12 @@ func TestDeferred_SimpleDelete(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	prr, err := cl.GetProofAfter(myID.Slice(), false, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	exist, err := prr.Proof.InclusionProof.Exists(myID.Slice())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.False(t, exist)
 }
 
@@ -2360,13 +2360,13 @@ func TestDeferred_PublicDelete(t *testing.T) {
 
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:deferred", "delete:deferred"}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	gDarc := &genesisMsg.GenesisDarc
 
 	genesisMsg.BlockInterval = time.Second
 
 	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// ------------------------------------------------------------------------
 	// 1. Spawn
@@ -2391,7 +2391,7 @@ func TestDeferred_PublicDelete(t *testing.T) {
 	expireBlockIndexBuf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(expireBlockIndexBuf, expireBlockIndexInt)
 	proposedTransactionBuf, err := protobuf.Encode(&proposedTransaction)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ctx, err := cl.CreateTransaction(byzcoin.Instruction{
 		InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
@@ -2414,11 +2414,11 @@ func TestDeferred_PublicDelete(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err := cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myID := ctx.Instructions[0].DeriveID("")
 	result, err := cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, result.ProposedTransaction, proposedTransaction)
 	require.Equal(t, len(result.ProposedTransaction.Instructions), 1)
@@ -2444,11 +2444,11 @@ func TestDeferred_PublicDelete(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer2))
 
 	atr, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	prr, err := cl.GetProofAfter(myID.Slice(), false, &atr.Proof.Latest)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	exist, err := prr.Proof.InclusionProof.Exists(myID.Slice())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.False(t, exist)
 }

--- a/byzcoin/contracts/contract_deferred_test.go
+++ b/byzcoin/contracts/contract_deferred_test.go
@@ -263,14 +263,15 @@ func TestDeferred_ScenarioSingleInstruction(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	result, err = cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(result.ExecResult))
 
 	time.Sleep(2 * genesisMsg.BlockInterval)
 	pr, err := cl.WaitProof(byzcoin.NewInstanceID(result.ExecResult[0]), 2*genesisMsg.BlockInterval, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, pr.InclusionProof.Match(result.ExecResult[0]))
 
 	valueRes, _, _, err := pr.Get(result.ExecResult[0])
@@ -545,9 +546,10 @@ func TestDeferred_ScenarioMultiInstructions(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	result, err = cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
+	require.NoError(t, err)
 
 	time.Sleep(2 * genesisMsg.BlockInterval)
 	pr, err := cl.WaitProof(byzcoin.NewInstanceID(result.ExecResult[0]), 2*genesisMsg.BlockInterval, nil)
@@ -562,11 +564,11 @@ func TestDeferred_ScenarioMultiInstructions(t *testing.T) {
 
 	time.Sleep(2 * genesisMsg.BlockInterval)
 	pr, err = cl.WaitProof(byzcoin.NewInstanceID(result.ExecResult[1]), 2*genesisMsg.BlockInterval, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, pr.InclusionProof.Match(result.ExecResult[1]))
 
 	valueRes, _, _, err = pr.Get(result.ExecResult[1])
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Such a miracle to retrieve this value that was set at the begining
 	require.Equal(t, valueRes, rootInstructionValue2)
@@ -1887,22 +1889,23 @@ func TestDeferred_ScenarioUpdateConfig(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	result, err = cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(result.ExecResult))
 
 	time.Sleep(2 * genesisMsg.BlockInterval)
 	pr, err := cl.WaitProof(byzcoin.NewInstanceID(byzcoin.ConfigInstanceID.Slice()), 2*genesisMsg.BlockInterval, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, pr.InclusionProof.Match(byzcoin.ConfigInstanceID.Slice()))
 
 	_, valueBuf, _, _, err := pr.KeyValue()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	configResult := byzcoin.ChainConfig{}
 	err = protobuf.Decode(valueBuf, &configResult)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// We check if what we get has the updated values
 	require.Equal(t, config.BlockInterval, configResult.BlockInterval)
@@ -2193,18 +2196,19 @@ func TestDeferred_ScenarioMultipleSigners(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	atr, err = cl.AddTransactionAndWait(ctx, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	result, err = cl.GetDeferredDataAfter(myID, &atr.Proof.Latest)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(result.ExecResult))
 
 	time.Sleep(2 * genesisMsg.BlockInterval)
 	pr, err = cl.WaitProof(byzcoin.NewInstanceID(valueID.Slice()), 2*genesisMsg.BlockInterval, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, pr.InclusionProof.Match(valueID.Slice()))
 
 	valueRes, _, _, err := pr.Get(valueID.Slice())
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Such a miracle to retrieve the updated value
 	require.Equal(t, valueRes, updatedValue)

--- a/byzcoin/contracts/insecure_darc_test.go
+++ b/byzcoin/contracts/insecure_darc_test.go
@@ -20,12 +20,12 @@ func TestInsecureDarc(t *testing.T) {
 
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:insecure_darc"}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	genesisMsg.DarcContractIDs = append(genesisMsg.DarcContractIDs, ContractInsecureDarcID)
 	gDarc := &genesisMsg.GenesisDarc
 	genesisMsg.BlockInterval = time.Second
 	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// spawn new darc
 	newDarc := gDarc.Copy()

--- a/byzcoin/contracts/insecure_darc_test.go
+++ b/byzcoin/contracts/insecure_darc_test.go
@@ -76,6 +76,7 @@ func TestInsecureDarc(t *testing.T) {
 	require.NoError(t, newDarc2.EvolveFrom(newDarc))
 	newDarc2.Rules.AddRule("spawn:coin", []byte(signer.Identity().String()))
 	newDarc2Buf, err := newDarc2.ToProto()
+	require.NoError(t, err)
 	ctx, err = cl.CreateTransaction(byzcoin.Instruction{
 		InstanceID: byzcoin.NewInstanceID(newDarc2.GetBaseID()),
 		Invoke: &byzcoin.Invoke{

--- a/byzcoin/contracts/value_test.go
+++ b/byzcoin/contracts/value_test.go
@@ -20,13 +20,13 @@ func TestValue_Spawn(t *testing.T) {
 
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:value"}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	gDarc := &genesisMsg.GenesisDarc
 
 	genesisMsg.BlockInterval = time.Second
 
 	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myvalue := []byte("1234")
 	ctx, err := cl.CreateTransaction(byzcoin.Instruction{
@@ -44,12 +44,12 @@ func TestValue_Spawn(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	_, err = cl.AddTransaction(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	pr, err := cl.WaitProof(byzcoin.NewInstanceID(ctx.Instructions[0].DeriveID("").Slice()), 2*genesisMsg.BlockInterval, myvalue)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, pr.InclusionProof.Match(ctx.Instructions[0].DeriveID("").Slice()))
 	v0, _, _, err := pr.Get(ctx.Instructions[0].DeriveID("").Slice())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, myvalue, v0)
 
 	local.WaitDone(genesisMsg.BlockInterval)
@@ -66,13 +66,13 @@ func TestValue_Invoke(t *testing.T) {
 
 	genesisMsg, err := byzcoin.DefaultGenesisMsg(byzcoin.CurrentVersion, roster,
 		[]string{"spawn:value", "invoke:value.update"}, signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	gDarc := &genesisMsg.GenesisDarc
 
 	genesisMsg.BlockInterval = time.Second
 
 	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myvalue := []byte("1234")
 	ctx, err := cl.CreateTransaction(byzcoin.Instruction{
@@ -90,15 +90,15 @@ func TestValue_Invoke(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	_, err = cl.AddTransaction(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	myID := ctx.Instructions[0].DeriveID("")
 	pr, err := cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, myvalue)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, pr.InclusionProof.Match(myID.Slice()))
 
 	v0, _, _, err := pr.Get(myID.Slice())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, myvalue, v0)
 
 	local.WaitDone(genesisMsg.BlockInterval)
@@ -123,14 +123,14 @@ func TestValue_Invoke(t *testing.T) {
 	require.Nil(t, ctx.FillSignersAndSignWith(signer))
 
 	_, err = cl.AddTransaction(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	pr, err = cl.WaitProof(byzcoin.NewInstanceID(myID.Slice()), 2*genesisMsg.BlockInterval, myvalue)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, pr.InclusionProof.Match(myID.Slice()))
 
 	v0, _, _, err = pr.Get(myID.Slice())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, myvalue, v0)
 
 	local.WaitDone(genesisMsg.BlockInterval)

--- a/byzcoin/proof_test.go
+++ b/byzcoin/proof_test.go
@@ -27,22 +27,22 @@ func TestNewProof(t *testing.T) {
 
 	key := []byte{1}
 	p, err := NewProof(s.c, s.s, s.genesis.Hash, key)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.False(t, p.InclusionProof.Match(key))
 
 	p, err = NewProof(s.c, s.s, s.genesis.Hash, s.key)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, p.InclusionProof.Match(s.key))
 }
 
 func TestVerify(t *testing.T) {
 	s := createSC(t)
 	p, err := NewProof(s.c, s.s, s.genesis.Hash, s.key)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, p.InclusionProof.Match(s.key))
 	require.Nil(t, p.Verify(s.genesis.SkipChainID()))
 	key, val, _, _, err := p.KeyValue()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, s.key, key)
 	require.Equal(t, s.value, val)
 
@@ -54,7 +54,7 @@ func TestVerify(t *testing.T) {
 	p.Latest.Data, err = protobuf.Encode(&DataHeader{
 		TrieRoot: getSBID("123"),
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, xerrors.Is(p.Verify(s.genesis.SkipChainID()), ErrorVerifyTrieRoot))
 }
 
@@ -75,18 +75,18 @@ type sc struct {
 func createSC(t *testing.T) (s sc) {
 	bnsc := []byte("skipblock-test")
 	f, err := ioutil.TempFile("", string(bnsc))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	fname := f.Name()
 	require.Nil(t, f.Close())
 
 	db, err := bbolt.Open(fname, 0600, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = db.Update(func(tx *bbolt.Tx) error {
 		_, err := tx.CreateBucket(bnsc)
 		return err
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	s.s = skipchain.NewSkipBlockDB(db, bnsc)
 
 	bucketName := []byte("a testing string")
@@ -94,7 +94,7 @@ func createSC(t *testing.T) (s sc) {
 		_, err := tx.CreateBucket(bucketName)
 		return err
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	s.c, err = newStateTrie(db, bucketName, []byte("nonce string"))
 	require.NoError(t, err)
 
@@ -113,13 +113,13 @@ func createSC(t *testing.T) (s sc) {
 	s.sb2.Data, err = protobuf.Encode(&DataHeader{
 		TrieRoot: s.c.GetRoot(),
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	s.sb2.Index = 1
 	s.sb2.Hash = s.sb2.CalculateHash()
 	s.genesis.ForwardLink = genForwardLink(t, s.genesis, s.sb2, s.genesisPrivs)
 
 	_, err = s.s.StoreBlocks([]*skipchain.SkipBlock{s.genesis, s.sb2})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	s.genesis2 = skipchain.NewSkipBlock()
 	s.genesis2.Height = 1
@@ -142,7 +142,7 @@ func genForwardLink(t *testing.T, from, to *skipchain.SkipBlock, privs []kyber.S
 		Msg: fwd.Hash(),
 		Sig: sig,
 	}
-	require.Nil(t, err)
+	require.NoError(t, err)
 	return []*skipchain.ForwardLink{fwd}
 }
 

--- a/byzcoin/proof_test.go
+++ b/byzcoin/proof_test.go
@@ -22,11 +22,11 @@ import (
 
 func TestNewProof(t *testing.T) {
 	s := createSC(t)
-	p, err := NewProof(s.c, s.s, skipchain.SkipBlockID{}, []byte{})
-	require.NotNil(t, err)
+	_, err := NewProof(s.c, s.s, skipchain.SkipBlockID{}, []byte{})
+	require.Error(t, err)
 
 	key := []byte{1}
-	p, err = NewProof(s.c, s.s, s.genesis.Hash, key)
+	p, err := NewProof(s.c, s.s, s.genesis.Hash, key)
 	require.Nil(t, err)
 	require.False(t, p.InclusionProof.Match(key))
 

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -2488,7 +2488,7 @@ func TestService_Repair(t *testing.T) {
 	n := 5
 	for i := 0; i < n; i++ {
 		ctx, err := createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, []byte{}, s.signer, uint64(i+1))
-		require.Nil(t, err)
+		require.NoError(t, err)
 		s.sendTxAndWait(t, ctx, 10)
 
 		// take a copy of the state trie at the middle

--- a/byzcoin/statereplay_test.go
+++ b/byzcoin/statereplay_test.go
@@ -129,6 +129,7 @@ func TestService_StateReplayFailures(t *testing.T) {
 
 		dHead.TrieRoot = []byte{1, 2, 3}
 		buf, err := protobuf.Encode(&dHead)
+		require.NoError(t, err)
 		sb.Data = buf
 		return sb, nil
 	}
@@ -154,6 +155,7 @@ func TestService_StateReplayFailures(t *testing.T) {
 			},
 		})
 		buf, err := protobuf.Encode(&dBody)
+		require.NoError(t, err)
 		sb.Payload = buf
 
 		var dHead DataHeader
@@ -164,6 +166,7 @@ func TestService_StateReplayFailures(t *testing.T) {
 
 		dHead.ClientTransactionHash = dBody.TxResults.Hash()
 		buf, err = protobuf.Encode(&dHead)
+		require.NoError(t, err)
 		sb.Data = buf
 		return sb, nil
 	}

--- a/byzcoin/statereplay_test.go
+++ b/byzcoin/statereplay_test.go
@@ -17,7 +17,7 @@ func TestService_StateReplay(t *testing.T) {
 	n := 2
 	for i := 0; i < n; i++ {
 		tx, err := createClientTxWithTwoInstrWithCounter(s.darc.GetBaseID(), dummyContract, []byte{}, s.signer, uint64(i*2+1))
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		_, err = s.service().AddTransaction(&AddTxRequest{
 			Version:       CurrentVersion,
@@ -25,7 +25,7 @@ func TestService_StateReplay(t *testing.T) {
 			Transaction:   tx,
 			InclusionWait: 10,
 		})
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	cb := func(sib skipchain.SkipBlockID) (*skipchain.SkipBlock, error) {
@@ -49,7 +49,7 @@ func TestService_StateReplayFailures(t *testing.T) {
 	defer s.local.CloseAll()
 
 	tx, err := createClientTxWithTwoInstrWithCounter(s.darc.GetBaseID(), dummyContract, []byte{}, s.signer, uint64(1))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	_, err = s.service().AddTransaction(&AddTxRequest{
 		Version:       CurrentVersion,
@@ -57,7 +57,7 @@ func TestService_StateReplayFailures(t *testing.T) {
 		Transaction:   tx,
 		InclusionWait: 10,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// 1. error when fetching the genesis block
 	cb := func(sib skipchain.SkipBlockID) (*skipchain.SkipBlock, error) {

--- a/byzcoin/statetrie_test.go
+++ b/byzcoin/statetrie_test.go
@@ -49,6 +49,7 @@ func TestStateTrie(t *testing.T) {
 	require.True(t, xerrors.Is(err, errKeyNotSet))
 
 	val, ver, cid, did, err := st.GetValues(key)
+	require.NoError(t, err)
 	require.Equal(t, value, val)
 	require.Equal(t, version, ver)
 	require.Equal(t, cid, string(contractID))

--- a/byzcoin/struct_test.go
+++ b/byzcoin/struct_test.go
@@ -63,10 +63,10 @@ func TestStateChangeStorage_Init(t *testing.T) {
 
 		return nil
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = scs.calculateSize()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, size, scs.size)
 }
 
@@ -83,7 +83,7 @@ func TestStateChangeStorage_SimpleCase(t *testing.T) {
 
 	sb := createBlock()
 	err := scs.append(ss, sb)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// check the size remains the same with already seen state changes
 	size := scs.size
@@ -92,14 +92,14 @@ func TestStateChangeStorage_SimpleCase(t *testing.T) {
 	require.Equal(t, size, scs.size)
 
 	entries, err := scs.getAll(ss[0].InstanceID, sb.SkipChainID())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 10, len(entries))
 
 	for i := 0; i < 10; i++ {
 		require.Equal(t, uint64(i), entries[i].StateChange.Version)
 		e, ok, err := scs.getByVersion(ss[0].InstanceID, uint64(i), sb.SkipChainID())
 
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.True(t, ok)
 		require.Equal(t, e.StateChange.Value, entries[i].StateChange.Value)
 	}
@@ -107,10 +107,10 @@ func TestStateChangeStorage_SimpleCase(t *testing.T) {
 	fakeID := genID().Slice()
 	_, ok, err := scs.getByVersion(fakeID, 0, sb.SkipChainID())
 	require.False(t, ok)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	sce, ok, err := scs.getLast(ss[0].InstanceID, sb.SkipChainID())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, uint64(9), sce.StateChange.Version)
 }
@@ -137,12 +137,12 @@ func TestStateChangeStorage_GetByBlock(t *testing.T) {
 				Value:      []byte{},
 			}
 			err := store.append(StateChanges{sc}, sbs[i])
-			require.Nil(t, err)
+			require.NoError(t, err)
 		}
 	}
 
 	sce, err := store.getByBlock(sbs[n-1].SkipChainID(), 0)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, k, len(sce))
 }
 
@@ -167,26 +167,26 @@ func TestStateChangeStorage_MultiSkipChain(t *testing.T) {
 				Value:      []byte{},
 			}
 			err := store.append(StateChanges{sc}, chains[i])
-			require.Nil(t, err)
+			require.NoError(t, err)
 		}
 	}
 
 	for _, chain := range chains {
 		sce, err := store.getAll(iid, chain.SkipChainID())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, k, len(sce))
 
 		sce, err = store.getByBlock(chain.SkipChainID(), k-1)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, 1, len(sce))
 
 		e, ok, err := store.getLast(iid, chain.SkipChainID())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.True(t, ok)
 		require.Equal(t, uint64(k-1), e.StateChange.Version)
 
 		e, ok, err = store.getByVersion(iid, uint64(1), chain.SkipChainID())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.True(t, ok)
 		require.Equal(t, uint64(1), e.StateChange.Version)
 	}
@@ -212,7 +212,7 @@ func TestStateChangeStorage_MaxSize(t *testing.T) {
 		Value:      make([]byte, 200),
 	}
 	buf, err := protobuf.Encode(&sc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	store.maxSize = len(buf) * size
 
@@ -220,7 +220,7 @@ func TestStateChangeStorage_MaxSize(t *testing.T) {
 		sc.Version = uint64(i)
 		sb1.Index = i
 		err = store.append(StateChanges{sc}, sb1)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	sc.InstanceID = iid2
@@ -229,11 +229,11 @@ func TestStateChangeStorage_MaxSize(t *testing.T) {
 		sc.Version = uint64(i)
 		sb2.Index = i
 		err = store.append(StateChanges{sc}, sb2)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	entries, err := store.getAll(iid2, sb2.SkipChainID())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, size, len(entries))
 
 	for i := 0; i < size; i++ {
@@ -241,7 +241,7 @@ func TestStateChangeStorage_MaxSize(t *testing.T) {
 	}
 
 	entries, err = store.getAll(iid1, sb1.SkipChainID())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 0, len(entries))
 }
 
@@ -275,11 +275,11 @@ func TestStateChangeStorage_MaxNbrBlock(t *testing.T) {
 		}
 
 		err := store.append(scs, sb)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	entries, err := store.getAll(iids[k-1], sb.SkipChainID())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, l*store.maxNbrBlock, len(entries))
 	require.Equal(t, n/l-store.maxNbrBlock, entries[0].BlockIndex)
 }
@@ -329,11 +329,11 @@ func generateStateChanges(n int) StateChanges {
 
 func generateDB(t *testing.T) (*stateChangeStorage, string) {
 	tmpDB, err := ioutil.TempFile("", "tmpDB")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	tmpDB.Close()
 
 	db, err := bbolt.Open(tmpDB.Name(), 0600, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	scs := stateChangeStorage{db: db, bucket: []byte("scstest")}
 	db.Update(func(tx *bbolt.Tx) error {

--- a/byzcoin/transaction_test.go
+++ b/byzcoin/transaction_test.go
@@ -20,7 +20,7 @@ func TestTransaction_Signing(t *testing.T) {
 
 	// create the tx
 	ctx, err := createOneClientTx(d.GetBaseID(), "dummy_kind", []byte("dummy_value"), signer)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// create a db/trie
 	mdb := trie.NewMemDB()

--- a/byzcoin/trie/db_test.go
+++ b/byzcoin/trie/db_test.go
@@ -92,53 +92,6 @@ func TestDBDryRun(t *testing.T) {
 	testMemAndDisk(t, testDB)
 }
 
-func testDBDryRun(t *testing.T, db DB) {
-	// Write values to the database.
-	err := db.Update(func(b Bucket) error {
-		for i := 0; i < 10; i++ {
-			k := []byte{byte(i)}
-			if err := b.Put(k, k); err != nil {
-				return err
-			}
-		}
-		return nil
-	})
-	require.NoError(t, err)
-
-	// Overwrite these values in a dry-run transaction, and in the same
-	// transaction, check that these new values exist.
-	err = db.UpdateDryRun(func(b Bucket) error {
-		for i := 0; i < 10; i++ {
-			k := []byte{byte(i)}
-			v := []byte{byte(i * 2)}
-			if err := b.Put(k, v); err != nil {
-				return err
-			}
-		}
-		for i := 0; i < 10; i++ {
-			k := []byte{byte(i)}
-			v := []byte{byte(i * 2)}
-			if v2 := b.Get(k); !bytes.Equal(v, v2) {
-				return xerrors.New("values are not updated in dry-run")
-			}
-		}
-		return nil
-	})
-	require.NoError(t, err)
-
-	// Check that the original are present.
-	err = db.View(func(b Bucket) error {
-		for i := 0; i < 10; i++ {
-			k := []byte{byte(i)}
-			if v := b.Get(k); !bytes.Equal(k, v) {
-				return xerrors.New("missing value after dry-run")
-			}
-		}
-		return nil
-	})
-	require.NoError(t, err)
-}
-
 func testMemAndDisk(t *testing.T, f func(*testing.T, DB)) {
 	mem := NewMemDB()
 	defer mem.Close()

--- a/byzcoin/trie/staging_test.go
+++ b/byzcoin/trie/staging_test.go
@@ -359,6 +359,7 @@ func TestStagingGetProof(t *testing.T) {
 	for i := 10; i < 20; i++ {
 		k := []byte{byte(i)}
 		p, err := sTrie.GetProof(k)
+		require.NoError(t, err)
 		ok, err := p.Exists(k)
 		require.NoError(t, err)
 		require.False(t, ok)
@@ -382,6 +383,7 @@ func TestStagingGetProof(t *testing.T) {
 	for i := 10; i < 20; i++ {
 		k := []byte{byte(i)}
 		p, err := testTrie.GetProof(k)
+		require.NoError(t, err)
 		ok, err := p.Exists(k)
 		require.NoError(t, err)
 		require.False(t, ok)

--- a/byzcoin/trie/trie_test.go
+++ b/byzcoin/trie/trie_test.go
@@ -385,10 +385,7 @@ func TestQuickCheck(t *testing.T) {
 		}
 
 		// Check that everything is ok.
-		if testTrie.IsValid() != nil {
-			return false
-		}
-		return true
+		return testTrie.IsValid() == nil
 	}
 	require.NoError(t, quick.Check(f, nil))
 }
@@ -448,10 +445,7 @@ func TestBatchQuickCheck(t *testing.T) {
 		}
 
 		// Check that everything is ok.
-		if testTrie.IsValid() != nil {
-			return false
-		}
-		return true
+		return testTrie.IsValid() == nil
 	}
 	require.NoError(t, quick.Check(f, nil))
 }

--- a/byzcoin/viewchange_test.go
+++ b/byzcoin/viewchange_test.go
@@ -191,14 +191,14 @@ func TestViewChange_LostSync(t *testing.T) {
 
 	// then new blocks have been added
 	tx1, err := createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, s.value, s.signer, 1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, err = s.services[1].AddTransaction(&AddTxRequest{
 		Version:       CurrentVersion,
 		SkipchainID:   s.genesis.SkipChainID(),
 		Transaction:   tx1,
 		InclusionWait: 5,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// give enough time for the propagation to be processed
 	time.Sleep(1 * time.Second)

--- a/byzcoinx/byzcoinx_test.go
+++ b/byzcoinx/byzcoinx_test.go
@@ -116,7 +116,7 @@ func TestBftCoSi(t *testing.T) {
 	const protoName = "TestBftCoSi"
 
 	err := GlobalInitBFTCoSiProtocol(testSuite, verify, ack, protoName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	for _, n := range []int{1, 2, 4, 9, 20} {
 		runProtocol(t, n, 0, 0, protoName, 0)
@@ -131,7 +131,7 @@ func TestBdnCoSi(t *testing.T) {
 	}
 
 	err := GlobalInitBdnCoSiProtocol(testSuite, verify, ack, protoName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	for _, n := range nNodes {
 		runProtocol(t, n, 0, 0, protoName, 1)
@@ -143,7 +143,7 @@ func TestBftCoSiRefuse(t *testing.T) {
 	const protoName = "TestBftCoSiRefuse"
 
 	err := GlobalInitBFTCoSiProtocol(testSuite, verifyRefuse, ack, protoName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// the refuseIndex has both leaf and sub leader failure
 	configs := []struct{ n, f, r int }{
@@ -161,7 +161,7 @@ func TestBftCoSiFault(t *testing.T) {
 	const protoName = "TestBftCoSiFault"
 
 	err := GlobalInitBFTCoSiProtocol(testSuite, verify, ack, protoName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	configs := []struct{ n, f, r int }{
 		{4, 1, 0},
@@ -183,7 +183,7 @@ func runProtocol(t *testing.T, nbrHosts int, nbrFault int, refuseIndex int, prot
 	require.NotNil(t, roster)
 
 	pi, err := local.CreateProtocol(protoName, tree)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	publics := roster.Publics()
 	bftCosiProto := pi.(*ByzCoinX)
@@ -209,11 +209,11 @@ func runProtocol(t *testing.T, nbrHosts int, nbrFault int, refuseIndex int, prot
 	}
 
 	err = bftCosiProto.Start()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// verify signature
 	err = getAndVerifySignature(bftCosiProto.FinalSignatureChan, publics, proposal, scheme)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// check the counters
 	counter.Lock()

--- a/byzcoinx/byzcoinx_test.go
+++ b/byzcoinx/byzcoinx_test.go
@@ -238,7 +238,7 @@ func getAndVerifySignature(sigChan chan FinalSignature, publics []kyber.Point, p
 	if sig.Sig == nil {
 		return fmt.Errorf("signature is nil")
 	}
-	if bytes.Compare(sig.Msg, proposal) != 0 {
+	if !bytes.Equal(sig.Msg, proposal) {
 		return fmt.Errorf("message in the signature is different from proposal")
 	}
 	err := func() error {

--- a/calypso/api_test.go
+++ b/calypso/api_test.go
@@ -27,13 +27,13 @@ func TestClient_CreateLTS(t *testing.T) {
 		[]string{"spawn:dummy", "spawn:" + ContractLongTermSecretID},
 		signer.Identity())
 	msg.BlockInterval = 500 * time.Millisecond
-	require.Nil(t, err)
+	require.NoError(t, err)
 	d := msg.GenesisDarc
 	require.Nil(t, d.Verify(true))
 
 	// Create the clients
 	c, _, err := byzcoin.NewLedger(msg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	calypsoClient := NewClient(c)
 	for _, who := range roster.List {
 		err := calypsoClient.Authorize(who, c.ID)
@@ -42,7 +42,7 @@ func TestClient_CreateLTS(t *testing.T) {
 
 	// Invoke CreateLTS
 	ltsReply, err := calypsoClient.CreateLTS(roster, d.GetBaseID(), []darc.Signer{signer}, []uint64{1})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, ltsReply.ByzCoinID)
 	require.NotNil(t, ltsReply.InstanceID)
 	require.NotNil(t, ltsReply.X)
@@ -59,13 +59,13 @@ func TestClient_Authorize(t *testing.T) {
 		[]string{"spawn:dummy", "spawn:" + ContractLongTermSecretID},
 		signer.Identity())
 	msg.BlockInterval = 500 * time.Millisecond
-	require.Nil(t, err)
+	require.NoError(t, err)
 	d := msg.GenesisDarc
 	require.Nil(t, d.Verify(true))
 
 	// Create the clients
 	c, _, err := byzcoin.NewLedger(msg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	reply := &AuthorizeReply{}
 	who := roster.List[0]
@@ -119,13 +119,13 @@ func TestClient_Calypso(t *testing.T) {
 		admin.Identity())
 
 	msg.BlockInterval = 500 * time.Millisecond
-	require.Nil(t, err)
+	require.NoError(t, err)
 	// The darc inside it should be valid.
 	gDarc := msg.GenesisDarc
 	require.Nil(t, gDarc.Verify(true))
 	//Create Ledger
 	c, _, err := byzcoin.NewLedger(msg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	//Create a Calypso Client (Byzcoin + Onet)
 	calypsoClient := NewClient(c)
 
@@ -136,7 +136,7 @@ func TestClient_Calypso(t *testing.T) {
 	}
 	ltsReply, err := calypsoClient.CreateLTS(roster, gDarc.GetBaseID(), []darc.Signer{admin}, []uint64{adminCt})
 	adminCt++
-	require.Nil(t, err)
+	require.NoError(t, err)
 	//If no error, assign it
 	calypsoClient.ltsReply = ltsReply
 
@@ -149,10 +149,10 @@ func TestClient_Calypso(t *testing.T) {
 	darc1.Rules.AddRule(darc.Action("spawn:"+ContractReadID),
 		expression.InitOrExpr(reader1.Identity().String()))
 	require.NotNil(t, darc1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, err = calypsoClient.SpawnDarc(admin, adminCt, gDarc, *darc1, 10)
 	adminCt++
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	//Create a similar darc for provider2, reader2
 	darc2 := darc.NewDarc(darc.InitRules([]darc.Identity{provider2.Identity()},
@@ -165,7 +165,7 @@ func TestClient_Calypso(t *testing.T) {
 	//Spawn it
 	_, err = calypsoClient.SpawnDarc(admin, adminCt, gDarc, *darc2, 10)
 	adminCt++
-	require.Nil(t, err)
+	require.NoError(t, err)
 	//Create a secret key
 	key1 := []byte("secret key 1")
 	//Create a Write instance
@@ -173,17 +173,17 @@ func TestClient_Calypso(t *testing.T) {
 		darc1.GetBaseID(), calypsoClient.ltsReply.X, key1)
 	//Write it to calypso
 	wr1, err := calypsoClient.AddWrite(write1, provider1, 1, *darc1, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, wr1.InstanceID)
 	//Get the write proof
 	prWr1, err := calypsoClient.WaitProof(wr1.InstanceID, time.Second, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, prWr1)
 
 	re1, err := calypsoClient.AddRead(prWr1, reader1, 1, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	prRe1, err := calypsoClient.WaitProof(re1.InstanceID, time.Second, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, prRe1.InclusionProof.Match(re1.InstanceID.Slice()))
 
 	key2 := []byte("secret key 2")
@@ -191,14 +191,14 @@ func TestClient_Calypso(t *testing.T) {
 	write2 := NewWrite(cothority.Suite, calypsoClient.ltsReply.InstanceID,
 		darc2.GetBaseID(), calypsoClient.ltsReply.X, key2)
 	wr2, err := calypsoClient.AddWrite(write2, provider2, 1, *darc2, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	prWr2, err := calypsoClient.WaitProof(wr2.InstanceID, time.Second, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, prWr2.InclusionProof.Match(wr2.InstanceID.Slice()))
 	re2, err := calypsoClient.AddRead(prWr2, reader2, 1, 10)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	prRe2, err := calypsoClient.WaitProof(re2.InstanceID, time.Second, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, prRe2.InclusionProof.Match(re2.InstanceID.Slice()))
 
 	// Make sure you can't decrypt with non-matching proofs
@@ -209,10 +209,10 @@ func TestClient_Calypso(t *testing.T) {
 
 	// Make sure you can actually decrypt
 	dk1, err := calypsoClient.DecryptKey(&DecryptKey{Read: *prRe1, Write: *prWr1})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, dk1.X.Equal(calypsoClient.ltsReply.X))
 	keyCopy1, err := dk1.RecoverKey(reader1.Ed25519.Secret)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, key1, keyCopy1)
 
 	// use keyCopy to unlock the stuff in writeInstance.Data

--- a/calypso/protocol/ocs_test.go
+++ b/calypso/protocol/ocs_test.go
@@ -200,8 +200,7 @@ func EncodeKey(suite suites.Suite, X kyber.Point, key []byte) (U kyber.Point, Cs
 	log.Lvl3("U is:", U.String())
 
 	for len(key) > 0 {
-		var kp kyber.Point
-		kp = suite.Point().Embed(key, suite.RandomStream())
+		kp := suite.Point().Embed(key, suite.RandomStream())
 		log.Lvl3("Keypoint:", kp.String())
 		log.Lvl3("X:", X.String())
 		Cs = append(Cs, suite.Point().Add(C, kp))

--- a/calypso/protocol/ocs_test.go
+++ b/calypso/protocol/ocs_test.go
@@ -71,16 +71,16 @@ func ocs(t *testing.T, nbrNodes, threshold, keylen, fail int, refuse bool) {
 	// 1 - setting up - in real life uses Setup-protocol
 	// Store the dkgs in the services
 	dkgs, err := CreateDKGs(tSuite.(dkg.Suite), nbrNodes, threshold)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	services := local.GetServices(servers, testServiceID)
 	for i := range services {
 		services[i].(*testService).Shared, _, err = dkgprotocol.NewSharedSecret(dkgs[i])
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	// Get the collective public key
 	dks, err := dkgs[0].DistKeyShare()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	X := dks.Public()
 
 	// 2 - writer - Encrypt a symmetric key and publish U, Cs
@@ -102,7 +102,7 @@ func ocs(t *testing.T, nbrNodes, threshold, keylen, fail int, refuse bool) {
 		s.Pause()
 	}
 	pi, err := services[0].(*testService).createOCS(tree, threshold)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	protocol := pi.(*OCS)
 	protocol.U = U
 	protocol.Xc = xc.Public
@@ -134,7 +134,7 @@ func ocs(t *testing.T, nbrNodes, threshold, keylen, fail int, refuse bool) {
 
 	// 6 - reader - gets the resulting symmetric key, encrypted under Xc
 	keyHat, err := DecodeKey(suite, X, Cs, XhatEnc, xc.Private)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, k, keyHat)
 }

--- a/calypso/service_test.go
+++ b/calypso/service_test.go
@@ -288,17 +288,17 @@ func TestService_DecryptKey(t *testing.T) {
 	require.NotNil(t, err)
 
 	dk1, err := s.services[0].DecryptKey(&DecryptKey{Read: *prRe1, Write: *prWr1})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, dk1.X.Equal(s.ltsReply.X))
 	keyCopy1, err := dk1.RecoverKey(s.signer.Ed25519.Secret)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, key1, keyCopy1)
 
 	dk2, err := s.services[0].DecryptKey(&DecryptKey{Read: *prRe2, Write: *prWr2})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, dk2.X.Equal(s.ltsReply.X))
 	keyCopy2, err := dk2.RecoverKey(s.signer.Ed25519.Secret)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, key2, keyCopy2)
 }
 
@@ -315,11 +315,11 @@ func TestService_DecryptEphemeralKey(t *testing.T) {
 	prRe1 := s.addReadAndWait(t, prWr1, ephemeral.Public)
 
 	dk1, err := s.services[0].DecryptKey(&DecryptKey{Read: *prRe1, Write: *prWr1})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, dk1.X.Equal(s.ltsReply.X))
 
 	keyCopy1, err := dk1.RecoverKey(ephemeral.Private)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, key1, keyCopy1)
 }
 
@@ -346,7 +346,7 @@ func (s *ts) addRead(t *testing.T, write *byzcoin.Proof, Xc kyber.Point, ctr uin
 	}
 	var err error
 	readBuf, err = protobuf.Encode(read)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	ctx := byzcoin.NewClientTransaction(byzcoin.CurrentVersion,
 		byzcoin.Instruction{
 			InstanceID: byzcoin.NewInstanceID(write.InclusionProof.Key()),
@@ -359,7 +359,7 @@ func (s *ts) addRead(t *testing.T, write *byzcoin.Proof, Xc kyber.Point, ctr uin
 	)
 	require.Nil(t, ctx.FillSignersAndSignWith(s.signer))
 	_, err = s.cl.AddTransaction(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	return ctx.Instructions[0].DeriveID("")
 }
 
@@ -444,12 +444,12 @@ func (s *ts) createGenesis(t *testing.T) {
 			"spawn:" + ContractLongTermSecretID,
 			"invoke:" + ContractLongTermSecretID + ".reshare"},
 		s.signer.Identity())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	s.gDarc = &s.genesisMsg.GenesisDarc
 	s.genesisMsg.BlockInterval = time.Second
 
 	s.cl, s.gbReply, err = byzcoin.NewLedger(s.genesisMsg, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	for _, svc := range s.services {
 		req := &Authorize{ByzCoinID: s.cl.ID}
@@ -491,7 +491,7 @@ func (s *ts) addWriteAndWait(t *testing.T, key []byte) *byzcoin.Proof {
 func (s *ts) addWrite(t *testing.T, key []byte, ctr uint64) byzcoin.InstanceID {
 	write := NewWrite(cothority.Suite, s.ltsReply.InstanceID, s.gDarc.GetBaseID(), s.ltsReply.X, key)
 	writeBuf, err := protobuf.Encode(write)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ctx := byzcoin.NewClientTransaction(byzcoin.CurrentVersion,
 		byzcoin.Instruction{
@@ -505,7 +505,7 @@ func (s *ts) addWrite(t *testing.T, key []byte, ctr uint64) byzcoin.InstanceID {
 	)
 	require.Nil(t, ctx.FillSignersAndSignWith(s.signer))
 	_, err = s.cl.AddTransaction(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	return ctx.Instructions[0].DeriveID("")
 }
 

--- a/calypso/service_test.go
+++ b/calypso/service_test.go
@@ -242,13 +242,13 @@ func TestContract_Write_Benchmark(t *testing.T) {
 			iids[i] = s.addWrite(t, []byte("secret key"), ctr)
 			ctr++
 		}
-		timeSend := time.Now().Sub(start)
+		timeSend := time.Since(start)
 		log.Lvlf1("Time to send %d writes to the ledger: %s", totalTrans, timeSend)
 		start = time.Now()
 		for i := 0; i < totalTrans; i++ {
 			s.waitInstID(t, iids[i])
 		}
-		timeWait := time.Now().Sub(start)
+		timeWait := time.Since(start)
 		log.Lvlf1("Time to wait for %d writes in the ledger: %s", totalTrans, timeWait)
 		times = append(times, timeSend+timeWait)
 		for _, ti := range times {

--- a/darc/darc_test.go
+++ b/darc/darc_test.go
@@ -539,11 +539,6 @@ func createDarc(nbrOwners int, desc string) testDarc {
 	return td
 }
 
-func createSigner() Signer {
-	s, _ := createSignerIdentity()
-	return s
-}
-
 func createIdentity() Identity {
 	_, id := createSignerIdentity()
 	return id

--- a/darc/darc_test.go
+++ b/darc/darc_test.go
@@ -39,7 +39,7 @@ func TestDarc_Copy(t *testing.T) {
 	// create two darcs
 	d1 := createDarc(1, "testdarc1").darc
 	err := d1.Rules.AddRule("ocs:write", d1.Rules.GetEvolutionExpr())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	d2 := d1.Copy()
 
 	// modify the first one
@@ -47,7 +47,7 @@ func TestDarc_Copy(t *testing.T) {
 	desc := []byte("testdarc2")
 	d1.Description = desc
 	err = d1.Rules.UpdateRule("ocs:write", []byte(createIdentity().String()))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// the two darcs should be different
 	require.NotEqual(t, d1.Version, d2.Version)
@@ -211,51 +211,51 @@ func TestDarc_Rules(t *testing.T) {
 	user1 := NewSignerEd25519(nil, nil)
 	user2 := NewSignerEd25519(nil, nil)
 	err := d.Rules.AddRule("use", expression.InitOrExpr(user1.Identity().String(), user2.Identity().String()))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	var r *Request
 
 	// happy case with signer 1
 	r, err = InitAndSignRequest(d.GetID(), "use", []byte("secrets are lies"), user1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, r.Verify(d))
 
 	// happy case with signer 2
 	r, err = InitAndSignRequest(d.GetID(), "use", []byte("sharing is caring"), user2)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, r.Verify(d))
 
 	// happy case with both signers
 	r, err = InitAndSignRequest(d.GetID(), "use", []byte("privacy is theft"), user1, user2)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, r.Verify(d))
 
 	// wrong ID
 	d2 := createDarc(1, "testdarc2").darc
 	r, err = InitAndSignRequest(d2.GetID(), "use", []byte("all animals are equal"), user1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, r.Verify(d))
 
 	// wrong action
 	r, err = InitAndSignRequest(d.GetID(), "go", []byte("four legs good"), user1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, r.Verify(d))
 
 	// wrong signer 1
 	user3 := NewSignerEd25519(nil, nil)
 	r, err = InitAndSignRequest(d.GetID(), "use", []byte("two legs bad"), user3)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, r.Verify(d))
 
 	// happy case where at least one signer is valid
 	r, err = InitAndSignRequest(d.GetID(), "use", []byte("four legs good"), user1, user3)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, r.Verify(d))
 
 	// tampered signature
 	r, err = InitAndSignRequest(d.GetID(), "use", []byte("two legs better"), user1, user3)
 	r.Signatures[0] = copyBytes(r.Signatures[1])
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, r.Verify(d))
 }
 
@@ -283,19 +283,19 @@ func TestDarc_EvolveRequest(t *testing.T) {
 	// but the verification shold fail
 	badOwner := NewSignerEd25519(nil, nil)
 	r, _, err = dNew.MakeEvolveRequest(badOwner)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, r)
 	require.NotNil(t, r.Verify(td.darc))
 
 	// create the request with the right signer and it should pass
 	r, dNewBuf, err := dNew.MakeEvolveRequest(td.owners[0])
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, r)
 	require.Nil(t, r.Verify(td.darc))
 
 	// check that the evolution is actually OK
 	dNew2, err := r.MsgToDarc(dNewBuf)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, dNew2.VerifyWithCB(func(s string, latest bool) *Darc {
 		if latest {
 			return nil

--- a/darc/expression/expression_test.go
+++ b/darc/expression/expression_test.go
@@ -50,10 +50,7 @@ func TestInitAnd(t *testing.T) {
 func TestParsing_One(t *testing.T) {
 	expr := []byte("ed25519:abc")
 	fn := func(s string) bool {
-		if s == "ed25519:abc" {
-			return true
-		}
-		return false
+		return s == "ed25519:abc"
 	}
 	v, s := InitParser(fn)(parsec.NewScanner(expr))
 	if v.(bool) != true {
@@ -67,10 +64,7 @@ func TestParsing_One(t *testing.T) {
 func TestParsing_Or(t *testing.T) {
 	expr := []byte("ed25519:abc | ed25519:abc | ed25519:abc")
 	fn := func(s string) bool {
-		if s == "ed25519:abc" {
-			return true
-		}
-		return false
+		return s == "ed25519:abc"
 	}
 	v, s := InitParser(fn)(parsec.NewScanner(expr))
 	if v.(bool) != true {

--- a/eventlog/api_test.go
+++ b/eventlog/api_test.go
@@ -34,7 +34,7 @@ func TestClient_Log(t *testing.T) {
 	defer s.close()
 
 	err := c.Create()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, c.Instance)
 
 	waitForKey(t, leader.omni, c.ByzCoin.ID, c.Instance.Slice(), testBlockInterval)
@@ -42,7 +42,7 @@ func TestClient_Log(t *testing.T) {
 	ids, err := c.Log(NewEvent("auth", "user alice logged out"),
 		NewEvent("auth", "user bob logged out"),
 		NewEvent("auth", "user bob logged back in"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 3, len(ids))
 	require.Equal(t, 32, len(ids[2]))
 
@@ -80,7 +80,7 @@ func TestClient_Log(t *testing.T) {
 	// Use the client API to get the event back
 	for _, key := range ids {
 		_, err = c.GetEvent(key)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	// Test naming, this is just a sanity check for eventlogs, the main
@@ -137,7 +137,7 @@ func TestClient_Log200(t *testing.T) {
 	defer s.close()
 
 	err := c.Create()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	waitForKey(t, leader.omni, c.ByzCoin.ID, c.Instance.Slice(), time.Second)
 
 	logCount := 100
@@ -167,7 +167,7 @@ func TestClient_Log200(t *testing.T) {
 			evs[j] = NewEvent("auth", fmt.Sprintf("user %v logged in", j+i*logCount/5))
 		}
 		_, err = c.Log(evs...)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		s.waitNextBlock(t, current)
 	}
@@ -181,7 +181,7 @@ func TestClient_Log200(t *testing.T) {
 			break
 		}
 	}
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Fetch index, and check its length.
 	idx := checkProof(t, leader.omni, c.Instance.Slice(), c.ByzCoin.ID)
@@ -206,7 +206,7 @@ func TestClient_Log200(t *testing.T) {
 		bucketID = b.Prev
 		err = fmt.Errorf("Didn't finish in time. Got %d instead of %d events", eventCount, 2*logCount)
 	}
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	for _, eventID := range eventIDs {
 		eventBuf := checkProof(t, leader.omni, eventID, c.ByzCoin.ID)
@@ -222,13 +222,13 @@ func TestClient_Search(t *testing.T) {
 	defer s.close()
 
 	err := c.Create()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	waitForKey(t, leader.omni, c.ByzCoin.ID, c.Instance.Slice(), testBlockInterval)
 
 	// Search before any events are logged.
 	req := &SearchRequest{}
 	resp, err := c.Search(req)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, 0, len(resp.Events))
 	require.False(t, resp.Truncated)
@@ -264,14 +264,14 @@ func TestClient_Search(t *testing.T) {
 	// Search for all.
 	req = &SearchRequest{}
 	resp, err = c.Search(req)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, 20, len(resp.Events))
 
 	// Search by time range.
 	req = &SearchRequest{Instance: c.Instance, ID: c.ByzCoin.ID, From: tm0 + 3, To: tm0 + 8}
 	resp, err = c.Search(req)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.False(t, resp.Truncated)
 	require.Equal(t, 5, len(resp.Events))
@@ -279,7 +279,7 @@ func TestClient_Search(t *testing.T) {
 	// Search by topic, should find half of them.
 	req = &SearchRequest{Instance: c.Instance, ID: c.ByzCoin.ID, Topic: "a"}
 	resp, err = c.Search(req)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.False(t, resp.Truncated)
 	require.Equal(t, 10, len(resp.Events))
@@ -287,7 +287,7 @@ func TestClient_Search(t *testing.T) {
 	// Search by time range and topic.
 	req = &SearchRequest{Instance: c.Instance, ID: c.ByzCoin.ID, Topic: "a", From: tm0 + 3, To: tm0 + 8}
 	resp, err = c.Search(req)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.False(t, resp.Truncated)
 	require.Equal(t, 3, len(resp.Events))
@@ -297,7 +297,7 @@ func TestClient_Search(t *testing.T) {
 	searchMax = 5
 	req = &SearchRequest{Instance: c.Instance, ID: c.ByzCoin.ID}
 	resp, err = c.Search(req)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, 5, len(resp.Events))
 	require.True(t, resp.Truncated)
@@ -306,14 +306,14 @@ func TestClient_Search(t *testing.T) {
 	// Put one more event on now.
 	tm := time.Now().UnixNano()
 	_, err = c.Log(Event{Topic: "none", Content: "one more", When: tm})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	leader.waitForBlock(c.ByzCoin.ID)
 	leader.waitForBlock(c.ByzCoin.ID)
 
 	// Search from the last event, expect only it, not previous ones.
 	req = &SearchRequest{Instance: c.Instance, ID: c.ByzCoin.ID, From: tm}
 	resp, err = c.Search(req)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, 1, len(resp.Events))
 	require.False(t, resp.Truncated)
@@ -474,7 +474,7 @@ func checkProof(t *testing.T, omni *byzcoin.Service, key []byte, scID skipchain.
 		ID:      scID,
 	}
 	resp, err := omni.GetProof(req)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	p := resp.Proof
 	require.True(t, p.InclusionProof.Match(key), "proof of exclusion of index")
@@ -572,14 +572,14 @@ func newSer(t *testing.T) (*ser, *Client) {
 
 func (s *ser) getCurrentBlock(t *testing.T) skipchain.SkipBlockID {
 	reply, err := skipchain.NewClient().GetUpdateChain(s.roster, s.id)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	return reply.Update[len(reply.Update)-1].Hash
 }
 
 func (s *ser) waitNextBlock(t *testing.T, current skipchain.SkipBlockID) {
 	for i := 0; i < 10; i++ {
 		reply, err := skipchain.NewClient().GetUpdateChain(s.roster, s.id)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		if !current.Equal(reply.Update[len(reply.Update)-1].Hash) {
 			return
 		}

--- a/eventlog/api_test.go
+++ b/eventlog/api_test.go
@@ -439,8 +439,8 @@ func TestClient_StreamEventsFrom(t *testing.T) {
 	}
 
 	wg := sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
 		defer wg.Done()
 
 		require.NoError(t, c.StreamEventsFrom(h, c.ByzCoin.ID))

--- a/evoting/protocol/decrypt_test.go
+++ b/evoting/protocol/decrypt_test.go
@@ -103,7 +103,7 @@ func runDecrypt(t *testing.T, n int) {
 		ballots[i] = &lib.Ballot{User: uint32(i), Alpha: a, Beta: b}
 		tx = lib.NewTransaction(ballots[i], election.Creator)
 		err := lib.StoreUsingWebsocket(election.ID, election.Roster, tx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	mixes := make([]*lib.Mix, n)
@@ -122,7 +122,7 @@ func runDecrypt(t *testing.T, n int) {
 		}
 		tx = lib.NewTransaction(mix, election.Creator)
 		err := lib.StoreUsingWebsocket(election.ID, election.Roster, tx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		x, y = v, w
 	}
 
@@ -208,7 +208,7 @@ func TestDecryptNodeFailure(t *testing.T) {
 		mixes[i] = mix
 		tx = lib.NewTransaction(mix, election.Creator)
 		err := lib.StoreUsingWebsocket(election.ID, election.Roster, tx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		x, y = v, w
 	}
 

--- a/evoting/protocol/shuffle_test.go
+++ b/evoting/protocol/shuffle_test.go
@@ -166,7 +166,7 @@ func runShuffle(t *testing.T, n int) {
 
 	select {
 	case err := <-shuffle.Finished:
-		require.Nil(t, err)
+		require.NoError(t, err)
 		box, _ := election.Box(services[0].(*shuffleService).skipchain)
 		mixes, _ := election.Mixes(services[0].(*shuffleService).skipchain)
 

--- a/evoting/service/service_test.go
+++ b/evoting/service/service_test.go
@@ -74,7 +74,7 @@ func TestService(t *testing.T) {
 		Key:    nodeKP.Public,
 		Admins: []uint32{idAdmin},
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	idAdminSig := generateSignature(nodeKP.Private, replyLink.ID, idAdmin)
 
@@ -109,7 +109,7 @@ func TestService(t *testing.T) {
 		User:      idAdmin,
 		Signature: idAdminSig,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	elec.ID = replyOpen.ID
 
 	// Try to modify an election on another master chain.
@@ -190,7 +190,7 @@ func TestService(t *testing.T) {
 		User:      idUser1,
 		Signature: idUser1Sig,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, local.WaitDone(time.Second))
 
 	// Cast a vote with empty points
@@ -230,7 +230,7 @@ func TestService(t *testing.T) {
 			User:      user,
 			Signature: generateSignature(nodeKP.Private, replyLink.ID, user),
 		})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		return cast
 	}
 	// User votes
@@ -263,7 +263,7 @@ func TestService(t *testing.T) {
 		User:      idAdmin,
 		Signature: idAdminSig,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Decrypt on non-leader
 	log.Lvl1("Decrypting")
@@ -280,7 +280,7 @@ func TestService(t *testing.T) {
 		User:      idAdmin,
 		Signature: idAdminSig,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, local.WaitDone(time.Second))
 
 	// Reconstruct on non-leader
@@ -293,7 +293,7 @@ func TestService(t *testing.T) {
 	reconstructReply, err := s0.Reconstruct(&evoting.Reconstruct{
 		ID: replyOpen.ID,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	for _, p := range reconstructReply.Points {
 		log.Lvl2("Point is:", p.String())
@@ -314,7 +314,7 @@ func runAnElection(t *testing.T, local *onet.LocalTest, s *Service, replyLink *e
 		User:      admin,
 		Signature: adminSig,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, local.WaitDone(time.Second))
 
 	// Prepare a helper for testing voting.
@@ -331,7 +331,7 @@ func runAnElection(t *testing.T, local *onet.LocalTest, s *Service, replyLink *e
 			User:      user,
 			Signature: generateSignature(nodeKP.Private, replyLink.ID, user),
 		})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Nil(t, local.WaitDone(time.Second))
 		return cast
 	}
@@ -349,7 +349,7 @@ func runAnElection(t *testing.T, local *onet.LocalTest, s *Service, replyLink *e
 		User:      admin,
 		Signature: adminSig,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, local.WaitDone(time.Second))
 
 	// Decrypt all votes
@@ -359,7 +359,7 @@ func runAnElection(t *testing.T, local *onet.LocalTest, s *Service, replyLink *e
 		User:      admin,
 		Signature: adminSig,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, local.WaitDone(defaultTimeout))
 
 	// Reconstruct votes
@@ -367,7 +367,7 @@ func runAnElection(t *testing.T, local *onet.LocalTest, s *Service, replyLink *e
 	_, err = s.Reconstruct(&evoting.Reconstruct{
 		ID: replyOpen.ID,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, local.WaitDone(time.Second))
 }
 
@@ -393,7 +393,7 @@ func TestEvolveRoster(t *testing.T) {
 		Key:    nodeKP.Public,
 		Admins: []uint32{idAdmin},
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	log.Lvl2("Wrote 1st roster")
 
 	runAnElection(t, local, s0, rl, nodeKP, idAdmin)
@@ -426,7 +426,7 @@ func TestEvolveRoster(t *testing.T) {
 		Key:       nodeKP.Public,
 		Admins:    []uint32{idAdmin, idAdmin2},
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, local.WaitDone(time.Second))
 
 	// Run an election on the new set of conodes, the new nodeKP, and the new
@@ -452,7 +452,7 @@ func setupElection(t *testing.T, s0 *Service, rl *evoting.LinkReply, nodeKP *key
 		User:      idAdmin,
 		Signature: adminSig,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Prepare a helper for testing voting.
 	vote := func(user uint32, bufCand []byte) *evoting.CastReply {
@@ -468,7 +468,7 @@ func setupElection(t *testing.T, s0 *Service, rl *evoting.LinkReply, nodeKP *key
 			User:      user,
 			Signature: generateSignature(nodeKP.Private, rl.ID, user),
 		})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		return cast
 	}
 
@@ -502,7 +502,7 @@ func TestShuffleBenignNodeFailure(t *testing.T) {
 		Key:    nodeKP.Public,
 		Admins: []uint32{idAdmin},
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	log.Lvl2("Wrote the roster")
 
 	electionID := setupElection(t, s0, rl, nodeKP)
@@ -518,7 +518,7 @@ func TestShuffleBenignNodeFailure(t *testing.T) {
 		User:      idAdmin,
 		Signature: adminSig,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestShuffleCatastrophicNodeFailure(t *testing.T) {
@@ -548,7 +548,7 @@ func TestShuffleCatastrophicNodeFailure(t *testing.T) {
 		Key:    nodeKP.Public,
 		Admins: []uint32{idAdmin},
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	log.Lvl2("Wrote the roster")
 
 	electionID := setupElection(t, s0, rl, nodeKP)
@@ -556,22 +556,22 @@ func TestShuffleCatastrophicNodeFailure(t *testing.T) {
 
 	// Append two Mixes manually to simulate a shuffle gone bad
 	election, err := lib.GetElection(s0.skipchain, electionID, false, 0)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	genMix := func(ballots []*lib.Ballot, election *lib.Election, serverIdentity *network.ServerIdentity, private kyber.Scalar) *lib.Mix {
 		a, b := lib.Split(ballots)
 		g, d, prov := shuffle.Shuffle(cothority.Suite, nil, election.Key, a, b, random.New())
 		proof, err := proof.HashProve(cothority.Suite, "", prov)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		mix := &lib.Mix{
 			Ballots: lib.Combine(g, d),
 			Proof:   proof,
 			NodeID:  serverIdentity.ID,
 		}
 		data, err := serverIdentity.Public.MarshalBinary()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		sig, err := schnorr.Sign(cothority.Suite, private, data)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		mix.Signature = sig
 		return mix
 	}
@@ -581,11 +581,11 @@ func TestShuffleCatastrophicNodeFailure(t *testing.T) {
 	mix := genMix(box.Ballots, election, roster.Get(0), local.GetPrivate(nodes[0]))
 	tx := lib.NewTransaction(mix, idAdmin)
 	_, err = lib.Store(s0.skipchain, election.ID, tx, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	mix2 := genMix(mix.Ballots, election, roster.Get(1), local.GetPrivate(nodes[1]))
 	tx = lib.NewTransaction(mix2, idAdmin)
 	_, err = lib.Store(s0.skipchain, election.ID, tx, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Fail 3 nodes. New blocks cannot be added now because consensus cannot be reached.
 	nodes[2].Pause()
@@ -614,7 +614,7 @@ func TestShuffleCatastrophicNodeFailure(t *testing.T) {
 		User:      idAdmin,
 		Signature: adminSig,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestDecryptBenignNodeFailure(t *testing.T) {
@@ -639,7 +639,7 @@ func TestDecryptBenignNodeFailure(t *testing.T) {
 		Key:    nodeKP.Public,
 		Admins: []uint32{idAdmin},
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	log.Lvl2("Wrote the roster")
 
 	electionID := setupElection(t, s0, rl, nodeKP)
@@ -651,7 +651,7 @@ func TestDecryptBenignNodeFailure(t *testing.T) {
 		User:      idAdmin,
 		Signature: adminSig,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Close 2 Nodes
 	nodes[2].Close()
@@ -663,7 +663,7 @@ func TestDecryptBenignNodeFailure(t *testing.T) {
 		User:      idAdmin,
 		Signature: adminSig,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestDecryptCatastrophicNodeFailure(t *testing.T) {
@@ -693,7 +693,7 @@ func TestDecryptCatastrophicNodeFailure(t *testing.T) {
 		Key:    nodeKP.Public,
 		Admins: []uint32{idAdmin},
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	log.Lvl2("Wrote the roster")
 
 	electionID := setupElection(t, s0, rl, nodeKP)
@@ -705,7 +705,7 @@ func TestDecryptCatastrophicNodeFailure(t *testing.T) {
 		User:      idAdmin,
 		Signature: adminSig,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Fail 3 nodes
 	nodes[2].Pause()
@@ -735,7 +735,7 @@ func TestDecryptCatastrophicNodeFailure(t *testing.T) {
 		User:      idAdmin,
 		Signature: adminSig,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestCastNodeFailureShuffleAllOk(t *testing.T) {
@@ -760,7 +760,7 @@ func TestCastNodeFailureShuffleAllOk(t *testing.T) {
 		Key:    nodeKP.Public,
 		Admins: []uint32{idAdmin},
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	log.Lvl2("Wrote the roster")
 
 	adminSig := generateSignature(nodeKP.Private, rl.ID, idAdmin)
@@ -775,7 +775,7 @@ func TestCastNodeFailureShuffleAllOk(t *testing.T) {
 		User:      idAdmin,
 		Signature: adminSig,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Prepare a helper for testing voting.
 	vote := func(user uint32, bufCand []byte) *evoting.CastReply {
@@ -791,7 +791,7 @@ func TestCastNodeFailureShuffleAllOk(t *testing.T) {
 			User:      user,
 			Signature: generateSignature(nodeKP.Private, rl.ID, user),
 		})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		return cast
 	}
 
@@ -812,7 +812,7 @@ func TestCastNodeFailureShuffleAllOk(t *testing.T) {
 		User:      idAdmin,
 		Signature: adminSig,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestLookupSciper(t *testing.T) {

--- a/evoting/service/service_test.go
+++ b/evoting/service/service_test.go
@@ -284,13 +284,13 @@ func TestService(t *testing.T) {
 	require.Nil(t, local.WaitDone(time.Second))
 
 	// Reconstruct on non-leader
-	reconstructReply, err := s1.Reconstruct(&evoting.Reconstruct{
+	_, err = s1.Reconstruct(&evoting.Reconstruct{
 		ID: replyOpen.ID,
 	})
 	require.Equal(t, err, errOnlyLeader)
 
 	// Reconstruct votes
-	reconstructReply, err = s0.Reconstruct(&evoting.Reconstruct{
+	reconstructReply, err := s0.Reconstruct(&evoting.Reconstruct{
 		ID: replyOpen.ID,
 	})
 	require.Nil(t, err)
@@ -577,6 +577,7 @@ func TestShuffleCatastrophicNodeFailure(t *testing.T) {
 	}
 
 	box, err := election.Box(s0.skipchain)
+	require.NoError(t, err)
 	mix := genMix(box.Ballots, election, roster.Get(0), local.GetPrivate(nodes[0]))
 	tx := lib.NewTransaction(mix, idAdmin)
 	_, err = lib.Store(s0.skipchain, election.ID, tx, nil)

--- a/ftcosi/protocol/protocol_test.go
+++ b/ftcosi/protocol/protocol_test.go
@@ -93,12 +93,8 @@ func TestProtocol(t *testing.T) {
 
 			// get and verify signature
 			_, err = getAndVerifySignature(cosiProtocol, publics, proposal, cosi.CompletePolicy{})
-			if err != nil {
-				local.CloseAll()
-				t.Fatal(err)
-			}
-
 			local.CloseAll()
+			require.NoError(t, err)
 		}
 	}
 }
@@ -531,8 +527,5 @@ func refuse(n *onet.TreeNodeInstance, msg, data []byte) bool {
 	counter.Lock()
 	defer counter.Unlock()
 	defer func() { counter.veriCount++ }()
-	if n.TreeNode().RosterIndex == counter.refuseIdx {
-		return false
-	}
-	return true
+	return n.TreeNode().RosterIndex != counter.refuseIdx
 }

--- a/ftcosi/protocol/protocol_test.go
+++ b/ftcosi/protocol/protocol_test.go
@@ -146,7 +146,7 @@ func TestProtocolQuickAnswer(t *testing.T) {
 			}
 
 			mask, err := cosi.NewMask(testSuite, publics, nil)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			lenRes := testSuite.PointLen() + testSuite.ScalarLen()
 			mask.SetMask(sig[lenRes:])
 			// Test that we have less than nNodes signatures

--- a/ftcosi/service/ftcosi_test.go
+++ b/ftcosi/service/ftcosi_test.go
@@ -34,10 +34,10 @@ func TestServiceCosi(t *testing.T) {
 		reply := &SignatureResponse{}
 		log.Lvl1("Sending request to service...")
 		err := client.SendProtobuf(dst, serviceReq, reply)
-		require.Nil(t, err, "Couldn't send")
+		require.NoError(t, err, "Couldn't send")
 
 		// verify the response still
-		require.Nil(t, cosi.Verify(tSuite, roster.Publics(), msg, reply.Signature, cosi.CompletePolicy{}))
+		require.NoError(t, cosi.Verify(tSuite, roster.Publics(), msg, reply.Signature, cosi.CompletePolicy{}))
 	}
 }
 
@@ -55,12 +55,12 @@ func TestCreateAggregate(t *testing.T) {
 
 	el1 := &onet.Roster{}
 	_, err := client.SignatureRequest(el1, msg)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	// Create a roster with a missing aggregate and ID.
 	el2 := &onet.Roster{List: roster.List}
 	res, err := client.SignatureRequest(el2, msg)
-	require.Nil(t, err, "Couldn't send")
+	require.NoError(t, err, "Couldn't send")
 
 	// verify the response still
-	require.Nil(t, cosi.Verify(tSuite, roster.Publics(), msg, res.Signature, cosi.CompletePolicy{}))
+	require.NoError(t, cosi.Verify(tSuite, roster.Publics(), msg, res.Signature, cosi.CompletePolicy{}))
 }

--- a/messaging/propagate_test.go
+++ b/messaging/propagate_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
@@ -54,19 +56,19 @@ func propagate(t *testing.T, nbrNodes, nbrFailures []int) {
 					t.Error("Didn't receive correct data")
 					return errors.New("Didn't receive correct data")
 				}, nbrFailures[i])
-			log.ErrFatal(err)
+			require.NoError(t, err)
 		}
 
 		// shut down some servers to simulate failure
 		for k := 0; k < nbrFailures[i]; k++ {
 			err = servers[len(servers)-1-k].Close()
-			log.ErrFatal(err)
+			require.NoError(t, err)
 		}
 
 		// start the propagation
 		log.Lvl2("Starting to propagate", reflect.TypeOf(msg))
 		children, err := propFuncs[0](el, msg, 1*time.Second)
-		log.ErrFatal(err)
+		require.NoError(t, err)
 		if recvCount+nbrFailures[i] != n {
 			t.Fatal("Didn't get data-request")
 		}

--- a/personhood/contracts/contract_credential_test.go
+++ b/personhood/contracts/contract_credential_test.go
@@ -23,5 +23,6 @@ func TestContractCredential_Spawn(t *testing.T) {
 	require.Equal(t, 1, len(scs))
 	cred2 := CredentialStruct{}
 	err = protobuf.Decode(scs[0].Value, &cred2)
+	require.NoError(t, err)
 	require.Equal(t, cred, cred2)
 }

--- a/personhood/contracts/contract_popparty_test.go
+++ b/personhood/contracts/contract_popparty_test.go
@@ -31,5 +31,6 @@ func TestContractPopParty(t *testing.T) {
 	require.Equal(t, 1, len(scs))
 	pps := PopPartyStruct{}
 	err = protobuf.Decode(scs[0].Value, &pps)
+	require.NoError(t, err)
 	require.Equal(t, desc, pps.Description)
 }

--- a/personhood/contracts/contract_ropasci_test.go
+++ b/personhood/contracts/contract_ropasci_test.go
@@ -10,7 +10,6 @@ import (
 	"go.dedis.ch/cothority/v3/calypso"
 
 	"go.dedis.ch/kyber/v3/util/random"
-	"golang.org/x/xerrors"
 
 	"go.dedis.ch/protobuf"
 
@@ -36,8 +35,7 @@ func TestContractRoPaSci(t *testing.T) {
 		for move2 := 0; move2 <= 2; move2++ {
 			cRPS := &ContractRoPaSci{}
 			// Creates
-			tr, err := newTestRPS(rost, move1, 100)
-			require.NoError(t, err)
+			tr := newTestRPS(t, rost, move1, 100)
 			coin1expected := tr.initial - tr.stake
 			coin2expected := tr.initial - tr.stake
 
@@ -97,8 +95,7 @@ func TestContractRoPaSciCalypso(t *testing.T) {
 		for move2 := 0; move2 <= 2; move2++ {
 			cRPS := &ContractRoPaSci{}
 			// Creates
-			tr, err := newTestRPS(rost, move1, 100)
-			require.NoError(t, err)
+			tr := newTestRPS(t, rost, move1, 100)
 			coin1expected := tr.initial - tr.stake
 			coin2expected := tr.initial - tr.stake
 
@@ -172,29 +169,20 @@ type testRPS struct {
 }
 
 // newTestRPS creates a new test-structure for RoPaSci games, including an LTS.
-func newTestRPS(s *rstSimul, firstMove int, stake uint64) (tr testRPS,
-	err error) {
+func newTestRPS(t *testing.T, s *rstSimul, firstMove int, stake uint64) (tr testRPS) {
+	var err error
+
 	tr.initial = 1e6
 	tr.coin1, err = s.createCoin("RoPaSci", tr.initial)
-	if err != nil {
-		err = xerrors.Errorf("couldn't create 1st coin: %+v", err)
-	}
+	require.NoError(t, err, "couldn't create 1st coin")
 	tr.coin2, err = s.createCoin("RoPaSci", tr.initial)
-	if err != nil {
-		err = xerrors.Errorf("couldn't create 2nd coin: %+v", err)
-	}
+	require.NoError(t, err, "couldn't create 2nd coin")
 	tr.firstMove = firstMove
 	tr.stake = stake
 	_, tr.stakeCoin1, err = s.withdrawCoin(tr.coin1, stake)
-	if err != nil {
-		err = xerrors.Errorf("couldn't withdraw stake 1: %+v", err)
-		return
-	}
+	require.NoError(t, err, "couldn't withdraw stake 1")
 	_, tr.stakeCoin2, err = s.withdrawCoin(tr.coin2, stake)
-	if err != nil {
-		err = xerrors.Errorf("couldn't withdraw stake 2: %+v", err)
-		return
-	}
+	require.NoError(t, err, "couldn't withdraw stake 2")
 	// Only take 28 random bytes so that it also fits into the calypsoWrite
 	tr.prehash = append([]byte{byte(firstMove)},
 		random.Bits(27*8, true, random.New())...)

--- a/personhood/contracts/contract_test.go
+++ b/personhood/contracts/contract_test.go
@@ -120,7 +120,7 @@ func (s *rstSimul) setCoin(id byzcoin.InstanceID, value uint64) error {
 	coin.Value = value
 	coinBuf, err := protobuf.Encode(&coin)
 	if err != nil {
-		err = xerrors.Errorf("couldn't encode coin: %+v", err)
+		return xerrors.Errorf("couldn't encode coin: %+v", err)
 	}
 	s.values[string(id[:])] = byzcoin.StateChangeBody{
 		StateAction: byzcoin.Update,
@@ -141,8 +141,9 @@ func (s *rstSimul) getCoin(id byzcoin.InstanceID) (coin byzcoin.Coin, err error)
 	if sc.ContractID != contracts.ContractCoinID {
 		err = xerrors.Errorf("id doesn't point to a coin, but to '%s'",
 			sc.ContractID)
+		return
 	}
-	if err := protobuf.Decode(sc.Value, &coin); err != nil {
+	if err = protobuf.Decode(sc.Value, &coin); err != nil {
 		err = xerrors.Errorf("couldn't decode coin: %+v", err)
 	}
 	return

--- a/skipchain/api_test.go
+++ b/skipchain/api_test.go
@@ -109,7 +109,7 @@ func TestClient_GetUpdateChain(t *testing.T) {
 	var err error
 	sbs[0], err = makeGenesisRosterArgs(s, onet.NewRoster(roster.List[0:2]),
 		nil, VerificationNone, 2, 3)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 
 	log.Lvl1("Initialize skipchain.")
 
@@ -351,10 +351,10 @@ func TestClient_GetSingleBlockByIndex(t *testing.T) {
 	blocks := make([]*SkipBlock, nbrBlocks)
 	var err error
 	blocks[0], err = c.CreateGenesis(roster, 2, 4, VerificationNone, nil)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	for i := 1; i < nbrBlocks; i++ {
 		reply, err := c.StoreSkipBlock(blocks[0], roster, nil)
-		log.ErrFatal(err)
+		require.NoError(t, err)
 		blocks[i] = reply.Latest
 	}
 
@@ -367,7 +367,7 @@ func TestClient_GetSingleBlockByIndex(t *testing.T) {
 	// 0
 	sb1 := blocks[0]
 	search, err := c.GetSingleBlockByIndex(roster, sb1.Hash, 0)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	require.True(t, sb1.Equal(search.SkipBlock))
 	require.Equal(t, links[0], len(search.Links))
 	require.True(t, sb1.SkipChainID().Equal(search.Links[0].To))
@@ -377,7 +377,7 @@ func TestClient_GetSingleBlockByIndex(t *testing.T) {
 	for i := 1; i < nbrBlocks; i++ {
 		log.Lvl1("Creating new block", i)
 		search, err = c.GetSingleBlockByIndex(roster, sb1.SkipChainID(), i)
-		log.ErrFatal(err)
+		require.NoError(t, err)
 		require.True(t, blocks[i].Hash.Equal(search.SkipBlock.Hash))
 		require.Equal(t, links[i], len(search.Links))
 		for _, link := range search.Links[1:] {

--- a/skipchain/api_test.go
+++ b/skipchain/api_test.go
@@ -30,11 +30,11 @@ func TestClient_CreateGenesis(t *testing.T) {
 	defer l.CloseAll()
 	c := newTestClient(l)
 	_, err := c.CreateGenesis(roster, 1, 1, VerificationNone, []byte{1, 2, 3})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, err = c.CreateGenesis(roster, 1, 0, VerificationNone, &testData{})
 	require.NotNil(t, err)
 	_, err = c.CreateGenesis(roster, 1, 1, VerificationNone, &testData{})
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestClient_CreateGenesisCorrupted(t *testing.T) {
@@ -119,14 +119,14 @@ func TestClient_GetUpdateChain(t *testing.T) {
 		service := local.Services[servers[i].ServerIdentity.ID][skipchainSID].(*Service)
 		log.Lvl2("Storing skipblock", i, servers[i].ServerIdentity, newSB.Roster.List)
 		reply, err := service.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: sbs[i-1].Hash, NewBlock: newSB})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, reply.Latest)
 		sbs[i] = reply.Latest
 	}
 
 	for i := 0; i < sbCount; i++ {
 		sbc, err := c.GetUpdateChain(sbs[i].Roster, sbs[i].Hash)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.True(t, len(sbc.Update) > 0, "Empty update-chain")
 		if !sbc.Update[0].Equal(sbs[i]) {
@@ -237,7 +237,7 @@ func TestClient_StoreSkipBlockCorrupted(t *testing.T) {
 	service.StoreSkipBlockReply = &StoreSkipBlockReply{}
 
 	_, err := c.StoreSkipBlock(genesis, ro, []byte{})
-	require.Nil(t, err) // empty reply
+	require.NoError(t, err) // empty reply
 
 	service.StoreSkipBlockReply.Previous = NewSkipBlock()
 	_, err = c.StoreSkipBlock(genesis, ro, []byte{})
@@ -260,14 +260,14 @@ func TestClient_GetAllSkipchains(t *testing.T) {
 	c := newTestClient(l)
 	log.Lvl1("Creating chain with one extra block")
 	sb1, err := c.CreateGenesis(ro, 1, 1, VerificationNone, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	r, err := c.StoreSkipBlock(sb1, ro, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, r.Latest.Index)
 
 	// See if it works with only one chain in the system?
 	sbs, err := c.GetAllSkipchains(ro.List[0])
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Expect 2 blocks here because GetAllSkipchains is broken and actually
 	// returns all the blocks.
@@ -285,20 +285,20 @@ func TestClient_GetAllSkipChainIDs(t *testing.T) {
 
 	log.Lvl1("Creating chain 1 with one extra block")
 	sb1, err := c.CreateGenesis(ro, 1, 1, VerificationNone, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	r1, err := c.StoreSkipBlock(sb1, ro, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, r1.Latest.Index)
 
 	log.Lvl1("Creating chain 2 with one extra block")
 	sb2, err := c.CreateGenesis(ro, 1, 1, VerificationNone, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	r2, err := c.StoreSkipBlock(sb2, ro, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, r2.Latest.Index)
 
 	reply, err := c.GetAllSkipChainIDs(ro.List[0])
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 2, len(reply.IDs))
 
 	// We don't know what order they come back out, but they both have to be there.
@@ -324,7 +324,7 @@ func TestClient_GetSingleBlock(t *testing.T) {
 	service.SkipBlock = sb
 
 	ret, err := c.GetSingleBlock(ro, sb.Hash)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, ret.Hash, sb.Hash)
 
 	service.SkipBlock = NewSkipBlock()
@@ -433,7 +433,7 @@ func TestClient_CreateLinkPrivate(t *testing.T) {
 	defer ls.local.CloseAll()
 	require.Equal(t, 0, len(ls.service.Storage.Clients))
 	err := ls.client.CreateLinkPrivate(ls.server.ServerIdentity, ls.servPriv, ls.pub)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestClient_SettingAuthentication(t *testing.T) {
@@ -441,7 +441,7 @@ func TestClient_SettingAuthentication(t *testing.T) {
 	defer ls.local.CloseAll()
 	require.Equal(t, 0, len(ls.service.Storage.Clients))
 	err := ls.client.CreateLinkPrivate(ls.si, ls.servPriv, ls.pub)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(ls.service.Storage.Clients))
 }
 
@@ -451,13 +451,13 @@ func TestClient_Follow(t *testing.T) {
 	require.Equal(t, 0, len(ls.service.Storage.Clients))
 	priv0 := ls.servPriv
 	err := ls.client.CreateLinkPrivate(ls.si, priv0, ls.pub)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	priv1 := ls.local.GetPrivate(ls.servers[1])
 	err = ls.client.CreateLinkPrivate(ls.roster.List[1], priv1, ls.servers[1].ServerIdentity.Public)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	priv2 := ls.local.GetPrivate(ls.servers[2])
 	err = ls.client.CreateLinkPrivate(ls.roster.List[2], priv2, ls.servers[2].ServerIdentity.Public)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	log.Lvl1(ls.roster)
 
 	// Verify that server1 doesn't allow a new skipchain using server0 and server1
@@ -467,18 +467,18 @@ func TestClient_Follow(t *testing.T) {
 
 	roster0 := onet.NewRoster([]*network.ServerIdentity{ls.si})
 	genesis, err := ls.client.CreateGenesisSignature(roster0, 1, 1, VerificationNone, nil, priv0)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Now server1 follows skipchain from server0, so it should allow a new skipblock,
 	// but not a new skipchain
 	log.Lvl1("(0) Following skipchain-id only")
 	err = ls.client.AddFollow(ls.roster.List[1], priv1, genesis.SkipChainID(),
 		FollowID, NewChainStrictNodes, "")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	block1, err := ls.client.StoreSkipBlockSignature(genesis, roster01, nil, priv0)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	genesis1, err := ls.client.CreateGenesisSignature(roster01, 1, 1, VerificationNone, nil, priv0)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, err = ls.client.StoreSkipBlockSignature(genesis1, roster01, nil, priv0)
 	require.NotNil(t, err)
 
@@ -487,13 +487,13 @@ func TestClient_Follow(t *testing.T) {
 	log.Lvl1("(1) Following roster of skipchain")
 	err = ls.client.AddFollow(ls.roster.List[1], priv1, genesis.SkipChainID(),
 		FollowSearch, NewChainStrictNodes, "")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	block2, err := ls.client.StoreSkipBlockSignature(block1.Latest, roster01, nil, priv0)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	genesis2, err := ls.client.CreateGenesisSignature(roster01, 1, 1, VerificationNone, nil, priv0)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, err = ls.client.StoreSkipBlockSignature(genesis2, roster01, nil, priv0)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Finally test with third server
 	log.Lvl1("(1) Following skipchain-id only on server2")
@@ -503,11 +503,11 @@ func TestClient_Follow(t *testing.T) {
 	log.Lvl1("(2) Following skipchain-id only on server2")
 	err = ls.client.AddFollow(ls.roster.List[2], priv2, genesis.SkipChainID(),
 		FollowLookup, NewChainStrictNodes, ls.server.Address().NetworkAddress())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, err = ls.client.StoreSkipBlockSignature(block2.Latest, ls.roster, nil, priv0)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, err = ls.client.CreateGenesisSignature(ls.roster, 1, 1, VerificationNone, nil, priv0)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestClient_DelFollow(t *testing.T) {
@@ -515,14 +515,14 @@ func TestClient_DelFollow(t *testing.T) {
 	defer ls.local.CloseAll()
 
 	sb, err := ls.client.CreateGenesis(ls.roster, 1, 1, VerificationNone, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = ls.client.AddFollow(ls.server.ServerIdentity, ls.priv, sb.SkipChainID(),
 		FollowID, NewChainNone, "")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(ls.service.Storage.FollowIDs))
 
 	err = ls.client.DelFollow(ls.server.ServerIdentity, ls.priv, sb.SkipChainID())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 0, len(ls.service.Storage.FollowIDs))
 }
 
@@ -531,18 +531,18 @@ func TestClient_ListFollow(t *testing.T) {
 	defer ls.local.CloseAll()
 
 	sb1, err := ls.client.CreateGenesis(ls.roster, 1, 1, VerificationNone, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = ls.client.AddFollow(ls.server.ServerIdentity, ls.priv, sb1.SkipChainID(),
 		FollowID, NewChainNone, "")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	sb2, err := ls.client.CreateGenesis(ls.roster, 1, 1, VerificationNone, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = ls.client.AddFollow(ls.server.ServerIdentity, ls.priv, sb2.SkipChainID(),
 		FollowLookup, NewChainNone, ls.server.ServerIdentity.Address.NetworkAddress())
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	list, err := ls.client.ListFollow(ls.server.ServerIdentity, ls.priv)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(*list.Follow))
 	require.Equal(t, 1, len(*list.FollowIDs))
 }
@@ -601,7 +601,7 @@ func TestClient_ParallelWrite(t *testing.T) {
 	cl := newTestClient(l)
 	msg := []byte("genesis")
 	gen, err := cl.CreateGenesis(ro, 2, 10, VerificationStandard, msg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	s := l.Services[svrs[0].ServerIdentity.ID][sid].(*Service)
 
@@ -615,7 +615,7 @@ func TestClient_ParallelWrite(t *testing.T) {
 
 			for j := 0; j < numWrites; j++ {
 				_, err := cl.StoreSkipBlock(gen, nil, msg)
-				require.Nil(t, err)
+				require.NoError(t, err)
 			}
 			wg.Done()
 		}(i)
@@ -629,7 +629,7 @@ func TestClient_ParallelWrite(t *testing.T) {
 
 	// Read the chain back, check it.
 	reply, err := cl.GetUpdateChain(ro, gen.SkipChainID())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	for i, sb := range reply.Update {
 		if i == 0 {
 			require.True(t, sb.SkipChainID().Equal(gen.Hash))

--- a/skipchain/long_test.go
+++ b/skipchain/long_test.go
@@ -80,14 +80,14 @@ func TestClient_ParallelGetUpdateChain(t *testing.T) {
 		clients[i] = newTestClient(l)
 	}
 	sb, err := clients[0].CreateGenesis(ro, 32, 32, VerificationStandard, []byte{})
-	log.ErrFatal(err)
+	require.NoError(t, err)
 
 	wg := sync.WaitGroup{}
 	for i := range [128]byte{} {
 		wg.Add(1)
 		go func(i int) {
 			_, err := clients[i%8].GetUpdateChain(sb.Roster, sb.Hash)
-			log.ErrFatal(err)
+			require.NoError(t, err)
 			wg.Done()
 		}(i)
 	}

--- a/skipchain/protocol_test.go
+++ b/skipchain/protocol_test.go
@@ -183,7 +183,7 @@ func testER(t *testing.T, tsid onet.ServiceID, nbrNodes int) {
 	// we should be able to proceed because skipchain is fault tolerant
 	if nbrNodes > 4 {
 		local = onet.NewLocalTest(cothority.Suite)
-		servers, roster, tree = local.GenBigTree(nbrNodes, nbrNodes, nbrNodes, true)
+		servers, _, tree = local.GenBigTree(nbrNodes, nbrNodes, nbrNodes, true)
 		tss = local.GetServices(servers, tsid)
 		for i := 3; i < nbrNodes; i++ {
 			log.Lvl2("Checking failing signature at", i)

--- a/skipchain/protocol_test.go
+++ b/skipchain/protocol_test.go
@@ -79,9 +79,9 @@ func TestGB(t *testing.T) {
 	ts2.Db = NewSkipBlockDB(db, bucket)
 	blocks := []*SkipBlock{sb0, sb1, sb2, sb3}
 	_, err := ts0.Db.StoreBlocks(blocks)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, err = ts1.Db.StoreBlocks(blocks)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	// do not save anything into ts2 so that
 	// it is totally out of date, and cannot answer anything
 

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -59,7 +59,7 @@ func storeSkipBlock(t *testing.T, nbrServers int, fail bool) {
 
 	// Setting up root roster
 	sbRoot, err := makeGenesisRoster(service, el)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	// make sure the correct default signature scheme is set to BDN
 	assert.Equal(t, BdnSignatureSchemeIndex, sbRoot.SignatureScheme)
 
@@ -235,7 +235,7 @@ func TestService_MultiLevel(t *testing.T) {
 			log.Lvl1("Making genesis for", base, maxHeight)
 			sbRoot, err := makeGenesisRosterArgs(service, ro, nil, VerificationNone,
 				base, maxHeight)
-			log.ErrFatal(err)
+			require.NoError(t, err)
 			latest := sbRoot
 			log.Lvl1("Adding blocks for", base, maxHeight)
 			for sbi := 1; sbi < 10; sbi++ {
@@ -243,14 +243,14 @@ func TestService_MultiLevel(t *testing.T) {
 				sb := NewSkipBlock()
 				sb.Roster = ro
 				psbr, err := service.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: latest.Hash, NewBlock: sb})
-				log.ErrFatal(err)
+				require.NoError(t, err)
 				latest = psbr.Latest
 				for n, i := range sb.BackLinkIDs {
 					for ns, s := range services {
 						for {
 							log.Lvl3("Checking backlink", n, ns)
 							bl, err := s.GetSingleBlock(&GetSingleBlock{i})
-							log.ErrFatal(err)
+							require.NoError(t, err)
 							if len(bl.ForwardLink) == n+1 &&
 								bl.ForwardLink[n].To.Equal(sb.Hash) {
 								break
@@ -276,7 +276,7 @@ func TestService_Verification(t *testing.T) {
 
 	elRoot := onet.NewRoster(el.List[0:3])
 	sbRoot, err := makeGenesisRoster(service, elRoot)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 
 	log.Lvl1("Creating non-conforming skipBlock")
 	sb := NewSkipBlock()
@@ -300,12 +300,12 @@ func TestService_Verification(t *testing.T) {
 
 	log.Lvl1("Creating skipblock with same Roster as root")
 	sbInter, err := makeGenesisRosterArgs(service, elRoot, sbRoot.Hash, sb.VerifierIDs, 1, 1)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	require.NotNil(t, sbInter)
 	log.Lvl1("Creating skipblock with sub-Roster from root")
 	elSub := onet.NewRoster(el.List[0:2])
 	_, err = makeGenesisRosterArgs(service, elSub, sbRoot.Hash, sb.VerifierIDs, 1, 1)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 }
 
 func TestService_SignBlock(t *testing.T) {
@@ -317,12 +317,12 @@ func TestService_SignBlock(t *testing.T) {
 	service := genService.(*Service)
 
 	sbRoot, err := makeGenesisRosterArgs(service, el, nil, VerificationNone, 1, 1)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	el2 := onet.NewRoster(el.List[0:2])
 	sb := NewSkipBlock()
 	sb.Roster = el2
 	reply, err := service.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: sbRoot.Hash, NewBlock: sb})
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	sbRoot = reply.Previous
 	sbSecond := reply.Latest
 	log.Lvl1("Verifying signatures")
@@ -348,11 +348,11 @@ func TestService_ProtocolVerification(t *testing.T) {
 	}
 
 	sbRoot, err := makeGenesisRosterArgs(s1, el, nil, []VerifierID{verifyID}, 1, 1)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	sbNext := sbRoot.Copy()
 	sbNext.BackLinkIDs = []SkipBlockID{sbRoot.Hash}
 	_, err = s1.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: sbRoot.Hash, NewBlock: sbNext})
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	for i := 0; i < 3; i++ {
 		select {
 		case <-count:
@@ -406,7 +406,7 @@ func TestService_RegisterVerification(t *testing.T) {
 		log.ErrFatal(s.registerVerification(VerifyTest, verifier))
 	}
 	sb, err := makeGenesisRosterArgs(s1, el, nil, []VerifierID{VerifyTest}, 1, 1)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	require.NotNil(t, sb.Data)
 	require.Equal(t, 0, len(ver))
 	_, err = s1.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: sb.Hash, NewBlock: sb})
@@ -414,7 +414,7 @@ func TestService_RegisterVerification(t *testing.T) {
 	require.Equal(t, 3, len(ver))
 
 	sb, err = makeGenesisRosterArgs(s1, el, nil, []VerifierID{ServiceVerifier}, 1, 1)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	require.NotNil(t, sb.Data)
 	require.Equal(t, 0, len(ServiceVerifierChan))
 	_, err = s1.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: sb.Hash, NewBlock: sb})
@@ -504,7 +504,7 @@ func TestService_StoreSkipBlockSpeed(t *testing.T) {
 		},
 	}
 	ssbrep, err := s1.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: nil, NewBlock: sbRoot})
-	log.ErrFatal(err)
+	require.NoError(t, err)
 
 	last := time.Now()
 	for i := 0; i < 500; i++ {
@@ -513,7 +513,7 @@ func TestService_StoreSkipBlockSpeed(t *testing.T) {
 		last = now
 		ssbrep, err = s1.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: ssbrep.Latest.Hash,
 			NewBlock: sbRoot})
-		log.ErrFatal(err)
+		require.NoError(t, err)
 	}
 }
 
@@ -578,7 +578,7 @@ func TestService_ParallelGUC(t *testing.T) {
 		},
 	}
 	ssbrep, err := s1.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: nil, NewBlock: sbRoot})
-	log.ErrFatal(err)
+	require.NoError(t, err)
 
 	wg := &sync.WaitGroup{}
 	wg.Add(nbrRoutines)
@@ -671,7 +671,7 @@ func TestService_Propagation(t *testing.T) {
 	firstFiveRoster := onet.NewRoster(fullRoster.List[:5])
 	sbRoot, err := makeGenesisRosterArgs(service, firstFiveRoster, nil, VerificationNone,
 		3, 3)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	require.NotNil(t, sbRoot)
 
 	k := 9
@@ -685,7 +685,7 @@ func TestService_Propagation(t *testing.T) {
 		}
 
 		ssbr, err := service.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: sbRoot.Hash, NewBlock: sb})
-		log.ErrFatal(err)
+		require.NoError(t, err)
 
 		blocks[i] = ssbr.Latest
 	}
@@ -801,7 +801,7 @@ func TestService_AddFollow(t *testing.T) {
 	priv0 := local.GetPrivate(servers[0])
 	priv1 := local.GetPrivate(servers[1])
 	sig, err := schnorr.Sign(cothority.Suite, priv1, ssb.NewBlock.CalculateHash())
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	ssb.Signature = &sig
 	_, err = service.StoreSkipBlock(ssb)
 	require.NotNil(t, err)
@@ -809,10 +809,10 @@ func TestService_AddFollow(t *testing.T) {
 	// Correct server signature
 	log.Lvl2("correct server signature")
 	sig, err = schnorr.Sign(cothority.Suite, priv0, ssb.NewBlock.CalculateHash())
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	ssb.Signature = &sig
 	master0, err := service.StoreSkipBlock(ssb)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 
 	// Not fully authenticated roster
 	log.Lvl2("2nd roster is not registered")
@@ -822,7 +822,7 @@ func TestService_AddFollow(t *testing.T) {
 	ssb.NewBlock = sb
 	sb.Roster = onet.NewRoster([]*network.ServerIdentity{ro.List[0], ro.List[1]}) // two in roster
 	sig, err = schnorr.Sign(cothority.Suite, priv0, ssb.NewBlock.CalculateHash())
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	ssb.Signature = &sig
 	require.Equal(t, 0, services[1].db.Length())
 	_, err = service.StoreSkipBlock(ssb)
@@ -837,10 +837,10 @@ func TestService_AddFollow(t *testing.T) {
 		closing:  make(chan bool),
 	}}
 	sig, err = schnorr.Sign(cothority.Suite, priv0, ssb.NewBlock.CalculateHash())
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	ssb.Signature = &sig
 	master1, err := service.StoreSkipBlock(ssb)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 
 	// update skipblock and follow the skipblock
 	log.Lvl2("3 node signing with block update")
@@ -855,15 +855,15 @@ func TestService_AddFollow(t *testing.T) {
 	ssb.NewBlock = sb
 	ssb.TargetSkipChainID = master1.Latest.Hash
 	sig, err = schnorr.Sign(cothority.Suite, priv1, ssb.NewBlock.CalculateHash())
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	ssb.Signature = &sig
 	sbs, err := service.db.getAll()
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	for _, sb := range sbs {
 		services[1].db.Store(sb)
 	}
 	master2, err := services[1].StoreSkipBlock(ssb)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	require.True(t, services[1].db.GetByID(master1.Latest.Hash).ForwardLink[0].To.Equal(master2.Latest.Hash))
 }
 
@@ -876,19 +876,19 @@ func TestService_CreateLinkPrivate(t *testing.T) {
 	service := local.GetServices(servers, skipchainSID)[0].(*Service)
 	require.Equal(t, 0, len(service.Storage.Clients))
 	links, err := service.Listlink(&Listlink{})
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	require.Equal(t, 0, len(links.Publics))
 	_, err = service.CreateLinkPrivate(&CreateLinkPrivate{Public: servers[0].ServerIdentity.Public, Signature: []byte{}})
 	require.NotNil(t, err)
 	msg, err := server.ServerIdentity.Public.MarshalBinary()
 	require.NoError(t, err)
 	sig, err := schnorr.Sign(cothority.Suite, local.GetPrivate(servers[0]), msg)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	_, err = service.CreateLinkPrivate(&CreateLinkPrivate{Public: servers[0].ServerIdentity.Public, Signature: sig})
-	log.ErrFatal(err)
+	require.NoError(t, err)
 
 	links, err = service.Listlink(&Listlink{})
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(links.Publics))
 }
 
@@ -903,9 +903,9 @@ func TestService_Unlink(t *testing.T) {
 	kp := key.NewKeyPair(cothority.Suite)
 	msg, _ := kp.Public.MarshalBinary()
 	sig, err := schnorr.Sign(cothority.Suite, local.GetPrivate(servers[0]), msg)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	_, err = service.CreateLinkPrivate(&CreateLinkPrivate{Public: kp.Public, Signature: sig})
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(service.Storage.Clients))
 
 	// Wrong signature and wrong public key
@@ -967,13 +967,13 @@ func TestService_DelFollow(t *testing.T) {
 
 	// Test wrong signature
 	sig, err := schnorr.Sign(cothority.Suite, privWrong, msg)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	_, err = service.DelFollow(&DelFollow{SkipchainID: iddel, Signature: sig})
 	require.NotNil(t, err)
 	require.Equal(t, 2, len(service.Storage.FollowIDs))
 
 	sig, err = schnorr.Sign(cothority.Suite, priv, msg)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	_, err = service.DelFollow(&DelFollow{SkipchainID: iddel, Signature: sig})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(service.Storage.FollowIDs))
@@ -982,7 +982,7 @@ func TestService_DelFollow(t *testing.T) {
 	iddel = []byte{2}
 	msg = append([]byte("delfollow:"), iddel...)
 	sig, err = schnorr.Sign(cothority.Suite, priv, msg)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	_, err = service.DelFollow(&DelFollow{SkipchainID: iddel, Signature: sig})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(service.Storage.Follow))
@@ -999,18 +999,18 @@ func TestService_ListFollow(t *testing.T) {
 
 	// Check wrong signature
 	msg, err := servers[1].ServerIdentity.Public.MarshalBinary()
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	msg = append([]byte("listfollow:"), msg...)
 	sig, err := schnorr.Sign(cothority.Suite, priv, msg)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	_, err = service.ListFollow(&ListFollow{Signature: sig})
 	require.NotNil(t, err)
 
 	msg, err = servers[0].ServerIdentity.Public.MarshalBinary()
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	msg = append([]byte("listfollow:"), msg...)
 	sig, err = schnorr.Sign(cothority.Suite, priv, msg)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	lf, err := service.ListFollow(&ListFollow{Signature: sig})
 	require.NoError(t, err)
 	require.Equal(t, 2, len(*lf.Follow))

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -137,7 +137,7 @@ func storeSkipBlock(t *testing.T, nbrServers int, fail bool) {
 	// link included.
 	for {
 		gucr, err := service.GetUpdateChain(&GetUpdateChain{LatestID: genesis.Hash})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		if len(gucr.Update) == 2 {
 			break
 		}
@@ -410,7 +410,7 @@ func TestService_RegisterVerification(t *testing.T) {
 	require.NotNil(t, sb.Data)
 	require.Equal(t, 0, len(ver))
 	_, err = s1.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: sb.Hash, NewBlock: sb})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 3, len(ver))
 
 	sb, err = makeGenesisRosterArgs(s1, el, nil, []VerifierID{ServiceVerifier}, 1, 1)
@@ -418,7 +418,7 @@ func TestService_RegisterVerification(t *testing.T) {
 	require.NotNil(t, sb.Data)
 	require.Equal(t, 0, len(ServiceVerifierChan))
 	_, err = s1.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: sb.Hash, NewBlock: sb})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 3, len(ServiceVerifierChan))
 }
 
@@ -463,7 +463,7 @@ func TestService_StoreSkipBlock2(t *testing.T) {
 	require.Error(t, err)
 	log.Lvl1("Correctly proposing new roster")
 	ssbr, err = s1.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: sbRoot.Hash, NewBlock: sb1})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, ssbr.Latest)
 
 	// Error testing
@@ -633,7 +633,7 @@ func TestService_ParallelGenesis(t *testing.T) {
 		go func(sb *SkipBlock) {
 			for j := 0; j < numBlocks; j++ {
 				_, err := s1.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: nil, NewBlock: sb})
-				require.Nil(t, err)
+				require.NoError(t, err)
 				stored <- true
 			}
 		}(sb0.Copy())
@@ -740,10 +740,10 @@ func TestService_ForgedPropagationMessage(t *testing.T) {
 	ro := onet.NewRoster(roster.List[:5])
 
 	p1, err := createSkipchain(service, ro)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	p2, err := createSkipchain(service, ro)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Use an unknown member of the roster
 	service = servers[5].GetService(ServiceName).(*Service)
@@ -753,7 +753,7 @@ func TestService_ForgedPropagationMessage(t *testing.T) {
 
 	// checks that it could propagate something, this one is correct
 	err = service.propagateProofHandler(&PropagateProof{p1})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// checks that the block cannot be tempered
 	p1[2].Data = []byte{1}
@@ -881,7 +881,7 @@ func TestService_CreateLinkPrivate(t *testing.T) {
 	_, err = service.CreateLinkPrivate(&CreateLinkPrivate{Public: servers[0].ServerIdentity.Public, Signature: []byte{}})
 	require.NotNil(t, err)
 	msg, err := server.ServerIdentity.Public.MarshalBinary()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	sig, err := schnorr.Sign(cothority.Suite, local.GetPrivate(servers[0]), msg)
 	log.ErrFatal(err)
 	_, err = service.CreateLinkPrivate(&CreateLinkPrivate{Public: servers[0].ServerIdentity.Public, Signature: sig})
@@ -944,12 +944,12 @@ func TestService_Unlink(t *testing.T) {
 	msg, _ = kp.Public.MarshalBinary()
 	msg = append([]byte("unlink:"), msg...)
 	sig, err = schnorr.Sign(cothority.Suite, kp.Private, msg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, err = service.Unlink(&Unlink{
 		Public:    kp.Public,
 		Signature: sig,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 0, len(service.Storage.Clients))
 }
 
@@ -975,7 +975,7 @@ func TestService_DelFollow(t *testing.T) {
 	sig, err = schnorr.Sign(cothority.Suite, priv, msg)
 	log.ErrFatal(err)
 	_, err = service.DelFollow(&DelFollow{SkipchainID: iddel, Signature: sig})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(service.Storage.FollowIDs))
 
 	// Test removal of Follow
@@ -984,7 +984,7 @@ func TestService_DelFollow(t *testing.T) {
 	sig, err = schnorr.Sign(cothority.Suite, priv, msg)
 	log.ErrFatal(err)
 	_, err = service.DelFollow(&DelFollow{SkipchainID: iddel, Signature: sig})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(service.Storage.Follow))
 }
 
@@ -1012,7 +1012,7 @@ func TestService_ListFollow(t *testing.T) {
 	sig, err = schnorr.Sign(cothority.Suite, priv, msg)
 	log.ErrFatal(err)
 	lf, err := service.ListFollow(&ListFollow{Signature: sig})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 2, len(*lf.Follow))
 	require.Equal(t, 2, len(*lf.FollowIDs))
 }
@@ -1040,14 +1040,14 @@ func TestService_MissingForwardlink(t *testing.T) {
 	log.Lvl1("Making genesis-block with list", ro1.List)
 	sbRoot, err := makeGenesisRosterArgs(service1, ro1, nil, VerificationNone,
 		2, 4)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	scid := sbRoot.SkipChainID()
 
 	log.Lvl1("Adding block #1 with list", ro2.List)
 	sb := NewSkipBlock()
 	sb.Roster = ro2
 	_, err = addBlockToChain(service2, scid, sb)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, local.WaitDone(time.Second))
 
 	log.Lvl1("Adding block #2 while node0 is down with list", ro3.List)
@@ -1055,7 +1055,7 @@ func TestService_MissingForwardlink(t *testing.T) {
 	sb = NewSkipBlock()
 	sb.Roster = ro3
 	_, err = addBlockToChain(service3, scid, sb)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	log.Lvl1("Adding block #3 while node0 is up again with list", ro3.List)
 	servers[0].Unpause()
@@ -1076,7 +1076,7 @@ func TestService_LeaderChange(t *testing.T) {
 	leader := service.(*Service)
 	sbRoot, err := makeGenesisRosterArgs(leader, ro, nil, VerificationNone, 2, 4)
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	servers[0].Pause()
 	leader = local.GetServices(servers, skipchainSID)[2].(*Service)
@@ -1084,10 +1084,10 @@ func TestService_LeaderChange(t *testing.T) {
 	sb := NewSkipBlock()
 	sb.Roster = onet.NewRoster(append(ro.List[2:], ro.List[0], ro.List[1]))
 	_, err = addBlockToChain(leader, sbRoot.Hash, sb)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	res, err := leader.getBlocks(sb.Roster, sbRoot.Hash, 2)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(res[0].ForwardLink))
 	// Forward link must be verified with the src block
 	require.Nil(t, res[0].ForwardLink[0].VerifyWithScheme(suite, ro.ServicePublics(ServiceName), BdnSignatureSchemeIndex))
@@ -1321,13 +1321,13 @@ func TestService_LeaderCatchup(t *testing.T) {
 		},
 	}
 	ssbrep, err := leader.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: []byte{}, NewBlock: sbRoot})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	blocks := make([]*SkipBlock, 10)
 	for i := 0; i < 10; i++ {
 		ssbrep, err = leader.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: ssbrep.Latest.Hash,
 			NewBlock: sbRoot.Copy()})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		blocks[i] = ssbrep.Latest
 	}
 
@@ -1340,7 +1340,7 @@ func TestService_LeaderCatchup(t *testing.T) {
 	// to handle this write.
 	ssbrep, err = leader.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: ssbrep.Latest.Hash,
 		NewBlock: sbRoot})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	sb11 := leader.db.GetByID(ssbrep.Latest.Hash)
 	require.Equal(t, sb11.Index, 11)
@@ -1351,7 +1351,7 @@ func TestService_LeaderCatchup(t *testing.T) {
 	// Write onto leader; the follower will need to sync to be able to sign this.
 	_, err = leader.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: ssbrep.Latest.Hash,
 		NewBlock: sbRoot})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Wait for forward-block propagation
 	require.Nil(t, waitForwardLinks(leader, blocks[8], 2))
@@ -1407,7 +1407,7 @@ func TestRosterAddCausesSync(t *testing.T) {
 			},
 		}
 		ssbrep, err := leader.StoreSkipBlock(&StoreSkipBlock{TargetSkipChainID: []byte{}, NewBlock: sbRoot})
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		log.Lvl1("Add last server into roster")
 		newBlock := &SkipBlock{
@@ -1419,7 +1419,7 @@ func TestRosterAddCausesSync(t *testing.T) {
 		ssbrep, err = leader.StoreSkipBlock(&StoreSkipBlock{
 			TargetSkipChainID: ssbrep.Latest.Hash,
 			NewBlock:          newBlock})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Nil(t, local.WaitDone(time.Second))
 
 		// Wake up #4. It does not know any blocks yet.
@@ -1431,7 +1431,7 @@ func TestRosterAddCausesSync(t *testing.T) {
 		_, err = leader.StoreSkipBlock(&StoreSkipBlock{
 			TargetSkipChainID: ssbrep.Latest.Hash,
 			NewBlock:          newBlock})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		log.Lvl1("Got block with servers[4]")
 	}
 }

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -51,19 +51,19 @@ func TestSkipBlock_GetResponsible(t *testing.T) {
 	inter1.BackLinkIDs = []SkipBlockID{inter0.Hash}
 
 	b, err := db.GetResponsible(root0)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	assert.True(t, root0.Equal(b))
 
 	b, err = db.GetResponsible(root1)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	assert.True(t, root0.Equal(b))
 
 	b, err = db.GetResponsible(inter0)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	assert.Equal(t, root1.Hash, b.Hash)
 
 	b, err = db.GetResponsible(inter1)
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	assert.True(t, inter0.Equal(b))
 }
 

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -270,10 +270,10 @@ func TestSkipBlock_GetFuzzy(t *testing.T) {
 
 	db.Update(func(tx *bbolt.Tx) error {
 		err := db.storeToTx(tx, sb0)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		err = db.storeToTx(tx, sb1)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		return nil
 	})
 
@@ -282,34 +282,34 @@ func TestSkipBlock_GetFuzzy(t *testing.T) {
 	require.NotNil(t, err)
 
 	sb, err = db.GetFuzzy("01")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, sb)
 	require.Equal(t, sb.Data[0], sb0.Data[0])
 
 	sb, err = db.GetFuzzy("02")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, sb)
 	require.Equal(t, sb.Data[0], sb1.Data[0])
 
 	sb, err = db.GetFuzzy("03")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, sb)
 
 	sb, err = db.GetFuzzy("04")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, sb)
 
 	sb, err = db.GetFuzzy("05")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, sb)
 	require.Equal(t, sb.Data[0], sb0.Data[0])
 
 	sb, err = db.GetFuzzy("06")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, sb)
 
 	sb, err = db.GetFuzzy("0102030605")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, sb)
 	require.Equal(t, sb.Data[0], sb0.Data[0])
 }
@@ -404,7 +404,7 @@ func TestSkipBlockDB_GetProof(t *testing.T) {
 	err = db.Update(func(tx *bbolt.Tx) error {
 		return tx.Bucket(db.bucketName).Delete(sb2.Hash)
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// last block is missing so it should return only until sb1.
 	bb, err := db.GetProof(root.Hash)
@@ -432,18 +432,18 @@ func TestProof_Verify(t *testing.T) {
 // The caller is responsible to close and remove the database file after using it.
 func setupSkipBlockDB(t *testing.T) (*SkipBlockDB, string) {
 	f, err := ioutil.TempFile("", "skipblock-test")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	fname := f.Name()
 	require.Nil(t, f.Close())
 
 	db, err := bbolt.Open(fname, 0600, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = db.Update(func(tx *bbolt.Tx) error {
 		_, err := tx.CreateBucket([]byte("skipblock-test"))
 		return err
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	return NewSkipBlockDB(db, []byte("skipblock-test")), fname
 }

--- a/status/service/status_test.go
+++ b/status/service/status_test.go
@@ -66,7 +66,7 @@ func TestStat_Request(t *testing.T) {
 	client := NewTestClient(local)
 	log.Lvl1("Sending request to service...")
 	stat, err := client.Request(el.List[0])
-	log.ErrFatal(err)
+	require.NoError(t, err)
 	log.Lvl1(stat)
 	assert.NotEmpty(t, stat.Status["Generic"].Field["Available_Services"])
 }

--- a/status/service/status_test.go
+++ b/status/service/status_test.go
@@ -43,7 +43,7 @@ func TestStat_Connectivity(t *testing.T) {
 	require.NoError(t, local.WaitDone(time.Second))
 
 	servers[2].Pause()
-	repl, err = cl.CheckConnectivity(priv, ro.List, time.Second, false)
+	_, err = cl.CheckConnectivity(priv, ro.List, time.Second, false)
 	require.Error(t, err)
 
 	repl, err = cl.CheckConnectivity(priv, ro.List, time.Second, true)


### PR DESCRIPTION
I've been playing with [staticcheck](https://staticcheck.io), a static code analyser for go (the best one/most complete out there IMO), and ran it on the codebase. This is a bunch of changes so I'm making a first pass for the `*_test.go` files which shouldn't change any behavior.

While I'm at it, I've also `sed` some inconsistent pattern to have nicer messages when encountering errors.

I still have some staticcheck errors, related to deprecated uses in tests. I didn't update theses as I wan't sure if it was wanted to check for theses code paths, but from the look of it, it's not explicit that its checking retro compatibility. Some could be change quite safely, such as using `Roster.GetID` instead of `Roster.ID` or moves to kyber, but some other, such as using bndproto instead of blscosi/protocol, might not be wanted. Here goes the list
```
blscosi/bdnproto/protocol_test.go:10:2: Package go.dedis.ch/cothority/v3/blscosi/protocol is deprecated: use the bdnproto instead to be robust against the rogue public-key attack described here: https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html  (SA1019)
byzcoin/proof_test.go:137:6: from.Roster.ID is deprecated: ID can be generated using the list of server identities. Use GetID instead.  (SA1019)
byzcoin/proof_test.go:137:27: to.Roster.ID is deprecated: ID can be generated using the list of server identities. Use GetID instead.  (SA1019)
byzcoin/service_test.go:1696:19: latest.Roster.ID is deprecated: ID can be generated using the list of server identities. Use GetID instead.  (SA1019)
byzcoin/service_test.go:1696:42: rosterR.ID is deprecated: ID can be generated using the list of server identities. Use GetID instead.  (SA1019)
byzcoin/service_test.go:1715:19: latest.Roster.ID is deprecated: ID can be generated using the list of server identities. Use GetID instead.  (SA1019)
byzcoin/service_test.go:1715:42: rosterR.ID is deprecated: ID can be generated using the list of server identities. Use GetID instead.  (SA1019)
byzcoin/service_test.go:1769:19: latest.Roster.ID is deprecated: ID can be generated using the list of server identities. Use GetID instead.  (SA1019)
byzcoin/service_test.go:1769:42: rosterR.ID is deprecated: ID can be generated using the list of server identities. Use GetID instead.  (SA1019)
byzcoinx/byzcoinx_test.go:15:2: Package go.dedis.ch/cothority/v3/blscosi/protocol is deprecated: use the bdnproto instead to be robust against the rogue public-key attack described here: https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html  (SA1019)
ftcosi/protocol/protocol_test.go:95:68: cosi.CompletePolicy is deprecated: the policy has moved to the package kyber/sign  (SA1019)
ftcosi/protocol/protocol_test.go:142:71: cosi.NewThresholdPolicy is deprecated: the policy has moved to the package kyber/sign  (SA1019)
ftcosi/protocol/protocol_test.go:222:68: cosi.NewThresholdPolicy is deprecated: the policy has moved to the package kyber/sign  (SA1019)
ftcosi/protocol/protocol_test.go:291:68: cosi.NewThresholdPolicy is deprecated: the policy has moved to the package kyber/sign  (SA1019)
ftcosi/protocol/protocol_test.go:470:57: cosi.CompletePolicy is deprecated: the policy has moved to the package kyber/sign  (SA1019)
ftcosi/protocol/protocol_test.go:476:57: cosi.NewThresholdPolicy is deprecated: the policy has moved to the package kyber/sign  (SA1019)
ftcosi/protocol/protocol_test.go:494:26: cosi.Policy is deprecated: the policies have moved to the package kyber/sign  (SA1019)
ftcosi/protocol/protocol_test.go:508:26: cosi.Policy is deprecated: the policies have moved to the package kyber/sign  (SA1019)
ftcosi/service/ftcosi_test.go:40:82: cosi.CompletePolicy is deprecated: the policy has moved to the package kyber/sign  (SA1019)
ftcosi/service/ftcosi_test.go:65:79: cosi.CompletePolicy is deprecated: the policy has moved to the package kyber/sign  (SA1019)
```

At some point, it would be great to add it to the CI, this is a great tool, but I'm not knowledgeable enough of the internals to do it safely. If someone else want to play with it, please do so :)