### PR TITLE
Use coinValue in spawner contract

### DIFF
--- a/byzcoin/struct.go
+++ b/byzcoin/struct.go
@@ -562,6 +562,20 @@ func (c *Coin) SafeSub(a uint64) error {
 	return xerrors.New("uint64 underflow")
 }
 
+// SafeTransfer takes val from one coin and puts it to another.
+// It checks that the source coin has enough,
+// and that the destination coin will not overflow.
+func (c *Coin) SafeTransfer(to *Coin, val uint64) error {
+	if err := c.SafeSub(val); err != nil {
+		return err
+	}
+	if err := to.SafeAdd(val); err != nil {
+		_ = c.SafeAdd(val)
+		return err
+	}
+	return nil
+}
+
 type notification struct {
 	block  *skipchain.SkipBlock
 	txs    TxResults

--- a/external/js/cothority/src/personhood/spawner-instance.ts
+++ b/external/js/cothority/src/personhood/spawner-instance.ts
@@ -39,6 +39,7 @@ export default class SpawnerInstance extends Instance {
     static readonly argumentDarcID = "darcID";
     static readonly argumentCoinID = "coinID";
     static readonly argumentCoinName = "coinName";
+    static readonly argumentCoinValue = "coinValue";
 
     /**
      * Spawn a spawner instance. It takes either an ICreateSpawner as single argument, or all the arguments
@@ -200,6 +201,7 @@ export default class SpawnerInstance extends Instance {
                     new Argument({name: SpawnerInstance.argumentCoinName, value: SPAWNER_COIN}),
                     new Argument({name: SpawnerInstance.argumentCoinID, value: coinID}),
                     new Argument({name: SpawnerInstance.argumentDarcID, value: darcID}),
+                    new Argument({name: SpawnerInstance.argumentCoinValue, value: Buffer.from(balance.toBytesLE())}),
                 ],
             ),
         ];

--- a/personhood/contracts/contract_spawner_test.go
+++ b/personhood/contracts/contract_spawner_test.go
@@ -1,6 +1,7 @@
 package contracts
 
 import (
+	"go.dedis.ch/cothority/v3/byzcoin/contracts"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,11 +32,68 @@ func TestContractSpawner(t *testing.T) {
 	scs, _, err := cs.Spawn(s, inst, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(scs))
-	spawner := &SpawnerStruct{}
-	err = protobuf.Decode(scs[0].Value, spawner)
+	err = protobuf.Decode(scs[0].Value, cs)
 	require.NoError(t, err)
-	require.Equal(t, uint64(200), spawner.CostDarc.Value)
-	require.Equal(t, uint64(200), spawner.CostCRead.Value)
-	require.Equal(t, uint64(100), spawner.CostCWrite.Value)
-	require.Equal(t, uint64(200), spawner.CostValue.Value)
+	require.Equal(t, uint64(200), cs.CostDarc.Value)
+	require.Equal(t, uint64(200), cs.CostCRead.Value)
+	require.Equal(t, uint64(100), cs.CostCWrite.Value)
+	require.Equal(t, uint64(200), cs.CostValue.Value)
+}
+
+func TestContractSpawnerCoin(t *testing.T) {
+	iid := byzcoin.NewInstanceID([]byte("some coin"))
+	s := newRstSimul()
+	s.values[string(iid.Slice())] = byzcoin.StateChangeBody{}
+	cs := &ContractSpawner{}
+	cost := byzcoin.Coin{Name: contracts.CoinName, Value: 200}
+	costBuf, err := protobuf.Encode(&cost)
+	require.NoError(t, err)
+	inst := byzcoin.Instruction{
+		InstanceID: iid,
+		Spawn: &byzcoin.Spawn{
+			ContractID: ContractSpawnerID,
+			Args: byzcoin.Arguments{
+				{Name: "costCoin", Value: costBuf},
+			},
+		},
+	}
+	scs, _, err := cs.Spawn(s, inst, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(scs))
+	s.Process(scs)
+
+	coin1 := byzcoin.Coin{Name: contracts.CoinName, Value: uint64(1000)}
+	err = protobuf.Decode(scs[0].Value, cs)
+	require.NoError(t, err)
+	var out []byzcoin.Coin
+	scs, out, err = cs.Spawn(s, byzcoin.Instruction{
+		InstanceID: iid,
+		Spawn: &byzcoin.Spawn{
+			ContractID: contracts.ContractCoinID,
+			Args: []byzcoin.Argument{
+				{Name: "coinValue", Value: []byte{100, 0, 0, 0, 0, 0, 0, 0}}},
+		}}, []byzcoin.Coin{coin1})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(scs))
+	require.Equal(t, uint64(700), out[0].Value)
+	var coinOut byzcoin.Coin
+	err = protobuf.Decode(scs[0].Value, &coinOut)
+	require.Equal(t, uint64(100), coinOut.Value)
+
+	coin1 = byzcoin.Coin{Name: contracts.CoinName, Value: uint64(300)}
+	coin2 := byzcoin.Coin{Name: contracts.CoinName, Value: uint64(100)}
+	require.NoError(t, err)
+	scs, out, err = cs.Spawn(s, byzcoin.Instruction{
+		InstanceID: iid,
+		Spawn: &byzcoin.Spawn{
+			ContractID: contracts.ContractCoinID,
+			Args: []byzcoin.Argument{
+				{Name: "coinValue", Value: []byte{200, 0, 0, 0, 0, 0, 0, 0}}},
+		}}, []byzcoin.Coin{coin1, coin2})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(scs))
+	require.Equal(t, uint64(0), out[0].Value)
+	require.Equal(t, uint64(0), out[1].Value)
+	err = protobuf.Decode(scs[0].Value, &coinOut)
+	require.Equal(t, uint64(200), coinOut.Value)
 }


### PR DESCRIPTION
Whenever a spawner contract creates a new coin instance, it fills it with all available coins.
This works fine if you only create one coin in a transaction. But if multiple instructions
with multiple spawners are created in the same transaction, it will fail.

This PR adds a new argument when spawning a coin that allows filling of the coin with only
a partial available amount.

@Gilthoniel there is a _real_ unit tests in this PR - it is possible ;)