### PR TITLE
Fix propagation protocol

### DIFF
--- a/ftcosi/simulation/protocol.go
+++ b/ftcosi/simulation/protocol.go
@@ -125,7 +125,6 @@ func (s *SimulationProtocol) Node(config *onet.SimulationConfig) error {
 
 // Run implements onet.Simulation.
 func (s *SimulationProtocol) Run(config *onet.SimulationConfig) error {
-	log.SetDebugVisible(2)
 	size := config.Tree.Size()
 	log.Lvl2("Size is:", size, "rounds:", s.Rounds)
 	for round := 0; round < s.Rounds; round++ {


### PR DESCRIPTION
The propagation protocol uses a tree, but it does not handle failing nodes.
Change the tree to a start-communication and fix an off-by-one error.

Also removes a debug-option from ftcosi.