### PR TITLE
Add a caching system for the stateTries …

### DIFF
--- a/byzcoin/contract_darc.go
+++ b/byzcoin/contract_darc.go
@@ -125,7 +125,7 @@ func (c *contractSecureDarc) Invoke(rst ReadOnlyStateTrie, inst Instruction, coi
 		if err != nil {
 			return nil, nil, xerrors.Errorf("darc encoding: %v", err)
 		}
-		oldD, err := LoadDarcFromTrie(rst, darcID)
+		oldD, err := rst.LoadDarcFromTrie(darcID)
 		if err != nil {
 			return nil, nil, xerrors.Errorf("darc from trie: %v", err)
 		}
@@ -161,7 +161,7 @@ func (c *contractSecureDarc) Invoke(rst ReadOnlyStateTrie, inst Instruction, coi
 		if err != nil {
 			return nil, nil, xerrors.Errorf("encoding darc: %v", err)
 		}
-		oldD, err := LoadDarcFromTrie(rst, darcID)
+		oldD, err := rst.LoadDarcFromTrie(darcID)
 		if err != nil {
 			return nil, nil, xerrors.Errorf("darc from trie: %v", err)
 		}

--- a/byzcoin/contract_darc.go
+++ b/byzcoin/contract_darc.go
@@ -125,7 +125,7 @@ func (c *contractSecureDarc) Invoke(rst ReadOnlyStateTrie, inst Instruction, coi
 		if err != nil {
 			return nil, nil, xerrors.Errorf("darc encoding: %v", err)
 		}
-		oldD, err := rst.LoadDarcFromTrie(darcID)
+		oldD, err := rst.LoadDarc(darcID)
 		if err != nil {
 			return nil, nil, xerrors.Errorf("darc from trie: %v", err)
 		}
@@ -161,7 +161,7 @@ func (c *contractSecureDarc) Invoke(rst ReadOnlyStateTrie, inst Instruction, coi
 		if err != nil {
 			return nil, nil, xerrors.Errorf("encoding darc: %v", err)
 		}
-		oldD, err := rst.LoadDarcFromTrie(darcID)
+		oldD, err := rst.LoadDarc(darcID)
 		if err != nil {
 			return nil, nil, xerrors.Errorf("darc from trie: %v", err)
 		}

--- a/byzcoin/contract_name.go
+++ b/byzcoin/contract_name.go
@@ -115,7 +115,7 @@ func (c *contractNaming) VerifyInstruction(rst ReadOnlyStateTrie, inst Instructi
 	if err != nil {
 		return xerrors.Errorf("failed to get the rst values of %s: %v", value, err)
 	}
-	d, err := LoadDarcFromTrie(rst, dID)
+	d, err := rst.LoadDarcFromTrie(dID)
 	if err != nil {
 		return xerrors.Errorf("failed to load darc from tries: %v", err)
 	}
@@ -147,7 +147,7 @@ func (c *contractNaming) VerifyInstruction(rst ReadOnlyStateTrie, inst Instructi
 		if err != nil {
 			return nil
 		}
-		d, err := LoadDarcFromTrie(rst, darcID)
+		d, err := rst.LoadDarcFromTrie(darcID)
 		if err != nil {
 			return nil
 		}

--- a/byzcoin/contract_name.go
+++ b/byzcoin/contract_name.go
@@ -115,7 +115,7 @@ func (c *contractNaming) VerifyInstruction(rst ReadOnlyStateTrie, inst Instructi
 	if err != nil {
 		return xerrors.Errorf("failed to get the rst values of %s: %v", value, err)
 	}
-	d, err := rst.LoadDarcFromTrie(dID)
+	d, err := rst.LoadDarc(dID)
 	if err != nil {
 		return xerrors.Errorf("failed to load darc from tries: %v", err)
 	}
@@ -147,7 +147,7 @@ func (c *contractNaming) VerifyInstruction(rst ReadOnlyStateTrie, inst Instructi
 		if err != nil {
 			return nil
 		}
-		d, err := rst.LoadDarcFromTrie(darcID)
+		d, err := rst.LoadDarc(darcID)
 		if err != nil {
 			return nil
 		}

--- a/byzcoin/contracts.go
+++ b/byzcoin/contracts.go
@@ -503,7 +503,7 @@ func (c *contractConfig) Invoke(rst ReadOnlyStateTrie, inst Instruction, coins [
 		}
 
 		var oldConfig *ChainConfig
-		oldConfig, err = rst.LoadConfigFromTrie()
+		oldConfig, err = rst.LoadConfig()
 		if err != nil {
 			return nil, nil, xerrors.Errorf("reading trie: %v", err)
 		}
@@ -557,7 +557,7 @@ func (c *contractConfig) Invoke(rst ReadOnlyStateTrie, inst Instruction, coins [
 }
 
 func updateRosterScs(rst ReadOnlyStateTrie, darcID darc.ID, newRoster onet.Roster) (StateChanges, error) {
-	config, err := rst.LoadConfigFromTrie()
+	config, err := rst.LoadConfig()
 	if err != nil {
 		return nil, xerrors.Errorf("reading trie: %v", err)
 	}

--- a/byzcoin/contracts/coins_test.go
+++ b/byzcoin/contracts/coins_test.go
@@ -3,6 +3,7 @@ package contracts
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -316,6 +317,14 @@ func (ct cvTest) StoreAllToReplica(scs byzcoin.StateChanges) (byzcoin.ReadOnlySt
 
 func (ct cvTest) GetSignerCounter(id darc.Identity) (uint64, error) {
 	return 0, xerrors.Errorf("not yet implemented")
+}
+
+func (ct cvTest) LoadConfigFromTrie() (*byzcoin.ChainConfig, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (ct cvTest) LoadDarcFromTrie(id darc.ID) (*darc.Darc, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (ct cvTest) setSignatureCounter(id string, v uint64) {

--- a/byzcoin/contracts/coins_test.go
+++ b/byzcoin/contracts/coins_test.go
@@ -319,11 +319,11 @@ func (ct cvTest) GetSignerCounter(id darc.Identity) (uint64, error) {
 	return 0, xerrors.Errorf("not yet implemented")
 }
 
-func (ct cvTest) LoadConfigFromTrie() (*byzcoin.ChainConfig, error) {
+func (ct cvTest) LoadConfig() (*byzcoin.ChainConfig, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (ct cvTest) LoadDarcFromTrie(id darc.ID) (*darc.Darc, error) {
+func (ct cvTest) LoadDarc(id darc.ID) (*darc.Darc, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/byzcoin/contracts/insecure_darc.go
+++ b/byzcoin/contracts/insecure_darc.go
@@ -86,7 +86,7 @@ func (c *contractInsecureDarc) Invoke(rst byzcoin.ReadOnlyStateTrie, inst byzcoi
 		if err != nil {
 			return nil, nil, err
 		}
-		oldD, err := byzcoin.LoadDarcFromTrie(rst, darcID)
+		oldD, err := rst.LoadDarcFromTrie(darcID)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/byzcoin/contracts/insecure_darc.go
+++ b/byzcoin/contracts/insecure_darc.go
@@ -86,7 +86,7 @@ func (c *contractInsecureDarc) Invoke(rst byzcoin.ReadOnlyStateTrie, inst byzcoi
 		if err != nil {
 			return nil, nil, err
 		}
-		oldD, err := rst.LoadDarcFromTrie(darcID)
+		oldD, err := rst.LoadDarc(darcID)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/byzcoin/rostsimul.go
+++ b/byzcoin/rostsimul.go
@@ -72,13 +72,13 @@ func (s *ROSTSimul) ForEach(func(k, v []byte) error) error {
 	return errors.New("not implemented")
 }
 
-// LoadConfigFromTrie is not implemented
-func (s *ROSTSimul) LoadConfigFromTrie() (*ChainConfig, error) {
+// LoadConfig is not implemented
+func (s *ROSTSimul) LoadConfig() (*ChainConfig, error) {
 	return nil, errors.New("not implemented")
 }
 
-// LoadDarcFromTrie is not implemented
-func (s *ROSTSimul) LoadDarcFromTrie(id darc.ID) (*darc.Darc, error) {
+// LoadDarc is not implemented
+func (s *ROSTSimul) LoadDarc(id darc.ID) (*darc.Darc, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/byzcoin/rostsimul.go
+++ b/byzcoin/rostsimul.go
@@ -2,6 +2,7 @@ package byzcoin
 
 import (
 	"errors"
+
 	"golang.org/x/xerrors"
 
 	"go.dedis.ch/cothority/v3"
@@ -69,6 +70,16 @@ func (s *ROSTSimul) GetNonce() ([]byte, error) {
 // ForEach is not implemented.
 func (s *ROSTSimul) ForEach(func(k, v []byte) error) error {
 	return errors.New("not implemented")
+}
+
+// LoadConfigFromTrie is not implemented
+func (s *ROSTSimul) LoadConfigFromTrie() (*ChainConfig, error) {
+	return nil, errors.New("not implemented")
+}
+
+// LoadDarcFromTrie is not implemented
+func (s *ROSTSimul) LoadDarcFromTrie(id darc.ID) (*darc.Darc, error) {
+	return nil, errors.New("not implemented")
 }
 
 // StoreAllToReplica stores all stateChanges, without checking for validity!

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -543,7 +543,7 @@ func (s *Service) CheckAuthorization(req *CheckAuthorization) (resp *CheckAuthor
 	if err != nil {
 		return nil, xerrors.Errorf("getting trie: %v", err)
 	}
-	d, err := LoadDarcFromTrie(st, req.DarcID)
+	d, err := st.LoadDarcFromTrie(req.DarcID)
 	if err != nil {
 		return nil, xerrors.Errorf("couldn't find darc: %v", err)
 	}
@@ -557,7 +557,7 @@ func (s *Service) CheckAuthorization(req *CheckAuthorization) (resp *CheckAuthor
 			log.Error("invalid darc id", s, len(id), err)
 			return nil
 		}
-		d, err := LoadDarcFromTrie(st, id)
+		d, err := st.LoadDarcFromTrie(id)
 		if err != nil {
 			log.Error("didn't find darc")
 			return nil
@@ -1852,7 +1852,7 @@ func (s *Service) LoadConfig(scID skipchain.SkipBlockID) (*ChainConfig, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("getting trie: %v", err)
 	}
-	cfg, err := LoadConfigFromTrie(st)
+	cfg, err := st.LoadConfigFromTrie()
 	return cfg, cothority.ErrorOrNil(err, "reading trie")
 }
 
@@ -1886,7 +1886,7 @@ func (s *Service) LoadBlockInfo(scID skipchain.SkipBlockID) (time.Duration, int,
 }
 
 func loadBlockInfo(st ReadOnlyStateTrie) (time.Duration, int, error) {
-	config, err := LoadConfigFromTrie(st)
+	config, err := st.LoadConfigFromTrie()
 	if err != nil {
 		if xerrors.Is(err, errKeyNotSet) {
 			err = nil
@@ -2062,7 +2062,7 @@ func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool
 		return false
 	}
 
-	config, err := LoadConfigFromTrie(sst)
+	config, err := sst.LoadConfigFromTrie()
 	if err != nil {
 		log.Error(s.ServerIdentity(), err)
 		return false

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -1625,7 +1625,8 @@ func (s *Service) updateTrieCallback(sbID skipchain.SkipBlockID) error {
 	log.Lvlf2("%s Updating %d transactions for %x on index %v", s.ServerIdentity(), len(body.TxResults), sb.SkipChainID(), sb.Index)
 	_, _, scs, _ := s.createStateChanges(st.MakeStagingStateTrie(), sb.SkipChainID(), body.TxResults, noTimeout, header.Version, header.Timestamp)
 
-	log.Lvlf3("%s Storing index %d with %d state changes %v", s.ServerIdentity(), sb.Index, len(scs), scs.ShortStrings())
+	log.Lvlf3("%s Storing index %d with %d state changes %v",
+		s.ServerIdentity(), sb.Index, len(scs), scs.ShortStrings())
 	// Update our global state using all state changes.
 	if err = st.VerifiedStoreAll(scs, sb.Index, header.Version, header.TrieRoot); err != nil {
 		return xerrors.Errorf("storing state changes: %v", err)

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -543,7 +543,7 @@ func (s *Service) CheckAuthorization(req *CheckAuthorization) (resp *CheckAuthor
 	if err != nil {
 		return nil, xerrors.Errorf("getting trie: %v", err)
 	}
-	d, err := st.LoadDarcFromTrie(req.DarcID)
+	d, err := st.LoadDarc(req.DarcID)
 	if err != nil {
 		return nil, xerrors.Errorf("couldn't find darc: %v", err)
 	}
@@ -557,7 +557,7 @@ func (s *Service) CheckAuthorization(req *CheckAuthorization) (resp *CheckAuthor
 			log.Error("invalid darc id", s, len(id), err)
 			return nil
 		}
-		d, err := st.LoadDarcFromTrie(id)
+		d, err := st.LoadDarc(id)
 		if err != nil {
 			log.Error("didn't find darc")
 			return nil
@@ -1852,7 +1852,7 @@ func (s *Service) LoadConfig(scID skipchain.SkipBlockID) (*ChainConfig, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("getting trie: %v", err)
 	}
-	cfg, err := st.LoadConfigFromTrie()
+	cfg, err := st.LoadConfig()
 	return cfg, cothority.ErrorOrNil(err, "reading trie")
 }
 
@@ -1886,7 +1886,7 @@ func (s *Service) LoadBlockInfo(scID skipchain.SkipBlockID) (time.Duration, int,
 }
 
 func loadBlockInfo(st ReadOnlyStateTrie) (time.Duration, int, error) {
-	config, err := st.LoadConfigFromTrie()
+	config, err := st.LoadConfig()
 	if err != nil {
 		if xerrors.Is(err, errKeyNotSet) {
 			err = nil
@@ -2062,7 +2062,7 @@ func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool
 		return false
 	}
 
-	config, err := sst.LoadConfigFromTrie()
+	config, err := sst.LoadConfig()
 	if err != nil {
 		log.Error(s.ServerIdentity(), err)
 		return false

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -2513,7 +2513,7 @@ func TestService_Repair(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			intermediateStateTrie = &stateTrie{*intermediateTrie}
+			intermediateStateTrie = &stateTrie{*intermediateTrie, trieCache{}}
 		} else if i == n-1 {
 			tmpTrie, err := s.service().getStateTrie(s.genesis.SkipChainID())
 			require.NoError(t, err)

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -2513,7 +2513,8 @@ func TestService_Repair(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			intermediateStateTrie = &stateTrie{*intermediateTrie, trieCache{}}
+			intermediateStateTrie = &stateTrie{*intermediateTrie,
+				trieCache{}, sync.Mutex{}}
 		} else if i == n-1 {
 			tmpTrie, err := s.service().getStateTrie(s.genesis.SkipChainID())
 			require.NoError(t, err)

--- a/byzcoin/statetrie.go
+++ b/byzcoin/statetrie.go
@@ -3,6 +3,8 @@ package byzcoin
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"sync"
 
 	"go.dedis.ch/onet/v3/network"
@@ -45,9 +47,13 @@ type ReadOnlyStateTrie interface {
 	// the state changes to the copy. The implementation should make sure
 	// that the original read-only trie is not be modified.
 	StoreAllToReplica(StateChanges) (ReadOnlyStateTrie, error)
+	// GetSignerCounter returns the latest counters available.
 	GetSignerCounter(id darc.Identity) (uint64, error)
-	LoadConfigFromTrie() (*ChainConfig, error)
-	LoadDarcFromTrie(id darc.ID) (*darc.Darc, error)
+	// LoadConfig returns the config,
+	// or a cache of it to speed up if there are many lookups.
+	LoadConfig() (*ChainConfig, error)
+	// LoadDarc returns a darc, or a cache of it.
+	LoadDarc(id darc.ID) (*darc.Darc, error)
 }
 
 // ReadOnlySkipChain holds the skipchain data.
@@ -157,11 +163,11 @@ func (t *stagingStateTrie) GetVersion() Version {
 	return readVersion(t)
 }
 
-func (t *stagingStateTrie) LoadConfigFromTrie() (*ChainConfig, error) {
+func (t *stagingStateTrie) LoadConfig() (*ChainConfig, error) {
 	return t.loadConfigFromTrie(t)
 }
 
-func (t *stagingStateTrie) LoadDarcFromTrie(id darc.ID) (*darc.Darc, error) {
+func (t *stagingStateTrie) LoadDarc(id darc.ID) (*darc.Darc, error) {
 	return t.loadDarcFromTrie(t, id)
 }
 
@@ -171,6 +177,10 @@ type trieCache struct {
 	sync.Mutex
 }
 
+// use a very defensive cache mechanism,
+// where every write to the trie invalidates all the cache.
+// This avoids having to search through the cache to find invalid entries on
+// each write.
 func (tc *trieCache) invalidate() {
 	tc.Lock()
 	tc.config = nil
@@ -188,17 +198,17 @@ func (tc *trieCache) loadConfigFromTrie(st ReadOnlyStateTrie) (*ChainConfig, err
 	// Find the genesis-darc ID.
 	val, _, contract, _, err := GetValueContract(st, NewInstanceID(nil).Slice())
 	if err != nil {
-		return nil, xerrors.Errorf("reading trie: %w", err)
+		return nil, fmt.Errorf("reading trie: %w", err)
 	}
-	if string(contract) != ContractConfigID {
-		return nil, xerrors.New("did not get " + ContractConfigID)
+	if contract != ContractConfigID {
+		return nil, errors.New("did not get " + ContractConfigID)
 	}
 
 	tc.config = &ChainConfig{}
 	err = protobuf.DecodeWithConstructors(val, tc.config,
 		network.DefaultConstructors(cothority.Suite))
 	if err != nil {
-		return nil, xerrors.Errorf("decoding config: %v", err)
+		return nil, fmt.Errorf("decoding config: %v", err)
 	}
 
 	return tc.config, nil
@@ -208,35 +218,44 @@ func (tc *trieCache) loadDarcFromTrie(st ReadOnlyStateTrie,
 	id darc.ID) (*darc.Darc, error) {
 	tc.Lock()
 	defer tc.Unlock()
-	if len(tc.darcs) > 0 {
-		if d := tc.darcs[string(id)]; d != nil {
+	if tc.darcs == nil {
+		tc.darcs = make(map[string]*darc.Darc)
+	} else {
+		if d, ok := tc.darcs[string(id)]; ok {
 			return d, nil
 		}
-	} else {
-		tc.darcs = make(map[string]*darc.Darc)
 	}
+
 	darcBuf, _, contract, _, err := st.GetValues(id)
 	if err != nil {
-		return nil, xerrors.Errorf("reading trie: %v", err)
+		return nil, fmt.Errorf("reading trie: %v", err)
 	}
+
+	tc.Unlock()
 	config, err := tc.loadConfigFromTrie(st)
+	tc.Lock()
+
 	if err != nil {
-		return nil, xerrors.Errorf("reading trie: %v", err)
+		return nil, fmt.Errorf("reading trie: %v", err)
 	}
 	var ok bool
 	for _, id := range config.DarcContractIDs {
 		if contract == id {
 			ok = true
+			break
 		}
 	}
+
 	if !ok {
-		return nil, xerrors.New("the contract \"" + contract + "\" is not in the set of DARC contracts")
+		return nil, fmt.Errorf("the contract '%s' is not in"+
+			" the set of DARC contracts", contract)
 	}
-	tc.darcs[string(id)], err = darc.NewFromProtobuf(darcBuf)
+	d, err := darc.NewFromProtobuf(darcBuf)
 	if err != nil {
-		return nil, xerrors.Errorf("decoding darc: %v", err)
+		return nil, fmt.Errorf("decoding darc: %v", err)
 	}
-	return tc.darcs[string(id)], nil
+	tc.darcs[string(id)] = d
+	return d, nil
 }
 
 const trieIndexKey = "trieIndexKey"
@@ -301,7 +320,7 @@ func (t *stateTrie) VerifiedStoreAll(scs StateChanges, index int, version Versio
 		}
 
 		if expectedRoot != nil && !bytes.Equal(t.GetRootWithBucket(b), expectedRoot) {
-			return xerrors.New("root verfication failed")
+			return xerrors.New("root verification failed")
 		}
 		return nil
 	})
@@ -368,11 +387,11 @@ func (t *stateTrie) GetSignerCounter(id darc.Identity) (uint64, error) {
 	return getSignerCounter(t, id.String())
 }
 
-func (t *stateTrie) LoadConfigFromTrie() (*ChainConfig, error) {
+func (t *stateTrie) LoadConfig() (*ChainConfig, error) {
 	return t.loadConfigFromTrie(t)
 }
 
-func (t *stateTrie) LoadDarcFromTrie(id darc.ID) (*darc.Darc, error) {
+func (t *stateTrie) LoadDarc(id darc.ID) (*darc.Darc, error) {
 	return t.loadDarcFromTrie(t, id)
 }
 

--- a/byzcoin/statetrie_test.go
+++ b/byzcoin/statetrie_test.go
@@ -2,7 +2,18 @@ package byzcoin
 
 import (
 	"bytes"
+	"encoding/hex"
+	"math/big"
+	"strings"
 	"testing"
+	"time"
+
+	"go.dedis.ch/onet/v3"
+
+	"go.dedis.ch/kyber/v3/util/random"
+
+	"github.com/ethereum/go-ethereum/common/math"
+	"go.dedis.ch/onet/v3/log"
 
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/cothority/v3/darc"
@@ -70,4 +81,126 @@ func TestStateTrie(t *testing.T) {
 	// test the commit of staging state trie, root should be computed differently now, but it should be the same
 	require.NoError(t, sst.Commit())
 	require.True(t, bytes.Equal(sst.GetRoot(), newRoot))
+}
+
+// TestDarcRetrieval is used as a benchmark here. It stores a lot of darcs
+// that are all linked in a tree-structure, and then uses EvalExprDarc to
+// check whether an identity is valid or not.
+// Use with
+//   go test -v -cpuprofile cpu.prof -run TestDarcRetrieval
+//   go tool pprof -pdf cpu.prof
+func TestDarcRetrieval(t *testing.T) {
+	darcDepth := 3
+	darcWidth := 10
+	entries := 10000
+
+	s := newSer(t, 1, 10*time.Second)
+	defer s.local.CloseAll()
+	s.local.Check = onet.CheckNone
+
+	st, err := s.service().getStateTrie(s.genesis.SkipChainID())
+	require.NoError(t, err)
+	require.NotNil(t, st)
+	require.NotEqual(t, -1, st.GetIndex())
+
+	log.Lvl1("Creating random entries")
+	value := random.Bits(1024, true, random.New())
+	start := time.Now()
+	var scs []StateChange
+	for e := 1; e <= entries; e++ {
+		scs = append(scs, StateChange{
+			StateAction: Create,
+			InstanceID:  random.Bits(256, true, random.New()),
+			ContractID:  ContractDarcID,
+			Value:       value,
+		})
+		if e%100 == 0 {
+			st.StoreAll(scs, 5, CurrentVersion)
+			scs = []StateChange{}
+			log.Print(e, time.Now().Sub(start))
+			start = time.Now()
+		}
+	}
+
+	log.Lvl1("Creating darcs")
+	counter := big.NewInt(0)
+	// Store the tree of darcs in a 2D-array with the root in index 0 and
+	// the leafs in index darcDepth-1
+	darcs := make([][]*darc.Darc, darcDepth)
+	for d := darcDepth - 1; d >= 0; d-- {
+		width := math.Exp(big.NewInt(int64(darcWidth)),
+			big.NewInt(int64(d))).Int64()
+		darcs[d] = make([]*darc.Darc, width)
+		// The leafs just hold a dummy reference to a darc
+		if d == darcDepth-1 {
+			for i := range darcs[d] {
+				counter.Add(counter, big.NewInt(1))
+				id := make([]byte, 32)
+				copy(id, counter.Bytes())
+				ids := []darc.Identity{darc.NewIdentityDarc(id)}
+				rules := darc.InitRules(ids, ids)
+				darcs[d][i] = darc.NewDarc(rules, []byte(counter.String()))
+			}
+		} else {
+			for i := range darcs[d] {
+				counter.Add(counter, big.NewInt(1))
+				ids := make([]darc.Identity, darcWidth)
+				for id := range ids {
+					ids[id] = darc.NewIdentityDarc(
+						darcs[d+1][i*darcWidth+id].GetBaseID())
+				}
+				rules := darc.InitRules(ids, ids)
+				darcs[d][i] = darc.NewDarc(rules, []byte(counter.String()))
+			}
+		}
+	}
+
+	scs = make([]StateChange, 0, counter.Int64())
+	for d := range darcs {
+		for w := range darcs[d] {
+			td := darcs[d][w]
+			log.Lvlf3("darc[%d][%d]: %x has %s", d, w,
+				td.GetBaseID(), td.Rules)
+			buf, err := td.ToProto()
+			require.NoError(t, err)
+			scs = append(scs, StateChange{
+				StateAction: Create,
+				InstanceID:  td.GetBaseID(),
+				ContractID:  ContractDarcID,
+				Value:       buf,
+				Version:     0,
+			})
+		}
+	}
+	require.NoError(t, st.StoreAll(scs, 5, CurrentVersion))
+
+	getDarcs := func(s string, latest bool) *darc.Darc {
+		if !latest {
+			log.Error("cannot handle intermediate darcs")
+			return nil
+		}
+		id, err := hex.DecodeString(strings.Replace(s, "darc:", "", 1))
+		if err != nil || len(id) != 32 {
+			log.Error("invalid darc id", s, len(id), err)
+			return nil
+		}
+		d, err := st.LoadDarcFromTrie(id)
+		if err != nil {
+			return nil
+		}
+		return d
+	}
+
+	root := darcs[0][0]
+	rootSign := root.Rules.GetSignExpr()
+	start = time.Now()
+	for i := range darcs[darcDepth-1] {
+		id := darc.ID(make([]byte, 32))
+		copy(id, big.NewInt(int64(i+1)).Bytes())
+		darcID := darc.NewIdentityDarc(id)
+		log.Print("Searching id", darcID.String())
+		err = darc.EvalExprDarc(rootSign, getDarcs, true, darcID.String())
+		require.NoError(t, err)
+	}
+	log.Lvl1("time to search:", time.Now().Sub(start))
 }

--- a/byzcoin/transaction.go
+++ b/byzcoin/transaction.go
@@ -418,7 +418,7 @@ func (instr Instruction) VerifyWithOption(st ReadOnlyStateTrie, msg []byte, ops 
 	}
 
 	// get the valid DARC contract IDs from the configuration
-	config, err := LoadConfigFromTrie(st)
+	config, err := st.LoadConfigFromTrie()
 	if err != nil {
 		return xerrors.Errorf("reading trie: %v", err)
 	}
@@ -464,7 +464,7 @@ func (instr Instruction) VerifyWithOption(st ReadOnlyStateTrie, msg []byte, ops 
 		if err != nil {
 			return nil
 		}
-		d, err := LoadDarcFromTrie(st, darcID)
+		d, err := st.LoadDarcFromTrie(darcID)
 		if err != nil {
 			return nil
 		}

--- a/byzcoin/transaction.go
+++ b/byzcoin/transaction.go
@@ -418,7 +418,7 @@ func (instr Instruction) VerifyWithOption(st ReadOnlyStateTrie, msg []byte, ops 
 	}
 
 	// get the valid DARC contract IDs from the configuration
-	config, err := st.LoadConfigFromTrie()
+	config, err := st.LoadConfig()
 	if err != nil {
 		return xerrors.Errorf("reading trie: %v", err)
 	}
@@ -464,7 +464,7 @@ func (instr Instruction) VerifyWithOption(st ReadOnlyStateTrie, msg []byte, ops 
 		if err != nil {
 			return nil
 		}
-		d, err := st.LoadDarcFromTrie(darcID)
+		d, err := st.LoadDarc(darcID)
 		if err != nil {
 			return nil
 		}

--- a/byzcoin/transaction_test.go
+++ b/byzcoin/transaction_test.go
@@ -26,7 +26,7 @@ func TestTransaction_Signing(t *testing.T) {
 	mdb := trie.NewMemDB()
 	tr, err := trie.NewTrie(mdb, []byte("my nonce"))
 	require.NoError(t, err)
-	sst := &stagingStateTrie{*tr.MakeStagingTrie()}
+	sst := &stagingStateTrie{*tr.MakeStagingTrie(), trieCache{}}
 
 	// verification should fail because trie is empty
 	ctxHash := ctx.Instructions.Hash()

--- a/byzcoin/transaction_test.go
+++ b/byzcoin/transaction_test.go
@@ -2,6 +2,7 @@ package byzcoin
 
 import (
 	"encoding/binary"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,7 +27,7 @@ func TestTransaction_Signing(t *testing.T) {
 	mdb := trie.NewMemDB()
 	tr, err := trie.NewTrie(mdb, []byte("my nonce"))
 	require.NoError(t, err)
-	sst := &stagingStateTrie{*tr.MakeStagingTrie(), trieCache{}}
+	sst := &stagingStateTrie{*tr.MakeStagingTrie(), trieCache{}, sync.Mutex{}}
 
 	// verification should fail because trie is empty
 	ctxHash := ctx.Instructions.Hash()

--- a/byzcoin/tx_pipeline.go
+++ b/byzcoin/tx_pipeline.go
@@ -259,7 +259,7 @@ func (s *defaultTxProcessor) ProcessTx(tx ClientTransaction, inState *txProcesso
 // ProposeBlock basically calls s.createNewBlock which might block. There is
 // nothing we can do about it other than waiting for the timeout.
 func (s *defaultTxProcessor) ProposeBlock(state *txProcessorState) error {
-	config, err := LoadConfigFromTrie(state.sst)
+	config, err := state.sst.LoadConfigFromTrie()
 	if err != nil {
 		return xerrors.Errorf("reading trie: %v", err)
 	}

--- a/byzcoin/tx_pipeline.go
+++ b/byzcoin/tx_pipeline.go
@@ -259,7 +259,7 @@ func (s *defaultTxProcessor) ProcessTx(tx ClientTransaction, inState *txProcesso
 // ProposeBlock basically calls s.createNewBlock which might block. There is
 // nothing we can do about it other than waiting for the timeout.
 func (s *defaultTxProcessor) ProposeBlock(state *txProcessorState) error {
-	config, err := state.sst.LoadConfigFromTrie()
+	config, err := state.sst.LoadConfig()
 	if err != nil {
 		return xerrors.Errorf("reading trie: %v", err)
 	}

--- a/personhood/contracts/contract_credential.go
+++ b/personhood/contracts/contract_credential.go
@@ -302,7 +302,7 @@ func checkDarcRule(rst byzcoin.ReadOnlyStateTrie, d *darc.Darc, id string) error
 		if err != nil {
 			return nil
 		}
-		d, err := byzcoin.LoadDarcFromTrie(rst, darcID)
+		d, err := rst.LoadDarcFromTrie(darcID)
 		if err != nil {
 			return nil
 		}

--- a/personhood/contracts/contract_credential.go
+++ b/personhood/contracts/contract_credential.go
@@ -302,7 +302,7 @@ func checkDarcRule(rst byzcoin.ReadOnlyStateTrie, d *darc.Darc, id string) error
 		if err != nil {
 			return nil
 		}
-		d, err := rst.LoadDarcFromTrie(darcID)
+		d, err := rst.LoadDarc(darcID)
 		if err != nil {
 			return nil
 		}


### PR DESCRIPTION
The current stateTries have two bottlenecks:
- LoadConfigFromTrie - which is called everytime a LoadDarcFromTrie is called and
decodes the config protobuf structure every time anew
- LoadDarcFromTrie - which is called when evaluating signatures or authorizations

This PR adds a cache for both of these methods, so that calls within the
same block are cached. The test, which is a bit artificial, gives the
following improvements:
- LoadConfigFromTrie - 3x faster authorization check
- LoadDarcFromTrie - 4x faster authorization check

The latter is a bit artificial, because it measures looking up the same darcs
repeatedly, which in practice happens rarely.

The first test, however, is very relevant. In the 9cc3-chain, it is even worse,
as the config contains more nodes, which will make protobuf.Decode even
slower.

Closes #2258 