### PR TITLE
Remove xerrors dependencies

### DIFF
--- a/bevm/bevm_attr_test.go
+++ b/bevm/bevm_attr_test.go
@@ -1,6 +1,7 @@
 package bevm
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"testing"
@@ -12,7 +13,6 @@ import (
 	"go.dedis.ch/cothority/v3/darc"
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
-	"golang.org/x/xerrors"
 )
 
 func init() {
@@ -42,7 +42,7 @@ func (c valueContract) Spawn(rst byzcoin.ReadOnlyStateTrie,
 	var darcID darc.ID
 	_, _, _, darcID, err = rst.GetValues(inst.InstanceID.Slice())
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to get darcID: %v", err)
+		return nil, nil, fmt.Errorf("failed to get darcID: %v", err)
 	}
 
 	sc = []byzcoin.StateChange{
@@ -62,7 +62,7 @@ func (c valueContract) Invoke(rst byzcoin.ReadOnlyStateTrie,
 
 	_, _, _, darcID, err = rst.GetValues(inst.InstanceID.Slice())
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to get darcID: %v", err)
+		return nil, nil, fmt.Errorf("failed to get darcID: %v", err)
 	}
 
 	switch inst.Invoke.Command {
@@ -73,7 +73,7 @@ func (c valueContract) Invoke(rst byzcoin.ReadOnlyStateTrie,
 		}
 		return
 	default:
-		return nil, nil, xerrors.New("Value contract can only update")
+		return nil, nil, errors.New("Value contract can only update")
 	}
 }
 

--- a/bevm/bevm_call_byzcoin.go
+++ b/bevm/bevm_call_byzcoin.go
@@ -1,10 +1,10 @@
 package bevm
 
 import (
+	"fmt"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"go.dedis.ch/cothority/v3/byzcoin"
-	"golang.org/x/xerrors"
 )
 
 // Whitelist of EVM-spawnable Byzcoin contracts.
@@ -177,11 +177,11 @@ func getInstrForEvent(name string, iface interface{}) (
 			}
 		})
 		if !ok {
-			return nil, xerrors.Errorf("failed to cast 'spawn' event")
+			return nil, fmt.Errorf("failed to cast 'spawn' event")
 		}
 
 		if !evmSpawnableContracts[event.ContractID] {
-			return nil, xerrors.Errorf("contract '%s' has not been "+
+			return nil, fmt.Errorf("contract '%s' has not been "+
 				"whitelisted to be spawned by an EVM contract",
 				event.ContractID)
 		}
@@ -205,7 +205,7 @@ func getInstrForEvent(name string, iface interface{}) (
 			}
 		})
 		if !ok {
-			return nil, xerrors.Errorf("failed to cast 'invoke' event")
+			return nil, fmt.Errorf("failed to cast 'invoke' event")
 		}
 
 		instr = &byzcoin.Instruction{
@@ -227,7 +227,7 @@ func getInstrForEvent(name string, iface interface{}) (
 			}
 		})
 		if !ok {
-			return nil, xerrors.Errorf("failed to cast 'delete' event")
+			return nil, fmt.Errorf("failed to cast 'delete' event")
 		}
 
 		instr = &byzcoin.Instruction{
@@ -239,7 +239,7 @@ func getInstrForEvent(name string, iface interface{}) (
 		}
 
 	default:
-		return nil, xerrors.Errorf("internal error: event '%s' not handled",
+		return nil, fmt.Errorf("internal error: event '%s' not handled",
 			name)
 	}
 

--- a/bevm/bevm_call_byzcoin_test.go
+++ b/bevm/bevm_call_byzcoin_test.go
@@ -1,6 +1,8 @@
 package bevm
 
 import (
+	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -10,7 +12,6 @@ import (
 	"go.dedis.ch/cothority/v3/darc"
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
-	"golang.org/x/xerrors"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -45,7 +46,7 @@ func (c myValueContract) Spawn(rst byzcoin.ReadOnlyStateTrie,
 	var darcID darc.ID
 	_, _, _, darcID, err = rst.GetValues(inst.InstanceID.Slice())
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to get darcID: %v", err)
+		return nil, nil, fmt.Errorf("failed to get darcID: %v", err)
 	}
 
 	var newInstanceID byzcoin.InstanceID
@@ -78,7 +79,7 @@ func (c myValueContract) Invoke(rst byzcoin.ReadOnlyStateTrie,
 
 	_, _, _, darcID, err = rst.GetValues(inst.InstanceID.Slice())
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to get darcID: %v", err)
+		return nil, nil, fmt.Errorf("failed to get darcID: %v", err)
 	}
 
 	switch inst.Invoke.Command {
@@ -94,7 +95,7 @@ func (c myValueContract) Invoke(rst byzcoin.ReadOnlyStateTrie,
 		return
 
 	default:
-		return nil, nil, xerrors.New("Value contract can only update")
+		return nil, nil, errors.New("Value contract can only update")
 	}
 }
 
@@ -108,7 +109,7 @@ func (c myValueContract) Delete(rst byzcoin.ReadOnlyStateTrie,
 
 	_, _, _, darcID, err = rst.GetValues(inst.InstanceID.Slice())
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to get darcID: %v", err)
+		return nil, nil, fmt.Errorf("failed to get darcID: %v", err)
 	}
 
 	sc = []byzcoin.StateChange{

--- a/bevm/bevm_client.go
+++ b/bevm/bevm_client.go
@@ -19,7 +19,6 @@ import (
 	"go.dedis.ch/cothority/v3/darc"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/protobuf"
-	"golang.org/x/xerrors"
 )
 
 // WeiPerEther represents the number of Wei (the smallest currency denomination
@@ -46,7 +45,7 @@ func NewEvmContract(name string, abiJSON string, binData string) (
 	*EvmContract, error) {
 	contractAbi, err := abi.JSON(strings.NewReader(abiJSON))
 	if err != nil {
-		return nil, xerrors.Errorf("failed to decode JSON for "+
+		return nil, fmt.Errorf("failed to decode JSON for "+
 			"contract ABI: %v", err)
 	}
 
@@ -86,7 +85,7 @@ func unpackResult(contractAbi abi.ABI, methodName string,
 	resultBytes []byte) (interface{}, error) {
 	methodAbi, ok := contractAbi.Methods[methodName]
 	if !ok {
-		return nil, xerrors.Errorf("method \"%s\" does not exist for "+
+		return nil, fmt.Errorf("method \"%s\" does not exist for "+
 			"this contract", methodName)
 	}
 
@@ -107,7 +106,7 @@ func unpackData(contractAbi abi.ABI, objectName string,
 		err := contractAbi.Unpack(result.Interface(),
 			objectName, dataBytes)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to unpack single "+
+			return nil, fmt.Errorf("failed to unpack single "+
 				"element of EVM data: %v", err)
 		}
 
@@ -138,7 +137,7 @@ func unpackData(contractAbi abi.ABI, objectName string,
 		err := contractAbi.Unpack(s.Interface(),
 			objectName, dataBytes)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to unpack multiple "+
+			return nil, fmt.Errorf("failed to unpack multiple "+
 				"elements of EVM data: %v", err)
 		}
 
@@ -160,7 +159,7 @@ func unpackData(contractAbi abi.ABI, objectName string,
 		// err := contractInstance.Parent.Abi.Unpack(result.Interface(),
 		// 	method, resultBytes)
 		// if err != nil {
-		// 	return nil, xerrors.Errorf("unpacking multiple result: %v", err)
+		// 	return nil, fmt.Errorf("unpacking multiple result: %v", err)
 		// }
 
 		// for i := range abiOutputs {
@@ -188,7 +187,7 @@ type EvmAccount struct {
 func NewEvmAccount(privateKey string) (*EvmAccount, error) {
 	privKey, err := crypto.HexToECDSA(privateKey)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to decode private "+
+		return nil, fmt.Errorf("failed to decode private "+
 			"key for account creation: %v", err)
 	}
 
@@ -224,7 +223,7 @@ func NewBEvm(bcClient *byzcoin.Client, signer darc.Signer, gDarc *darc.Darc) (
 			Args:       byzcoin.Arguments{},
 		})
 	if err != nil {
-		return instanceID, xerrors.Errorf("failed to execute ByzCoin "+
+		return instanceID, fmt.Errorf("failed to execute ByzCoin "+
 			"spawn command for BEvm contract: %v", err)
 	}
 
@@ -250,7 +249,7 @@ func (client *Client) Delete() error {
 		ContractID: ContractBEvmID,
 	})
 	if err != nil {
-		return xerrors.Errorf("failed to execute ByzCoin "+
+		return fmt.Errorf("failed to execute ByzCoin "+
 			"delete command for BEvm instance: %v", err)
 	}
 
@@ -266,7 +265,7 @@ func (client *Client) Deploy(gasLimit uint64, gasPrice uint64, amount uint64,
 
 	packedArgs, err := contract.packConstructor(args...)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to pack arguments for "+
+		return nil, nil, fmt.Errorf("failed to pack arguments for "+
 			"contract constructor: %v", err)
 	}
 
@@ -275,7 +274,7 @@ func (client *Client) Deploy(gasLimit uint64, gasPrice uint64, amount uint64,
 		gasLimit, big.NewInt(int64(gasPrice)), callData)
 	signedTxBuffer, err := account.signAndMarshalTx(tx)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to prepare EVM transaction "+
+		return nil, nil, fmt.Errorf("failed to prepare EVM transaction "+
 			"for EVM contract deployment: %v", err)
 	}
 
@@ -283,7 +282,7 @@ func (client *Client) Deploy(gasLimit uint64, gasPrice uint64, amount uint64,
 		{Name: "tx", Value: signedTxBuffer},
 	})
 	if err != nil {
-		return nil, nil, xerrors.Errorf("failed to invoke ByzCoin transaction "+
+		return nil, nil, fmt.Errorf("failed to invoke ByzCoin transaction "+
 			"for EVM contract deployment: %v", err)
 	}
 
@@ -307,7 +306,7 @@ func (client *Client) Transaction(gasLimit uint64, gasPrice uint64,
 
 	callData, err := contractInstance.packMethod(method, args...)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to pack arguments for contract "+
+		return nil, fmt.Errorf("failed to pack arguments for contract "+
 			"method '%s': %v", method, err)
 	}
 
@@ -316,7 +315,7 @@ func (client *Client) Transaction(gasLimit uint64, gasPrice uint64,
 		callData)
 	signedTxBuffer, err := account.signAndMarshalTx(tx)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to prepare EVM transaction for "+
+		return nil, fmt.Errorf("failed to prepare EVM transaction for "+
 			"EVM method execution: %v", err)
 	}
 
@@ -324,7 +323,7 @@ func (client *Client) Transaction(gasLimit uint64, gasPrice uint64,
 		{Name: "tx", Value: signedTxBuffer},
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("failed to invoke ByzCoin transaction for "+
+		return nil, fmt.Errorf("failed to invoke ByzCoin transaction for "+
 			"EVM method execution: %v", err)
 	}
 
@@ -345,14 +344,14 @@ func (client *Client) Call(account *EvmAccount,
 	// Pack the method call and arguments
 	callData, err := contractInstance.packMethod(method, args...)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to pack arguments for contract "+
+		return nil, fmt.Errorf("failed to pack arguments for contract "+
 			"view method '%s': %v", method, err)
 	}
 
 	// Retrieve the EVM state
 	stateDb, err := getEvmDb(client.bcClient, client.instanceID)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to retrieve EVM state: %v", err)
+		return nil, fmt.Errorf("failed to retrieve EVM state: %v", err)
 	}
 
 	// Compute timestamp for the EVM
@@ -369,14 +368,14 @@ func (client *Client) Call(account *EvmAccount,
 		contractInstance.Address, callData, uint64(1*WeiPerEther),
 		big.NewInt(0))
 	if err != nil {
-		return nil, xerrors.Errorf("failed to execute EVM view "+
+		return nil, fmt.Errorf("failed to execute EVM view "+
 			"method: %v", err)
 	}
 
 	// Unpack the result
 	result, err := unpackResult(contractInstance.getAbi(), method, ret)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to unpack EVM view "+
+		return nil, fmt.Errorf("failed to unpack EVM view "+
 			"method result: %v", err)
 	}
 
@@ -391,7 +390,7 @@ func (client *Client) CreditAccount(amount *big.Int,
 		{Name: "amount", Value: amount.Bytes()},
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("failed to credit EVM account: %v", err)
+		return nil, fmt.Errorf("failed to credit EVM account: %v", err)
 	}
 
 	log.Lvlf2("Credited %d wei on '%x'", amount, address)
@@ -404,7 +403,7 @@ func (client *Client) GetAccountBalance(address common.Address) (
 	*big.Int, error) {
 	stateDb, err := getEvmDb(client.bcClient, client.instanceID)
 	if err != nil {
-		return nil, xerrors.Errorf("failed toretrieve EVM state: %v", err)
+		return nil, fmt.Errorf("failed toretrieve EVM state: %v", err)
 	}
 
 	balance := stateDb.GetBalance(address)
@@ -429,7 +428,7 @@ func DecodeEvmArgs(encodedArgs []string, abi abi.Arguments) (
 		var arg interface{}
 		err := json.Unmarshal([]byte(argJSON), &arg)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to decode JSON-encoded "+
+			return nil, fmt.Errorf("failed to decode JSON-encoded "+
 				"arguments for EVM call: %v", err)
 		}
 
@@ -438,13 +437,13 @@ func DecodeEvmArgs(encodedArgs []string, abi abi.Arguments) (
 		if arrayBracket == -1 {
 			args[i], err = decodeEvmValue(abiTypeStr, abi[i].Type.Type, arg)
 			if err != nil {
-				return nil, xerrors.Errorf("failed to decode simple-type "+
+				return nil, fmt.Errorf("failed to decode simple-type "+
 					"value for EVM call: %v", err)
 			}
 		} else {
 			args[i], err = decodeEvmArray(abiTypeStr[:arrayBracket], abi[i], arg)
 			if err != nil {
-				return nil, xerrors.Errorf("failed to decode array-type "+
+				return nil, fmt.Errorf("failed to decode array-type "+
 					"value for EVM call: %v", err)
 			}
 		}
@@ -466,13 +465,13 @@ func decodeEvmValue(abiType string, argType reflect.Type, arg interface{}) (
 		// We use strings to ensure big numbers are handled properly in JSON
 		argAsString, ok := arg.(string)
 		if !ok {
-			return nil, xerrors.Errorf("received '%v' for value of type "+
+			return nil, fmt.Errorf("received '%v' for value of type "+
 				"'%s', expected to be a JSON string", arg, abiType)
 		}
 
 		val, ok := big.NewInt(0).SetString(argAsString, 0)
 		if !ok {
-			return nil, xerrors.Errorf("invalid big number value: %v", arg)
+			return nil, fmt.Errorf("invalid big number value: %v", arg)
 		}
 
 		decodedArg = val
@@ -482,7 +481,7 @@ func decodeEvmValue(abiType string, argType reflect.Type, arg interface{}) (
 		// expects uint{32,16,8}
 		argAsFloat, ok := arg.(float64)
 		if !ok {
-			return nil, xerrors.Errorf("received '%v' for value of type "+
+			return nil, fmt.Errorf("received '%v' for value of type "+
 				"'%s', expected to be a JSON number", arg, abiType)
 		}
 
@@ -496,7 +495,7 @@ func decodeEvmValue(abiType string, argType reflect.Type, arg interface{}) (
 		// expects int{32,16,8}
 		argAsFloat, ok := arg.(float64)
 		if !ok {
-			return nil, xerrors.Errorf("received '%v' for value of type "+
+			return nil, fmt.Errorf("received '%v' for value of type "+
 				"'%s', expected to be a JSON number", arg, abiType)
 		}
 
@@ -508,7 +507,7 @@ func decodeEvmValue(abiType string, argType reflect.Type, arg interface{}) (
 	case "address":
 		argAsString, ok := arg.(string)
 		if !ok {
-			return nil, xerrors.Errorf("received '%v' for value of type "+
+			return nil, fmt.Errorf("received '%v' for value of type "+
 				"'%s', expected to be a JSON string", arg, abiType)
 		}
 
@@ -517,14 +516,14 @@ func decodeEvmValue(abiType string, argType reflect.Type, arg interface{}) (
 	case "string":
 		argAsString, ok := arg.(string)
 		if !ok {
-			return nil, xerrors.Errorf("received '%v' for value of type "+
+			return nil, fmt.Errorf("received '%v' for value of type "+
 				"'%s', expected to be a JSON string", arg, abiType)
 		}
 
 		decodedArg = argAsString
 
 	default:
-		return nil, xerrors.Errorf("unsupported type for EVM argument "+
+		return nil, fmt.Errorf("unsupported type for EVM argument "+
 			"value: %s", abiType)
 	}
 
@@ -538,11 +537,11 @@ func decodeEvmArray(abiType string, abi abi.Argument, arg interface{}) (
 
 	argAsArray, ok := arg.([]interface{})
 	if !ok {
-		return nil, xerrors.Errorf("received '%v' for value of type "+
+		return nil, fmt.Errorf("received '%v' for value of type "+
 			"'%s[%d]', expected to be a JSON array", arg, abiType, arr.Len())
 	}
 	if len(argAsArray) != arr.Len() {
-		return nil, xerrors.Errorf("incorrect array size %d for value of "+
+		return nil, fmt.Errorf("incorrect array size %d for value of "+
 			"type '%s[%d]'", len(argAsArray), abiType, arr.Len())
 	}
 
@@ -550,7 +549,7 @@ func decodeEvmArray(abiType string, abi abi.Argument, arg interface{}) (
 	for i := 0; i < arr.Len(); i++ {
 		val, err := decodeEvmValue(abiType, abi.Type.Type.Elem(), argAsArray[i])
 		if err != nil {
-			return nil, xerrors.Errorf("failed to decode element of "+
+			return nil, fmt.Errorf("failed to decode element of "+
 				"EVM array value: %v", err)
 		}
 		arr.Index(i).Set(reflect.ValueOf(val))
@@ -570,12 +569,12 @@ func (account EvmAccount) signAndMarshalTx(tx *types.Transaction) (
 
 	signedTx, err := types.SignTx(tx, signer, account.PrivateKey)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to sign EVM transaction: %v", err)
+		return nil, fmt.Errorf("failed to sign EVM transaction: %v", err)
 	}
 
 	signedBuffer, err := signedTx.MarshalJSON()
 	if err != nil {
-		return nil, xerrors.Errorf("failed to serialize EVM transaction "+
+		return nil, fmt.Errorf("failed to serialize EVM transaction "+
 			"to JSON: %v", err)
 	}
 
@@ -588,27 +587,27 @@ func getEvmDb(bcClient *byzcoin.Client, instID byzcoin.InstanceID) (
 	// Retrieve the proof of the Byzcoin instance
 	proofResponse, err := bcClient.GetProofFromLatest(instID[:])
 	if err != nil {
-		return nil, xerrors.Errorf("failed to retrieve BEvm instance: %v", err)
+		return nil, fmt.Errorf("failed to retrieve BEvm instance: %v", err)
 	}
 
 	// Extract the value from the proof
 	_, value, _, _, err := proofResponse.Proof.KeyValue()
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get BEvm instance value: %v", err)
+		return nil, fmt.Errorf("failed to get BEvm instance value: %v", err)
 	}
 
 	// Decode the proof value into an EVM State
 	var bs State
 	err = protobuf.Decode(value, &bs)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to decode BEvm instance "+
+		return nil, fmt.Errorf("failed to decode BEvm instance "+
 			"value: %v", err)
 	}
 
 	// Create a client ByzDB instance
 	byzDb, err := NewClientByzDatabase(instID, bcClient)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to creatw a new ByzDB "+
+		return nil, fmt.Errorf("failed to creatw a new ByzDB "+
 			"instance: %v", err)
 	}
 
@@ -626,7 +625,7 @@ func (client *Client) invoke(command string, args byzcoin.Arguments) (
 		Args:       args,
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("failed to execute ByzCoin invoke "+
+		return nil, fmt.Errorf("failed to execute ByzCoin invoke "+
 			"instruction: %v", err)
 	}
 
@@ -657,7 +656,7 @@ func execByzCoinTx(bcClient *byzcoin.Client,
 	deleteInstr *byzcoin.Delete) (*byzcoin.ClientTransaction, error) {
 	counters, err := bcClient.GetSignerCounters(signer.Identity().String())
 	if err != nil {
-		return nil, xerrors.Errorf("failed to retrieve signer "+
+		return nil, fmt.Errorf("failed to retrieve signer "+
 			"counters from ByzCoin: %v", err)
 	}
 
@@ -669,13 +668,13 @@ func execByzCoinTx(bcClient *byzcoin.Client,
 		Delete:        deleteInstr,
 	})
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create ByzCoin "+
+		return nil, fmt.Errorf("failed to create ByzCoin "+
 			"transaction: %v", err)
 	}
 
 	err = tx.FillSignersAndSignWith(signer)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to sign ByzCoin "+
+		return nil, fmt.Errorf("failed to sign ByzCoin "+
 			"transaction: %v", err)
 	}
 
@@ -683,7 +682,7 @@ func execByzCoinTx(bcClient *byzcoin.Client,
 	// global state - first we must wait for the new block to be created.
 	_, err = bcClient.AddTransactionAndWait(tx, 5)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to send ByzCoin "+
+		return nil, fmt.Errorf("failed to send ByzCoin "+
 			"transaction: %v", err)
 	}
 

--- a/bevm/bevmadmin/main.go
+++ b/bevm/bevmadmin/main.go
@@ -16,7 +16,6 @@ import (
 	"go.dedis.ch/onet/v3/cfgpath"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
-	"golang.org/x/xerrors"
 )
 
 func init() {
@@ -125,7 +124,7 @@ func spawn(c *cli.Context) error {
 
 	cfg, cl, err := lib.LoadConfig(bcFile)
 	if err != nil {
-		return xerrors.Errorf("failed to load ByzCoin config: %v", err)
+		return fmt.Errorf("failed to load ByzCoin config: %v", err)
 	}
 
 	var signer *darc.Signer
@@ -136,7 +135,7 @@ func spawn(c *cli.Context) error {
 		signer, err = lib.LoadKeyFromString(signerStr)
 	}
 	if err != nil {
-		return xerrors.Errorf("failed to load signer key: %v", err)
+		return fmt.Errorf("failed to load signer key: %v", err)
 	}
 
 	var darc *darc.Darc
@@ -146,18 +145,18 @@ func spawn(c *cli.Context) error {
 	}
 	darc, err = lib.GetDarcByString(cl, darcStr)
 	if err != nil {
-		return xerrors.Errorf("failed to load DARC data: %v", err)
+		return fmt.Errorf("failed to load DARC data: %v", err)
 	}
 
 	bevmInstID, err := bevm.NewBEvm(cl, *signer, darc)
 	if err != nil {
-		return xerrors.Errorf("failed to spawn new BEvm instance: %v", err)
+		return fmt.Errorf("failed to spawn new BEvm instance: %v", err)
 	}
 
 	_, err = fmt.Fprintf(c.App.Writer, "Created BEvm instance with ID: %s\n",
 		bevmInstID)
 	if err != nil {
-		return xerrors.Errorf("failed to write report msg: %v", err)
+		return fmt.Errorf("failed to write report msg: %v", err)
 	}
 
 	// Save ID in file if provided
@@ -165,7 +164,7 @@ func spawn(c *cli.Context) error {
 	if outFile != "" {
 		err = ioutil.WriteFile(outFile, []byte(bevmInstID.String()), 0644)
 		if err != nil {
-			return xerrors.Errorf("failed to write BEvm ID to file: %v", err)
+			return fmt.Errorf("failed to write BEvm ID to file: %v", err)
 		}
 	}
 
@@ -177,7 +176,7 @@ func delete(c *cli.Context) error {
 
 	cfg, cl, err := lib.LoadConfig(bcFile)
 	if err != nil {
-		return xerrors.Errorf("failed to load ByzCoin config: %v", err)
+		return fmt.Errorf("failed to load ByzCoin config: %v", err)
 	}
 
 	var signer *darc.Signer
@@ -188,31 +187,31 @@ func delete(c *cli.Context) error {
 		signer, err = lib.LoadKeyFromString(signerStr)
 	}
 	if err != nil {
-		return xerrors.Errorf("failed to load signer key: %v", err)
+		return fmt.Errorf("failed to load signer key: %v", err)
 	}
 
 	bevmIDStr := c.String("bevmID")
 
 	bevmID, err := hex.DecodeString(bevmIDStr)
 	if err != nil {
-		return xerrors.Errorf("invalid BEvm ID provided: %v", err)
+		return fmt.Errorf("invalid BEvm ID provided: %v", err)
 	}
 	bevmClient, err := bevm.NewClient(cl, *signer,
 		byzcoin.NewInstanceID(bevmID))
 	if err != nil {
-		return xerrors.Errorf("failed to retrieve BEvm client "+
+		return fmt.Errorf("failed to retrieve BEvm client "+
 			"instance: %v", err)
 	}
 
 	err = bevmClient.Delete()
 	if err != nil {
-		return xerrors.Errorf("failed to delete BEvm instance: %v", err)
+		return fmt.Errorf("failed to delete BEvm instance: %v", err)
 	}
 
 	_, err = fmt.Fprintf(c.App.Writer, "Delete BEvm instance with ID: %s\n",
 		bevmIDStr)
 	if err != nil {
-		return xerrors.Errorf("failed to write report msg: %v", err)
+		return fmt.Errorf("failed to write report msg: %v", err)
 	}
 
 	return nil

--- a/bevm/bevmclient/utils.go
+++ b/bevm/bevmclient/utils.go
@@ -13,7 +13,6 @@ import (
 	"go.dedis.ch/cothority/v3/byzcoin"
 	"go.dedis.ch/cothority/v3/byzcoin/bcadmin/lib"
 	"go.dedis.ch/cothority/v3/darc"
-	"golang.org/x/xerrors"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -37,10 +36,10 @@ func writeFile(file string, data []byte, check bool) error {
 
 			err = os.Rename(file, newName)
 			if err != nil {
-				return xerrors.Errorf("failed to rename file: %v", err)
+				return fmt.Errorf("failed to rename file: %v", err)
 			}
 		} else if !os.IsNotExist(err) {
-			return xerrors.Errorf("failed to stat file: %v", err)
+			return fmt.Errorf("failed to stat file: %v", err)
 		}
 	}
 
@@ -55,7 +54,7 @@ func writeAccountFile(account *bevm.EvmAccount, name string, check bool) error {
 
 	jsonData, err := json.Marshal(tmp)
 	if err != nil {
-		return xerrors.Errorf("failed to serialize account "+
+		return fmt.Errorf("failed to serialize account "+
 			"information: %v", err)
 	}
 
@@ -65,19 +64,19 @@ func writeAccountFile(account *bevm.EvmAccount, name string, check bool) error {
 func readAccountFile(name string) (*bevm.EvmAccount, error) {
 	jsonData, err := ioutil.ReadFile(fmt.Sprintf("%s.bevm_account", name))
 	if err != nil {
-		return nil, xerrors.Errorf("failed to read account file: %v", err)
+		return nil, fmt.Errorf("failed to read account file: %v", err)
 	}
 
 	var tmp userEvmAccount
 	err = json.Unmarshal(jsonData, &tmp)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to deserialize account "+
+		return nil, fmt.Errorf("failed to deserialize account "+
 			"information: %v", err)
 	}
 
 	account, err := bevm.NewEvmAccount(tmp.PrivateKey)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to create new account from "+
+		return nil, fmt.Errorf("failed to create new account from "+
 			"file data: %v", err)
 	}
 
@@ -95,7 +94,7 @@ func writeContractFile(contractInstance *bevm.EvmContractInstance,
 	abiFilepath string, name string, check bool) error {
 	jsonAbi, err := ioutil.ReadFile(abiFilepath)
 	if err != nil {
-		return xerrors.Errorf("failed to read contract ABI: %v", err)
+		return fmt.Errorf("failed to read contract ABI: %v", err)
 	}
 
 	tmp := userEvmContract{
@@ -105,7 +104,7 @@ func writeContractFile(contractInstance *bevm.EvmContractInstance,
 
 	jsonData, err := json.Marshal(tmp)
 	if err != nil {
-		return xerrors.Errorf("failed to serialize contract "+
+		return fmt.Errorf("failed to serialize contract "+
 			"information: %v", err)
 	}
 
@@ -115,19 +114,19 @@ func writeContractFile(contractInstance *bevm.EvmContractInstance,
 func readContractFile(name string) (*bevm.EvmContractInstance, error) {
 	jsonData, err := ioutil.ReadFile(fmt.Sprintf("%s.bevm_contract", name))
 	if err != nil {
-		return nil, xerrors.Errorf("failed to read contract file: %v", err)
+		return nil, fmt.Errorf("failed to read contract file: %v", err)
 	}
 
 	var tmp userEvmContract
 	err = json.Unmarshal(jsonData, &tmp)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to deserialize contract "+
+		return nil, fmt.Errorf("failed to deserialize contract "+
 			"information: %v", err)
 	}
 
 	abi, err := abi.JSON(strings.NewReader(tmp.Abi))
 	if err != nil {
-		return nil, xerrors.Errorf("failed to deserialize contract "+
+		return nil, fmt.Errorf("failed to deserialize contract "+
 			"ABI: %v", err)
 	}
 
@@ -155,12 +154,12 @@ func handleCommonOptions(ctx *cli.Context) (*commonOptions, error) {
 
 	bevmID, err := hex.DecodeString(bevmIDStr)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to decode BEvm ID: %v", err)
+		return nil, fmt.Errorf("failed to decode BEvm ID: %v", err)
 	}
 
 	cfg, cl, err := lib.LoadConfig(bcFile)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to load ByzCoin config: %v", err)
+		return nil, fmt.Errorf("failed to load ByzCoin config: %v", err)
 	}
 
 	var signer *darc.Signer
@@ -170,19 +169,19 @@ func handleCommonOptions(ctx *cli.Context) (*commonOptions, error) {
 		signer, err = lib.LoadKey(cfg.AdminIdentity)
 	}
 	if err != nil {
-		return nil, xerrors.Errorf("failed to load signer key: %v", err)
+		return nil, fmt.Errorf("failed to load signer key: %v", err)
 	}
 
 	bevmClient, err := bevm.NewClient(cl, *signer,
 		byzcoin.NewInstanceID(bevmID))
 	if err != nil {
-		return nil, xerrors.Errorf("failed to retrieve BEvm client "+
+		return nil, fmt.Errorf("failed to retrieve BEvm client "+
 			"instance: %v", err)
 	}
 
 	account, err := readAccountFile(accountName)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to read account from file: %v", err)
+		return nil, fmt.Errorf("failed to read account from file: %v", err)
 	}
 
 	return &commonOptions{

--- a/bevm/database_byz.go
+++ b/bevm/database_byz.go
@@ -2,12 +2,13 @@ package bevm
 
 import (
 	"crypto/sha256"
+	"errors"
+	"fmt"
 	"sort"
 	"sync"
 
 	"go.dedis.ch/cothority/v3/byzcoin"
 	"go.dedis.ch/onet/v3/log"
-	"golang.org/x/xerrors"
 
 	"github.com/ethereum/go-ethereum/ethdb"
 )
@@ -61,7 +62,7 @@ func NewStateTrieByzDatabase(bevmIID byzcoin.InstanceID,
 
 // Put implements Putter.Put()
 func (db *StateTrieByzDatabase) Put(key []byte, value []byte) error {
-	return xerrors.New("Put() not allowed on StateTrieByzDatabase")
+	return errors.New("Put() not allowed on StateTrieByzDatabase")
 }
 
 // Retrieve the value from a BEVM value instance
@@ -71,7 +72,7 @@ func (db *StateTrieByzDatabase) getBEvmValue(key []byte) ([]byte, error) {
 	// Retrieve the value associated to the key
 	value, _, _, _, err := db.rst.GetValues(instID[:])
 	if err != nil {
-		return nil, xerrors.Errorf("failed to retrieve BEvmValue "+
+		return nil, fmt.Errorf("failed to retrieve BEvmValue "+
 			"instance for EVM state DB: %v", err)
 	}
 
@@ -89,7 +90,7 @@ func (db *StateTrieByzDatabase) Has(key []byte) (bool, error) {
 func (db *StateTrieByzDatabase) Get(key []byte) ([]byte, error) {
 	value, err := db.getBEvmValue(key)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get EVM State DB value for "+
+		return nil, fmt.Errorf("failed to get EVM State DB value for "+
 			"key '%v': %v", key, err)
 	}
 
@@ -98,7 +99,7 @@ func (db *StateTrieByzDatabase) Get(key []byte) ([]byte, error) {
 
 // Delete implements Deleter.Delete()
 func (db *StateTrieByzDatabase) Delete(key []byte) error {
-	return xerrors.New("Delete() not allowed on StateTrieByzDatabase")
+	return errors.New("Delete() not allowed on StateTrieByzDatabase")
 }
 
 // NewBatch implements NewBatch()
@@ -131,7 +132,7 @@ func NewClientByzDatabase(bevmIID byzcoin.InstanceID, client *byzcoin.Client) (
 
 // Put implements Putter.Put()
 func (db *ClientByzDatabase) Put(key []byte, value []byte) error {
-	return xerrors.New("Put() not allowed on ClientByzDatabase")
+	return errors.New("Put() not allowed on ClientByzDatabase")
 }
 
 // Retrieve the value from a BEVM value instance
@@ -141,14 +142,14 @@ func (db *ClientByzDatabase) getBEvmValue(key []byte) ([]byte, error) {
 	// Retrieve the proof of the BEvmValue instance
 	proofResponse, err := db.client.GetProofFromLatest(instID[:])
 	if err != nil {
-		return nil, xerrors.Errorf("failed to retrieve BEvmValue "+
+		return nil, fmt.Errorf("failed to retrieve BEvmValue "+
 			"instance for EVM state DB: %v", err)
 	}
 
 	// Extract the value from the proof
 	_, value, _, _, err := proofResponse.Proof.KeyValue()
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get BEvmValue "+
+		return nil, fmt.Errorf("failed to get BEvmValue "+
 			"instance value: %v", err)
 	}
 
@@ -166,7 +167,7 @@ func (db *ClientByzDatabase) Has(key []byte) (bool, error) {
 func (db *ClientByzDatabase) Get(key []byte) ([]byte, error) {
 	value, err := db.getBEvmValue(key)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get EVM State DB value for "+
+		return nil, fmt.Errorf("failed to get EVM State DB value for "+
 			"key '%v': %v", key, err)
 	}
 
@@ -175,7 +176,7 @@ func (db *ClientByzDatabase) Get(key []byte) ([]byte, error) {
 
 // Delete implements Deleter.Delete()
 func (db *ClientByzDatabase) Delete(key []byte) error {
-	return xerrors.New("Delete() not allowed on ClientByzDatabase")
+	return errors.New("Delete() not allowed on ClientByzDatabase")
 }
 
 // NewBatch implements NewBatch()
@@ -248,7 +249,7 @@ func (db *ServerByzDatabase) Dump() ([]byzcoin.StateChange, []string, error) {
 	for _, s := range db.stateChanges {
 		k := string(s.Key())
 		if val, ok := keyMap[k]; ok && val != string(s.Value) {
-			return nil, nil, xerrors.New("internal error: the set of " +
+			return nil, nil, errors.New("internal error: the set of " +
 				"changes produced by the EVM is not unique on keys")
 		}
 		keyMap[k] = string(s.Value)
@@ -273,7 +274,7 @@ func (db *ServerByzDatabase) Dump() ([]byzcoin.StateChange, []string, error) {
 		case byzcoin.Remove:
 			nbRemove++
 		default:
-			return nil, nil, xerrors.Errorf("unknown StateChange "+
+			return nil, nil, fmt.Errorf("unknown StateChange "+
 				"action: %d", s.StateAction)
 		}
 	}
@@ -332,7 +333,7 @@ func (db *ServerByzDatabase) Get(key []byte) ([]byte, error) {
 
 	value, _, _, _, err := db.roStateTrie.GetValues(instID[:])
 	if err != nil {
-		return nil, xerrors.Errorf("failed to read value from ByzCoin "+
+		return nil, fmt.Errorf("failed to read value from ByzCoin "+
 			"state trie: %v", err)
 	}
 

--- a/bevm/database_mem.go
+++ b/bevm/database_mem.go
@@ -19,12 +19,12 @@ package bevm
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"sort"
 	"sync"
 
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/protobuf"
-	"golang.org/x/xerrors"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -55,7 +55,7 @@ func NewMemDatabase(data []byte) (*MemDatabase, error) {
 
 	err := protobuf.Decode(data, kvs)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to decode in-memory EVM "+
+		return nil, fmt.Errorf("failed to decode in-memory EVM "+
 			"state DB: %v", err)
 	}
 
@@ -124,7 +124,7 @@ func (db *MemDatabase) Get(key []byte) ([]byte, error) {
 		return common.CopyBytes(entry), nil
 	}
 
-	return nil, xerrors.Errorf("key '%s' not found in EVM state DB",
+	return nil, fmt.Errorf("key '%s' not found in EVM state DB",
 		hex.EncodeToString(key))
 }
 

--- a/bftcosi/bftcosi_test.go
+++ b/bftcosi/bftcosi_test.go
@@ -272,7 +272,7 @@ func runProtocolOnceGo(t *testing.T, nbrHosts int, name string, refuseCount int,
 		sig := root.Signature()
 		err := sig.Verify(root.Suite(), root.Roster().Publics())
 		if succeed && err != nil {
-			return fmt.Errorf("%s Verification of the signature refused: %s - %+v", root.Name(), err.Error(), sig.Sig)
+			return fmt.Errorf("%s Verification of the signature refused: %s - %v", root.Name(), err.Error(), sig.Sig)
 		}
 		if !succeed && err == nil {
 			return fmt.Errorf("%s: Shouldn't have succeeded for %d hosts, but signed for count: %d",

--- a/byzcoin/api_test.go
+++ b/byzcoin/api_test.go
@@ -1,6 +1,7 @@
 package byzcoin
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -12,7 +13,6 @@ import (
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/protobuf"
-	"golang.org/x/xerrors"
 )
 
 func init() {
@@ -386,7 +386,7 @@ func newTestService(c *onet.Context) (onet.Service, error) {
 
 func (cs *corruptedService) GetProof(req *GetProof) (resp *GetProofResponse, err error) {
 	if cs.GetProofResponse == nil {
-		return nil, xerrors.New("empty response")
+		return nil, errors.New("empty response")
 	}
 
 	return cs.GetProofResponse, nil
@@ -394,7 +394,7 @@ func (cs *corruptedService) GetProof(req *GetProof) (resp *GetProofResponse, err
 
 func (cs *corruptedService) CreateGenesisBlock(req *CreateGenesisBlock) (*CreateGenesisBlockResponse, error) {
 	if cs.CreateGenesisBlockResponse == nil {
-		return nil, xerrors.New("empty response")
+		return nil, errors.New("empty response")
 	}
 
 	return cs.CreateGenesisBlockResponse, nil

--- a/byzcoin/bcadmin/clicontracts/config.go
+++ b/byzcoin/bcadmin/clicontracts/config.go
@@ -1,11 +1,12 @@
 package clicontracts
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"time"
 
 	"go.dedis.ch/onet/v3/log"
-	"golang.org/x/xerrors"
 
 	"github.com/urfave/cli"
 	"go.dedis.ch/cothority/v3"
@@ -28,7 +29,7 @@ func ConfigInvokeUpdateConfig(c *cli.Context) error {
 	// ---
 	bcArg := c.String("bc")
 	if bcArg == "" {
-		return xerrors.New("--bc flag is required")
+		return errors.New("--bc flag is required")
 	}
 
 	cfg, cl, err := lib.LoadConfig(bcArg)
@@ -51,18 +52,18 @@ func ConfigInvokeUpdateConfig(c *cli.Context) error {
 	// Get the latest chain config
 	pr, err := cl.GetProofFromLatest(byzcoin.ConfigInstanceID.Slice())
 	if err != nil {
-		return xerrors.Errorf("couldn't get proof for chainConfig: %v", err)
+		return fmt.Errorf("couldn't get proof for chainConfig: %v", err)
 	}
 	proof := pr.Proof
 
 	_, value, _, _, err := proof.KeyValue()
 	if err != nil {
-		return xerrors.Errorf("couldn't get value out of proof: %v", err)
+		return fmt.Errorf("couldn't get value out of proof: %v", err)
 	}
 	config := byzcoin.ChainConfig{}
 	err = protobuf.DecodeWithConstructors(value, &config, network.DefaultConstructors(cothority.Suite))
 	if err != nil {
-		return xerrors.Errorf("couldn't decode chainConfig: %v", err)
+		return fmt.Errorf("couldn't decode chainConfig: %v", err)
 	}
 
 	// BlockInterval
@@ -71,7 +72,7 @@ func ConfigInvokeUpdateConfig(c *cli.Context) error {
 	if blockInterval != "" {
 		duration, err := time.ParseDuration(blockInterval)
 		if err != nil {
-			return xerrors.Errorf("couldn't parse blockInterval: %v", err)
+			return fmt.Errorf("couldn't parse blockInterval: %v", err)
 		}
 		config.BlockInterval = duration
 	}
@@ -80,7 +81,7 @@ func ConfigInvokeUpdateConfig(c *cli.Context) error {
 	maxBlockSize := c.Int("maxBlockSize")
 	if maxBlockSize > 0 {
 		if maxBlockSize < 16000 && maxBlockSize > 8e6 {
-			return xerrors.New("maxBlockSize out of bounds: must be between 16e3 and 8e6")
+			return errors.New("maxBlockSize out of bounds: must be between 16e3 and 8e6")
 		}
 		config.MaxBlockSize = maxBlockSize
 	}
@@ -95,12 +96,12 @@ func ConfigInvokeUpdateConfig(c *cli.Context) error {
 
 	configBuf, err := protobuf.Encode(&config)
 	if err != nil {
-		return xerrors.Errorf("failed to encode config: %v", err)
+		return fmt.Errorf("failed to encode config: %v", err)
 	}
 
 	counters, err := cl.GetSignerCounters(signer.Identity().String())
 	if err != nil {
-		return xerrors.Errorf("couldn't get counters: %v", err)
+		return fmt.Errorf("couldn't get counters: %v", err)
 	}
 
 	invoke := byzcoin.Invoke{
@@ -149,18 +150,18 @@ func ConfigInvokeUpdateConfig(c *cli.Context) error {
 	}
 	pr, err = cl.GetProofFromLatest(byzcoin.ConfigInstanceID.Slice())
 	if err != nil {
-		return xerrors.Errorf("couldn't get proof for config: %v", err)
+		return fmt.Errorf("couldn't get proof for config: %v", err)
 	}
 	proof = pr.Proof
 	_, resultBuf, _, _, err := proof.KeyValue()
 	if err != nil {
-		return xerrors.Errorf("couldn't get value out of proof: %v", err)
+		return fmt.Errorf("couldn't get value out of proof: %v", err)
 	}
 
 	contractConfig := byzcoin.ChainConfig{}
 	err = protobuf.Decode(resultBuf, &contractConfig)
 	if err != nil {
-		return xerrors.Errorf("failed to decode contractConfig: %v", err)
+		return fmt.Errorf("failed to decode contractConfig: %v", err)
 	}
 
 	newInstID := ctx.Instructions[0].DeriveID("").Slice()
@@ -174,7 +175,7 @@ func ConfigInvokeUpdateConfig(c *cli.Context) error {
 func ConfigGet(c *cli.Context) error {
 	bcArg := c.String("bc")
 	if bcArg == "" {
-		return xerrors.New("--bc flag is required")
+		return errors.New("--bc flag is required")
 	}
 
 	_, cl, err := lib.LoadConfig(bcArg)
@@ -185,18 +186,18 @@ func ConfigGet(c *cli.Context) error {
 	// Get the latest chain config
 	pr, err := cl.GetProofFromLatest(byzcoin.ConfigInstanceID.Slice())
 	if err != nil {
-		return xerrors.Errorf("couldn't get proof for chainConfig: %v", err)
+		return fmt.Errorf("couldn't get proof for chainConfig: %v", err)
 	}
 	proof := pr.Proof
 
 	_, value, _, _, err := proof.KeyValue()
 	if err != nil {
-		return xerrors.Errorf("couldn't get value out of proof: %v", err)
+		return fmt.Errorf("couldn't get value out of proof: %v", err)
 	}
 	config := byzcoin.ChainConfig{}
 	err = protobuf.DecodeWithConstructors(value, &config, network.DefaultConstructors(cothority.Suite))
 	if err != nil {
-		return xerrors.Errorf("couldn't decode chainConfig: %v", err)
+		return fmt.Errorf("couldn't decode chainConfig: %v", err)
 	}
 
 	log.Infof("Here is the config data:\n%s", config)

--- a/byzcoin/bcadmin/clicontracts/value.go
+++ b/byzcoin/bcadmin/clicontracts/value.go
@@ -2,10 +2,10 @@ package clicontracts
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"go.dedis.ch/onet/v3/log"
-	"golang.org/x/xerrors"
 
 	"github.com/urfave/cli"
 	"go.dedis.ch/cothority/v3/byzcoin"
@@ -18,12 +18,12 @@ import (
 func ValueSpawn(c *cli.Context) error {
 	bcArg := c.String("bc")
 	if bcArg == "" {
-		return xerrors.New("--bc flag is required")
+		return errors.New("--bc flag is required")
 	}
 
 	value := c.String("value")
 	if value == "" {
-		return xerrors.New("--value flag is required")
+		return errors.New("--value flag is required")
 	}
 	valueBuf := []byte(value)
 
@@ -98,22 +98,22 @@ func ValueSpawn(c *cli.Context) error {
 func ValueInvokeUpdate(c *cli.Context) error {
 	bcArg := c.String("bc")
 	if bcArg == "" {
-		return xerrors.New("--bc flag is required")
+		return errors.New("--bc flag is required")
 	}
 
 	value := c.String("value")
 	if value == "" {
-		return xerrors.New("--value flag is required")
+		return errors.New("--value flag is required")
 	}
 	valueBuf := []byte(value)
 
 	instID := c.String("instid")
 	if instID == "" {
-		return xerrors.New("--instid flag is required")
+		return errors.New("--instid flag is required")
 	}
 	instIDBuf, err := hex.DecodeString(instID)
 	if err != nil {
-		return xerrors.New("failed to decode the instid string")
+		return errors.New("failed to decode the instid string")
 	}
 
 	cfg, cl, err := lib.LoadConfig(bcArg)
@@ -184,7 +184,7 @@ func ValueGet(c *cli.Context) error {
 
 	bcArg := c.String("bc")
 	if bcArg == "" {
-		return xerrors.New("--bc flag is required")
+		return errors.New("--bc flag is required")
 	}
 
 	_, cl, err := lib.LoadConfig(bcArg)
@@ -194,35 +194,35 @@ func ValueGet(c *cli.Context) error {
 
 	instID := c.String("instid")
 	if instID == "" {
-		return xerrors.New("--instid flag is required")
+		return errors.New("--instid flag is required")
 	}
 	instIDBuf, err := hex.DecodeString(instID)
 	if err != nil {
-		return xerrors.New("failed to decode the instID string" + instID)
+		return errors.New("failed to decode the instID string" + instID)
 	}
 
 	pr, err := cl.GetProofFromLatest(instIDBuf)
 	if err != nil {
-		return xerrors.Errorf("couldn't get proof: %v", err)
+		return fmt.Errorf("couldn't get proof: %v", err)
 	}
 	proof := pr.Proof
 
 	exist, err := proof.InclusionProof.Exists(instIDBuf)
 	if err != nil {
-		return xerrors.Errorf("error while checking if proof exist: %v", err)
+		return fmt.Errorf("error while checking if proof exist: %v", err)
 	}
 	if !exist {
-		return xerrors.New("proof not found")
+		return errors.New("proof not found")
 	}
 
 	match := proof.InclusionProof.Match(instIDBuf)
 	if !match {
-		return xerrors.New("proof does not match")
+		return errors.New("proof does not match")
 	}
 
 	_, resultBuf, _, _, err := proof.KeyValue()
 	if err != nil {
-		return xerrors.Errorf("couldn't get value out of proof: %v", err)
+		return fmt.Errorf("couldn't get value out of proof: %v", err)
 	}
 
 	log.Infof("%s", resultBuf)
@@ -234,16 +234,16 @@ func ValueGet(c *cli.Context) error {
 func ValueDelete(c *cli.Context) error {
 	bcArg := c.String("bc")
 	if bcArg == "" {
-		return xerrors.New("--bc flag is required")
+		return errors.New("--bc flag is required")
 	}
 
 	instID := c.String("instid")
 	if instID == "" {
-		return xerrors.New("--instid flag is required")
+		return errors.New("--instid flag is required")
 	}
 	instIDBuf, err := hex.DecodeString(instID)
 	if err != nil {
-		return xerrors.New("failed to decode the instid string")
+		return errors.New("failed to decode the instid string")
 	}
 
 	cfg, cl, err := lib.LoadConfig(bcArg)

--- a/byzcoin/bcadmin/lib/config.go
+++ b/byzcoin/bcadmin/lib/config.go
@@ -17,7 +17,6 @@ import (
 	"go.dedis.ch/onet/v3/app"
 	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/protobuf"
-	"golang.org/x/xerrors"
 )
 
 // ConfigPath points to where the files will be stored by default.
@@ -60,7 +59,7 @@ func LoadKey(id darc.Identity) (*darc.Signer, error) {
 	// Check if this is an empty identity. Note: we expect an identity to use 32
 	// bytes
 	if bytes.Equal(id.GetPublicBytes(), emptyID) {
-		return nil, xerrors.New("failed to load the key because the identity is empty")
+		return nil, errors.New("failed to load the key because the identity is empty")
 	}
 	// Find private key file.
 	fn := fmt.Sprintf("key-%s.cfg", id)
@@ -81,7 +80,7 @@ func LoadKeyFromString(id string) (*darc.Signer, error) {
 func LoadSigner(fn string) (*darc.Signer, error) {
 	buf, err := ioutil.ReadFile(fn)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to read this path: '%s': %v", fn, err)
+		return nil, fmt.Errorf("failed to read this path: '%s': %v", fn, err)
 	}
 
 	var signer darc.Signer
@@ -104,7 +103,7 @@ func SaveKey(signer darc.Signer) error {
 	// perms = 0400 because there is key material inside this file.
 	f, err := os.OpenFile(fn, os.O_RDWR|os.O_CREATE, 0400)
 	if err != nil {
-		return xerrors.Errorf("could not write %v: %v", fn, err)
+		return fmt.Errorf("could not write %v: %v", fn, err)
 	}
 
 	buf, err := protobuf.Encode(&signer)
@@ -176,7 +175,7 @@ func LoadConfig(file string) (cfg Config, cl *byzcoin.Client, err error) {
 func ReadRoster(file string) (r *onet.Roster, err error) {
 	in, err := os.Open(file)
 	if err != nil {
-		return nil, xerrors.Errorf("Could not open roster %v: %v", file, err)
+		return nil, fmt.Errorf("Could not open roster %v: %v", file, err)
 	}
 	defer in.Close()
 
@@ -186,7 +185,7 @@ func ReadRoster(file string) (r *onet.Roster, err error) {
 	}
 
 	if len(group.Roster.List) == 0 {
-		return nil, xerrors.New("empty roster")
+		return nil, errors.New("empty roster")
 	}
 	return group.Roster, nil
 }

--- a/byzcoin/bcadmin/lib/utils.go
+++ b/byzcoin/bcadmin/lib/utils.go
@@ -3,12 +3,12 @@ package lib
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
+	"fmt"
 	"io"
 	"math/big"
 	"os"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"go.dedis.ch/kyber/v3/util/random"
 
@@ -21,7 +21,7 @@ import (
 // StringToDarcID converts a string representation of a DARC to a byte array
 func StringToDarcID(id string) ([]byte, error) {
 	if id == "" {
-		return nil, xerrors.New("no string given")
+		return nil, errors.New("no string given")
 	}
 	if strings.HasPrefix(id, "darc:") {
 		id = id[5:]
@@ -33,7 +33,7 @@ func StringToDarcID(id string) ([]byte, error) {
 // byte array
 func StringToEd25519Buf(pub string) ([]byte, error) {
 	if pub == "" {
-		return nil, xerrors.New("no string given")
+		return nil, errors.New("no string given")
 	}
 	if strings.HasPrefix(pub, "ed25519:") {
 		pub = pub[8:]
@@ -61,10 +61,10 @@ func GetDarcByID(cl *byzcoin.Client, id []byte) (*darc.Darc, error) {
 
 	vs, cid, _, err := p.Get(id)
 	if err != nil {
-		return nil, xerrors.Errorf("could not find darc for %x", id)
+		return nil, fmt.Errorf("could not find darc for %x", id)
 	}
 	if cid != byzcoin.ContractDarcID {
-		return nil, xerrors.Errorf("unexpected contract %v, expected a darc", cid)
+		return nil, fmt.Errorf("unexpected contract %v, expected a darc", cid)
 	}
 
 	d, err := darc.NewFromProtobuf(vs)
@@ -94,12 +94,12 @@ func ExportTransaction(tx byzcoin.ClientTransaction) error {
 	tx.Instructions = instrs
 	buf, err := protobuf.Encode(&tx)
 	if err != nil {
-		return xerrors.Errorf("failed to encode tx: %v", err)
+		return fmt.Errorf("failed to encode tx: %v", err)
 	}
 	reader := bytes.NewReader(buf)
 	_, err = io.Copy(os.Stdout, reader)
 	if err != nil {
-		return xerrors.Errorf("failed to copy to stdout: %v", err)
+		return fmt.Errorf("failed to copy to stdout: %v", err)
 	}
 	return nil
 }

--- a/byzcoin/contract_darc.go
+++ b/byzcoin/contract_darc.go
@@ -2,10 +2,11 @@ package byzcoin
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 
 	"go.dedis.ch/cothority/v3"
 	"go.dedis.ch/cothority/v3/darc"
-	"golang.org/x/xerrors"
 )
 
 // ContractDarcID denotes a secure version of the DARC contract. We
@@ -34,7 +35,7 @@ const cmdDarcEvolve = "evolve"
 func contractSecureDarcFromBytes(in []byte) (Contract, error) {
 	d, err := darc.NewFromProtobuf(in)
 	if err != nil {
-		return nil, xerrors.Errorf("darc decoding: %v", err)
+		return nil, fmt.Errorf("darc decoding: %v", err)
 	}
 	c := &contractSecureDarc{Darc: *d}
 	return c, nil
@@ -61,10 +62,10 @@ func (c *contractSecureDarc) Spawn(rst ReadOnlyStateTrie, inst Instruction, coin
 		darcBuf := inst.Spawn.Args.Search("darc")
 		d, err := darc.NewFromProtobuf(darcBuf)
 		if err != nil {
-			return nil, nil, xerrors.Errorf("given DARC could not be decoded: %v", err)
+			return nil, nil, fmt.Errorf("given DARC could not be decoded: %v", err)
 		}
 		if d.Version != 0 {
-			return nil, nil, xerrors.New("DARC version must start at 0")
+			return nil, nil, errors.New("DARC version must start at 0")
 		}
 
 		id := d.GetBaseID()
@@ -75,7 +76,7 @@ func (c *contractSecureDarc) Spawn(rst ReadOnlyStateTrie, inst Instruction, coin
 		// of roles -> identities, and roles -> whitelist of rules.
 		// Then modify this contract to check the whitelist.
 		if d.Rules.Contains("spawn:insecure_darc") {
-			return nil, nil, xerrors.New("a secure DARC is not allowed to spawn an insecure DARC")
+			return nil, nil, errors.New("a secure DARC is not allowed to spawn an insecure DARC")
 		}
 
 		return []StateChange{
@@ -87,12 +88,12 @@ func (c *contractSecureDarc) Spawn(rst ReadOnlyStateTrie, inst Instruction, coin
 	// a new instance of contract xxx, so do that.
 
 	if c.contracts == nil {
-		return nil, nil, xerrors.New("contracts registry is missing due to bad initialization")
+		return nil, nil, errors.New("contracts registry is missing due to bad initialization")
 	}
 
 	cfact, found := c.contracts.Search(inst.Spawn.ContractID)
 	if !found {
-		return nil, nil, xerrors.New("couldn't find this contract type: " + inst.Spawn.ContractID)
+		return nil, nil, errors.New("couldn't find this contract type: " + inst.Spawn.ContractID)
 	}
 
 	// Pass nil into the contract factory here because this instance does not exist yet.
@@ -101,7 +102,7 @@ func (c *contractSecureDarc) Spawn(rst ReadOnlyStateTrie, inst Instruction, coin
 	// into the trie.
 	c2, err := cfact(nil)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("could not spawn new zero instance: %v", err)
+		return nil, nil, fmt.Errorf("could not spawn new zero instance: %v", err)
 	}
 	if cwr, ok := c2.(ContractWithRegistry); ok {
 		cwr.SetRegistry(c.contracts)
@@ -117,33 +118,33 @@ func (c *contractSecureDarc) Invoke(rst ReadOnlyStateTrie, inst Instruction, coi
 		var darcID darc.ID
 		_, _, _, darcID, err := rst.GetValues(inst.InstanceID.Slice())
 		if err != nil {
-			return nil, nil, xerrors.Errorf("reading trie: %v", err)
+			return nil, nil, fmt.Errorf("reading trie: %v", err)
 		}
 
 		darcBuf := inst.Invoke.Args.Search("darc")
 		newD, err := darc.NewFromProtobuf(darcBuf)
 		if err != nil {
-			return nil, nil, xerrors.Errorf("darc encoding: %v", err)
+			return nil, nil, fmt.Errorf("darc encoding: %v", err)
 		}
 		oldD, err := rst.LoadDarc(darcID)
 		if err != nil {
-			return nil, nil, xerrors.Errorf("darc from trie: %v", err)
+			return nil, nil, fmt.Errorf("darc from trie: %v", err)
 		}
 		// do not allow modification of evolve_unrestricted
 		if isChangingEvolveUnrestricted(oldD, newD) {
-			return nil, nil, xerrors.New("the evolve command is not allowed to change the the evolve_unrestricted rule")
+			return nil, nil, errors.New("the evolve command is not allowed to change the the evolve_unrestricted rule")
 		}
 		if err := newD.SanityCheck(oldD); err != nil {
-			return nil, nil, xerrors.Errorf("sanity check: %v", err)
+			return nil, nil, fmt.Errorf("sanity check: %v", err)
 		}
 		// use the subset rule if it's not a genesis Darc
 		_, _, _, genesisDarcID, err := GetValueContract(rst, NewInstanceID(nil).Slice())
 		if err != nil {
-			return nil, nil, xerrors.Errorf("getting contract: %v", err)
+			return nil, nil, fmt.Errorf("getting contract: %v", err)
 		}
 		if !genesisDarcID.Equal(oldD.GetBaseID()) {
 			if !newD.Rules.IsSubset(oldD.Rules) {
-				return nil, nil, xerrors.New("rules in the new version must be a subset of the previous version")
+				return nil, nil, errors.New("rules in the new version must be a subset of the previous version")
 			}
 		}
 		return []StateChange{
@@ -153,26 +154,26 @@ func (c *contractSecureDarc) Invoke(rst ReadOnlyStateTrie, inst Instruction, coi
 		var darcID darc.ID
 		_, _, _, darcID, err := rst.GetValues(inst.InstanceID.Slice())
 		if err != nil {
-			return nil, nil, xerrors.Errorf("reading trie: %v", err)
+			return nil, nil, fmt.Errorf("reading trie: %v", err)
 		}
 
 		darcBuf := inst.Invoke.Args.Search("darc")
 		newD, err := darc.NewFromProtobuf(darcBuf)
 		if err != nil {
-			return nil, nil, xerrors.Errorf("encoding darc: %v", err)
+			return nil, nil, fmt.Errorf("encoding darc: %v", err)
 		}
 		oldD, err := rst.LoadDarc(darcID)
 		if err != nil {
-			return nil, nil, xerrors.Errorf("darc from trie: %v", err)
+			return nil, nil, fmt.Errorf("darc from trie: %v", err)
 		}
 		if err := newD.SanityCheck(oldD); err != nil {
-			return nil, nil, xerrors.Errorf("sanity check: %v", err)
+			return nil, nil, fmt.Errorf("sanity check: %v", err)
 		}
 		return []StateChange{
 			NewStateChange(Update, inst.InstanceID, ContractDarcID, darcBuf, darcID),
 		}, coins, nil
 	default:
-		return nil, nil, xerrors.New("invalid command: " + inst.Invoke.Command)
+		return nil, nil, errors.New("invalid command: " + inst.Invoke.Command)
 	}
 }
 

--- a/byzcoin/contract_deferred.go
+++ b/byzcoin/contract_deferred.go
@@ -3,12 +3,12 @@ package byzcoin
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"strings"
 
 	"go.dedis.ch/cothority/v3/darc"
 	"go.dedis.ch/protobuf"
-	"golang.org/x/xerrors"
 )
 
 // The deferred contract allows a group of signers to agree on and sign a
@@ -84,7 +84,7 @@ func contractDeferredFromBytes(in []byte) (Contract, error) {
 
 	err := protobuf.Decode(in, &c.DeferredData)
 	if err != nil {
-		return nil, xerrors.Errorf("couldn't unmarshal instance data: %v", err)
+		return nil, fmt.Errorf("couldn't unmarshal instance data: %v", err)
 	}
 	return c, nil
 }
@@ -107,14 +107,14 @@ func (c *contractDeferred) Spawn(rst ReadOnlyStateTrie, inst Instruction, coins 
 	// Find the darcID for this instance.
 	_, _, _, darcID, err := rst.GetValues(inst.InstanceID.Slice())
 	if err != nil {
-		return nil, nil, xerrors.Errorf("reading trie: %v", err)
+		return nil, nil, fmt.Errorf("reading trie: %v", err)
 	}
 
 	// 1. Reads and parses the input
 	proposedTransaction := ClientTransaction{}
 	err = protobuf.Decode(inst.Spawn.Args.Search("proposedTransaction"), &proposedTransaction)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("couldn't decode proposedTransaction: %v", err)
+		return nil, nil, fmt.Errorf("couldn't decode proposedTransaction: %v", err)
 	}
 
 	expireBlockIndexBuf := inst.Spawn.Args.Search("expireBlockIndex")
@@ -124,7 +124,7 @@ func (c *contractDeferred) Spawn(rst ReadOnlyStateTrie, inst Instruction, coins 
 	} else {
 		expireBlockIndex = binary.LittleEndian.Uint64(expireBlockIndexBuf)
 		if err != nil {
-			return nil, nil, xerrors.Errorf("couldn't convert expireBlockIndex: %v", err)
+			return nil, nil, fmt.Errorf("couldn't convert expireBlockIndex: %v", err)
 		}
 	}
 
@@ -145,7 +145,7 @@ func (c *contractDeferred) Spawn(rst ReadOnlyStateTrie, inst Instruction, coins 
 	}
 	dataBuf, err := protobuf.Encode(&data)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("couldn't encode DeferredData: %v", err)
+		return nil, nil, fmt.Errorf("couldn't encode DeferredData: %v", err)
 	}
 
 	sc := StateChanges{NewStateChange(Create, inst.DeriveID(""), ContractDeferredID, dataBuf, darcID)}
@@ -163,7 +163,7 @@ func (c *contractDeferred) Invoke(rst ReadOnlyStateTrie, inst Instruction, coins
 	//   - index uint32 (index of the instruction wrt the transaction)
 	err = c.checkInvoke(rst, inst.Invoke)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("checks of invoke failed: %v", err)
+		return nil, nil, fmt.Errorf("checks of invoke failed: %v", err)
 	}
 
 	cout = coins
@@ -184,31 +184,31 @@ func (c *contractDeferred) Invoke(rst ReadOnlyStateTrie, inst Instruction, coins
 		// Get the given index
 		indexBuf := inst.Invoke.Args.Search("index")
 		if indexBuf == nil {
-			return nil, nil, xerrors.New("index args is nil")
+			return nil, nil, errors.New("index args is nil")
 		}
 		index := binary.LittleEndian.Uint32(indexBuf)
 
 		// Check if the index is in range
 		numInstruction := len(c.DeferredData.ProposedTransaction.Instructions)
 		if index >= uint32(numInstruction) {
-			return nil, nil, xerrors.Errorf("index is out of range (%d >= %d)", index, numInstruction)
+			return nil, nil, fmt.Errorf("index is out of range (%d >= %d)", index, numInstruction)
 		}
 
 		// Get the given Identity
 		identityBuf := inst.Invoke.Args.Search("identity")
 		if identityBuf == nil {
-			return nil, nil, xerrors.New("identity args is nil")
+			return nil, nil, errors.New("identity args is nil")
 		}
 		identity := darc.Identity{}
 		err = protobuf.Decode(identityBuf, &identity)
 		if err != nil {
-			return nil, nil, xerrors.New("couldn't decode Identity")
+			return nil, nil, errors.New("couldn't decode Identity")
 		}
 
 		// Get the given signature
 		signature := inst.Invoke.Args.Search("signature")
 		if signature == nil {
-			return nil, nil, xerrors.New("signature args is nil")
+			return nil, nil, errors.New("signature args is nil")
 		}
 		// Update the contract's data with the given signature and identity
 		c.DeferredData.ProposedTransaction.Instructions[index].SignerIdentities = append(c.DeferredData.ProposedTransaction.Instructions[index].SignerIdentities, identity)
@@ -216,7 +216,7 @@ func (c *contractDeferred) Invoke(rst ReadOnlyStateTrie, inst Instruction, coins
 		// Save and send the modifications
 		cosiDataBuf, err2 := protobuf.Encode(&c.DeferredData)
 		if err2 != nil {
-			return nil, nil, xerrors.New("couldn't encode DeferredData")
+			return nil, nil, errors.New("couldn't encode DeferredData")
 		}
 		sc = append(sc, NewStateChange(Update, inst.InstanceID,
 			ContractDeferredID, cosiDataBuf, darcID))
@@ -242,21 +242,21 @@ func (c *contractDeferred) Invoke(rst ReadOnlyStateTrie, inst Instruction, coins
 			// its buferred data and then calling its constructor.
 			contractBuf, _, contractID, _, err := rst.GetValues(proposedInstr.InstanceID.Slice())
 			if err != nil {
-				return nil, nil, xerrors.Errorf("couldn't get contract buf: %v", err)
+				return nil, nil, fmt.Errorf("couldn't get contract buf: %v", err)
 			}
 			// Get the contract's constructor (like "contractValueFromByte(...)")
 			if c.contracts == nil {
-				return nil, nil, xerrors.New("contracts registry is missing due to bad initialization")
+				return nil, nil, errors.New("contracts registry is missing due to bad initialization")
 			}
 
 			fn, exists := c.contracts.Search(contractID)
 			if !exists {
-				return nil, nil, xerrors.New("couldn't get the root function")
+				return nil, nil, errors.New("couldn't get the root function")
 			}
 			// Invoke the contructor and get the contract's instance
 			contract, err := fn(contractBuf)
 			if err != nil {
-				return nil, nil, xerrors.Errorf("couldn't get the root contract: %v", err)
+				return nil, nil, fmt.Errorf("couldn't get the root contract: %v", err)
 			}
 			if cwr, ok := contract.(ContractWithRegistry); ok {
 				cwr.SetRegistry(c.contracts)
@@ -264,7 +264,7 @@ func (c *contractDeferred) Invoke(rst ReadOnlyStateTrie, inst Instruction, coins
 
 			err = contract.VerifyDeferredInstruction(rst, proposedInstr, c.DeferredData.InstructionHashes[i])
 			if err != nil {
-				return nil, nil, xerrors.Errorf("verifying the instruction failed: %v", err)
+				return nil, nil, fmt.Errorf("verifying the instruction failed: %v", err)
 			}
 
 			var stateChanges []StateChange
@@ -279,12 +279,12 @@ func (c *contractDeferred) Invoke(rst ReadOnlyStateTrie, inst Instruction, coins
 			}
 
 			if err != nil {
-				return nil, nil, xerrors.Errorf("error while executing an instruction: %v", err)
+				return nil, nil, fmt.Errorf("error while executing an instruction: %v", err)
 			}
 
 			rst, err = rst.StoreAllToReplica(stateChanges)
 			if err != nil {
-				return nil, nil, xerrors.Errorf("error while storing state changes: %v", err)
+				return nil, nil, fmt.Errorf("error while storing state changes: %v", err)
 			}
 
 			sc = append(sc, stateChanges...)
@@ -296,14 +296,14 @@ func (c *contractDeferred) Invoke(rst ReadOnlyStateTrie, inst Instruction, coins
 		c.DeferredData.MaxNumExecution = c.DeferredData.MaxNumExecution - 1
 		resultBuf, err2 := protobuf.Encode(&c.DeferredData)
 		if err2 != nil {
-			return nil, nil, xerrors.New("couldn't encode the result")
+			return nil, nil, errors.New("couldn't encode the result")
 		}
 		sc = append(sc, NewStateChange(Update, inst.InstanceID,
 			ContractDeferredID, resultBuf, darcID))
 
 		return
 	default:
-		return nil, nil, xerrors.New("deferred contract can only addProof and execProposedTx")
+		return nil, nil, errors.New("deferred contract can only addProof and execProposedTx")
 	}
 }
 
@@ -314,7 +314,7 @@ func (c *contractDeferred) Delete(rst ReadOnlyStateTrie, inst Instruction, coins
 	var darcID darc.ID
 	_, _, _, darcID, err = rst.GetValues(inst.InstanceID.Slice())
 	if err != nil {
-		return nil, nil, xerrors.Errorf("reading trie: %v", err)
+		return nil, nil, fmt.Errorf("reading trie: %v", err)
 	}
 
 	sc = StateChanges{
@@ -332,14 +332,14 @@ func (c *contractDeferred) checkInvoke(rst ReadOnlyStateTrie, invoke *Invoke) er
 
 	// 1.
 	if c.DeferredData.MaxNumExecution < uint64(1) {
-		return xerrors.New("maximum number of executions reached")
+		return errors.New("maximum number of executions reached")
 	}
 
 	// 2.
 	expireBlockIndex := c.DeferredData.ExpireBlockIndex
 	currentIndex := uint64(rst.GetIndex())
 	if currentIndex > expireBlockIndex {
-		return xerrors.Errorf("current block index is too high (%d > %d)", currentIndex, expireBlockIndex)
+		return fmt.Errorf("current block index is too high (%d > %d)", currentIndex, expireBlockIndex)
 	}
 
 	if invoke.Command == "addProof" {
@@ -351,34 +351,34 @@ func (c *contractDeferred) checkInvoke(rst ReadOnlyStateTrie, invoke *Invoke) er
 		// Get the given Identity
 		identityBuf := invoke.Args.Search("identity")
 		if identityBuf == nil {
-			return xerrors.New("identity args is nil")
+			return errors.New("identity args is nil")
 		}
 		identity := darc.Identity{}
 		err := protobuf.Decode(identityBuf, &identity)
 		if err != nil {
-			return xerrors.New("couldn't decode Identity")
+			return errors.New("couldn't decode Identity")
 		}
 		// Get the instruction index
 		indexBuf := invoke.Args.Search("index")
 		if indexBuf == nil {
-			return xerrors.New("index args is nil")
+			return errors.New("index args is nil")
 		}
 		index := binary.LittleEndian.Uint32(indexBuf)
 
 		for _, storedIdentity := range c.DeferredData.ProposedTransaction.Instructions[index].SignerIdentities {
 			if identity.Equal(&storedIdentity) {
-				return xerrors.New("identity already stored")
+				return errors.New("identity already stored")
 			}
 		}
 		// 2:
 		// Get the given signature
 		signature := invoke.Args.Search("signature")
 		if signature == nil {
-			return xerrors.New("signature args is nil")
+			return errors.New("signature args is nil")
 		}
 		err = identity.Verify(c.InstructionHashes[index], signature)
 		if err != nil {
-			return xerrors.New("bad signature")
+			return errors.New("bad signature")
 		}
 	}
 	return nil
@@ -391,7 +391,7 @@ func (c *contractDeferred) VerifyInstruction(rst ReadOnlyStateTrie, inst Instruc
 		return nil
 	}
 	if err := inst.Verify(rst, ctxHash); err != nil {
-		return xerrors.Errorf("failed to verify instruction: %v", err)
+		return fmt.Errorf("failed to verify instruction: %v", err)
 	}
 	return nil
 }
@@ -405,7 +405,7 @@ func (c *contractDeferred) VerifyDeferredInstruction(rst ReadOnlyStateTrie, inst
 		return nil
 	}
 	if err := inst.VerifyWithOption(rst, ctxHash, &VerificationOptions{IgnoreCounters: true}); err != nil {
-		return xerrors.Errorf("failed to verify deferred instruction: %v", err)
+		return fmt.Errorf("failed to verify deferred instruction: %v", err)
 	}
 	return nil
 }

--- a/byzcoin/contracts/attr_test.go
+++ b/byzcoin/contracts/attr_test.go
@@ -1,6 +1,7 @@
 package contracts
 
 import (
+	"errors"
 	"net/url"
 	"strconv"
 	"strings"
@@ -13,7 +14,6 @@ import (
 	"go.dedis.ch/cothority/v3/darc"
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
-	"golang.org/x/xerrors"
 )
 
 func init() {
@@ -78,7 +78,7 @@ func (c contractAttrValue) Invoke(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.In
 		}
 		return
 	default:
-		return nil, nil, xerrors.New("Value contract can only update")
+		return nil, nil, errors.New("value contract can only update")
 	}
 }
 
@@ -93,17 +93,17 @@ func (c contractAttrValue) VerifyInstruction(rst byzcoin.ReadOnlyStateTrie, inst
 
 		s := string(c.value)
 		if !strings.HasPrefix(s, prefix) {
-			return xerrors.New("wrong prefix")
+			return errors.New("wrong prefix")
 		}
 		if !strings.HasSuffix(s, suffix) {
-			return xerrors.New("wrong suffix")
+			return errors.New("wrong suffix")
 		}
 		return nil
 	}
 	cbSigScheme := func(attr string) error {
 		roSC, ok := rst.(byzcoin.ReadOnlySkipChain)
 		if !ok {
-			return xerrors.New("cannot access read only skipchain")
+			return errors.New("cannot access read only skipchain")
 		}
 		sb, err := roSC.GetLatest()
 		if err != nil {
@@ -121,27 +121,27 @@ func (c contractAttrValue) VerifyInstruction(rst byzcoin.ReadOnlyStateTrie, inst
 				return err
 			}
 			if !sb0.Equal(gen) {
-				return xerrors.New("genesis block is not at index 0")
+				return errors.New("genesis block is not at index 0")
 			}
 			sb2, err := roSC.GetBlock(sb.Hash)
 			if err != nil {
 				return err
 			}
 			if !sb2.Equal(sb) {
-				return xerrors.New("sb and sb2 should be the same")
+				return errors.New("sb and sb2 should be the same")
 			}
 		}
 
 		sigSchemeBuf := inst.Invoke.Args.Search("sigscheme")
 		if len(sigSchemeBuf) == 0 {
-			return xerrors.New("cannot find sigscheme argument")
+			return errors.New("cannot find sigscheme argument")
 		}
 		sigScheme, err := strconv.Atoi(string(sigSchemeBuf))
 		if err != nil {
 			return err
 		}
 		if int(sb.SignatureScheme) != sigScheme {
-			return xerrors.New("signature scheme did not match")
+			return errors.New("signature scheme did not match")
 		}
 		return nil
 	}

--- a/byzcoin/contracts/coins_test.go
+++ b/byzcoin/contracts/coins_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,7 +14,6 @@ import (
 	"go.dedis.ch/cothority/v3/darc/expression"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/protobuf"
-	"golang.org/x/xerrors"
 )
 
 var ciZero, ciOne, ciTwo []byte
@@ -292,7 +292,7 @@ func (ct cvTest) GetContractID(key []byte) (string, error) {
 	return ct.contractIDs[string(key)], nil
 }
 func (ct cvTest) GetProof(key []byte) (*trie.Proof, error) {
-	return nil, xerrors.New("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 func (ct cvTest) GetIndex() int {
@@ -304,19 +304,19 @@ func (ct cvTest) GetVersion() byzcoin.Version {
 }
 
 func (ct cvTest) ForEach(f func(k, v []byte) error) error {
-	return xerrors.New("not implemented")
+	return errors.New("not implemented")
 }
 
 func (ct cvTest) GetNonce() ([]byte, error) {
-	return nil, xerrors.New("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 func (ct cvTest) StoreAllToReplica(scs byzcoin.StateChanges) (byzcoin.ReadOnlyStateTrie, error) {
-	return nil, xerrors.New("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 func (ct cvTest) GetSignerCounter(id darc.Identity) (uint64, error) {
-	return 0, xerrors.Errorf("not yet implemented")
+	return 0, fmt.Errorf("not yet implemented")
 }
 
 func (ct cvTest) LoadConfig() (*byzcoin.ChainConfig, error) {

--- a/byzcoin/contracts/insecure_darc.go
+++ b/byzcoin/contracts/insecure_darc.go
@@ -1,9 +1,10 @@
 package contracts
 
 import (
+	"errors"
+	"fmt"
 	"go.dedis.ch/cothority/v3/byzcoin"
 	"go.dedis.ch/cothority/v3/darc"
-	"golang.org/x/xerrors"
 )
 
 // ContractInsecureDarcID denotes a darc-contract
@@ -38,10 +39,10 @@ func (c *contractInsecureDarc) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin
 		darcBuf := inst.Spawn.Args.Search("darc")
 		d, err := darc.NewFromProtobuf(darcBuf)
 		if err != nil {
-			return nil, nil, xerrors.Errorf("given darc could not be decoded: %v", err)
+			return nil, nil, fmt.Errorf("given darc could not be decoded: %v", err)
 		}
 		if d.Version != 0 {
-			return nil, nil, xerrors.New("DARC version must start at 0")
+			return nil, nil, errors.New("DARC version must start at 0")
 		}
 		id := d.GetBaseID()
 		return []byzcoin.StateChange{
@@ -53,12 +54,12 @@ func (c *contractInsecureDarc) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin
 	// a new instance of contract xxx, so do that.
 
 	if c.contracts == nil {
-		return nil, nil, xerrors.New("contracts registry is missing due to bad initialization")
+		return nil, nil, errors.New("contracts registry is missing due to bad initialization")
 	}
 
 	cfact, found := c.contracts.Search(inst.Spawn.ContractID)
 	if !found {
-		return nil, nil, xerrors.New("couldn't find this contract type: " + inst.Spawn.ContractID)
+		return nil, nil, errors.New("couldn't find this contract type: " + inst.Spawn.ContractID)
 	}
 
 	// Pass nil into the contract factory here because this instance does not exist yet.
@@ -67,7 +68,7 @@ func (c *contractInsecureDarc) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin
 	// into the trie.
 	c2, err := cfact(nil)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("could not spawn new zero instance: %v", err)
+		return nil, nil, fmt.Errorf("could not spawn new zero instance: %v", err)
 	}
 	return c2.Spawn(rst, inst, coins)
 }
@@ -97,6 +98,6 @@ func (c *contractInsecureDarc) Invoke(rst byzcoin.ReadOnlyStateTrie, inst byzcoi
 			byzcoin.NewStateChange(byzcoin.Update, inst.InstanceID, ContractInsecureDarcID, darcBuf, darcID),
 		}, coins, nil
 	default:
-		return nil, nil, xerrors.New("invalid command: " + inst.Invoke.Command)
+		return nil, nil, errors.New("invalid command: " + inst.Invoke.Command)
 	}
 }

--- a/byzcoin/contracts/value.go
+++ b/byzcoin/contracts/value.go
@@ -1,10 +1,10 @@
 package contracts
 
 import (
+	"errors"
 	"fmt"
 	"go.dedis.ch/cothority/v3/byzcoin"
 	"go.dedis.ch/cothority/v3/darc"
-	"golang.org/x/xerrors"
 )
 
 // The value contract can simply store a value in an instance and serves
@@ -76,7 +76,7 @@ func (c ContractValue) Invoke(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instru
 		}
 		return
 	default:
-		return nil, nil, xerrors.New("Value contract can only update")
+		return nil, nil, errors.New("Value contract can only update")
 	}
 }
 

--- a/byzcoin/heartbeat.go
+++ b/byzcoin/heartbeat.go
@@ -1,10 +1,9 @@
 package byzcoin
 
 import (
+	"errors"
 	"sync"
 	"time"
-
-	"golang.org/x/xerrors"
 )
 
 // heartbeat is used for monitoring signals (or heartbeats) that are suppose to
@@ -40,7 +39,7 @@ func (r *heartbeats) beat(key string) error {
 		c.beatChan <- true
 		return nil
 	}
-	return xerrors.New("key does not exist")
+	return errors.New("key does not exist")
 }
 
 func (r *heartbeats) getLatestHeartbeat(key string) (time.Time, error) {
@@ -52,7 +51,7 @@ func (r *heartbeats) getLatestHeartbeat(key string) (time.Time, error) {
 		t := <-resultsChan
 		return t, nil
 	}
-	return time.Unix(0, 0), xerrors.New("key does not exist")
+	return time.Unix(0, 0), errors.New("key does not exist")
 }
 
 func (r *heartbeats) closeAll() {
@@ -98,7 +97,7 @@ func (r *heartbeats) start(key string, timeout time.Duration, timeoutChan chan s
 	r.Lock()
 	defer r.Unlock()
 	if _, ok := r.heartbeatMap[key]; ok {
-		return xerrors.New("key already exists")
+		return errors.New("key already exists")
 	}
 
 	r.heartbeatMap[key] = &heartbeat{

--- a/byzcoin/proof_test.go
+++ b/byzcoin/proof_test.go
@@ -2,6 +2,7 @@ package byzcoin
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"testing"
@@ -16,8 +17,7 @@ import (
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/protobuf"
-	bbolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
+	"go.etcd.io/bbolt"
 )
 
 func TestNewProof(t *testing.T) {
@@ -46,16 +46,16 @@ func TestVerify(t *testing.T) {
 	require.Equal(t, s.key, key)
 	require.Equal(t, s.value, val)
 
-	require.True(t, xerrors.Is(p.Verify(s.genesis2.SkipChainID()), ErrorVerifySkipchain))
+	require.True(t, errors.Is(p.Verify(s.genesis2.SkipChainID()), ErrorVerifySkipchain))
 
 	p.Latest.BaseHeight = 123
-	require.True(t, xerrors.Is(p.Verify(s.genesis.SkipChainID()), ErrorVerifyHash))
+	require.True(t, errors.Is(p.Verify(s.genesis.SkipChainID()), ErrorVerifyHash))
 
 	p.Latest.Data, err = protobuf.Encode(&DataHeader{
 		TrieRoot: getSBID("123"),
 	})
 	require.NoError(t, err)
-	require.True(t, xerrors.Is(p.Verify(s.genesis.SkipChainID()), ErrorVerifyTrieRoot))
+	require.True(t, errors.Is(p.Verify(s.genesis.SkipChainID()), ErrorVerifyTrieRoot))
 }
 
 type sc struct {

--- a/byzcoin/rostsimul.go
+++ b/byzcoin/rostsimul.go
@@ -2,8 +2,7 @@ package byzcoin
 
 import (
 	"errors"
-
-	"golang.org/x/xerrors"
+	"fmt"
 
 	"go.dedis.ch/cothority/v3"
 	"go.dedis.ch/cothority/v3/byzcoin/trie"
@@ -98,7 +97,7 @@ func (s *ROSTSimul) StoreAllToReplica(scs StateChanges) (ReadOnlyStateTrie, erro
 
 // GetSignerCounter is not implemented
 func (s *ROSTSimul) GetSignerCounter(id darc.Identity) (uint64, error) {
-	return 0, xerrors.Errorf("not yet implemented")
+	return 0, fmt.Errorf("not yet implemented")
 }
 
 //
@@ -118,7 +117,7 @@ func (s *ROSTSimul) CreateBasicDarc(signer *darc.Identity, desc string) (*darc.D
 	err := s.CreateSCB(Create, ContractDarcID,
 		NewInstanceID(d.GetBaseID()), d, nil)
 	if err != nil {
-		return nil, xerrors.Errorf("store darc: %v", err)
+		return nil, fmt.Errorf("store darc: %v", err)
 	}
 	return d, nil
 }
@@ -148,7 +147,7 @@ func (s *ROSTSimul) CreateSCB(sa StateAction, cID string, id InstanceID,
 	value interface{}, darcID darc.ID) (err error) {
 	valueBuf, err := protobuf.Encode(value)
 	if err != nil {
-		err = xerrors.Errorf("couldn't encode coin: %+v", err)
+		err = fmt.Errorf("couldn't encode coin: %v", err)
 	}
 	if darcID == nil {
 		darcID = make([]byte, 32)
@@ -171,7 +170,7 @@ func (s *ROSTSimul) CreateSCB(sa StateAction, cID string, id InstanceID,
 func (s *ROSTSimul) SetCoin(id InstanceID, value uint64) error {
 	coin, err := s.GetCoin(id)
 	if err != nil {
-		return xerrors.Errorf("couldn't get coin: %+v", err)
+		return fmt.Errorf("couldn't get coin: %v", err)
 	}
 	coin.Value = value
 	return s.CreateSCB(Update, coinID, id, &coin, nil)
@@ -181,16 +180,16 @@ func (s *ROSTSimul) SetCoin(id InstanceID, value uint64) error {
 func (s *ROSTSimul) GetCoin(id InstanceID) (coin Coin, err error) {
 	sc, found := s.Values[string(id[:])]
 	if !found {
-		err = xerrors.New("didn't find this coin")
+		err = errors.New("didn't find this coin")
 		return
 	}
 	if sc.ContractID != coinID {
-		err = xerrors.Errorf("id doesn't point to a coin, but to '%s'",
+		err = fmt.Errorf("id doesn't point to a coin, but to '%s'",
 			sc.ContractID)
 		return
 	}
 	if err = protobuf.Decode(sc.Value, &coin); err != nil {
-		err = xerrors.Errorf("couldn't decode coin: %+v", err)
+		err = fmt.Errorf("couldn't decode coin: %v", err)
 	}
 	return
 }
@@ -203,17 +202,17 @@ func (s *ROSTSimul) WithdrawCoin(id InstanceID,
 	value uint64) (updated, withdrawn Coin, err error) {
 	updated, err = s.GetCoin(id)
 	if err != nil {
-		err = xerrors.Errorf("couldn't get coin: %+v", err)
+		err = fmt.Errorf("couldn't get coin: %v", err)
 		return
 	}
 	if updated.Value < value {
-		err = xerrors.New("coin doesn't have enough value")
+		err = errors.New("coin doesn't have enough value")
 		return
 	}
 	updated.Value -= value
 	err = s.SetCoin(id, updated.Value)
 	if err != nil {
-		err = xerrors.Errorf("couldn't set coin to new value: %+v", err)
+		err = fmt.Errorf("couldn't set coin to new value: %v", err)
 		return
 	}
 	withdrawn.Name = updated.Name

--- a/byzcoin/statechange_cache.go
+++ b/byzcoin/statechange_cache.go
@@ -2,10 +2,10 @@ package byzcoin
 
 import (
 	"bytes"
+	"errors"
 	"sync"
 
 	"go.dedis.ch/cothority/v3/skipchain"
-	"golang.org/x/xerrors"
 )
 
 // stateChangeCache is a simple struct that maintains a cache of state changes
@@ -38,11 +38,11 @@ func (c *stateChangeCache) get(scID skipchain.SkipBlockID, digest []byte) (merkl
 	key := string(scID)
 	out, ok := c.cache[key]
 	if !ok {
-		err = xerrors.New("key does not exist")
+		err = errors.New("key does not exist")
 		return
 	}
 	if !bytes.Equal(out.digest, digest) {
-		err = xerrors.New("digest is not the same")
+		err = errors.New("digest is not the same")
 		return
 	}
 

--- a/byzcoin/statereplay.go
+++ b/byzcoin/statereplay.go
@@ -4,12 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"go.dedis.ch/cothority/v3/byzcoin/trie"
-	"go.dedis.ch/kyber/v3/pairing"
-	"golang.org/x/xerrors"
 
 	"go.dedis.ch/cothority/v3"
+	"go.dedis.ch/cothority/v3/byzcoin/trie"
 	"go.dedis.ch/cothority/v3/skipchain"
+	"go.dedis.ch/kyber/v3/pairing"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/protobuf"
 )
@@ -31,7 +30,7 @@ type ReplayStateOptions struct {
 }
 
 func replayError(sb *skipchain.SkipBlock, err error) error {
-	return cothority.ErrorOrNilSkip(err, fmt.Sprintf("replay failed in block at index %d with message", sb.Index), 2)
+	return cothority.ErrorOrNil(err, fmt.Sprintf("replay failed in block at index %d with message", sb.Index))
 }
 
 // ReplayState builds the state changes from the genesis of the given skipchain ID until
@@ -115,7 +114,7 @@ func (s *Service) ReplayState(id skipchain.SkipBlockID,
 			dBody.TxResults.SetVersion(dHead.Version)
 
 			if !bytes.Equal(dHead.ClientTransactionHash, dBody.TxResults.Hash()) {
-				return nil, replayError(sb, xerrors.New("client transaction hash does not match"))
+				return nil, replayError(sb, errors.New("client transaction hash does not match"))
 			}
 
 			sst := st.MakeStagingStateTrie()
@@ -136,7 +135,7 @@ func (s *Service) ReplayState(id skipchain.SkipBlockID,
 				} else {
 					_, _, err = s.processOneTx(sst, tx.ClientTransaction, id, dHead.Timestamp)
 					if err == nil {
-						return nil, replayError(sb, xerrors.New("refused transaction passes"))
+						return nil, replayError(sb, errors.New("refused transaction passes"))
 					}
 				}
 			}
@@ -156,7 +155,7 @@ func (s *Service) ReplayState(id skipchain.SkipBlockID,
 						}
 					}
 				}
-				err = xerrors.New("merkle tree root doesn't match with trie root")
+				err = errors.New("merkle tree root doesn't match with trie root")
 				return nil, replayError(sb, err)
 			}
 
@@ -184,7 +183,7 @@ func (s *Service) ReplayState(id skipchain.SkipBlockID,
 					err = fl.VerifyWithScheme(pairing.NewSuiteBn256(), pubs, sb.SignatureScheme)
 					if err != nil {
 						log.Errorf("Found error in forward-link: '%s' - #%d: %+v", err, j, fl)
-						return nil, xerrors.Errorf("invalid forward-link: %v", err)
+						return nil, fmt.Errorf("invalid forward-link: %v", err)
 					}
 				}
 			}

--- a/byzcoin/statetrie_test.go
+++ b/byzcoin/statetrie_test.go
@@ -4,13 +4,12 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"math/big"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
-
-	"golang.org/x/xerrors"
 
 	"github.com/stretchr/testify/require"
 
@@ -48,7 +47,7 @@ func TestStateTrie(t *testing.T) {
 	// store with bad expected root hash should fail, value should not be inside
 	require.Error(t, st.VerifiedStoreAll([]StateChange{sc}, 5, CurrentVersion, []byte("badhash")))
 	_, _, _, _, err = st.GetValues(key)
-	require.True(t, xerrors.Is(err, errKeyNotSet))
+	require.True(t, errors.Is(err, errKeyNotSet))
 
 	// store the state changes normally using StoreAll and it should work
 	require.NoError(t, st.StoreAll([]StateChange{sc}, 5, CurrentVersion))
@@ -58,7 +57,7 @@ func TestStateTrie(t *testing.T) {
 	require.Equal(t, st.GetIndex(), 6)
 
 	_, _, _, _, err = st.GetValues(append(key, byte(0)))
-	require.True(t, xerrors.Is(err, errKeyNotSet))
+	require.True(t, errors.Is(err, errKeyNotSet))
 
 	val, ver, cid, did, err := st.GetValues(key)
 	require.NoError(t, err)

--- a/byzcoin/trie/db_test.go
+++ b/byzcoin/trie/db_test.go
@@ -2,10 +2,10 @@ package trie
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 )
 
 func TestDB(t *testing.T) {
@@ -24,7 +24,7 @@ func testDB(t *testing.T, db DB) {
 		for i := 0; i < 10; i++ {
 			k := []byte{byte(i)}
 			if v := b.Get(k); !bytes.Equal(k, v) {
-				return xerrors.New("got an unexpected value")
+				return errors.New("got an unexpected value")
 			}
 		}
 		return nil
@@ -36,7 +36,7 @@ func testDB(t *testing.T, db DB) {
 		for i := 0; i < 10; i++ {
 			k := []byte{byte(i)}
 			if v := b.Get(k); !bytes.Equal(k, v) {
-				return xerrors.New("got an unexpected value")
+				return errors.New("got an unexpected value")
 			}
 		}
 		return nil
@@ -53,7 +53,7 @@ func testDB(t *testing.T, db DB) {
 	err = db.View(func(b Bucket) error {
 		v := b.Get([]byte("hello"))
 		if v != nil {
-			return xerrors.New("failed tx exists")
+			return errors.New("failed tx exists")
 		}
 		return nil
 	})

--- a/byzcoin/trie/dfs.go
+++ b/byzcoin/trie/dfs.go
@@ -1,6 +1,6 @@
 package trie
 
-import "golang.org/x/xerrors"
+import "errors"
 
 type nodeProcessor interface {
 	OnEmpty(n emptyNode, k, v []byte) error
@@ -13,7 +13,7 @@ type nodeProcessor interface {
 func (t *Trie) dfs(p nodeProcessor, nodeKey []byte, b Bucket) error {
 	nodeVal := b.Get(nodeKey)
 	if len(nodeVal) == 0 {
-		return xerrors.New("node key does not exist in copyTo")
+		return errors.New("node key does not exist in copyTo")
 	}
 	switch nodeType(nodeVal[0]) {
 	case typeEmpty:
@@ -44,7 +44,7 @@ func (t *Trie) dfs(p nodeProcessor, nodeKey []byte, b Bucket) error {
 		}
 		return nil
 	}
-	return xerrors.New("invalid node type")
+	return errors.New("invalid node type")
 }
 
 type countNodeProcessor struct {

--- a/byzcoin/trie/diskdb.go
+++ b/byzcoin/trie/diskdb.go
@@ -1,11 +1,11 @@
 package trie
 
 import (
-	bbolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
+	"errors"
+	"go.etcd.io/bbolt"
 )
 
-var errDryRun = xerrors.New("this is a dry-run")
+var errDryRun = errors.New("this is a dry-run")
 
 // diskDB is the DB implementation for boltdb.
 type diskDB struct {
@@ -26,7 +26,7 @@ func (r *diskDB) Update(f func(Bucket) error) error {
 	return r.db.Update(func(tx *bbolt.Tx) error {
 		b := tx.Bucket(r.bucket)
 		if b == nil {
-			return xerrors.New("bucket does not exist")
+			return errors.New("bucket does not exist")
 		}
 		return f(&diskBucket{b})
 	})
@@ -36,7 +36,7 @@ func (r *diskDB) View(f func(Bucket) error) error {
 	return r.db.View(func(tx *bbolt.Tx) error {
 		b := tx.Bucket(r.bucket)
 		if b == nil {
-			return xerrors.New("bucket does not exist")
+			return errors.New("bucket does not exist")
 		}
 		return f(&diskBucket{b})
 	})
@@ -50,7 +50,7 @@ func (r *diskDB) UpdateDryRun(f func(Bucket) error) error {
 	err := r.db.Update(func(tx *bbolt.Tx) error {
 		b := tx.Bucket(r.bucket)
 		if b == nil {
-			return xerrors.New("bucket does not exist")
+			return errors.New("bucket does not exist")
 		}
 		if err := f(&diskBucket{b}); err != nil {
 			return err

--- a/byzcoin/trie/memdb.go
+++ b/byzcoin/trie/memdb.go
@@ -3,7 +3,7 @@ package trie
 import (
 	"sync"
 
-	"golang.org/x/xerrors"
+	"errors"
 )
 
 // memDB is the DB implementation for an in-memory database.
@@ -77,7 +77,7 @@ func (r *memBucket) Get(k []byte) []byte {
 
 func (r *memBucket) Put(k, v []byte) error {
 	if !r.writable {
-		return xerrors.New("trying to use Put in a read-only transaction")
+		return errors.New("trying to use Put in a read-only transaction")
 	}
 	r.storage[string(k)] = clone(v)
 	return nil
@@ -85,7 +85,7 @@ func (r *memBucket) Put(k, v []byte) error {
 
 func (r *memBucket) Delete(k []byte) error {
 	if !r.writable {
-		return xerrors.New("trying to use Put in a read-only transaction")
+		return errors.New("trying to use Put in a read-only transaction")
 	}
 	delete(r.storage, string(k))
 	return nil

--- a/byzcoin/trie/metadata.go
+++ b/byzcoin/trie/metadata.go
@@ -3,7 +3,7 @@ package trie
 import (
 	"bytes"
 
-	"golang.org/x/xerrors"
+	"errors"
 )
 
 const entryKey = "dedis_trie"
@@ -30,10 +30,10 @@ func (t *Trie) SetMetadata(key []byte, val []byte) error {
 // transaction.
 func (t *Trie) SetMetadataWithBucket(key []byte, val []byte, b Bucket) error {
 	if len(key) > metaMaxLen {
-		return xerrors.New("key must be " + string(metaMaxLen) + " bytes or shorter")
+		return errors.New("key must be " + string(metaMaxLen) + " bytes or shorter")
 	}
 	if isIllegalKey(key) {
-		return xerrors.New("the key is illegal, it cannot be \"" + entryKey + "\" or \"" + nonceKey + "\"")
+		return errors.New("the key is illegal, it cannot be \"" + entryKey + "\" or \"" + nonceKey + "\"")
 	}
 	return b.Put(key, val)
 }
@@ -81,10 +81,10 @@ func (t *Trie) DeleteMetadata(key []byte) error {
 // transaction.
 func (t *Trie) DeleteMetadataWithBucket(key []byte, b Bucket) error {
 	if len(key) > metaMaxLen {
-		return xerrors.New("key must be " + string(metaMaxLen) + " bytes or shorter")
+		return errors.New("key must be " + string(metaMaxLen) + " bytes or shorter")
 	}
 	if isIllegalKey(key) {
-		return xerrors.New("the key is illegal, it cannot be \"" + entryKey + "\" or \"" + nonceKey + "\"")
+		return errors.New("the key is illegal, it cannot be \"" + entryKey + "\" or \"" + nonceKey + "\"")
 	}
 	return b.Delete(key)
 }

--- a/byzcoin/trie/node.go
+++ b/byzcoin/trie/node.go
@@ -4,8 +4,8 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 
+	"errors"
 	"go.dedis.ch/protobuf"
-	"golang.org/x/xerrors"
 )
 
 type nodeType int
@@ -40,11 +40,11 @@ func newInteriorNode(left, right []byte) interiorNode {
 
 func decodeInteriorNode(buf []byte) (node interiorNode, err error) {
 	if len(buf) == 0 {
-		err = xerrors.New("empty buffer")
+		err = errors.New("empty buffer")
 		return
 	}
 	if nodeType(buf[0]) != typeInterior {
-		err = xerrors.New("wrong node type")
+		err = errors.New("wrong node type")
 		return
 	}
 	if err = protobuf.Decode(buf[1:], &node); err != nil {
@@ -81,11 +81,11 @@ func (n *emptyNode) encode() ([]byte, error) {
 
 func decodeEmptyNode(buf []byte) (node emptyNode, err error) {
 	if len(buf) == 0 {
-		err = xerrors.New("empty buffer")
+		err = errors.New("empty buffer")
 		return
 	}
 	if nodeType(buf[0]) != typeEmpty {
-		err = xerrors.New("wrong node type")
+		err = errors.New("wrong node type")
 		return
 	}
 	if err = protobuf.Decode(buf[1:], &node); err != nil {
@@ -127,11 +127,11 @@ func (n *leafNode) encode() ([]byte, error) {
 
 func decodeLeafNode(buf []byte) (node leafNode, err error) {
 	if len(buf) == 0 {
-		err = xerrors.New("empty buffer")
+		err = errors.New("empty buffer")
 		return
 	}
 	if nodeType(buf[0]) != typeLeaf {
-		err = xerrors.New("wrong node type")
+		err = errors.New("wrong node type")
 		return
 	}
 	if err = protobuf.Decode(buf[1:], &node); err != nil {

--- a/byzcoin/trie/staging.go
+++ b/byzcoin/trie/staging.go
@@ -1,9 +1,8 @@
 package trie
 
 import (
+	"errors"
 	"sync"
-
-	"golang.org/x/xerrors"
 )
 
 // OpType is the operation type that modifies state.
@@ -142,7 +141,7 @@ func (t *StagingTrie) Batch(pairs []KVPair) error {
 			}
 		case Nop:
 		default:
-			return xerrors.New("no such operation")
+			return errors.New("no such operation")
 		}
 	}
 	return nil
@@ -165,7 +164,7 @@ func (t *StagingTrie) Commit() error {
 					return err
 				}
 			default:
-				return xerrors.New("invalid instruction during commit")
+				return errors.New("invalid instruction during commit")
 			}
 		}
 		return nil
@@ -196,7 +195,7 @@ func (t *StagingTrie) GetRoot() []byte {
 					return err
 				}
 			default:
-				return xerrors.New("invalid instruction during get root")
+				return errors.New("invalid instruction during get root")
 			}
 		}
 		root = clone(t.source.GetRootWithBucket(b))
@@ -226,13 +225,13 @@ func (t *StagingTrie) GetProof(key []byte) (*Proof, error) {
 					return err
 				}
 			default:
-				return xerrors.New("invalid instruction during get proof")
+				return errors.New("invalid instruction during get proof")
 			}
 		}
 		// create the proof
 		rootKey := t.source.GetRootWithBucket(b)
 		if rootKey == nil {
-			return xerrors.New("no root key")
+			return errors.New("no root key")
 		}
 		p.Nonce = clone(t.source.nonce)
 		return t.source.getProof(0, rootKey, t.source.binSlice(key), p, b)
@@ -280,7 +279,7 @@ func (t *StagingTrie) sanityCheck() error {
 	defer t.Unlock()
 	for k := range t.deleteList {
 		if _, ok := t.overlay[k]; ok {
-			return xerrors.New("deleted key in overlay")
+			return errors.New("deleted key in overlay")
 		}
 	}
 	return nil

--- a/byzcoin/trie/staging_test.go
+++ b/byzcoin/trie/staging_test.go
@@ -2,11 +2,11 @@ package trie
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 )
 
 func TestStaging(t *testing.T) {
@@ -123,7 +123,7 @@ func testStagingForEach(t *testing.T, db DB) {
 	require.NoError(t, testTrie.ForEach(func(k, v []byte) error {
 		m[string(k)] = struct{}{}
 		if !bytes.Equal(dummyVal, v) {
-			return xerrors.New("bad value")
+			return errors.New("bad value")
 		}
 		return nil
 	}))
@@ -140,7 +140,7 @@ func testStagingForEach(t *testing.T, db DB) {
 	require.NoError(t, sTrie.ForEach(func(k, v []byte) error {
 		m[string(k)] = struct{}{}
 		if !bytes.Equal(dummyVal, v) {
-			return xerrors.New("bad value")
+			return errors.New("bad value")
 		}
 		return nil
 	}))
@@ -158,7 +158,7 @@ func testStagingForEach(t *testing.T, db DB) {
 	require.NoError(t, sTrie.ForEach(func(k, v []byte) error {
 		m[string(k)] = struct{}{}
 		if !bytes.Equal(dummyVal, v) {
-			return xerrors.New("bad value")
+			return errors.New("bad value")
 		}
 		return nil
 	}))
@@ -175,7 +175,7 @@ func testStagingForEach(t *testing.T, db DB) {
 	require.NoError(t, sTrie.ForEach(func(k, v []byte) error {
 		m[string(k)] = struct{}{}
 		if !bytes.Equal(dummyVal, v) {
-			return xerrors.New("bad value")
+			return errors.New("bad value")
 		}
 		return nil
 	}))
@@ -191,7 +191,7 @@ func testStagingForEach(t *testing.T, db DB) {
 	require.NoError(t, sTrie.ForEach(func(k, v []byte) error {
 		m[string(k)] = struct{}{}
 		if !bytes.Equal(dummyVal, v) {
-			return xerrors.New("bad value")
+			return errors.New("bad value")
 		}
 		return nil
 	}))
@@ -208,7 +208,7 @@ func testStagingForEach(t *testing.T, db DB) {
 	require.NoError(t, sTrie.ForEach(func(k, v []byte) error {
 		m[string(k)] = struct{}{}
 		if !bytes.Equal(dummyVal, v) {
-			return xerrors.New("bad value")
+			return errors.New("bad value")
 		}
 		return nil
 	}))

--- a/byzcoin/trie/trie_test.go
+++ b/byzcoin/trie/trie_test.go
@@ -3,13 +3,13 @@ package trie
 import (
 	"bytes"
 	"crypto/rand"
+	"errors"
 	"os"
 	"testing"
 	"testing/quick"
 
 	"github.com/stretchr/testify/require"
 	bbolt "go.etcd.io/bbolt"
-	"golang.org/x/xerrors"
 )
 
 const testDBName = "test_trie.db"
@@ -310,7 +310,7 @@ func TestIsValid(t *testing.T) {
 		k := p.Leaf.hash(testTrie.nonce)
 		leafValBuf := b.Get(k)
 		if leafValBuf == nil {
-			return xerrors.New("can't find leaf")
+			return errors.New("can't find leaf")
 		}
 
 		leaf, err := decodeLeafNode(leafValBuf)
@@ -361,7 +361,7 @@ func TestQuickCheck(t *testing.T) {
 		err := testTrie.ForEach(func(k, v []byte) error {
 			cnt++
 			if _, ok := keysMap[string(k)]; !ok {
-				return xerrors.New("missing key/value pair in foreach")
+				return errors.New("missing key/value pair in foreach")
 			}
 			return nil
 		})
@@ -503,10 +503,10 @@ func TestCopy(t *testing.T) {
 				return err
 			}
 			if v2 == nil {
-				return xerrors.New("extra node in source trie")
+				return errors.New("extra node in source trie")
 			}
 			if !bytes.Equal(v, v2) {
-				return xerrors.New("values are not equal")
+				return errors.New("values are not equal")
 			}
 			return nil
 		})
@@ -535,7 +535,7 @@ func getRootNode(t *testing.T, db DB) interiorNode {
 	err := db.View(func(b Bucket) error {
 		rootKey := b.Get([]byte(entryKey))
 		if rootKey == nil {
-			return xerrors.New("no root")
+			return errors.New("no root")
 		}
 		rootBuf := b.Get(rootKey)
 		var err error

--- a/byzcoin/tx_pipeline.go
+++ b/byzcoin/tx_pipeline.go
@@ -2,6 +2,7 @@ package byzcoin
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -10,7 +11,6 @@ import (
 	"go.dedis.ch/cothority/v3/skipchain"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/protobuf"
-	"golang.org/x/xerrors"
 )
 
 // collectTxResult contains the aggregated response of the conodes to the
@@ -107,7 +107,7 @@ func (s *defaultTxProcessor) CollectTx() (*collectTxResult, error) {
 	if err != nil {
 		log.Error(s.ServerIdentity(), "couldn't get configuration - this is bad and probably "+
 			"a problem with the database! ", err)
-		return nil, xerrors.Errorf("reading config: %v", err)
+		return nil, fmt.Errorf("reading config: %v", err)
 	}
 
 	if s.skService().ChainIsProcessing(s.scID) {
@@ -121,7 +121,7 @@ func (s *defaultTxProcessor) CollectTx() (*collectTxResult, error) {
 		log.Errorf("Error while searching for %x", s.scID[:])
 		log.Error("DB is in bad state and cannot find skipchain anymore."+
 			" This function should never be called on a skipchain that does not exist.", err)
-		return nil, xerrors.Errorf("reading latest: %v", err)
+		return nil, fmt.Errorf("reading latest: %v", err)
 	}
 
 	// Keep track of the latest block for the processing
@@ -139,7 +139,7 @@ func (s *defaultTxProcessor) CollectTx() (*collectTxResult, error) {
 			" e.g., the protocol does not exist."+
 			" Hence, we cannot recover from this failure without putting"+
 			" the server in a strange state, so we panic.", err)
-		return nil, xerrors.Errorf("creating protocol: %v", err)
+		return nil, fmt.Errorf("creating protocol: %v", err)
 	}
 	root := proto.(*CollectTxProtocol)
 	root.SkipchainID = s.scID
@@ -151,7 +151,7 @@ func (s *defaultTxProcessor) CollectTx() (*collectTxResult, error) {
 			" Start() only returns an error when the protocol is not initialised correctly,"+
 			" e.g., not all the required fields are set."+
 			" If you see this message then there may be a programmer error.", err)
-		return nil, xerrors.Errorf("starting protocol: %v", err)
+		return nil, fmt.Errorf("starting protocol: %v", err)
 	}
 
 	// When we poll, the child nodes must reply within half of the block
@@ -201,12 +201,12 @@ func (s *defaultTxProcessor) ProcessTx(tx ClientTransaction, inState *txProcesso
 	latest := s.latest
 	s.Unlock()
 	if latest == nil {
-		return nil, xerrors.New("missing latest block in processor")
+		return nil, errors.New("missing latest block in processor")
 	}
 
 	header, err := decodeBlockHeader(latest)
 	if err != nil {
-		return nil, xerrors.Errorf("decoding header: %v", err)
+		return nil, fmt.Errorf("decoding header: %v", err)
 	}
 
 	tx.Instructions.SetVersion(header.Version)
@@ -261,7 +261,7 @@ func (s *defaultTxProcessor) ProcessTx(tx ClientTransaction, inState *txProcesso
 func (s *defaultTxProcessor) ProposeBlock(state *txProcessorState) error {
 	config, err := state.sst.LoadConfig()
 	if err != nil {
-		return xerrors.Errorf("reading trie: %v", err)
+		return fmt.Errorf("reading trie: %v", err)
 	}
 	_, err = s.createNewBlock(s.scID, &config.Roster, state.txs)
 	return cothority.ErrorOrNil(err, "creating block")

--- a/byzcoin/tx_pipeline_test.go
+++ b/byzcoin/tx_pipeline_test.go
@@ -3,11 +3,11 @@ package byzcoin
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"sync"
 
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/cothority/v3/darc"
-	"golang.org/x/xerrors"
 
 	"testing"
 	"time"
@@ -85,7 +85,7 @@ func (p *defaultMockTxProc) ProposeBlock(state *txProcessorState) error {
 	if len(p.proposed) <= p.failAt && p.failAt < len(p.proposed)+len(state.txs) {
 		// we only fail it once, so reset it here
 		p.failAt = len(p.txs)
-		return xerrors.New("simulating proposal failure")
+		return errors.New("simulating proposal failure")
 	}
 
 	p.proposed = append(p.proposed, state.txs...)

--- a/byzcoin/wallet/main.go
+++ b/byzcoin/wallet/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -27,7 +28,6 @@ import (
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/protobuf"
-	"golang.org/x/xerrors"
 
 	"github.com/urfave/cli"
 )
@@ -115,11 +115,11 @@ func main() {
 
 func join(c *cli.Context) error {
 	if _, _, err := loadConfig(); err == nil {
-		return xerrors.Errorf("configuration already exists - please delete %s first",
+		return fmt.Errorf("configuration already exists - please delete %s first",
 			filepath.Join(configPath, configName))
 	}
 	if c.NArg() < 1 {
-		return xerrors.New("please give bc-xxx.cfg")
+		return errors.New("please give bc-xxx.cfg")
 	}
 
 	bcCfg, _, err := lib.LoadConfig(c.Args().First())
@@ -177,7 +177,7 @@ func show(c *cli.Context) error {
 
 func transfer(c *cli.Context) error {
 	if c.NArg() < 2 {
-		return xerrors.New("please give the following arguments: balance address")
+		return errors.New("please give the following arguments: balance address")
 	}
 	amount, err := strconv.ParseUint(c.Args().First(), 10, 64)
 	if err != nil {
@@ -222,7 +222,7 @@ func transfer(c *cli.Context) error {
 		cl.Roster = cfg.BCConfig.Roster
 	}
 	if amount > balance {
-		return xerrors.New("your account doesn't have enough coins in it")
+		return errors.New("your account doesn't have enough coins in it")
 	}
 
 	signer := darc.NewSignerEd25519(cfg.KeyPair.Public, cfg.KeyPair.Private)

--- a/calypso/csadmin/clicontracts/write.go
+++ b/calypso/csadmin/clicontracts/write.go
@@ -3,12 +3,13 @@ package clicontracts
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 
 	"go.dedis.ch/onet/v3/log"
-	"golang.org/x/xerrors"
 
 	"github.com/urfave/cli"
 	"go.dedis.ch/cothority/v3"
@@ -35,12 +36,12 @@ import (
 func WriteSpawn(c *cli.Context) error {
 	bcArg := c.String("bc")
 	if bcArg == "" {
-		return xerrors.New("--bc flag is required")
+		return errors.New("--bc flag is required")
 	}
 
 	cfg, cl, err := lib.LoadConfig(bcArg)
 	if err != nil {
-		return xerrors.Errorf("loading configuration: %v", err)
+		return fmt.Errorf("loading configuration: %v", err)
 	}
 
 	dstr := c.String("darc")
@@ -55,12 +56,12 @@ func WriteSpawn(c *cli.Context) error {
 	var dataBuf []byte
 	if c.Bool("readData") {
 		if c.Bool("readExtra") {
-			return xerrors.New("--readData can not be used toghether with" +
+			return errors.New("--readData can not be used toghether with" +
 				"--readExtra")
 		}
 		dataBuf, err = ioutil.ReadAll(os.Stdin)
 		if err != nil {
-			return xerrors.Errorf("failed to read from stdin: %v", err)
+			return fmt.Errorf("failed to read from stdin: %v", err)
 		}
 	} else {
 		dataBuf = []byte(c.String("data"))
@@ -70,7 +71,7 @@ func WriteSpawn(c *cli.Context) error {
 	if c.Bool("readExtra") {
 		extraDataBuf, err = ioutil.ReadAll(os.Stdin)
 		if err != nil {
-			return xerrors.Errorf("failed to read from stdin: %v", err)
+			return fmt.Errorf("failed to read from stdin: %v", err)
 		}
 		// We found out that a newline is automatically added when using pipes
 		extraDataBuf = bytes.TrimRight(extraDataBuf, "\n")
@@ -80,34 +81,34 @@ func WriteSpawn(c *cli.Context) error {
 
 	secret := c.String("secret")
 	if secret == "" {
-		return xerrors.New("please provide secret with --secret")
+		return errors.New("please provide secret with --secret")
 	}
 	secretBuf, err := hex.DecodeString(secret)
 	if err != nil {
-		return xerrors.Errorf("failed to decode secret as hexadecimal: %v", err)
+		return fmt.Errorf("failed to decode secret as hexadecimal: %v", err)
 	}
 
 	instidstr := c.String("instid")
 	if instidstr == "" {
-		return xerrors.New("please provide the LTS instance ID with --instid")
+		return errors.New("please provide the LTS instance ID with --instid")
 	}
 	instidbuf, err := hex.DecodeString(instidstr)
 	if err != nil {
-		return xerrors.Errorf("failed to decode instance id: %v", err)
+		return fmt.Errorf("failed to decode instance id: %v", err)
 	}
 
 	keyStr := c.String("key")
 	if keyStr == "" {
-		return xerrors.New("please provide the hex string public key with --key")
+		return errors.New("please provide the hex string public key with --key")
 	}
 	keyBuf, err := hex.DecodeString(keyStr)
 	if err != nil {
-		return xerrors.Errorf("failed to decode hex string key: %v", err)
+		return fmt.Errorf("failed to decode hex string key: %v", err)
 	}
 	p := cothority.Suite.Point()
 	err = p.UnmarshalBinary(keyBuf)
 	if err != nil {
-		return xerrors.Errorf("failed to unmarshal key: %v", err)
+		return fmt.Errorf("failed to unmarshal key: %v", err)
 	}
 
 	instid := byzcoin.NewInstanceID(instidbuf)
@@ -116,14 +117,14 @@ func WriteSpawn(c *cli.Context) error {
 
 	write := calypso.NewWrite(cothority.Suite, instid, d.GetBaseID(), p, secretBuf)
 	if write == nil {
-		return xerrors.New("got a nil write, this is due to a key that is " +
+		return errors.New("got a nil write, this is due to a key that is " +
 			"too long to be embeded")
 	}
 	write.Data = dataBuf
 	write.ExtraData = extraDataBuf
 	writeBuf, err := protobuf.Encode(write)
 	if err != nil {
-		return xerrors.Errorf("failed to encode Write struct: %v", err)
+		return fmt.Errorf("failed to encode Write struct: %v", err)
 	}
 
 	var signer *darc.Signer
@@ -135,12 +136,12 @@ func WriteSpawn(c *cli.Context) error {
 		signer, err = lib.LoadKeyFromString(sstr)
 	}
 	if err != nil {
-		return xerrors.Errorf("failed to parse the signer: %v", err)
+		return fmt.Errorf("failed to parse the signer: %v", err)
 	}
 
 	counters, err := cl.GetSignerCounters(signer.Identity().String())
 	if err != nil {
-		return xerrors.Errorf("getting signer counters: %v", err)
+		return fmt.Errorf("getting signer counters: %v", err)
 	}
 
 	ctx := byzcoin.NewClientTransaction(byzcoin.CurrentVersion,
@@ -157,18 +158,18 @@ func WriteSpawn(c *cli.Context) error {
 
 	err = ctx.FillSignersAndSignWith(*signer)
 	if err != nil {
-		return xerrors.Errorf("failed to sign transaction: %v", err)
+		return fmt.Errorf("failed to sign transaction: %v", err)
 	}
 
 	reply.InstanceID = ctx.Instructions[0].DeriveID("")
 	reply.AddTxResponse, err = cl.AddTransactionAndWait(ctx, 10)
 	if err != nil {
-		return xerrors.Errorf("failed to send transaction: %v", err)
+		return fmt.Errorf("failed to send transaction: %v", err)
 	}
 
 	err = lib.WaitPropagation(c, cl)
 	if err != nil {
-		return xerrors.Errorf("waiting for block propagation: %v", err)
+		return fmt.Errorf("waiting for block propagation: %v", err)
 	}
 
 	iidStr := hex.EncodeToString(reply.InstanceID.Slice())
@@ -176,7 +177,7 @@ func WriteSpawn(c *cli.Context) error {
 		reader := bytes.NewReader([]byte(iidStr))
 		_, err = io.Copy(os.Stdout, reader)
 		if err != nil {
-			return xerrors.Errorf("failed to copy to stdout: %v", err)
+			return fmt.Errorf("failed to copy to stdout: %v", err)
 		}
 		return nil
 	}
@@ -192,57 +193,57 @@ func WriteGet(c *cli.Context) error {
 
 	bcArg := c.String("bc")
 	if bcArg == "" {
-		return xerrors.New("--bc flag is required")
+		return errors.New("--bc flag is required")
 	}
 
 	_, cl, err := lib.LoadConfig(bcArg)
 	if err != nil {
-		return xerrors.Errorf("loading configuration: %v", err)
+		return fmt.Errorf("loading configuration: %v", err)
 	}
 
 	instID := c.String("instid")
 	if instID == "" {
-		return xerrors.New("--instid flag is required")
+		return errors.New("--instid flag is required")
 	}
 	instIDBuf, err := hex.DecodeString(instID)
 	if err != nil {
-		return xerrors.New("failed to decode the instID string")
+		return errors.New("failed to decode the instID string")
 	}
 
 	pr, err := cl.GetProofFromLatest(instIDBuf)
 	if err != nil {
-		return xerrors.Errorf("couldn't get proof: %v", err)
+		return fmt.Errorf("couldn't get proof: %v", err)
 	}
 	proof := pr.Proof
 
 	exist, err := proof.InclusionProof.Exists(instIDBuf)
 	if err != nil {
-		return xerrors.Errorf("error while checking if proof exist: %v", err)
+		return fmt.Errorf("error while checking if proof exist: %v", err)
 	}
 	if !exist {
-		return xerrors.New("proof not found")
+		return errors.New("proof not found")
 	}
 
 	match := proof.InclusionProof.Match(instIDBuf)
 	if !match {
-		return xerrors.New("proof does not match")
+		return errors.New("proof does not match")
 	}
 
 	var write calypso.Write
 	err = proof.VerifyAndDecode(cothority.Suite, calypso.ContractWriteID, &write)
 	if err != nil {
-		return xerrors.Errorf("didn't get a write instance: %v", err)
+		return fmt.Errorf("didn't get a write instance: %v", err)
 	}
 
 	if c.Bool("export") {
 		_, buf, _, _, err := proof.KeyValue()
 		if err != nil {
-			return xerrors.Errorf("failed to get value from proof: %v", err)
+			return fmt.Errorf("failed to get value from proof: %v", err)
 		}
 		reader := bytes.NewReader(buf)
 		_, err = io.Copy(os.Stdout, reader)
 		if err != nil {
-			return xerrors.Errorf("failed to copy to stdout: %v", err)
+			return fmt.Errorf("failed to copy to stdout: %v", err)
 		}
 		return nil
 	}
@@ -250,12 +251,12 @@ func WriteGet(c *cli.Context) error {
 	if c.Bool("export") {
 		_, buf, _, _, err := proof.KeyValue()
 		if err != nil {
-			return xerrors.Errorf("failed to get value from proof: %v", err)
+			return fmt.Errorf("failed to get value from proof: %v", err)
 		}
 		reader := bytes.NewReader(buf)
 		_, err = io.Copy(os.Stdout, reader)
 		if err != nil {
-			return xerrors.Errorf("failed to copy to stdout: %v", err)
+			return fmt.Errorf("failed to copy to stdout: %v", err)
 		}
 		return nil
 	}

--- a/calypso/db.go
+++ b/calypso/db.go
@@ -1,6 +1,8 @@
 package calypso
 
 import (
+	"errors"
+	"fmt"
 	"sync"
 
 	"go.dedis.ch/cothority/v3"
@@ -9,7 +11,6 @@ import (
 	dkg "go.dedis.ch/kyber/v3/share/dkg/pedersen"
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
-	"golang.org/x/xerrors"
 )
 
 const dbVersion = 1
@@ -38,7 +39,7 @@ func (s *Service) save() error {
 	err := s.Save(storageKey, s.storage)
 	if err != nil {
 		log.Error("Couldn't save data:", err)
-		return xerrors.Errorf("saving data: %v", err)
+		return fmt.Errorf("saving data: %v", err)
 	}
 	return nil
 }
@@ -49,7 +50,7 @@ func (s *Service) tryLoad() error {
 	s.storage = &storage{}
 	ver, err := s.LoadVersion()
 	if err != nil {
-		return xerrors.Errorf("loading configuration: %v", err)
+		return fmt.Errorf("loading configuration: %v", err)
 	}
 
 	// Make sure we don't have any unallocated maps.
@@ -78,13 +79,13 @@ func (s *Service) tryLoad() error {
 	if ver < dbVersion {
 		// There is no version 0. Save empty storage and update version number.
 		if err = s.save(); err != nil {
-			return xerrors.Errorf("saving storage: %v", err)
+			return fmt.Errorf("saving storage: %v", err)
 		}
 		return cothority.ErrorOrNil(s.SaveVersion(dbVersion), "saving version")
 	}
 	msg, err := s.Load(storageKey)
 	if err != nil {
-		return xerrors.Errorf("loading storage: %v", err)
+		return fmt.Errorf("loading storage: %v", err)
 	}
 	if msg == nil {
 		return nil
@@ -92,7 +93,7 @@ func (s *Service) tryLoad() error {
 	var ok bool
 	s.storage, ok = msg.(*storage)
 	if !ok {
-		return xerrors.New("data of wrong type")
+		return errors.New("data of wrong type")
 	}
 	return nil
 }

--- a/calypso/protocol/ocs_test.go
+++ b/calypso/protocol/ocs_test.go
@@ -1,6 +1,8 @@
 package protocol
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -15,7 +17,6 @@ import (
 	"go.dedis.ch/kyber/v3/util/random"
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
-	"golang.org/x/xerrors"
 )
 
 var tSuite = cothority.Suite
@@ -165,7 +166,7 @@ func (s *testService) NewProtocol(tn *onet.TreeNodeInstance, conf *onet.GenericC
 	case NameOCS:
 		pi, err := NewOCS(tn)
 		if err != nil {
-			return nil, xerrors.Errorf("creating new OCS instance: %v", err)
+			return nil, fmt.Errorf("creating new OCS instance: %v", err)
 		}
 		ocs := pi.(*OCS)
 		ocs.Shared = s.Shared
@@ -174,7 +175,7 @@ func (s *testService) NewProtocol(tn *onet.TreeNodeInstance, conf *onet.GenericC
 		}
 		return ocs, nil
 	default:
-		return nil, xerrors.New("unknown protocol for this service")
+		return nil, errors.New("unknown protocol for this service")
 	}
 }
 
@@ -248,7 +249,7 @@ func DecodeKey(suite kyber.Group, X kyber.Point, Cs []kyber.Point, XhatEnc kyber
 		keyPart, err := keyPointHat.Data()
 		log.Lvl3("keyPart:", keyPart)
 		if err != nil {
-			return nil, xerrors.Errorf("getting data from keypoint: %v", err)
+			return nil, fmt.Errorf("getting data from keypoint: %v", err)
 		}
 		key = append(key, keyPart...)
 	}

--- a/calypso/protocol/onchain_test.go
+++ b/calypso/protocol/onchain_test.go
@@ -4,6 +4,8 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -16,7 +18,6 @@ import (
 	"go.dedis.ch/kyber/v3/util/key"
 	"go.dedis.ch/kyber/v3/util/random"
 	"go.dedis.ch/onet/v3/log"
-	"golang.org/x/xerrors"
 )
 
 var suite = suites.MustFind("Ed25519")
@@ -106,7 +107,7 @@ func CreateDKGs(suite dkg.Suite, nbrNodes, threshold int) (dkgs []*dkg.DistKeyGe
 		dkgs[i], err = dkg.NewDistKeyGenerator(suite,
 			scalars[i], points, threshold)
 		if err != nil {
-			err = xerrors.Errorf("creating new distirbuted key generator: %v", err)
+			err = fmt.Errorf("creating new distirbuted key generator: %v", err)
 			return
 		}
 	}
@@ -116,12 +117,12 @@ func CreateDKGs(suite dkg.Suite, nbrNodes, threshold int) (dkgs []*dkg.DistKeyGe
 		responses[i] = make([]*dkg.Response, nbrNodes)
 		deals, err := p.Deals()
 		if err != nil {
-			return nil, xerrors.Errorf("getting deals: %v", err)
+			return nil, fmt.Errorf("getting deals: %v", err)
 		}
 		for j, d := range deals {
 			responses[i][j], err = dkgs[j].ProcessDeal(d)
 			if err != nil {
-				return nil, xerrors.Errorf("processing deals: %v", err)
+				return nil, fmt.Errorf("processing deals: %v", err)
 			}
 		}
 	}
@@ -134,11 +135,11 @@ func CreateDKGs(suite dkg.Suite, nbrNodes, threshold int) (dkgs []*dkg.DistKeyGe
 					justification, err := p.ProcessResponse(r)
 					if err != nil {
 						return nil,
-							xerrors.Errorf("processing responses: %v", err)
+							fmt.Errorf("processing responses: %v", err)
 					}
 					if justification != nil {
 						return nil,
-							xerrors.New("there should be no justification")
+							errors.New("there should be no justification")
 					}
 				}
 			}
@@ -148,7 +149,7 @@ func CreateDKGs(suite dkg.Suite, nbrNodes, threshold int) (dkgs []*dkg.DistKeyGe
 	// Verify if all is OK
 	for _, p := range dkgs {
 		if !p.Certified() {
-			return nil, xerrors.New("one of the dkgs is not finished yet")
+			return nil, errors.New("one of the dkgs is not finished yet")
 		}
 	}
 	return
@@ -168,19 +169,19 @@ func aeadSeal(symKey, data []byte) ([]byte, error) {
 	block, err := aes.NewCipher(symKey)
 	if err != nil {
 		return nil,
-			xerrors.Errorf("creating aes cipher block instance: %v", err)
+			fmt.Errorf("creating aes cipher block instance: %v", err)
 	}
 
 	// Never use more than 2^32 random nonces with a given key because of the risk of a repeat.
 	nonce := make([]byte, nonceLen)
 	_, err = io.ReadFull(rand.Reader, nonce)
 	if err != nil {
-		return nil, xerrors.Errorf("reading nonce: %v", err)
+		return nil, fmt.Errorf("reading nonce: %v", err)
 	}
 
 	aesgcm, err := cipher.NewGCM(block)
 	if err != nil {
-		return nil, xerrors.Errorf("creating aesgcm instance: %v", err)
+		return nil, fmt.Errorf("creating aesgcm instance: %v", err)
 	}
 	encData := aesgcm.Seal(nil, nonce, data, nil)
 	encData = append(encData, nonce...)
@@ -191,17 +192,17 @@ func aeadOpen(t *testing.T, key, ciphertext []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil,
-			xerrors.Errorf("creating aes cipher block instance: %v", err)
+			fmt.Errorf("creating aes cipher block instance: %v", err)
 	}
 
 	aesgcm, err := cipher.NewGCM(block)
 	if err != nil {
-		return nil, xerrors.Errorf("creating aesgcm instance: %v", err)
+		return nil, fmt.Errorf("creating aesgcm instance: %v", err)
 	}
 	require.NoError(t, err)
 
 	if len(ciphertext) < 12 {
-		return nil, xerrors.New("ciphertext too short")
+		return nil, errors.New("ciphertext too short")
 	}
 	nonce := ciphertext[len(ciphertext)-nonceLen:]
 	out, err := aesgcm.Open(nil, nonce, ciphertext[0:len(ciphertext)-nonceLen], nil)

--- a/calypso/service_test.go
+++ b/calypso/service_test.go
@@ -1,11 +1,11 @@
 package calypso
 
 import (
+	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
-
-	"golang.org/x/xerrors"
 
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/cothority/v3"
@@ -544,11 +544,11 @@ func (s *ts) reconstructKeyFunc() (kyber.Scalar, error) {
 	n := len(s.ltsRoster.List)
 	th := n - (n-1)/3
 	if n != len(sshares) {
-		return nil, xerrors.New("not correct amount of shares")
+		return nil, errors.New("not correct amount of shares")
 	}
 	sec, err := share.RecoverSecret(cothority.Suite, sshares, th, n)
 	if err != nil {
-		return nil, xerrors.Errorf("while recovering secret: %v", err)
+		return nil, fmt.Errorf("while recovering secret: %v", err)
 	}
 	return sec, nil
 }

--- a/darc/darc.go
+++ b/darc/darc.go
@@ -47,8 +47,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"golang.org/x/xerrors"
-
 	"go.dedis.ch/cothority/v3"
 	"go.dedis.ch/cothority/v3/darc/expression"
 	"go.dedis.ch/kyber/v3"
@@ -1088,7 +1086,7 @@ func (id IdentityEvmContract) Verify(msg, s []byte) error {
 		return nil
 	}
 
-	return xerrors.Errorf("invalid EVM Contract signature")
+	return fmt.Errorf("invalid EVM Contract signature")
 }
 
 // ParseIdentity returns an Identity structure that matches
@@ -1160,13 +1158,13 @@ func parseIDProxy(in string) (Identity, error) {
 func parseIDEvmContract(in string) (Identity, error) {
 	fields := strings.Split(in, ":")
 	if len(fields) != 2 {
-		return Identity{}, xerrors.Errorf("failed to parse EVM contract " +
+		return Identity{}, fmt.Errorf("failed to parse EVM contract " +
 			"identity: expected format 'evm_contract:bevm_id:contract_address'")
 	}
 
 	bevmID, err := hex.DecodeString(fields[0])
 	if err != nil {
-		return Identity{}, xerrors.Errorf("failed to parse BEvmID of EVM "+
+		return Identity{}, fmt.Errorf("failed to parse BEvmID of EVM "+
 			"contract identity: %v", err)
 	}
 

--- a/error.go
+++ b/error.go
@@ -2,73 +2,13 @@ package cothority
 
 import (
 	"fmt"
-
-	"golang.org/x/xerrors"
 )
-
-// Error is a wrapper around an standard error that allows
-// to print the stack trace from the call of the constructor.
-type Error struct {
-	err   error
-	msg   string
-	frame xerrors.Frame
-}
 
 // ErrorOrNil returns the error if any with the stack trace
 // beginning at the call of the function.
 func ErrorOrNil(err error, msg string) error {
-	return ErrorOrNilSkip(err, msg, 1)
-}
-
-// ErrorOrNilSkip returns the error if any with the stack trace
-// beginning at the call of the skip-nth caller.
-func ErrorOrNilSkip(err error, msg string, skip int) error {
 	if err == nil {
-		return nil
+		return err
 	}
-	return &Error{
-		err:   err,
-		msg:   msg,
-		frame: xerrors.Caller(skip),
-	}
-}
-
-// WrapError returns a wrapper of the error is it can be used
-// for comparison.
-func WrapError(err error) error {
-	return ErrorOrNilSkip(err, "", 2)
-}
-
-func (e *Error) Error() string {
-	if e.msg != "" {
-		return e.msg + ": " + fmt.Sprintf("%v", e.err)
-	}
-	return fmt.Sprintf("%v", e.err)
-}
-
-// Unwrap returns the next error in the chain.
-func (e *Error) Unwrap() error {
-	return e.err
-}
-
-// Format prints the error to the formatter.
-func (e *Error) Format(f fmt.State, c rune) {
-	xerrors.FormatError(e, f, c)
-}
-
-// FormatError prints the error to the printer. It prints
-// the stack trace when the '+' is used in combination with
-// 'v'.
-func (e *Error) FormatError(p xerrors.Printer) error {
-	if e.msg != "" {
-		p.Printf("%s: %v", e.msg, e.err)
-	} else {
-		p.Printf("%v", e.err)
-	}
-
-	if p.Detail() {
-		e.frame.Format(p)
-		p.Printf("%+v", e.err)
-	}
-	return nil
+	return fmt.Errorf("%s: %v", msg, err)
 }

--- a/error_test.go
+++ b/error_test.go
@@ -1,45 +1,17 @@
 package cothority
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 )
-
-var errExample = xerrors.New("example")
-
-func makeError() error {
-	return xerrors.Errorf("oops: %w", errExample)
-}
 
 // Test that the basic function create an error when the parameter
 // is not nil, and returns nil otherwise.
 func TestError_ErrorOrNil(t *testing.T) {
-	err := ErrorOrNil(makeError(), "test")
+	err := ErrorOrNil(errors.New("example-error"), "oops")
 
-	require.Equal(t, "test: oops: example", err.Error())
+	require.Equal(t, "oops: example-error", err.Error())
 	require.Nil(t, ErrorOrNil(nil, ""))
-}
-
-// Test that the skip option is correctly used to prevent a call
-// to be included in the stack trace.
-func TestError_ErrorOrNilSkip(t *testing.T) {
-	err := ErrorOrNilSkip(makeError(), "test", 2)
-
-	println(t.Name())
-	require.NotContains(t, fmt.Sprintf("%+v", err), t.Name())
-	require.Contains(t, fmt.Sprintf("%+v", err), ".makeError")
-}
-
-// Test that the wrapper is invisible but allows the error
-// comparison to work.
-func TestError_WrapError(t *testing.T) {
-	err := WrapError(makeError())
-
-	require.Equal(t, "oops: example", err.Error())
-	require.Contains(t, fmt.Sprintf("%+v", err), ".makeError")
-	require.True(t, xerrors.Is(err, errExample))
-	require.False(t, xerrors.Is(err, xerrors.New("abc")))
 }

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	golang.org/x/net v0.0.0-20200319234117-63522dbf7eec // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sys v0.0.0-20200523222454-059865788121
-	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/satori/go.uuid.v1 v1.2.0
 	gopkg.in/square/go-jose.v2 v2.4.1 // indirect

--- a/personhood/api_popparty.go
+++ b/personhood/api_popparty.go
@@ -3,6 +3,7 @@ package personhood
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 
 	"go.dedis.ch/cothority/v3"
 	"go.dedis.ch/cothority/v3/byzcoin"
@@ -13,7 +14,6 @@ import (
 	"go.dedis.ch/kyber/v3/util/key"
 	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/protobuf"
-	"golang.org/x/xerrors"
 )
 
 // PopPartySpawn returns the instanceID of the newly created pop-party, or an error if it
@@ -187,7 +187,7 @@ func PopPartyMineDetailed(
 ) (*byzcoin.AddTxResponse, error) {
 	if (coinIID == nil && d == nil) ||
 		(coinIID != nil && d != nil) {
-		return nil, xerrors.New("either set coinIID or d, but not both")
+		return nil, errors.New("either set coinIID or d, but not both")
 	}
 	if atts == nil {
 		popProof, err := cl.GetProofAfter(popIID.Slice(), true, barrier)
@@ -199,7 +199,7 @@ func PopPartyMineDetailed(
 			return nil, err
 		}
 		if cID != contracts.ContractPopPartyID {
-			return nil, xerrors.New(
+			return nil, errors.New(
 				"given popIID is not of contract-type PopParty")
 		}
 		var pop contracts.PopPartyStruct
@@ -218,7 +218,7 @@ func PopPartyMineDetailed(
 		}
 	}
 	if mine == -1 {
-		return nil, xerrors.New(
+		return nil, errors.New(
 			"didn't find public key of keypair in attendees")
 	}
 

--- a/personhood/contracts/contract_credential.go
+++ b/personhood/contracts/contract_credential.go
@@ -5,9 +5,8 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"strings"
-
-	"golang.org/x/xerrors"
 
 	"go.dedis.ch/cothority/v3"
 	"go.dedis.ch/cothority/v3/darc/expression"
@@ -65,7 +64,7 @@ func (c *ContractCredential) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.I
 		var cid string
 		_, _, cid, darcID, err = rst.GetValues(inst.InstanceID.Slice())
 		if err != nil {
-			err = xerrors.Errorf("couldn't get darc: %+v", err)
+			err = fmt.Errorf("couldn't get darc: %v", err)
 			return
 		}
 		if cid != byzcoin.ContractDarcID {

--- a/personhood/contracts/contract_popparty.go
+++ b/personhood/contracts/contract_popparty.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	"golang.org/x/xerrors"
-
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/kyber/v3/group/edwards25519"
 	"go.dedis.ch/kyber/v3/sign/anon"
@@ -315,7 +313,7 @@ func NewInstructionPoppartySpawn(dst byzcoin.InstanceID, did darc.ID,
 	binary.LittleEndian.PutUint64(rewardBuf, reward)
 	descBuf, err := protobuf.Encode(&desc)
 	if err != nil {
-		err = xerrors.Errorf("couldn't encode description: %+v", err)
+		err = fmt.Errorf("couldn't encode description: %v", err)
 	}
 	inst.Spawn = &byzcoin.Spawn{
 		ContractID: ContractCredentialID,

--- a/personhood/contracts/contract_ropasci.go
+++ b/personhood/contracts/contract_ropasci.go
@@ -8,8 +8,6 @@ import (
 
 	"go.dedis.ch/kyber/v3"
 
-	"golang.org/x/xerrors"
-
 	"go.dedis.ch/cothority/v3"
 	"go.dedis.ch/cothority/v3/calypso"
 	"go.dedis.ch/onet/v3/network"
@@ -92,7 +90,7 @@ func (c ContractRoPaSci) Spawn(rst byzcoin.ReadOnlyStateTrie, inst byzcoin.Instr
 	var darcID darc.ID
 	_, _, _, darcID, err = rst.GetValues(inst.InstanceID.Slice())
 	if err != nil {
-		err = xerrors.Errorf("couldn't get darc: %+v", err)
+		err = fmt.Errorf("couldn't get darc: %v", err)
 		return
 	}
 
@@ -171,7 +169,7 @@ func NewInstructionRoPaSciSpawn(did darc.ID, srps RoPaSciStruct) (
 	inst.InstanceID = byzcoin.NewInstanceID(did)
 	sBuf, err := protobuf.Encode(&srps)
 	if err != nil {
-		err = xerrors.Errorf("couldn't encode rpsStruct: %+v", err)
+		err = fmt.Errorf("couldn't encode rpsStruct: %v", err)
 		return
 	}
 	inst.Spawn = &byzcoin.Spawn{
@@ -196,7 +194,7 @@ func NewInstructionRoPaSciSpawnSecret(did darc.ID,
 	}
 	sBuf, err := protobuf.Encode(&secret)
 	if err != nil {
-		err = xerrors.Errorf("couldn't encode secret: %+v", err)
+		err = fmt.Errorf("couldn't encode secret: %v", err)
 	}
 	inst.Spawn.Args = append(inst.Spawn.Args, newArg("secret", sBuf))
 	return
@@ -385,7 +383,7 @@ func NewInstructionRoPaSciInvokeSecondSecret(acc byzcoin.InstanceID,
 	choice int, pub kyber.Point) (*byzcoin.Instruction, error) {
 	pubBuf, err := pub.MarshalBinary()
 	if err != nil {
-		return nil, xerrors.Errorf("couldn't marshal the point: %+v", err)
+		return nil, fmt.Errorf("couldn't marshal the point: %v", err)
 	}
 	return &byzcoin.Instruction{
 		InstanceID: emptyInstance,

--- a/personhood/contracts/contract_test.go
+++ b/personhood/contracts/contract_test.go
@@ -2,12 +2,12 @@ package contracts
 
 import (
 	"errors"
+	"fmt"
 
 	"go.dedis.ch/cothority/v3/byzcoin/contracts"
 	"go.dedis.ch/protobuf"
 
 	"go.dedis.ch/kyber/v3/util/random"
-	"golang.org/x/xerrors"
 
 	"go.dedis.ch/cothority/v3"
 
@@ -72,7 +72,7 @@ func (s *rstSimul) Process(scs byzcoin.StateChanges) {
 }
 
 func (s *rstSimul) GetSignerCounter(id darc.Identity) (uint64, error) {
-	return 0, xerrors.Errorf("not yet implemented")
+	return 0, fmt.Errorf("not yet implemented")
 }
 
 func (s *rstSimul) addDarc(signer *darc.Identity, desc string) (*darc.Darc,
@@ -85,7 +85,7 @@ func (s *rstSimul) addDarc(signer *darc.Identity, desc string) (*darc.Darc,
 	d := darc.NewDarc(darc.InitRules(ids, ids), []byte(desc))
 	buf, err := d.ToProto()
 	if err != nil {
-		return nil, xerrors.Errorf("couldn't convert darc to protobuf: %+v",
+		return nil, fmt.Errorf("couldn't convert darc to protobuf: %v",
 			err)
 	}
 	s.values[string(d.GetBaseID())] = byzcoin.StateChangeBody{
@@ -104,7 +104,7 @@ func (s *rstSimul) createCoin(name string, value uint64) (id byzcoin.InstanceID,
 	id = byzcoin.NewInstanceID(random.Bits(256, true, random.New()))
 	coinBuf, err := protobuf.Encode(&coin)
 	if err != nil {
-		err = xerrors.Errorf("couldn't encode coin: %+v", err)
+		err = fmt.Errorf("couldn't encode coin: %v", err)
 	}
 	s.values[string(id[:])] = byzcoin.StateChangeBody{
 		StateAction: byzcoin.Create,
@@ -119,12 +119,12 @@ func (s *rstSimul) createCoin(name string, value uint64) (id byzcoin.InstanceID,
 func (s *rstSimul) setCoin(id byzcoin.InstanceID, value uint64) error {
 	coin, err := s.getCoin(id)
 	if err != nil {
-		return xerrors.Errorf("couldn't get coin: %+v", err)
+		return fmt.Errorf("couldn't get coin: %v", err)
 	}
 	coin.Value = value
 	coinBuf, err := protobuf.Encode(&coin)
 	if err != nil {
-		return xerrors.Errorf("couldn't encode coin: %+v", err)
+		return fmt.Errorf("couldn't encode coin: %v", err)
 	}
 	s.values[string(id[:])] = byzcoin.StateChangeBody{
 		StateAction: byzcoin.Update,
@@ -139,16 +139,16 @@ func (s *rstSimul) setCoin(id byzcoin.InstanceID, value uint64) error {
 func (s *rstSimul) getCoin(id byzcoin.InstanceID) (coin byzcoin.Coin, err error) {
 	sc, found := s.values[string(id[:])]
 	if !found {
-		err = xerrors.New("didn't find this coin")
+		err = errors.New("didn't find this coin")
 		return
 	}
 	if sc.ContractID != contracts.ContractCoinID {
-		err = xerrors.Errorf("id doesn't point to a coin, but to '%s'",
+		err = fmt.Errorf("id doesn't point to a coin, but to '%s'",
 			sc.ContractID)
 		return
 	}
 	if err = protobuf.Decode(sc.Value, &coin); err != nil {
-		err = xerrors.Errorf("couldn't decode coin: %+v", err)
+		err = fmt.Errorf("couldn't decode coin: %v", err)
 	}
 	return
 }
@@ -162,17 +162,17 @@ func (s *rstSimul) withdrawCoin(id byzcoin.InstanceID,
 	value uint64) (updated, withdrawn byzcoin.Coin, err error) {
 	updated, err = s.getCoin(id)
 	if err != nil {
-		err = xerrors.Errorf("couldn't get coin: %+v", err)
+		err = fmt.Errorf("couldn't get coin: %v", err)
 		return
 	}
 	if updated.Value < value {
-		err = xerrors.New("coin doesn't have enough value")
+		err = errors.New("coin doesn't have enough value")
 		return
 	}
 	updated.Value -= value
 	err = s.setCoin(id, updated.Value)
 	if err != nil {
-		err = xerrors.Errorf("couldn't set coin to new value: %+v", err)
+		err = fmt.Errorf("couldn't set coin to new value: %v", err)
 		return
 	}
 	withdrawn.Name = updated.Name

--- a/personhood/db.go
+++ b/personhood/db.go
@@ -1,6 +1,7 @@
 package personhood
 
 import (
+	"errors"
 	"sync"
 
 	"go.dedis.ch/cothority/v3/personhood/contracts"
@@ -11,7 +12,6 @@ import (
 	"go.dedis.ch/onet/v3/network"
 
 	"go.dedis.ch/protobuf"
-	"golang.org/x/xerrors"
 )
 
 const dbVersion = 2
@@ -62,7 +62,7 @@ func (s *Service) tryLoad() error {
 		return protobuf.DecodeWithConstructors(buf[16:], s.storage,
 			network.DefaultConstructors(cothority.Suite))
 	default:
-		return xerrors.New("unknown version")
+		return errors.New("unknown version")
 	}
 }
 

--- a/personhood/phapp/main.go
+++ b/personhood/phapp/main.go
@@ -24,7 +24,6 @@ import (
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	"go.dedis.ch/protobuf"
-	"golang.org/x/xerrors"
 )
 
 func init() {
@@ -536,21 +535,21 @@ func adminDarcIDsGet(c *cli.Context) error {
 
 	pt, err := os.Open(c.Args().First())
 	if err != nil {
-		return xerrors.Errorf("couldn't open file: %v", err)
+		return fmt.Errorf("couldn't open file: %v", err)
 	}
 	group, err := app.ReadGroupDescToml(pt)
 	if err != nil {
-		return xerrors.Errorf("wrong public.toml: %v", err)
+		return fmt.Errorf("wrong public.toml: %v", err)
 	}
 	if len(group.Roster.List) == 0 {
-		return xerrors.New("no server defined")
+		return errors.New("no server defined")
 	}
 
 	cl := personhood.NewClient()
 	log.Info("Fetching all admin-darc-IDs")
 	rep, errs := cl.GetAdminDarcIDs(group.Roster.List[0])
 	if len(errs) > 0 {
-		return xerrors.Errorf("got error while fetching ids: %s", errs)
+		return fmt.Errorf("got error while fetching ids: %s", errs)
 	}
 	for i, id := range rep.AdminDarcIDs {
 		log.Infof("Admin darc ID #%d: %x", i, id[:])
@@ -578,7 +577,7 @@ func adminDarcIDsSet(c *cli.Context) error {
 	for i, idStr := range c.Args()[1:] {
 		did, err := hex.DecodeString(idStr)
 		if err != nil {
-			return xerrors.Errorf("couldn't parse id %d: %v", i, err)
+			return fmt.Errorf("couldn't parse id %d: %v", i, err)
 		}
 		dids[i] = did
 	}
@@ -586,7 +585,7 @@ func adminDarcIDsSet(c *cli.Context) error {
 	cl := personhood.NewClient()
 	errs := cl.SetAdminDarcIDs(si, dids, si.GetPrivate())
 	if len(errs) > 0 {
-		return xerrors.Errorf("couldn't set admin darc IDs: %+v", errs)
+		return fmt.Errorf("couldn't set admin darc IDs: %v", errs)
 	}
 	log.Info("Successfully set admin darc IDs")
 

--- a/personhood/service.go
+++ b/personhood/service.go
@@ -22,7 +22,6 @@ import (
 	"go.dedis.ch/kyber/v3/sign/schnorr"
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
-	"golang.org/x/xerrors"
 )
 
 // Used for tests
@@ -349,7 +348,7 @@ func (s *Service) verifySignature(bcID skipchain.SkipBlockID, identity darc.Iden
 			return true, nil
 		}
 	}
-	return false, xerrors.New("didn't find matching adminDarc")
+	return false, errors.New("didn't find matching adminDarc")
 }
 
 // PartyList can either store a new party in the list, or just return the list of

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -20,9 +20,8 @@ import (
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
-	"golang.org/x/xerrors"
 
-	bbolt "go.etcd.io/bbolt"
+	"go.etcd.io/bbolt"
 	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
@@ -859,7 +858,7 @@ func (db *SkipBlockDB) StoreBlocks(blocks []*SkipBlock) ([]SkipBlockID, error) {
 						}
 					}
 					if !found {
-						return fmt.Errorf("Tried to store unlinkable block: %+v", sb.SkipBlockFix)
+						return fmt.Errorf("Tried to store unlinkable block: %v", sb.SkipBlockFix)
 					}
 				}
 
@@ -1310,7 +1309,7 @@ func (db *SkipBlockDB) storeToTx(tx *bbolt.Tx, sb *SkipBlock) error {
 // The caller must ensure that this function is called from within a valid transaction.
 func (db *SkipBlockDB) getFromTx(tx *bbolt.Tx, sbID SkipBlockID) (*SkipBlock, error) {
 	if sbID == nil {
-		return nil, xerrors.New("cannot look up skipblock with ID == nil")
+		return nil, errors.New("cannot look up skipblock with ID == nil")
 	}
 
 	val := tx.Bucket(db.bucketName).Get(sbID)


### PR DESCRIPTION
- replaced all xerrors.Errorf with fmt.Errorf
- replaced all xerrors.New with errors.New
- removed most of cothority/error.go
- replaced all %+v in fmt.Errorf with %v
- replaced most %w in fmt.Errorf with %v, only kept constant errors

Most of `cothority/error.go` seems to be redundant to what the `errors` package offers. 
- [ ] @Gilthoniel confirms the above sentence ;)