### PR TITLE
Jenkins failures

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -2596,10 +2596,10 @@ func (s *Service) TestClose() {
 // TestRestart activates a test that has been closed using TestClose. This
 // allows to simulate restarting of nodes in the tests.
 func (s *Service) TestRestart() error {
-	if err := s.startAllChains(); err != nil {
+	if err := s.skService().TestRestart(); err != nil {
 		return err
 	}
-	return s.skService().TestRestart()
+	return s.startAllChains()
 }
 
 func (s *Service) cleanupGoroutines() {

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -239,7 +239,7 @@ func testAddTransaction(t *testing.T, blockInterval time.Duration, sendToIdx int
 			// Now read the key/values from a new service
 			log.Lvl1("Recreate services and fetch keys again")
 			s.service().TestClose()
-			require.NoError(t, s.service().startAllChains())
+			require.NoError(t, s.service().TestRestart())
 		}
 		for _, tx := range txs {
 			pr := s.waitProofWithIdx(t, tx.Instructions[0].Hash(), 0)
@@ -260,7 +260,7 @@ func testAddTransaction(t *testing.T, blockInterval time.Duration, sendToIdx int
 	if failure {
 		log.Lvl1("bringing the failed node back up")
 		s.hosts[len(s.hosts)-1].Unpause()
-		require.NoError(t, s.services[len(s.hosts)-1].startAllChains())
+		require.NoError(t, s.services[len(s.hosts)-1].TestRestart())
 
 		for _, tx := range txs {
 			pr := s.waitProofWithIdx(t, tx.Instructions[0].Hash(), len(s.hosts)-1)

--- a/byzcoin/tx_pipeline.go
+++ b/byzcoin/tx_pipeline.go
@@ -113,7 +113,7 @@ func (s *defaultTxProcessor) CollectTx() (*collectTxResult, error) {
 	if s.skService().ChainIsProcessing(s.scID) {
 		// When a block is processed,
 		// return immediately without processing any tx from the nodes.
-		return &collectTxResult{Txs: nil, CommonVersion: CurrentVersion - 1}, nil
+		return &collectTxResult{Txs: nil, CommonVersion: 0}, nil
 	}
 
 	latest, err := s.db().GetLatestByID(s.scID)

--- a/byzcoin/viewchange_test.go
+++ b/byzcoin/viewchange_test.go
@@ -114,7 +114,7 @@ func testViewChange(t *testing.T, nHosts, nFailures int, interval time.Duration)
 	for i := 0; i < nFailures; i++ {
 		log.Lvl1("starting node at index", i)
 		s.hosts[i].Unpause()
-		require.NoError(t, s.services[i].startAllChains())
+		require.NoError(t, s.services[i].TestRestart())
 	}
 	for i := 0; i < nFailures; i++ {
 		pr = s.waitProofWithIdx(t, tx1.Instructions[0].InstanceID.Slice(), i)
@@ -131,6 +131,7 @@ func testViewChange(t *testing.T, nHosts, nFailures int, interval time.Duration)
 	require.NoError(t, err)
 	s.sendTxToAndWait(t, tx1, nFailures, 10)
 	log.Lvl1("Sent two tx")
+	s.waitPropagation(t, -1)
 }
 
 // Tests that a view change can happen when the leader index is out of bound


### PR DESCRIPTION
Some small improvements to make the tests pass. The viewchange tests are
still flaky - but using the go-test cache, it will eventually pass :(