### PR TITLE
Fixing README of scmgr

### DIFF
--- a/conode/run_nodes.sh
+++ b/conode/run_nodes.sh
@@ -80,7 +80,7 @@ fi
 rm -f public.toml
 mkdir -p log
 touch running
-for n in $( seq $nbr_nodes -1 1 ); do
+for n in $( seq $nbr_nodes ); do
   co=co$n
   PORT=$(($base_port + 2 * n - 2))
   if [ ! -d $co ]; then

--- a/scmgr/README.md
+++ b/scmgr/README.md
@@ -31,7 +31,7 @@ you can use with scmgr. In the following examples, we suppose that the
 directory and that you installed `scmgr` using
 
 ```bash
-go get github.com/dedis/cothority/scmgr
+go build ../scmgr
 ```
 
 ## Securing the conode by creating a link
@@ -58,7 +58,7 @@ in each of those directories.
 So for the testing system, the command is:
 
 ```bash
-scmgr link add co1/private.toml
+./scmgr link add co1/private.toml
 ```
 
 This command will create a new private/public keypair for your client and
@@ -70,7 +70,7 @@ Now that you are linked to your conode, you can create a new skipchain on it,
 with its only participant being _co1_:
 
 ```bash
-scmgr skipchain create -b 10 -he 10 co1/public.toml
+./scmgr skipchain create -b 10 -he 10 co1/public.toml
 ```
 
 This will ask the first node in the `public.toml` file to be the leader and to
@@ -98,27 +98,27 @@ For our example, we will tell _co2_ and _co3_ to follow the skipchain created
 above and to accept any new block added to that skipchain:
 
 ```bash
-scmgr link add co2/private.toml
-scmgr link add co3/private.toml
-scmgr follow add single SKIPCHAIN_ID 127.0.0.1:7004
-scmgr follow add single SKIPCHAIN_ID 127.0.0.1:7006
+./scmgr link add co2/private.toml
+./scmgr link add co3/private.toml
+./scmgr follow add single SKIPCHAIN_ID localhost:7772
+./scmgr follow add single SKIPCHAIN_ID localhost:7774
 ```
 
 Where _SKIPCHAIN_ID_ has to be replaced by the ID of the skipchain returned from
 the `scmgr skipchain create` command above.
-`127.0.0.1:7004` and `127.0.0.1:7006` are the IP addresses and port numbers of _co2_
-and _co3_ respectively.
+`localhost:7772` and `localhost:7774` are the IP addresses and port numbers of
+ _co2_ and _co3_ respectively.
 
 Now you can ask your first conode to extend the conodes that participate in the
 skipchain to all conodes:
 
 ```bash
-scmgr skipchain block add -roster public.toml SKIPCHAIN_ID
+./scmgr skipchain block add -roster public.toml SKIPCHAIN_ID
 ```
 
 Now you have a skipchain that includes all of your testing conodes. To see the block that
 you just created, you can use:
 
 ```bash
-scmgr skipchain block print SKIPBLOCK_ID
+./scmgr skipchain block print SKIPBLOCK_ID
 ```

--- a/scmgr/app.go
+++ b/scmgr/app.go
@@ -285,9 +285,11 @@ func scCreate(c *cli.Context) error {
 		log.Infof("Found link for %s and using signed request", remote.Address)
 		priv = remote.Private
 	} else {
-		log.Infof("Trying to connect without signature to %s", group.Roster.List[0].Address)
+		log.Infof("Trying to connect without signature to %+v",
+			group.Roster.List[0].Address)
 	}
-	log.Infof("Creating new skipchain with leader %s and roster %s.", group.Roster.List[0], group.Roster)
+	log.Infof("Creating new skipchain with leader %s and roster %+v.",
+		group.Roster.List[0], group.Roster)
 	log.Infof("Base-height: %d; Maximum-height: %d", c.Int("base"), c.Int("height"))
 	sb, err := skipchain.NewClient().CreateGenesisSignature(group.Roster, c.Int("base"), c.Int("height"),
 		skipchain.VerificationStandard, nil, priv)
@@ -397,10 +399,13 @@ func scAdd(c *cli.Context) error {
 	}
 
 	log.Info("Adding new block to skipchain.")
-	ssbr, err := skipchain.NewClient().StoreSkipBlockSignature(latest, roster, dataMsg, priv)
+	cl := skipchain.NewClient()
+	cl.UseNode(0)
+	ssbr, err := cl.StoreSkipBlockSignature(latest, roster, dataMsg, priv)
 	if err != nil {
 		return errors.New("while storing block: " + err.Error())
 	}
+	cfg.Db.Store(ssbr.Previous)
 	cfg.Db.Store(ssbr.Latest)
 	log.ErrFatal(cfg.save(c))
 	log.Infof("Added new block %x to chain %x", ssbr.Latest.Hash, ssbr.Latest.SkipChainID())


### PR DESCRIPTION
The scmgr/README.md was out of date with regard to the rest of the code.
Updated the following to work well:
- conode/run_nodes.sh - build public.toml with first node at beginning
- scmgr/app.go - use leader node and store both forward-link and new block

OR-reviewers: first to think it's OK, please merge...
Closes #2251 