### PR TITLE
Removing the BLS signature from the view-change

### DIFF
--- a/byzcoin/messages.go
+++ b/byzcoin/messages.go
@@ -24,4 +24,7 @@ func init() {
 type Version int
 
 // CurrentVersion is what we're running now
-const CurrentVersion Version = 3
+const CurrentVersion Version = 4
+
+// VersionViewchange removed the BLS-signature on the view-change requests
+const VersionViewchange = 4

--- a/byzcoin/viewchange.go
+++ b/byzcoin/viewchange.go
@@ -170,38 +170,40 @@ func (s *Service) sendNewView(proof []viewchange.InitReq) {
 		}
 	}
 
-	sb := s.db().GetByID(proof[0].View.ID)
-	req := viewchange.NewViewReq{
-		Roster: *rotateRoster(sb.Roster, proof[0].View.LeaderIndex),
-		Proof:  proof,
-	}
-
 	log.Lvl2(s.ServerIdentity(), "Got", len(proof), "proofs")
-	pl, err := protobuf.Encode(&req)
+	sb := s.db().GetByID(proof[0].View.ID)
+	req, err := viewchange.NewNewViewReq(sb.Roster, proof)
 	if err != nil {
-		log.Error("Couldn't encode request:", err)
-		return
-	}
-	if !s.verifyViewChange(req.Hash(), pl) {
-		log.Error("Will not ask for view change I cannot verify")
-		return
+		log.Errorf("couldn't create request: %v", err)
 	}
 
 	go func() {
 		s.working.Add(1)
 		defer s.working.Done()
-		// This go-routine eventually exists because both cosi and
-		// block creation have a timeout.
-		sig, err := s.startViewChangeCosi(req)
-		if err != nil {
-			log.Error(s.ServerIdentity(), "Error while starting view-change:", err)
+		var header DataHeader
+		if err := protobuf.Decode(sb.Data, &header); err != nil {
+			log.Errorf("couldn't get header of block: %+v", err)
 			return
 		}
-		if len(sig) == 0 {
-			log.Error(s.ServerIdentity(), "empty viewchange cosi signature")
-			return
+		var sig []byte
+		// Only version < VersionViewchange uses the signing of the view-change
+		// request.
+		// Versions >= VersionViewchange use the normal verification
+		// mechanism of/the/block verification.
+		if header.Version < VersionViewchange {
+			// This go-routine eventually exists because both cosi and
+			// block creation have a timeout.
+			sig, err = s.startViewChangeCosi(*req)
+			if err != nil {
+				log.Error(s.ServerIdentity(), "Error while starting view-change:", err)
+				return
+			}
+			if len(sig) == 0 {
+				log.Error(s.ServerIdentity(), "empty viewchange cosi signature")
+				return
+			}
 		}
-		if err := s.createViewChangeBlock(req, sig); err != nil {
+		if err := s.createViewChangeBlock(*req, sig); err != nil {
 			log.Error(s.ServerIdentity(), err)
 		}
 	}()
@@ -277,6 +279,7 @@ func (s *Service) handleViewChangeReq(env *network.Envelope) error {
 	return nil
 }
 
+// DEPRECATED - with Byzcoin version 4, this method is not used anymore.
 func (s *Service) startViewChangeCosi(req viewchange.NewViewReq) ([]byte, error) {
 	defer log.Lvl2(s.ServerIdentity(), "finished view-change blscosi")
 	sb := s.db().GetByID(req.GetView().ID)
@@ -314,6 +317,7 @@ func (s *Service) startViewChangeCosi(req viewchange.NewViewReq) ([]byte, error)
 }
 
 // verifyViewChange is registered in the view-change ftcosi.
+// DEPRECATED - with Byzcoin version 4, this method is not used anymore.
 func (s *Service) verifyViewChange(msg []byte, data []byte) bool {
 	// Parse message and check hash.
 	var req viewchange.NewViewReq
@@ -398,8 +402,12 @@ func (s *Service) createViewChangeBlock(req viewchange.NewViewReq, multisig []by
 	if err != nil {
 		return xerrors.Errorf("getting latest: %v", err)
 	}
-	if len(sb.Roster.List) < 4 {
+	if len(req.Roster.List) < 4 {
 		return xerrors.New("roster size is too small, must be >= 4")
+	}
+	header, err := decodeBlockHeader(sb)
+	if err != nil {
+		return xerrors.Errorf("decoding header: %v", err)
 	}
 
 	reqBuf, err := protobuf.Encode(&req)
@@ -429,10 +437,6 @@ func (s *Service) createViewChangeBlock(req viewchange.NewViewReq, multisig []by
 						Name:  "newview",
 						Value: reqBuf,
 					},
-					{
-						Name:  "multisig",
-						Value: multisig,
-					},
 				},
 			},
 			SignerIdentities: []darc.Identity{signer.Identity()},
@@ -440,9 +444,11 @@ func (s *Service) createViewChangeBlock(req viewchange.NewViewReq, multisig []by
 		}},
 	}
 
-	header, err := decodeBlockHeader(sb)
-	if err != nil {
-		return xerrors.Errorf("decoding header: %v", err)
+	// Only add the multisignature if it's a version that still signs the
+	// requests.
+	if header.Version < VersionViewchange {
+		ctx.Instructions[0].Invoke.Args = append(ctx.Instructions[0].Invoke.
+			Args, Argument{Name: "multisig", Value: multisig})
 	}
 
 	ctx.Instructions.SetVersion(header.Version)

--- a/byzcoin/viewchange/viewchange_test.go
+++ b/byzcoin/viewchange/viewchange_test.go
@@ -38,8 +38,9 @@ func testSetupViewChangeF1(t *testing.T, signerID [16]byte, dur time.Duration, f
 		vcChan <- true
 		return nil
 	}
-	nvF := func(proof []InitReq) {
+	nvF := func(proof []InitReq) error {
 		nvChan <- true
+		return nil
 	}
 	vcl := NewController(vcF, nvF, func(v View) bool { return true })
 	go vcl.Start(signerID, []byte{}, dur, 2*f+1)


### PR DESCRIPTION
As @LefKok validated #2264, this PR removes the BLSCoSi round for the view-change. This makes it faster and simpler.

One more idea would be to avoid the view-change requests completely. But that will break even more stuff. So let's start small...