### PR TITLE
Correctly report error

### DIFF
--- a/external/js/cothority/src/network/websocket.ts
+++ b/external/js/cothority/src/network/websocket.ts
@@ -152,7 +152,7 @@ export class WebSocketConnection implements IConnection {
                 if (err !== undefined) {
                     sub.error(new Error(`error in websocket ${url.href}: ${err.message}`));
                 } else {
-                    sub.complete();
+                    sub.error(new Error("unknown reason"));
                 }
             });
 


### PR DESCRIPTION
When the websocket gets an error, even if it is empty,
it should be reported.