### PR TITLE
Patch up split and db

### DIFF
--- a/byzcoin/proof.go
+++ b/byzcoin/proof.go
@@ -3,6 +3,8 @@ package byzcoin
 import (
 	"bytes"
 
+	"go.dedis.ch/onet/v3/log"
+
 	"golang.org/x/xerrors"
 
 	"go.dedis.ch/cothority/v3"
@@ -43,7 +45,12 @@ func NewProof(c ReadOnlyStateTrie, s *skipchain.SkipBlockDB, id skipchain.SkipBl
 			link = sb.ForwardLink[height]
 			sbTemp := s.GetByID(link.To)
 			if sbTemp == nil {
-				return nil, xerrors.New("missing block in chain")
+				log.Warnf("Found block %d with invalid forward-link at level"+
+					" %d", sb.Index, height)
+				if height == 0 {
+					return nil, xerrors.New("missing block in chain")
+				}
+				continue
 			}
 			if sbTemp.Index <= sb.Index {
 				return nil, cothority.ErrorOrNil(skipchain.ErrorInconsistentForwardLink, "")

--- a/byzcoin/viewchange.go
+++ b/byzcoin/viewchange.go
@@ -207,6 +207,8 @@ func (s *Service) sendNewView(proof []viewchange.InitReq) {
 	}()
 }
 
+// computeInitialDuration returns `rotationWindow * interval` of the given
+// skipchain.
 func (s *Service) computeInitialDuration(scID skipchain.SkipBlockID) (time.Duration, error) {
 	interval, _, err := s.LoadBlockInfo(scID)
 	if err != nil {


### PR DESCRIPTION
Two small patches for byzcoin:
- on 14th of May, another split occured, with higher-level forward-links pointing to
one block, and lower-level to another block. After restarting the nodes, it was still
in an unstable state, as the lower-level links led to another block than the higher-
level links. This patch makes sure that higher-level links that lead to nowhere are
removed from the db.
- part of the code spanned a lot of 'bbolt.Bucket's. This is fixed, and a method is
added to clean up