### PR TITLE
Calypso update

### DIFF
--- a/calypso/contracts_test.go
+++ b/calypso/contracts_test.go
@@ -1,0 +1,50 @@
+package calypso
+
+import (
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/cothority/v3/byzcoin"
+	"go.dedis.ch/protobuf"
+	"testing"
+)
+
+func TestContractWrite_Invoke(t *testing.T) {
+	rost := byzcoin.NewROSTSimul()
+
+	cw := ContractWrite{
+		Write: Write{
+			Data:      []byte("data"),
+			ExtraData: []byte("extradata"),
+		},
+	}
+	cwID, err := rost.CreateRandomInstance(ContractWriteID, &cw, nil)
+	require.NoError(t, err)
+	instr := byzcoin.Instruction{
+		InstanceID: cwID,
+		Invoke: &byzcoin.Invoke{
+			ContractID: ContractWriteID,
+			Command:    "updates",
+			Args: byzcoin.Arguments{{
+				Name:  "data",
+				Value: []byte("newData"),
+			}},
+		}}
+	scs, _, err := cw.Invoke(rost, instr, nil)
+	require.Error(t, err)
+
+	instr.Invoke.Command = "update"
+	scs, _, err = cw.Invoke(rost, instr, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(scs))
+	var cwNew ContractWrite
+	require.NoError(t, protobuf.Decode(scs[0].Value, &cwNew))
+	require.Equal(t, []byte("newData"), cwNew.Data)
+
+	instr.Invoke.Args[0] = byzcoin.Argument{
+		Name:  "extraData",
+		Value: []byte("newExtraData")}
+	scs, _, err = cw.Invoke(rost, instr, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(scs))
+	require.NoError(t, protobuf.Decode(scs[0].Value, &cwNew))
+	require.Equal(t, []byte("newExtraData"), cwNew.ExtraData)
+}

--- a/external/js/cothority/src/calypso/calypso-instance.ts
+++ b/external/js/cothority/src/calypso/calypso-instance.ts
@@ -162,10 +162,10 @@ export class CalypsoWriteInstance extends Instance {
      */
     async update(u: {data?: Buffer; extraData?: Buffer}) {
         const args: Argument[] = [];
-        if (u.data && u.data.length > 0) {
+        if (u.data) {
             args.push(new Argument({name: CalypsoWriteInstance.argumentData, value: u.data}));
         }
-        if (u.extraData && u.extraData.length > 0) {
+        if (u.extraData) {
             args.push(new Argument({name: CalypsoWriteInstance.argumentExtraData, value: u.extraData}));
         }
         if (args.length === 0) {

--- a/external/js/cothority/src/calypso/calypso-instance.ts
+++ b/external/js/cothority/src/calypso/calypso-instance.ts
@@ -70,9 +70,12 @@ export class OnChainSecretInstance extends Instance {
 
 export class CalypsoWriteInstance extends Instance {
     static readonly contractID = "calypsoWrite";
+    static readonly commandUpdate = "update";
     static readonly argumentWrite = "write";
     static readonly argumentDarcID = "darcID";
     static readonly argumentPreID = "preID";
+    static readonly argumentData = "data";
+    static readonly argumentExtraData = "extraData";
 
     /**
      * Spawn a calypsoWrite instance
@@ -149,6 +152,28 @@ export class CalypsoWriteInstance extends Instance {
             ]);
         }
         return CalypsoReadInstance.spawn(this.rpc, this.id, pub, signers, pay, preID);
+    }
+
+    /**
+     * Update sends an update command to an existing CalypsoWriteInstance and changes the data and/or the extraData
+     * field of the Write structure. If neither data, nor extraData is given, it returns without sending a
+     * transaction to byzcoin.
+     * @param u a structure holding the data and/or extraData to be updated.
+     */
+    async update(u: {data?: Buffer; extraData?: Buffer}) {
+        const args: Argument[] = [];
+        if (u.data && u.data.length > 0) {
+            args.push(new Argument({name: CalypsoWriteInstance.argumentData, value: u.data}));
+        }
+        if (u.extraData && u.extraData.length > 0) {
+            args.push(new Argument({name: CalypsoWriteInstance.argumentExtraData, value: u.extraData}));
+        }
+        if (args.length === 0) {
+            return;
+        }
+        const ctx = ClientTransaction.make(this.rpc.getProtocolVersion(), Instruction.createInvoke(
+            this.id, this.contractID, CalypsoWriteInstance.commandUpdate, args));
+        return this.rpc.sendTransactionAndWait(ctx, 10);
     }
 }
 

--- a/personhood/contracts/contract_spawner.go
+++ b/personhood/contracts/contract_spawner.go
@@ -123,6 +123,7 @@ func (c *ContractSpawner) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Inst
 				"credential\\.(update|recover)|" +
 				"popParty\\.(barrier|finalize|mine|addParty)|" +
 				"ropasci\\.(second|confirm)|" +
+				"calypsoWrite\\.update|" +
 				"value\\.update)|" +
 				"spawn:(calypsoRead)|" +
 				"delete:.*)$")


### PR DESCRIPTION
Allow the CalypsoWrite contract to update the Data and ExtraData part of the
Write structure.

Depends on #2240 