### PR TITLE
Improve behaviour when nodes are down

### DIFF
--- a/byzcoin/wallet/test.sh
+++ b/byzcoin/wallet/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 DBG_TEST=1
-DBG_SRV=2
+DBG_SRV=1
 DBG_BA=2
 
 NBR_SERVERS=3


### PR DESCRIPTION
This PR only applies 'cl.UseNode' in the case '-multi' is used.
For simple transfers, two nodes are chosen randomly, thus avoiding
a failing transfer if one node is down.