### PR TITLE
Speed up proofs

### DIFF
--- a/external/js/cothority/spec/personhood/spawner-instance.spec.ts
+++ b/external/js/cothority/spec/personhood/spawner-instance.spec.ts
@@ -228,7 +228,7 @@ describe("SpawnerInstance Tests", () => {
 
         const user = SignerEd25519.fromBytes(Buffer.from([1, 2, 3, 4, 5, 6]));
         const userDarc = await spawnUserDarc(si, ci, [SIGNER], user.public);
-        await expectAsync(spawnUserDarc(si, ci, [SIGNER], user.public)).toBeRejected();
+        await expectAsync(si.spawnDarcs(ci, [SIGNER], userDarc.darc)).toBeRejected();
 
         await si.spawnCredential(ci, [SIGNER], userDarc.darc.getBaseID(),
             generateCredential(user.public));

--- a/external/js/cothority/src/byzcoin/proof.ts
+++ b/external/js/cothority/src/byzcoin/proof.ts
@@ -79,7 +79,7 @@ export default class Proof extends Message<Proof> {
         registerMessage("byzcoin.Proof", Proof, InclusionProof, SkipBlock, ForwardLink);
     }
     // The id of the latest known proof - supposes there is only one ByzCoin
-    private static latestID: InstanceID;
+    private static latestID: InstanceID | undefined;
 
     readonly inclusionproof: InclusionProof;
     readonly latest: SkipBlock;

--- a/external/js/cothority/src/darc/darc.ts
+++ b/external/js/cothority/src/darc/darc.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "crypto";
 import { createHash } from "crypto-browserify";
 import Long from "long";
 import { Message, Properties } from "protobufjs/light";
@@ -63,7 +64,7 @@ export default class Darc extends Message<Darc> {
         const darc = new Darc({
             baseID: Buffer.from([]),
             description: desc,
-            prevID: createHash("sha256").digest(),
+            prevID: randomBytes(32),
             rules: this.initRules(owners, signers),
             version: Long.fromNumber(0, true),
         });

--- a/external/js/cothority/src/darc/darc.ts
+++ b/external/js/cothority/src/darc/darc.ts
@@ -64,6 +64,8 @@ export default class Darc extends Message<Darc> {
         const darc = new Darc({
             baseID: Buffer.from([]),
             description: desc,
+            // Assure that two otherwise identical darcs get another base-id by using a random prevID,
+            // even for a genesis-darc.
             prevID: randomBytes(32),
             rules: this.initRules(owners, signers),
             version: Long.fromNumber(0, true),

--- a/external/js/cothority/src/personhood/credentials-instance.ts
+++ b/external/js/cothority/src/personhood/credentials-instance.ts
@@ -282,8 +282,10 @@ export class CredentialStruct extends Message<CredentialStruct> {
      * @param value         The value to set
      */
     setAttribute(credential: string, attribute: string, value?: Buffer | string) {
-        if (!(value instanceof Buffer)) {
-            value = Buffer.from(value ? value : "");
+        if (value === undefined) {
+            value = Buffer.from("");
+        } else if (typeof value === "string") {
+            value = Buffer.from(value);
         }
         const attr = new Attribute({name: attribute, value});
         const cred = this.credentials.find((c) => c.name === credential);

--- a/external/js/cothority/src/personhood/credentials-instance.ts
+++ b/external/js/cothority/src/personhood/credentials-instance.ts
@@ -5,7 +5,6 @@ import ByzCoinRPC from "../byzcoin/byzcoin-rpc";
 import ClientTransaction, { Argument, Instruction } from "../byzcoin/client-transaction";
 import Instance, { InstanceID } from "../byzcoin/instance";
 import Signer from "../darc/signer";
-import Log from "../log";
 import { EMPTY_BUFFER, registerMessage } from "../protobuf";
 
 export default class CredentialsInstance extends Instance {
@@ -108,7 +107,6 @@ export default class CredentialsInstance extends Instance {
         Promise<CredentialsInstance> {
         return new CredentialsInstance(bc, await Instance.fromByzcoin(bc, iid, waitMatch, interval));
     }
-
     credential: CredentialStruct;
 
     constructor(private rpc: ByzCoinRPC, readonly inst: Instance) {
@@ -283,7 +281,10 @@ export class CredentialStruct extends Message<CredentialStruct> {
      * @param attribute     Name of the attribute
      * @param value         The value to set
      */
-    setAttribute(credential: string, attribute: string, value?: Buffer) {
+    setAttribute(credential: string, attribute: string, value?: Buffer | string) {
+        if (!(value instanceof Buffer)) {
+            value = Buffer.from(value ? value : "");
+        }
         const attr = new Attribute({name: attribute, value});
         const cred = this.credentials.find((c) => c.name === credential);
         if (cred === undefined) {


### PR DESCRIPTION
In the latest dynacred2, there can be a lot of proofs requested when a new block
comes in. The previous code checked the forward-links for every proof, which
made it very slow.

This PR stores the latest trusted block, and doesn't check the forward-links
if a proof with that latest block is received.

Also changes new darcs with `version=0` to have a random `prevID`, enabling
to store a darc with the same rules and description twice under a different
ID.

Also extends the `Credential.setAttribute` method to allow for strings in the value.