### PR TITLE
Moving StateTrie simulator to byzcoin

### DIFF
--- a/byzcoin/rostsimul.go
+++ b/byzcoin/rostsimul.go
@@ -1,0 +1,231 @@
+package byzcoin
+
+import (
+	"errors"
+
+	"go.dedis.ch/protobuf"
+
+	"go.dedis.ch/kyber/v3/util/random"
+	"golang.org/x/xerrors"
+
+	"go.dedis.ch/cothority/v3"
+
+	"go.dedis.ch/cothority/v3/byzcoin/trie"
+
+	"go.dedis.ch/cothority/v3/darc"
+)
+
+// ROSTSimul makes it easy to test contracts without having to use the whole
+// of byzcoin. It is a simulation of a ReadOnlyStateTrie without the consensus
+// algorithm of ByzCoin.
+// Several convenience methods make it easy to do basic tasks.
+type ROSTSimul struct {
+	Values  map[string]StateChangeBody
+	Version Version
+}
+
+// NewROSTSimul returns a new ReadOnlyStateTrie that can be used to simulate
+// contracts.
+func NewROSTSimul() *ROSTSimul {
+	return &ROSTSimul{
+		Values:  make(map[string]StateChangeBody),
+		Version: CurrentVersion,
+	}
+}
+
+const coinID = "coin"
+
+// GetValues implements the interface of a ReadOnlyStateTrie
+func (s *ROSTSimul) GetValues(key []byte) (value []byte, version uint64, contractID string, darcID darc.ID, err error) {
+	scb, ok := s.Values[string(key)]
+	if !ok {
+		err = errors.New("this key doesn't exist")
+		return
+	}
+	value = scb.Value
+	version = scb.Version
+	contractID = scb.ContractID
+	darcID = scb.DarcID
+	return
+}
+
+// GetProof is not implemented yet
+func (s *ROSTSimul) GetProof(key []byte) (*trie.Proof, error) {
+	return nil, errors.New("not implemented")
+}
+
+// GetIndex always returns -1
+func (s *ROSTSimul) GetIndex() int {
+	return -1
+}
+
+// GetVersion returns the version stored,
+// which can be updated to test contracts.
+func (s *ROSTSimul) GetVersion() Version {
+	return s.Version
+}
+
+// GetNonce is not implemented.
+func (s *ROSTSimul) GetNonce() ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+// ForEach is not implemented.
+func (s *ROSTSimul) ForEach(func(k, v []byte) error) error {
+	return errors.New("not implemented")
+}
+
+// StoreAllToReplica stores all stateChanges, without checking for validity!
+func (s *ROSTSimul) StoreAllToReplica(scs StateChanges) (ReadOnlyStateTrie, error) {
+	for _, sc := range scs {
+		s.Values[string(sc.InstanceID)] = StateChangeBody{
+			StateAction: Update,
+			ContractID:  sc.ContractID,
+			Value:       sc.Value,
+			Version:     sc.Version,
+			DarcID:      sc.DarcID,
+		}
+	}
+	return s, nil
+}
+
+// GetSignerCounter is not implemented
+func (s *ROSTSimul) GetSignerCounter(id darc.Identity) (uint64, error) {
+	return 0, xerrors.Errorf("not yet implemented")
+}
+
+//
+// Convenience methods for easier usage in tests
+//
+
+// CreateBasicDarc stores a darc with the _sign and "invoke:darc.
+// evolve" rules set to the signer.
+func (s *ROSTSimul) CreateBasicDarc(signer *darc.Identity, desc string) (*darc.Darc,
+	error) {
+	if signer == nil {
+		id := darc.NewIdentityEd25519(cothority.Suite.Point())
+		signer = &id
+	}
+	ids := []darc.Identity{*signer}
+	d := darc.NewDarc(darc.InitRules(ids, ids), []byte(desc))
+	buf, err := d.ToProto()
+	if err != nil {
+		return nil, xerrors.Errorf("couldn't convert darc to protobuf: %+v",
+			err)
+	}
+	s.Values[string(d.GetBaseID())] = StateChangeBody{
+		Value:      buf,
+		Version:    0,
+		ContractID: ContractDarcID,
+		DarcID:     nil,
+	}
+	return d, nil
+}
+
+// CreateCoin stores a new coin under a new random ID.
+func (s *ROSTSimul) CreateCoin(name string, value uint64) (id InstanceID,
+	err error) {
+	coin := Coin{Name: NewInstanceID([]byte(name)),
+		Value: value}
+	id = NewInstanceID(random.Bits(256, true, random.New()))
+	coinBuf, err := protobuf.Encode(&coin)
+	if err != nil {
+		err = xerrors.Errorf("couldn't encode coin: %+v", err)
+	}
+	s.Values[string(id[:])] = StateChangeBody{
+		StateAction: Create,
+		ContractID:  coinID,
+		Value:       coinBuf,
+		Version:     0,
+		DarcID:      make([]byte, 32),
+	}
+	return
+}
+
+// CreateRandomInstance adds a new instance given by the contractID and the
+// contract-structure. The ID will be chosen randomly,
+// the darcID can be nil, in which case it will be initialized to all-zeros.
+func (s *ROSTSimul) CreateRandomInstance(cID string,
+	value interface{}, darcID darc.ID) (id InstanceID, err error) {
+	id = NewInstanceID(random.Bits(256, true, random.New()))
+	valueBuf, err := protobuf.Encode(value)
+	if err != nil {
+		err = xerrors.Errorf("couldn't encode coin: %+v", err)
+	}
+	if darcID == nil {
+		darcID = make([]byte, 32)
+	}
+	s.Values[string(id[:])] = StateChangeBody{
+		StateAction: Create,
+		ContractID:  cID,
+		Value:       valueBuf,
+		Version:     0,
+		DarcID:      darcID,
+	}
+	return id, nil
+}
+
+// SetCoin 'mints' coins by setting its value directly.
+func (s *ROSTSimul) SetCoin(id InstanceID, value uint64) error {
+	coin, err := s.GetCoin(id)
+	if err != nil {
+		return xerrors.Errorf("couldn't get coin: %+v", err)
+	}
+	coin.Value = value
+	coinBuf, err := protobuf.Encode(&coin)
+	if err != nil {
+		return xerrors.Errorf("couldn't encode coin: %+v", err)
+	}
+	s.Values[string(id[:])] = StateChangeBody{
+		StateAction: Update,
+		ContractID:  coinID,
+		Value:       coinBuf,
+		Version:     0,
+		DarcID:      make([]byte, 32),
+	}
+	return nil
+}
+
+// GetCoin returns a coin given its id.
+func (s *ROSTSimul) GetCoin(id InstanceID) (coin Coin, err error) {
+	sc, found := s.Values[string(id[:])]
+	if !found {
+		err = xerrors.New("didn't find this coin")
+		return
+	}
+	if sc.ContractID != coinID {
+		err = xerrors.Errorf("id doesn't point to a coin, but to '%s'",
+			sc.ContractID)
+		return
+	}
+	if err = protobuf.Decode(sc.Value, &coin); err != nil {
+		err = xerrors.Errorf("couldn't decode coin: %+v", err)
+	}
+	return
+}
+
+// WithdrawCoin looks up given coin if it has enough value. If yes,
+// withdraws that value,
+// updates the coin, and returns the updated coin as well as the withdrawn
+// coin.
+func (s *ROSTSimul) WithdrawCoin(id InstanceID,
+	value uint64) (updated, withdrawn Coin, err error) {
+	updated, err = s.GetCoin(id)
+	if err != nil {
+		err = xerrors.Errorf("couldn't get coin: %+v", err)
+		return
+	}
+	if updated.Value < value {
+		err = xerrors.New("coin doesn't have enough value")
+		return
+	}
+	updated.Value -= value
+	err = s.SetCoin(id, updated.Value)
+	if err != nil {
+		err = xerrors.Errorf("couldn't set coin to new value: %+v", err)
+		return
+	}
+	withdrawn.Name = updated.Name
+	withdrawn.Value = value
+	return
+}

--- a/personhood/contracts/contract_credential_test.go
+++ b/personhood/contracts/contract_credential_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestContractCredential_Spawn(t *testing.T) {
 	cc := &ContractCredential{}
-	rost := newRstSimul()
+	rost := byzcoin.NewROSTSimul()
 	cred := CredentialStruct{}
-	d, err := rost.addDarc(nil, "credential")
+	d, err := rost.CreateBasicDarc(nil, "credential")
 	require.NoError(t, err)
 	inst, err := NewInstructionCredentialSpawn(byzcoin.NewInstanceID(nil), d.GetBaseID(),
 		byzcoin.NewInstanceID(nil), cred)

--- a/personhood/contracts/contract_popparty_test.go
+++ b/personhood/contracts/contract_popparty_test.go
@@ -13,8 +13,8 @@ import (
 // Creates a party, activates the barrier point, finalizes it, and mines the coins.
 func TestContractPopParty(t *testing.T) {
 	cpp := &ContractPopParty{}
-	rost := newRstSimul()
-	d, err := rost.addDarc(nil, "pp")
+	rost := byzcoin.NewROSTSimul()
+	d, err := rost.CreateBasicDarc(nil, "pp")
 	require.NoError(t, err)
 	desc := PopDesc{
 		Name:     "Test",

--- a/personhood/contracts/contract_spawner.go
+++ b/personhood/contracts/contract_spawner.go
@@ -154,7 +154,7 @@ func (c *ContractSpawner) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Inst
 			if arg.Name == "coinValue" {
 				if len(arg.Value) < 8 {
 					return nil, nil,
-						errors.New("GetCoin needs to have a value of 8 bytes")
+						errors.New("getCoin needs to have a value of 8 bytes")
 				}
 				addCoin = binary.LittleEndian.Uint64(arg.Value)
 			}

--- a/personhood/contracts/contract_spawner.go
+++ b/personhood/contracts/contract_spawner.go
@@ -154,7 +154,7 @@ func (c *ContractSpawner) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Inst
 			if arg.Name == "coinValue" {
 				if len(arg.Value) < 8 {
 					return nil, nil,
-						errors.New("getCoin needs to have a value of 8 bytes")
+						errors.New("GetCoin needs to have a value of 8 bytes")
 				}
 				addCoin = binary.LittleEndian.Uint64(arg.Value)
 			}

--- a/personhood/contracts/contract_spawner_test.go
+++ b/personhood/contracts/contract_spawner_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestContractSpawner(t *testing.T) {
 	iid := byzcoin.NewInstanceID([]byte("some coin"))
-	s := newRstSimul()
-	s.values[string(iid.Slice())] = byzcoin.StateChangeBody{}
+	s := byzcoin.NewROSTSimul()
+	s.Values[string(iid.Slice())] = byzcoin.StateChangeBody{}
 	cs := &ContractSpawner{}
 	cost := byzcoin.Coin{Name: iid, Value: 200}
 	costBuf, err := protobuf.Encode(&cost)
@@ -42,8 +42,8 @@ func TestContractSpawner(t *testing.T) {
 
 func TestContractSpawnerCoin(t *testing.T) {
 	iid := byzcoin.NewInstanceID([]byte("some coin"))
-	s := newRstSimul()
-	s.values[string(iid.Slice())] = byzcoin.StateChangeBody{}
+	s := byzcoin.NewROSTSimul()
+	s.Values[string(iid.Slice())] = byzcoin.StateChangeBody{}
 	cs := &ContractSpawner{}
 	cost := byzcoin.Coin{Name: contracts.CoinName, Value: 200}
 	costBuf, err := protobuf.Encode(&cost)
@@ -60,7 +60,8 @@ func TestContractSpawnerCoin(t *testing.T) {
 	scs, _, err := cs.Spawn(s, inst, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(scs))
-	s.Process(scs)
+	_, err = s.StoreAllToReplica(scs)
+	require.NoError(t, err)
 
 	coin1 := byzcoin.Coin{Name: contracts.CoinName, Value: uint64(1000)}
 	err = protobuf.Decode(scs[0].Value, cs)


### PR DESCRIPTION
In order to test also other than personhood contracts in a more unit-testing manner,
move the ReadOnlyStateTrieSimulator to the byzcoin directory.