### PR TITLE
Ignore non-existing instances in GetUpdates

### DIFF
--- a/byzcoin/api_test.go
+++ b/byzcoin/api_test.go
@@ -351,47 +351,6 @@ func TestClient_SignerCounterDecoder(t *testing.T) {
 	require.Error(t, c.signerCounterDecoder(buf, &reply))
 }
 
-func TestClient_GetUpdates(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
-
-	req := &GetUpdatesRequest{
-		Instances:     nil,
-		Flags:         0,
-		LatestBlockID: nil,
-	}
-	_, err := s.service().GetUpdates(req)
-	require.Error(t, err)
-
-	req.Instances = []IDVersion{{ConfigInstanceID, 0}}
-	req.LatestBlockID = s.genesis.SkipChainID()
-	gur, err := s.service().GetUpdates(req)
-	require.NoError(t, err)
-	require.Equal(t, 0, len(gur.Proofs))
-
-	req.Flags = GUFSendVersion0
-	gur, err = s.service().GetUpdates(req)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(gur.Proofs))
-	require.True(t, gur.Proofs[0].Match(ConfigInstanceID[:]))
-
-	ctx, _ := createConfigTxWithCounter(t, time.Millisecond*100, *s.roster,
-		1e5, s, 1)
-	s.sendTxAndWait(t, ctx, 10)
-
-	req.Flags = 0
-	_, err = s.service().GetUpdates(req)
-	require.Error(t, err)
-	latest, err := s.service().db().GetLatest(s.genesis)
-	req.LatestBlockID = latest.Hash
-	require.NoError(t, err)
-
-	gur, err = s.service().GetUpdates(req)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(gur.Proofs))
-	require.True(t, gur.Proofs[0].Match(ConfigInstanceID[:]))
-}
-
 const testServiceName = "TestByzCoin"
 
 type corruptedService struct {

--- a/byzcoin/struct.go
+++ b/byzcoin/struct.go
@@ -725,4 +725,7 @@ const (
 	// GUFSendVersion0 will make GetUpdates to send all instances with
 	// version 0, even those that are note updated.
 	GUFSendVersion0 = GetUpdatesFlags(1 << iota)
+	// GUFSendMissingProofs will make GetUpdates send proofs for missing
+	// instances. If not present, missing instances are ignored.
+	GUFSendMissingProofs
 )


### PR DESCRIPTION
Currently GetUpdates returns an error if it is queried for an unknown instance.
This is not correct, as instances can disappear. 

It should either ignore them, or return a proof of missing instance.
Both is possible now, depending on the flag sent to GetUpdates.