### PR TITLE
Lts roster

### DIFF
--- a/calypso/csadmin/clicontracts/lts.go
+++ b/calypso/csadmin/clicontracts/lts.go
@@ -3,6 +3,7 @@ package clicontracts
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"os"
 
@@ -60,6 +61,14 @@ func LTSSpawn(c *cli.Context) error {
 
 	// Make the transaction and get its proof
 	ltsInstanceInfo := calypso.LtsInstanceInfo{Roster: cfg.Roster}
+	if rFile := c.String("roster"); rFile != "" {
+		r, err := lib.ReadRoster(rFile)
+		if err != nil {
+			return fmt.Errorf("couldn't load roster: %v", err)
+		}
+		log.Info("Setting roster to:", r.List)
+		ltsInstanceInfo.Roster = *r
+	}
 	buf, err := protobuf.Encode(&ltsInstanceInfo)
 	if err != nil {
 		return xerrors.Errorf("failed to encode instance info: %v", err)

--- a/calypso/csadmin/clicontracts/lts.go
+++ b/calypso/csadmin/clicontracts/lts.go
@@ -59,6 +59,8 @@ func LTSSpawn(c *cli.Context) error {
 		return xerrors.Errorf("failed to get the signer counters: %v", err)
 	}
 
+	export := c.Bool("export")
+
 	// Make the transaction and get its proof
 	ltsInstanceInfo := calypso.LtsInstanceInfo{Roster: cfg.Roster}
 	if rFile := c.String("roster"); rFile != "" {
@@ -66,7 +68,9 @@ func LTSSpawn(c *cli.Context) error {
 		if err != nil {
 			return fmt.Errorf("couldn't load roster: %v", err)
 		}
-		log.Info("Setting roster to:", r.List)
+		if !export {
+			log.Info("Setting roster to:", r.List)
+		}
 		ltsInstanceInfo.Roster = *r
 	}
 	buf, err := protobuf.Encode(&ltsInstanceInfo)
@@ -108,7 +112,7 @@ func LTSSpawn(c *cli.Context) error {
 	}
 
 	iidStr := hex.EncodeToString(newInstID)
-	if c.Bool("export") {
+	if export {
 		reader := bytes.NewReader([]byte(iidStr))
 		_, err = io.Copy(os.Stdout, reader)
 		if err != nil {
@@ -119,6 +123,5 @@ func LTSSpawn(c *cli.Context) error {
 
 	log.Infof("Spawned a new LTS contract. Its instance id is:\n"+
 		"%s", iidStr)
-
 	return nil
 }

--- a/calypso/csadmin/commands.go
+++ b/calypso/csadmin/commands.go
@@ -118,6 +118,10 @@ var cmds = cli.Commands{
 								Usage:  "the ByzCoin config to use (required)",
 							},
 							cli.StringFlag{
+								Name:  "roster",
+								Usage: "change the roster for the calypso",
+							},
+							cli.StringFlag{
 								Name:  "darc",
 								Usage: "DARC with the right to create an LTS (default is the admin DARC)",
 							},

--- a/calypso/csadmin/commands.go
+++ b/calypso/csadmin/commands.go
@@ -118,8 +118,9 @@ var cmds = cli.Commands{
 								Usage:  "the ByzCoin config to use (required)",
 							},
 							cli.StringFlag{
-								Name:  "roster",
-								Usage: "change the roster for the calypso",
+								Name: "roster",
+								Usage: "the path of a roster file to be used as argument for the spawn. " +
+									"If not provided the config roster is used (optional)",
 							},
 							cli.StringFlag{
 								Name:  "darc",

--- a/calypso/service.go
+++ b/calypso/service.go
@@ -442,7 +442,7 @@ func (s *Service) verifyProof(proof *byzcoin.Proof) error {
 		return xerrors.New("this ByzCoin ID is not authorised")
 	}
 
-	sb, err := s.fetchGenesisBlock(scID, proof.Links[0].NewRoster)
+	sb, err := s.fetchGenesisBlock(scID, proof.Latest.Roster)
 	if err != nil {
 		return xerrors.Errorf("fetching genesis block: %v", err)
 	}


### PR DESCRIPTION
When creating a new LTS instance on byzcoin, the roster used for the re-encryption can be different from the roster used by byzcoin.

This PR adds the possibility to `csadmin` to indicate a different roster. It also contacts the correct set of nodes for the different operations.