### PR TITLE
Adding deletion and preIDs for Calypso contracts

### DIFF
--- a/byzcoin/contracts.go
+++ b/byzcoin/contracts.go
@@ -296,9 +296,17 @@ func (b BasicContract) Invoke(ReadOnlyStateTrie, Instruction, []Coin) (sc []Stat
 
 // Delete is not implmented in a BasicContract. Types which embed BasicContract
 // must override this method if they support deleting.
-func (b BasicContract) Delete(ReadOnlyStateTrie, Instruction, []Coin) (sc []StateChange, c []Coin, err error) {
-	err = notImpl("Delete")
-	return
+func (b BasicContract) Delete(ro ReadOnlyStateTrie, inst Instruction,
+	coins []Coin) (sc []StateChange, c []Coin, err error) {
+	_, _, cID, _, err := ro.GetValues(inst.InstanceID[:])
+	if err != nil {
+		return nil, nil, xerrors.Errorf("couldn't get contractID: %v", err)
+	}
+	if cID != inst.Delete.ContractID {
+		return nil, nil, xerrors.New("wrong contractID")
+	}
+	return []StateChange{NewStateChange(Remove, inst.InstanceID, cID, nil,
+		nil)}, c, nil
 }
 
 //

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -2468,6 +2468,10 @@ func (s *Service) executeInstruction(gs GlobalState, cin []Coin,
 	default:
 		return nil, nil, xerrors.New("unexpected contract type")
 	}
+	if err != nil {
+		return nil, nil, xerrors.Errorf(
+			"error while executing instruction %s: %v", instr, err)
+	}
 
 	// As the InstanceID of each sc is not necessarily the same as the
 	// instruction, we need to get the version from the trie

--- a/byzcoin/transaction.go
+++ b/byzcoin/transaction.go
@@ -231,6 +231,23 @@ func (instr Instruction) DeriveID(what string) InstanceID {
 	// strict domain separation now.
 }
 
+// DeriveIDArg calculates the id of the new instance for a spawn-instruction.
+// If the 'arg' is not present in the spawn-arguments,
+// it behaves like DeriveID(what).
+// If the instruction is not a spawn-instruction, it returns an error.
+func (instr Instruction) DeriveIDArg(what, arg string) (InstanceID, error) {
+	if instr.GetType() != SpawnType {
+		return NewInstanceID(nil), xerrors.New("can only get ID from spawn")
+	}
+	if instIDBuf := instr.Spawn.Args.Search(arg); instIDBuf != nil {
+		h := sha256.New()
+		h.Write([]byte(instr.Spawn.ContractID))
+		h.Write(instIDBuf)
+		return NewInstanceID(h.Sum(nil)), nil
+	}
+	return instr.DeriveID(what), nil
+}
+
 // Action returns the action that the user wants to do with this
 // instruction.
 func (instr Instruction) Action() string {

--- a/byzcoin/transaction_test.go
+++ b/byzcoin/transaction_test.go
@@ -124,6 +124,21 @@ func TestTransactionBuffer_TakeDisabled(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestInstruction_DeriveIDArg(t *testing.T) {
+	inst := Instruction{
+		InstanceID: NewInstanceID([]byte("new instance")),
+	}
+	_, err := inst.DeriveIDArg("", "testID")
+	require.Error(t, err)
+	inst.Spawn = &Spawn{ContractID: "test"}
+	id1, err := inst.DeriveIDArg("", "testID")
+	require.NoError(t, err)
+	inst.Spawn.Args = Arguments{{Name: "testID", Value: []byte("testing")}}
+	id2, err := inst.DeriveIDArg("", "testID")
+	require.NoError(t, err)
+	require.NotEqual(t, id1, id2)
+}
+
 func setSignerCounter(sst *stagingStateTrie, id string, v uint64) error {
 	key := publicVersionKey(id)
 	verBuf := make([]byte, 8)

--- a/calypso/contracts.go
+++ b/calypso/contracts.go
@@ -79,7 +79,11 @@ func (c ContractWrite) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instruc
 			err = xerrors.Errorf("proof of write failed: %v", err)
 			return
 		}
-		instID := inst.DeriveID("")
+		instID, err := inst.DeriveIDArg("", "preID")
+		if err != nil {
+			return nil, nil, xerrors.Errorf(
+				"couldn't get ID for instance: %v", err)
+		}
 		log.Lvlf3("Successfully verified write request and will store in %x", instID)
 		sc = append(sc, byzcoin.NewStateChange(byzcoin.Create, instID, ContractWriteID, w, darcID))
 	case ContractReadID:
@@ -107,7 +111,13 @@ func (c ContractWrite) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instruc
 				}
 			}
 		}
-		sc = byzcoin.StateChanges{byzcoin.NewStateChange(byzcoin.Create, inst.DeriveID(""), ContractReadID, r, darcID)}
+		instID, err := inst.DeriveIDArg("", "preID")
+		if err != nil {
+			return nil, nil, xerrors.Errorf(
+				"couldn't get ID for instance: %v", err)
+		}
+		sc = byzcoin.StateChanges{byzcoin.NewStateChange(byzcoin.Create,
+			instID, ContractReadID, r, darcID)}
 	default:
 		err = xerrors.New("can only spawn writes and reads")
 	}

--- a/external/js/cothority/spec/calypso/calypso.spec.ts
+++ b/external/js/cothority/spec/calypso/calypso.spec.ts
@@ -153,4 +153,20 @@ describe("Online Calypso Tests", async () => {
         const newKey = await readInst.decrypt(lts, signer.secret);
         expect(newKey).toEqual(key);
     });
+
+    it("should create a write, and a read, using preID", async () => {
+        const key = Buffer.from("Very Secret Key");
+
+        const preID = Buffer.from("some text");
+        const write = await Write.createWrite(lts.id, darc.id, lts.X, key);
+        const wrInst = await CalypsoWriteInstance.spawn(bc, darc.id, write, [SIGNER], preID);
+        expect(wrInst.id.equals(CalypsoWriteInstance.preToInstID(preID))).toBeTruthy();
+
+        const signer = SignerEd25519.random();
+        const readInst = await wrInst.spawnRead(signer.public, [SIGNER], undefined, undefined,
+            preID);
+        expect(readInst.id.equals(CalypsoReadInstance.preToInstID(preID))).toBeTruthy();
+        const newKey = await readInst.decrypt(lts, signer.secret);
+        expect(newKey).toEqual(key);
+    });
 });

--- a/external/js/cothority/src/byzcoin/instance.ts
+++ b/external/js/cothority/src/byzcoin/instance.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto-browserify";
 import { Properties } from "protobufjs/light";
 import ByzCoinRPC from "./byzcoin-rpc";
 import Proof from "./proof";
@@ -51,6 +52,17 @@ export default class Instance {
         });
     }
 
+    /**
+     * Returns the instanceID given a contract and a preID
+     * @param contractID
+     * @param preID
+     */
+    static calcInstID(contractID: string, preID: Buffer): InstanceID {
+        const h = createHash("sha256");
+        h.update(contractID);
+        h.update(preID);
+        return h.digest();
+    }
     readonly id: InstanceID;
     readonly contractID: string;
     darcID: InstanceID;

--- a/external/js/cothority/src/calypso/calypso-rpc.ts
+++ b/external/js/cothority/src/calypso/calypso-rpc.ts
@@ -98,7 +98,7 @@ export class LongTermSecret extends OnChainSecretRPC {
      * @param signers needed to authenticate longTermSecret spawns
      * @param roster if given, the roster for the DKG, if null, the full roster of bc will be used
      */
-    static async spawn(bc: ByzCoinRPC, darcID: InstanceID, signers: [Signer], roster?: Roster):
+    static async spawn(bc: ByzCoinRPC, darcID: InstanceID, signers: Signer[], roster?: Roster):
         Promise<LongTermSecret> {
         if (!roster) {
             roster = bc.getConfig().roster;

--- a/external/js/cothority/src/skipchain/skipchain-rpc.ts
+++ b/external/js/cothority/src/skipchain/skipchain-rpc.ts
@@ -180,7 +180,8 @@ export default class SkipchainRPC {
             const last = newBlocks[newBlocks.length - 1];
             let isInRoster = false;
             for (const n of last.roster.list) {
-                if (n.getWebSocketAddress() === this.conn.getURL()) {
+                if (n.getWebSocketAddress().replace(/^ws+:\/\//, "") ===
+                    this.conn.getURL().replace(/^ws+:\/\//, "")) {
                     isInRoster = true;
                     break;
                 }
@@ -188,7 +189,7 @@ export default class SkipchainRPC {
             if (!isInRoster) {
                 // A correct node will never return a last block where it is not in the roster.
                 // So this is in fact a wrong node.
-                Log.warn("Got a wrong return from node", this.conn.getURL());
+                Log.warn("A node replied that is not in the roster", this.conn.getURL());
                 latestID = last.hash;
                 if (this.conn instanceof RosterWSConnection) {
                     this.conn.invalidate(this.conn.getURL());

--- a/personhood/contracts/contract_spawner.go
+++ b/personhood/contracts/contract_spawner.go
@@ -124,7 +124,8 @@ func (c *ContractSpawner) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Inst
 				"popParty\\.(barrier|finalize|mine|addParty)|" +
 				"ropasci\\.(second|confirm)|" +
 				"value\\.update)|" +
-				"spawn:(calypsoRead))$")
+				"spawn:(calypsoRead)|" +
+				"delete:.*)$")
 			for _, rule := range d.Rules.List {
 				if !allowed.MatchString(string(rule.Action)) {
 					return nil, nil, errors.New("cannot spawn darc with rule: " +


### PR DESCRIPTION
This PR adds the following new features to ByzCoin:
- deleting instances by default: now the BasicContract includes a default 'Delete'
- added preIDs to Instruction: there is now a default way to calculate the preIDs for a contract
- using preIDs in CalypsoContracts: allowing to choose the pre-image of the IDs of the Write and Read Instances
- fixes small bugs:
  - missing error handling in executeTransaction
  - missing argument strings in calypso-instance.ts

Both the go-code and the js-code have been updated.