### PR TITLE
Another fix for the viewchange

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -2662,6 +2662,8 @@ func (s *Service) monitorLeaderFailure() {
 						LeaderIndex: 1,
 					},
 				}
+				log.Lvlf2("Starting a view-change by putting our own request"+
+					": %+v", req)
 				s.viewChangeMan.addReq(req)
 			}
 		case <-s.closeLeaderMonitorChan:
@@ -2804,8 +2806,10 @@ func (s *Service) startChain(genesisID skipchain.SkipBlockID) error {
 	if err != nil {
 		return xerrors.Errorf("getting initial duration: %v", err)
 	}
-	s.viewChangeMan.add(s.sendViewChangeReq, s.sendNewView, s.isLeader, string(genesisID))
-	s.viewChangeMan.start(s.ServerIdentity().ID, genesisID, initialDur, s.getFaultThreshold(genesisID))
+	s.viewChangeMan.add(s.sendViewChangeReq, s.sendNewView, s.isLeader,
+		string(genesisID))
+	s.viewChangeMan.start(s.ServerIdentity().ID, genesisID, initialDur,
+		s.getFaultThreshold(latest.Hash))
 
 	return nil
 }

--- a/byzcoin/viewchange.go
+++ b/byzcoin/viewchange.go
@@ -156,7 +156,8 @@ func (s *Service) sendNewView(proof []viewchange.InitReq) {
 	if len(proof) == 0 {
 		log.Error(s.ServerIdentity(), "no proofs")
 	}
-	log.Lvl2(s.ServerIdentity(), "sending new-view request for view:", proof[0].View)
+	log.Lvlf2("%s: sending new-view request with %d proofs for view: %+v",
+		s.ServerIdentity(), len(proof), proof[0].View)
 
 	// Our own proof might not be signed, so sign it.
 	for i := range proof {
@@ -269,6 +270,7 @@ func (s *Service) handleViewChangeReq(env *network.Envelope) error {
 		return xerrors.Errorf("%v: %v", s.ServerIdentity(), err)
 	}
 
+	log.Lvlf2("Adding valid view-change from %s: %+v", env.ServerIdentity, req)
 	// Store it in our log.
 	s.viewChangeMan.addReq(*req)
 	return nil

--- a/byzcoin/viewchange/viewchange.go
+++ b/byzcoin/viewchange/viewchange.go
@@ -163,6 +163,8 @@ func (c *Controller) Start(myID network.ServerIdentityID, genesis skipchain.Skip
 					ctr = c.processAnomaly(reqNew, &meta, ctr)
 				}
 			}
+			log.Lvlf2("counter: %d, f: %d, meta (ctr/state): %d/%d, "+
+				"req: %+v", ctr, f, meta.countOf(ctr), meta.stateOf(ctr), req)
 			if meta.countOf(ctr) > 2*f && meta.stateOf(ctr) < startedTimerState && meta.acceptOf(ctr) {
 				// To avoid starting the next view-change too
 				// soon, start view-change timer after
@@ -270,7 +272,8 @@ func (c *Controller) processAnomaly(req InitReq, meta *stateLogs, ctr int) int {
 		// controller has already moved on and it will
 		// only wait for relevant messages for its
 		// current or later view.
-		log.Lvl4("Controller is not accepting anomalies for earlier views")
+		log.Lvlf4("Controller is not accepting anomalies for earlier views"+
+			": %d <= %d", req.View.LeaderIndex, ctr)
 	}
 	return ctr
 }


### PR DESCRIPTION
This patch fixes the initialization of the viewchange when the node
starts up: instead of calculating 'f' from the genesis-block, it
looks up the latest block and calculates 'f' from this one.