### PR TITLE
Use crypto-browserify

### DIFF
--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@dedis/cothority",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "description": "A typescript implementation of the cothority",
   "main": "index.js",
   "browser": "bundle.min.js",

--- a/external/js/cothority/src/darc/darc.ts
+++ b/external/js/cothority/src/darc/darc.ts
@@ -1,5 +1,4 @@
-import { randomBytes } from "crypto";
-import { createHash } from "crypto-browserify";
+import { createHash, randomBytes } from "crypto-browserify";
 import Long from "long";
 import { Message, Properties } from "protobufjs/light";
 import { EMPTY_BUFFER, registerMessage } from "../protobuf";


### PR DESCRIPTION
One of the imports in cothority has been using 'crypto', which
makes it fail when used. Replaced with 'crypto-browserify'.