### PR TITLE
byzcoin: move C4DT node to 443

### DIFF
--- a/byzcoin/bcadmin/README.md
+++ b/byzcoin/bcadmin/README.md
@@ -264,4 +264,4 @@ bcadmin db merge --overwrite path/to/conode.db _bcID_ cached.db
 The `--overwrite` is necessary to store all blocks from the `cached.db` file 
 to the existing database.
 
-A `cached.db` is available at https://conode.c4dt.org/files/cached.db
+A `cached.db` is available at https://demo.c4dt.org/omniledger/cached.db

--- a/dedis-cothority.toml
+++ b/dedis-cothority.toml
@@ -60,7 +60,7 @@
 
 [[servers]]
   Address = "tls://conode.c4dt.org:7770"
-  Url = "https://conode.c4dt.org:7771"
+  Url = "https://conode.c4dt.org:443"
   Suite = "Ed25519"
   Public = "67e30e168f83c4d4614e277cefba42dbc1fb5886b3945364ea5dae3f4e4fbc0d"
   Description = "C4DT Conode"


### PR DESCRIPTION
Following the recent update of the Roster, bumping the group's config.

Also, bumping the README of bcamin because of the decommissioning of the HTTP server on conde.c4dt.org.