### PR TITLE
test{F,}Grep(): display output when failing

### DIFF
--- a/libtest.sh
+++ b/libtest.sh
@@ -144,7 +144,7 @@ testGrep(){
   runOutFile "$@"
   doGrep "$S"
   if [ ! "$EGREP" ]; then
-    fail "Didn't find '$S' in output of '$@': $GREP"
+    fail "Didn't find '$S' in output of '$@': $(cat $RUNOUT)"
   fi
 }
 
@@ -161,7 +161,7 @@ testFGrep(){
   runOutFile "$@"
   doFGrep "$S"
   if [ ! "$EGREP" ]; then
-    fail "Didn't find '$S' in output of '$@': $GREP"
+    fail "Didn't find '$S' in output of '$@': $(cat $RUNOUT)"
   fi
 }
 


### PR DESCRIPTION
**What this PR does**

In `libtest.sh`'s functions `testGrep()` and `testFGrep()`, unlike the other `test*Grep()`, the output is not displayed when the grep fails. As it is useful for debugging, this PR makes them all uniform.

*See commit message*
