### PR TITLE
Propagate verify argument

### DIFF
--- a/external/js/cothority/src/byzcoin/byzcoin-rpc.ts
+++ b/external/js/cothority/src/byzcoin/byzcoin-rpc.ts
@@ -353,7 +353,7 @@ export default class ByzCoinRPC implements ICounterUpdater {
             throw new Error("no latest block found");
         }
 
-        return this.getProofFrom(this._latest, id, waitMatch, interval);
+        return this.getProofFrom(this._latest, id, waitMatch, interval, verify);
     }
 
     /**


### PR DESCRIPTION
Makes verify being respected when calling ByzCoinRPC.getProofFromLatest