### PR TITLE
Work on db replay

### DIFF
--- a/byzcoin/bcadmin/README.md
+++ b/byzcoin/bcadmin/README.md
@@ -229,7 +229,7 @@ and return success:
 
 ```bash
 bcadmin db catchup cached.db _bcID_ _url_
-bcadmin db replay cached.db _bcID_ --continue
+bcadmin db replay cached.db _bcID_
 ```
 
 The `_bcID_` has to be replaced by the hexadecimal representation of the 

--- a/byzcoin/bcadmin/commands.go
+++ b/byzcoin/bcadmin/commands.go
@@ -656,18 +656,28 @@ var cmds = cli.Commands{
 				Usage:  "Replay a chain and check the global state is consistent",
 				Action: dbReplay,
 				Flags: []cli.Flag{
-					cli.BoolFlag{
-						Name:  "continue, cont",
-						Usage: "continue an aborted replay",
-					},
 					cli.IntFlag{
 						Name:  "blocks",
 						Usage: "how many blocks to apply",
+						Value: -1,
 					},
 					cli.IntFlag{
 						Name:  "summarize, sum",
 						Usage: "summarize this many blocks in output",
 						Value: 1,
+					},
+					cli.BoolFlag{
+						Name:  "verifyFLSig",
+						Usage: "turns on forward-link signature verification",
+					},
+					cli.BoolFlag{
+						Name: "continue",
+						Usage: "take the existing trie and replay from the" +
+							" latest block",
+					},
+					cli.BoolFlag{
+						Name:  "write",
+						Usage: "write the new trie to the db",
 					},
 				},
 			},

--- a/byzcoin/bcadmin/test.sh
+++ b/byzcoin/bcadmin/test.sh
@@ -5,7 +5,7 @@
 # Options:
 #   -b   re-builds bcadmin package
 
-DBG_TEST=2
+DBG_TEST=1
 DBG_SRV=1
 DBG_BCADMIN=2
 
@@ -84,15 +84,15 @@ testDbReplay(){
   testOK runBA db catchup conode.db $bcID http://localhost:2003
   testGrep "Replaying block at index 0" runBA db replay conode.db $bcID
 
-  testOK runBA mint $bc $key $keyPub 1000
-  testOK runBA mint $bc $key $keyPub 1000
-
   # replay with more than 1 block
+  testOK runBA mint $bc $key $keyPub 1000
+  testOK runBA mint $bc $key $keyPub 1000
   runBA db catchup conode.db $bcID http://localhost:2003
-  testNGrep "Replaying block at index 0" runBA db replay conode.db $bcID --cont
-  testReGrep "Replaying block at index 1"
   testGrep "Replaying block at index 0" runBA db replay conode.db $bcID
-  testOK runBA db replay conode.db $bcID --cont
+  testGrep "index 0" runBA db catchup conode.db $bcID --write --blocks 1
+  testReNGrep "index 1"
+  testNGrep "index 0" runBA db catchup conode.db $bcID --write --continue
+  testReGrep "index 1"
 }
 
 testDbMerge(){
@@ -322,7 +322,7 @@ testAddDarc(){
   testGrep "${ID:5:${#ID}-0}" runBA darc show --darc "$ID"
 
   # checks the --shortPrint option
-  OUTRES=$(runBA darc add --shortPrint)
+  OUTRES=$(runBA0 darc add --shortPrint)
   matchOK "$OUTRES" "darc:[0-9a-f]{64}
 \[ed25519:[0-9a-f]{64}\]" 
 }
@@ -478,7 +478,7 @@ runBA(){
 }
 
 runBA0(){
-  dbgRun ./bcadmin -c config/ --debug 0 "$@"
+  ./bcadmin -c config/ --debug 0 "$@"
 }
 
 testQR() {

--- a/byzcoin/contracts.go
+++ b/byzcoin/contracts.go
@@ -541,6 +541,13 @@ func (c *contractConfig) Invoke(rst ReadOnlyStateTrie, inst Instruction, coins [
 		if err != nil {
 			return nil, nil, xerrors.Errorf("decoding: %v", err)
 		}
+
+		_, err := rst.(ReadOnlySkipChain).GetBlockByIndex(rst.GetIndex())
+		if err != nil {
+			return nil, nil,
+				fmt.Errorf("couldn't get latest skipblock: %v", err)
+		}
+
 		if rst.GetVersion() < VersionViewchange {
 			// If everything is correctly signed, then we trust it, no need
 			// to do additional verification.

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -2173,7 +2173,7 @@ func (s *Service) createStateChanges(sst *stagingStateTrie, scID skipchain.SkipB
 		if err != nil {
 			tx.Accepted = false
 			txOut = append(txOut, tx)
-			log.Error(s.ServerIdentity(), err)
+			log.Warn(s.ServerIdentity(), err)
 		} else {
 			// We would like to be able to check if this txn is so big it could never fit into a block,
 			// and if so, drop it. But we can't with the current API of createStateChanges.


### PR DESCRIPTION
This PR does the following for 'bcadmin db replay':
- clean up the different backward-compatible but used nowhere extensions of `StateReplay`
- add all blocks to the skipchain.db, so that contracts using 'ReadOnlySkipchain' work
- by default doesn't verify the forward link signature of blocks, as this is very costly,
and can be supposed to be correct if its in 'cached.db'
- use a memory state trie instead of a disk state trie when replaying -> much faster
- can discard, write, resume blocks

This makes replaying the current chain having 50k blocks possible in about 30' on a fast machine.