### PR TITLE
Speedup BEVMClient

### DIFF
--- a/bevm/bevm_client.go
+++ b/bevm/bevm_client.go
@@ -586,16 +586,9 @@ func (account EvmAccount) signAndMarshalTx(tx *types.Transaction) (
 func getEvmDb(bcClient *byzcoin.Client, instID byzcoin.InstanceID) (
 	*state.StateDB, error) {
 	// Retrieve the proof of the Byzcoin instance
-	proofResponse, err := bcClient.GetProof(instID[:])
+	proofResponse, err := bcClient.GetProofFromLatest(instID[:])
 	if err != nil {
 		return nil, xerrors.Errorf("failed to retrieve BEvm instance: %v", err)
-	}
-
-	// Validate the proof
-	err = proofResponse.Proof.Verify(bcClient.ID)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to verify BEvm instance "+
-			"proof: %v", err)
 	}
 
 	// Extract the value from the proof

--- a/bevm/database_byz.go
+++ b/bevm/database_byz.go
@@ -139,17 +139,10 @@ func (db *ClientByzDatabase) getBEvmValue(key []byte) ([]byte, error) {
 	instID := db.getValueInstanceID(key)
 
 	// Retrieve the proof of the BEvmValue instance
-	proofResponse, err := db.client.GetProof(instID[:])
+	proofResponse, err := db.client.GetProofFromLatest(instID[:])
 	if err != nil {
 		return nil, xerrors.Errorf("failed to retrieve BEvmValue "+
 			"instance for EVM state DB: %v", err)
-	}
-
-	// Validate the proof
-	err = proofResponse.Proof.Verify(db.client.ID)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to verify BEvmValue "+
-			"instance proof: %v", err)
 	}
 
 	// Extract the value from the proof


### PR DESCRIPTION
Improved the following two steps in bevmclient:
- use GetProofFromLatest for more succint, but still validatable proofs
- don't verify the proof twice: GetProof.* already verifies the proof