### PR TITLE
Add more information to warnings

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -1450,7 +1450,8 @@ func (s *Service) catchUp(sb *skipchain.SkipBlock) {
 			// Asked to catch up on an unknown chain, but don't want to download, instead only replay
 			// the blocks. This is mostly useful for testing, in a real deployement the catchupDownloadAll
 			// will be smaller than any chain that is online for more than a day.
-			log.Warn(s.ServerIdentity(), "problem with trie, will create a new one:", err)
+			log.Warnf("%s: problem with trie, "+
+				"will create a new one: %+v", s.ServerIdentity(), err)
 			genesis, err := cl.GetSingleBlock(sb.Roster, sb.SkipChainID())
 			if err != nil {
 				log.Error("Couldn't get genesis-block:", err)
@@ -2192,7 +2193,7 @@ func (s *Service) createStateChanges(sst *stagingStateTrie, scID skipchain.SkipB
 		if err != nil {
 			tx.Accepted = false
 			txOut = append(txOut, tx)
-			log.Warn(s.ServerIdentity(), err)
+			log.Warnf("%s: %+v", s.ServerIdentity(), err)
 		} else {
 			// We would like to be able to check if this txn is so big it could never fit into a block,
 			// and if so, drop it. But we can't with the current API of createStateChanges.
@@ -2441,6 +2442,7 @@ func (s *Service) executeInstruction(gs GlobalState, cin []Coin,
 	err error) {
 	defer func() {
 		if re := recover(); re != nil {
+			log.Lvl2("Recovered from panic:\n", log.Stack())
 			err = xerrors.Errorf("executing instr: %v", re)
 		}
 	}()


### PR DESCRIPTION
Also print the paths to the errors using %+v format.