### PR TITLE
stateChangeStorage background calculation

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -1130,12 +1130,6 @@ func (s *Service) createNewBlock(scID skipchain.SkipBlockID, r *onet.Roster, tx 
 		return nil, xerrors.Errorf("storing block: %v", err)
 	}
 
-	// State changes are cached only when the block is confirmed
-	err = s.stateChangeStorage.append(scs, ssbReply.Latest)
-	if err != nil {
-		log.Error(err)
-	}
-
 	return ssbReply.Latest, nil
 }
 
@@ -3149,8 +3143,12 @@ func newService(c *onet.Context) (onet.Service, error) {
 		return nil, xerrors.Errorf("unknown db version number %v", ver)
 	}
 
-	// initialize the stats of the storage
-	s.stateChangeStorage.calculateSize()
+	go func() {
+		// initialize the stats of the storage
+		if err := s.stateChangeStorage.calculateSize(); err != nil {
+			log.Errorf("couldn't calculate size: %v", err)
+		}
+	}()
 
 	if err := s.startAllChains(); err != nil {
 		return nil, xerrors.Errorf("starting chains: %v", err)

--- a/byzcoin/struct_test.go
+++ b/byzcoin/struct_test.go
@@ -85,10 +85,10 @@ func TestStateChangeStorage_SimpleCase(t *testing.T) {
 	err := scs.append(ss, sb)
 	require.NoError(t, err)
 
-	// check the size remains the same with already seen state changes
+	// check that the same scs cannot be appended twice
 	size := scs.size
 	err = scs.append(ss, sb)
-	require.NoError(t, err)
+	require.Error(t, err)
 	require.Equal(t, size, scs.size)
 
 	entries, err := scs.getAll(ss[0].InstanceID, sb.SkipChainID())


### PR DESCRIPTION
- Background calculation of stateChangeStorage - else it takes 90s on startup
- Only calculate the scs once in byzcoin/service.go