### PR TITLE
Sign viewchange only with active nodes

### DIFF
--- a/blscosi/protocol/protocol.go
+++ b/blscosi/protocol/protocol.go
@@ -197,7 +197,8 @@ func (p *BlsCosi) runSubProtocols() {
 	p.subProtocolsLock.Lock()
 	p.subProtocols = make([]*SubBlsCosi, len(p.subTrees))
 	for i, tree := range p.subTrees {
-		log.Lvlf3("Invoking start sub protocol on %v", tree.Root.ServerIdentity)
+		log.Lvlf3("Invoking start sub protocol on %v\n%s",
+			tree.Root.ServerIdentity, tree.Dump())
 		var err error
 		p.subProtocols[i], err = p.startSubProtocol(tree)
 		if err != nil {
@@ -280,7 +281,8 @@ func (p *BlsCosi) startSubProtocol(tree *onet.Tree) (*SubBlsCosi, error) {
 	// responses. The main protocol will deal with early answers.
 	cosiSubProtocol.Threshold = tree.Size() - 1
 
-	log.Lvlf3("Starting sub protocol with subleader %v", tree.Root.Children[0].ServerIdentity)
+	log.Lvlf3("Starting sub protocol with subleader %v",
+		tree.Root.Children[0].ServerIdentity)
 	err = cosiSubProtocol.Start()
 	if err != nil {
 		return nil, err
@@ -380,7 +382,6 @@ func (p *BlsCosi) collectSignatures() (ResponseMap, error) {
 					count := mask.CountEnabled()
 					numSignature += count
 					numFailure += res.SubtreeCount() + 1 - count
-
 					responseMap[index] = &res.Response
 				}
 			}

--- a/blscosi/protocol/sub_protocol.go
+++ b/blscosi/protocol/sub_protocol.go
@@ -262,6 +262,8 @@ func (p *SubBlsCosi) dispatchSubLeader() error {
 		if index != -1 {
 			responses[index] = own
 		}
+	} else {
+		log.Warn("Subleader didn't sign", p.ServerIdentity())
 	}
 
 	// we need to timeout the children faster than the root timeout to let it
@@ -311,7 +313,8 @@ func (p *SubBlsCosi) dispatchSubLeader() error {
 				log.Warnf("Duplicate refusal from %v", reply.ServerIdentity)
 			}
 		case <-timeout:
-			log.Lvlf3("Subleader reached timeout waiting for children responses: %v", p.ServerIdentity())
+			log.Lvlf3("Subleader reached timeout waiting for children"+
+				" responses: %v", p.ServerIdentity())
 			// Use whatever we received until then to try to finish
 			// the protocol
 			done = len(p.Children())

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -2675,8 +2675,8 @@ func (s *Service) monitorLeaderFailure() {
 						LeaderIndex: 1,
 					},
 				}
-				log.Lvlf2("Starting a view-change by putting our own request"+
-					": %+v", req)
+				log.Lvlf2("%s: Starting a view-change by putting our own"+
+					" request: %+v", s.ServerIdentity(), req)
 				s.viewChangeMan.addReq(req)
 			}
 		case <-s.closeLeaderMonitorChan:

--- a/byzcoin/viewchange/viewchange.go
+++ b/byzcoin/viewchange/viewchange.go
@@ -145,11 +145,13 @@ func (c *Controller) Start(myID network.ServerIdentityID, genesis skipchain.Skip
 			// the timer and move the state if there are 2f+1 valid
 			// requests.
 			if myID.Equal(req.SignerID) {
-				log.Lvl4("adding anomaly:", req.View.LeaderIndex, req.SignerID.String())
+				log.Lvl4("adding anomaly:", req.View.LeaderIndex,
+					req.SignerID.String())
 				meta.add(req)
 				ctr = c.processAnomaly(req, &meta, ctr)
 			} else {
-				log.Lvl4("adding req:", req.View.LeaderIndex, req.SignerID.String())
+				log.Lvl4("adding req:", req.View.LeaderIndex,
+					req.SignerID.String())
 				meta.add(req)
 				if meta.highest() > ctr && meta.countOf(meta.highest()) > f {
 					// To avoid starting view-change too late, if

--- a/byzcoin/viewchange_test.go
+++ b/byzcoin/viewchange_test.go
@@ -271,14 +271,15 @@ func TestViewChange_MonitorFailure(t *testing.T) {
 // is offline, it will never catch up.
 func TestViewChange_NeedCatchUp(t *testing.T) {
 	rw := time.Duration(3)
-	s := newSerN(t, 1, testInterval, 5, rw)
+	s := newSerN(t, 1, testInterval, 4, rw)
 	defer s.local.CloseAll()
 
 	for _, service := range s.services {
 		service.SetPropagationTimeout(2 * testInterval)
 	}
 
-	s.hosts[3].Pause()
+	log.Lvl1("Closing", s.hosts[3].ServerIdentity)
+	s.services[3].TestClose()
 
 	// Create a block that host 4 will miss
 	tx1, err := createOneClientTx(s.darc.GetBaseID(), dummyContract, s.value, s.signer)
@@ -289,12 +290,13 @@ func TestViewChange_NeedCatchUp(t *testing.T) {
 
 	// Kill the leader, but the view change won't happen as
 	// 2 nodes are down
+	log.Lvl1("Closing and pausing", s.hosts[0].ServerIdentity)
 	s.services[0].TestClose()
-	s.hosts[0].Pause()
 
-	s.hosts[3].Unpause()
+	log.Lvl1("Starting again", s.hosts[3].ServerIdentity)
+	s.services[3].TestRestart()
 	// This will trigger the proof to be propagated. In that test, the catch up
-	// won't be trigger as only one block is missing.
+	// won't be triggered as only one block is missing.
 	s.services[3].sendViewChangeReq(viewchange.View{
 		ID:          s.genesis.Hash,
 		Gen:         s.genesis.SkipChainID(),
@@ -305,7 +307,7 @@ func TestViewChange_NeedCatchUp(t *testing.T) {
 	// more if it goes to the leader index 2 so we give enough time.
 	sb := s.genesis
 	for i := 0; i < 60 && sb.Index != 2; i++ {
-		proof, err := s.services[4].skService().GetDB().GetProof(s.genesis.Hash)
+		proof, err := s.services[3].skService().GetDB().GetProof(s.genesis.Hash)
 		require.NoError(t, err)
 		sb = proof[len(proof)-1]
 
@@ -314,7 +316,7 @@ func TestViewChange_NeedCatchUp(t *testing.T) {
 	}
 
 	// Check that a view change was finally executed
-	leader, err := s.services[4].getLeader(s.genesis.SkipChainID())
+	leader, err := s.services[3].getLeader(s.genesis.SkipChainID())
 	require.NoError(t, err)
 	require.NotNil(t, leader)
 	require.False(t, leader.Equal(s.services[0].ServerIdentity()))


### PR DESCRIPTION
Once the new leader receives confirmation of all nodes that he
can propose a view-change, he will do a blsCoSi to confirm that
the view-change will be happening. See also #2264.

To help BLSCoSi, this PR will only ask nodes who sent a view-change
request to sign it.

Is useless after #2266 