### PR TITLE
travis: revert to old npm publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ jobs:
           cd external/js/kyber &&
           npm ci &&
           npm version prerelease --preid=p`date +%y%m.%d%H.%M%S` &&
-          npm run test-publish -- --tag dev
+          ./publish --tag dev
     - name: "NPM: js > cothority"
       <<: *stage_deploy_npm
       deploy:
@@ -135,7 +135,7 @@ jobs:
           cd external/js/cothority &&
           npm ci &&
           npm version prerelease --preid=p`date +%y%m.%d%H.%M%S` &&
-          npm run test-publish -- --tag dev
+          ./publish --tag dev
 
 notifications:
   email: false


### PR DESCRIPTION
Running tests twice doesn't make much sense; also, I broke deploy on master by not linking kyber in the previous iteration, so, two birds, one stone.