### PR TITLE
Update cached instances when new blocks arrive

### DIFF
--- a/external/js/cothority/src/byzcoin/client-transaction.ts
+++ b/external/js/cothority/src/byzcoin/client-transaction.ts
@@ -140,6 +140,7 @@ export class Instruction extends Message<Instruction> {
         }
         throw new Error("instruction without type");
     }
+
     /**
      * @see README#Message classes
      */

--- a/external/js/cothority/tsconfig.json
+++ b/external/js/cothority/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "downlevelIteration": true,
     "outDir": "./dist/",
     "module": "commonjs",
     "target": "es6",


### PR DESCRIPTION
This PR adds error-handling and an improvement of updating the cached
instances by sending a grouped update-request to ByzCoin.
This allows the web-client to have a quick first value of an instance
which might be outdated, and then receive a new value as soon as it's
available.