### PR TITLE
Cleaning up using staticcheck

### DIFF
--- a/byzcoin/api.go
+++ b/byzcoin/api.go
@@ -380,7 +380,7 @@ func (c *Client) GetDeferredDataAfter(instrID InstanceID, barrier *skipchain.Ski
 
 	header, err := decodeBlockHeader(c.Latest)
 	if err != nil {
-		return nil, xerrors.Errorf("decoding header: %w")
+		return nil, xerrors.Errorf("decoding header: %v", err)
 	}
 
 	result.ProposedTransaction.Instructions.SetVersion(header.Version)
@@ -426,6 +426,9 @@ func (c *Client) GetGenDarc() (*darc.Darc, error) {
 
 	// Sanity check the values.
 	_, _, contract, darcID, err := p.Proof.KeyValue()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get genesis darc: %v", err)
+	}
 	if contract != ContractConfigID {
 		return nil, xerrors.New("expected contract to be config but got: " + contract)
 	}
@@ -477,6 +480,9 @@ func (c *Client) GetChainConfig() (*ChainConfig, error) {
 	}
 
 	_, configBuf, contract, _, err := p.Proof.KeyValue()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get chain config: %v", err)
+	}
 	if contract != ContractConfigID {
 		return nil, xerrors.New("expected contract to be config but got: " + contract)
 	}
@@ -516,7 +522,7 @@ func (c *Client) WaitProof(id InstanceID, interval time.Duration, value []byte) 
 			if err != nil {
 				return nil, xerrors.Errorf("couldn't get keyvalue: %+v", err)
 			}
-			if bytes.Compare(buf, value) == 0 {
+			if bytes.Equal(buf, value) {
 				return &pr, nil
 			}
 		}

--- a/byzcoin/bcadmin/clicontracts/deferred.go
+++ b/byzcoin/bcadmin/clicontracts/deferred.go
@@ -470,11 +470,6 @@ func DeferredDelete(c *cli.Context) error {
 		return err
 	}
 
-	dstr := c.String("darc")
-	if dstr == "" {
-		dstr = cfg.AdminDarc.GetIdentityString()
-	}
-
 	var signer *darc.Signer
 
 	sstr := c.String("sign")

--- a/byzcoin/bcadmin/clicontracts/name.go
+++ b/byzcoin/bcadmin/clicontracts/name.go
@@ -2,6 +2,7 @@ package clicontracts
 
 import (
 	"encoding/hex"
+	"fmt"
 
 	"github.com/urfave/cli"
 	"go.dedis.ch/cothority/v3"
@@ -44,6 +45,9 @@ func NameSpawn(c *cli.Context) error {
 	}
 
 	counters, err := cl.GetSignerCounters(signer.Identity().String())
+	if err != nil {
+		return fmt.Errorf("couldn't get signer counters: %v", err)
+	}
 
 	ctx, err := cl.CreateTransaction(byzcoin.Instruction{
 		InstanceID: byzcoin.NewInstanceID(gDarc.GetBaseID()),
@@ -52,6 +56,9 @@ func NameSpawn(c *cli.Context) error {
 		},
 		SignerCounter: []uint64{counters.Counters[0] + 1},
 	})
+	if err != nil {
+		return fmt.Errorf("couldn't create transaction: %v", err)
+	}
 
 	err = ctx.FillSignersAndSignWith(*signer)
 	if err != nil {

--- a/byzcoin/bcadmin/clicontracts/value.go
+++ b/byzcoin/bcadmin/clicontracts/value.go
@@ -54,6 +54,9 @@ func ValueSpawn(c *cli.Context) error {
 	}
 
 	counters, err := cl.GetSignerCounters(signer.Identity().String())
+	if err != nil {
+		return fmt.Errorf("couldn't get signer counters: %v", err)
+	}
 
 	spawn := byzcoin.Spawn{
 		ContractID: contracts.ContractValueID,
@@ -121,11 +124,6 @@ func ValueInvokeUpdate(c *cli.Context) error {
 		return err
 	}
 
-	dstr := c.String("darc")
-	if dstr == "" {
-		dstr = cfg.AdminDarc.GetIdentityString()
-	}
-
 	var signer *darc.Signer
 
 	sstr := c.String("sign")
@@ -139,6 +137,9 @@ func ValueInvokeUpdate(c *cli.Context) error {
 	}
 
 	counters, err := cl.GetSignerCounters(signer.Identity().String())
+	if err != nil {
+		return fmt.Errorf("couldn't get signer counters: %v", err)
+	}
 
 	invoke := byzcoin.Invoke{
 		ContractID: contracts.ContractValueID,
@@ -251,11 +252,6 @@ func ValueDelete(c *cli.Context) error {
 		return err
 	}
 
-	dstr := c.String("darc")
-	if dstr == "" {
-		dstr = cfg.AdminDarc.GetIdentityString()
-	}
-
 	var signer *darc.Signer
 
 	sstr := c.String("sign")
@@ -269,14 +265,17 @@ func ValueDelete(c *cli.Context) error {
 	}
 
 	counters, err := cl.GetSignerCounters(signer.Identity().String())
+	if err != nil {
+		return fmt.Errorf("couldn't get signer counters: %v", err)
+	}
 
-	delete := byzcoin.Delete{
+	delInst := byzcoin.Delete{
 		ContractID: contracts.ContractValueID,
 	}
 
 	ctx, err := cl.CreateTransaction(byzcoin.Instruction{
 		InstanceID:    byzcoin.NewInstanceID([]byte(instIDBuf)),
-		Delete:        &delete,
+		Delete:        &delInst,
 		SignerCounter: []uint64{counters.Counters[0] + 1},
 	})
 	if err != nil {

--- a/byzcoin/bcadmin/commands.go
+++ b/byzcoin/bcadmin/commands.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/urfave/cli"
@@ -48,7 +47,7 @@ var cmds = cli.Commands{
 		},
 		// UsageText should be used instead, but its not working:
 		// see https://github.com/urfave/cli/issues/592
-		Description: fmt.Sprint(`
+		Description: `
    bcadmin [--export] contract CONTRACT { 
                                spawn  --bc <byzcoin config> 
                                       [--<arg name> <arg value>, ...]
@@ -64,10 +63,9 @@ var cmds = cli.Commands{
                                       --instid, i <instance ID>,
                                delete --bc <byzcoin config>
                                       --instid, i <instance ID>
-                                      [--darc <darc id>] 
                                       [--sign <pub key>]     
                              }
-   CONTRACT   {value,deferred,config}`),
+   CONTRACT   {value,deferred,config}`,
 		Subcommands: cli.Commands{
 			{
 				Name:  "value",
@@ -161,10 +159,6 @@ var cmds = cli.Commands{
 							cli.StringFlag{
 								Name:  "instid, i",
 								Usage: "the instance ID of the value contract",
-							},
-							cli.StringFlag{
-								Name:  "darc",
-								Usage: "DARC with the right to invoke.update a value contract (default is the admin DARC)",
 							},
 							cli.StringFlag{
 								Name:  "sign",
@@ -290,10 +284,6 @@ var cmds = cli.Commands{
 							cli.StringFlag{
 								Name:  "instid, i",
 								Usage: "the instance ID of the value contract",
-							},
-							cli.StringFlag{
-								Name:  "darc",
-								Usage: "DARC with the right to invoke.update a value contract (default is the admin DARC)",
 							},
 							cli.StringFlag{
 								Name:  "sign",

--- a/byzcoin/bcadmin/lib/utils.go
+++ b/byzcoin/bcadmin/lib/utils.go
@@ -23,10 +23,7 @@ func StringToDarcID(id string) ([]byte, error) {
 	if id == "" {
 		return nil, xerrors.New("no string given")
 	}
-	if strings.HasPrefix(id, "darc:") {
-		id = id[5:]
-	}
-	return hex.DecodeString(id)
+	return hex.DecodeString(strings.TrimPrefix(id, "darc:"))
 }
 
 // StringToEd25519Buf converts the string representation of an ed25519 key to a
@@ -35,10 +32,7 @@ func StringToEd25519Buf(pub string) ([]byte, error) {
 	if pub == "" {
 		return nil, xerrors.New("no string given")
 	}
-	if strings.HasPrefix(pub, "ed25519:") {
-		pub = pub[8:]
-	}
-	return hex.DecodeString(pub)
+	return hex.DecodeString(strings.TrimPrefix(pub, "ed25519:"))
 }
 
 // GetDarcByString returns a DARC given its ID as a string

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -89,7 +89,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("error: %+v", err)
 	}
-	return
 }
 
 func create(c *cli.Context) error {
@@ -221,7 +220,7 @@ func link(c *cli.Context) error {
 			"of the given skipchain-id")
 	}
 
-	newDarc := &darc.Darc{}
+	var newDarc *darc.Darc
 
 	dstr := c.String("darc")
 	if dstr == "" {
@@ -730,6 +729,9 @@ func mint(c *cli.Context) error {
 		},
 		SignerCounter: counters,
 	})
+	if err != nil {
+		return fmt.Errorf("couldn't create mint transaction: %v", err)
+	}
 	err = ctx.FillSignersAndSignWith(*signer)
 	if err != nil {
 		return err
@@ -955,6 +957,9 @@ func darcCdesc(c *cli.Context) error {
 	}
 
 	counters, err := cl.GetSignerCounters(signer.Identity().String())
+	if err != nil {
+		return fmt.Errorf("couldn't get signer counters: %v", err)
+	}
 
 	invoke := byzcoin.Invoke{
 		ContractID: byzcoin.ContractDarcID,
@@ -1389,6 +1394,9 @@ func darcAdd(c *cli.Context) error {
 	instID := byzcoin.NewInstanceID(dSpawn.GetBaseID())
 
 	counters, err := cl.GetSignerCounters(signer.Identity().String())
+	if err != nil {
+		return fmt.Errorf("couldn't get signer counters: %v", err)
+	}
 
 	spawn := byzcoin.Spawn{
 		ContractID: byzcoin.ContractDarcID,
@@ -1538,6 +1546,9 @@ func darcRule(c *cli.Context) error {
 	}
 
 	counters, err := cl.GetSignerCounters(signer.Identity().String())
+	if err != nil {
+		return fmt.Errorf("couldn't get signer counters: %v", err)
+	}
 
 	command := "evolve_unrestricted"
 	if c.Bool("restricted") {
@@ -1655,14 +1666,16 @@ func qrcode(c *cli.Context) error {
 				Pub:  signer.Identity().String(),
 			},
 		})
+		if err != nil {
+			return fmt.Errorf("couldn't marshal adminconfig: %v", err)
+		}
 	} else {
 		toWrite, err = json.Marshal(baseconfig{
 			ByzCoinID: cfg.ByzCoinID,
 		})
-	}
-
-	if err != nil {
-		return err
+		if err != nil {
+			return fmt.Errorf("couldn't marshal baseconfig: %v", err)
+		}
 	}
 
 	qr, err := qrgo.NewQR(string(toWrite))

--- a/byzcoin/proof_test.go
+++ b/byzcoin/proof_test.go
@@ -25,10 +25,10 @@ func TestNewProof(t *testing.T) {
 	_, err := NewProof(s.c, s.s, skipchain.SkipBlockID{}, []byte{})
 	require.Error(t, err)
 
-	key := []byte{1}
-	p, err := NewProof(s.c, s.s, s.genesis.Hash, key)
+	instKey := []byte{1}
+	p, err := NewProof(s.c, s.s, s.genesis.Hash, instKey)
 	require.NoError(t, err)
-	require.False(t, p.InclusionProof.Match(key))
+	require.False(t, p.InclusionProof.Match(instKey))
 
 	p, err = NewProof(s.c, s.s, s.genesis.Hash, s.key)
 	require.NoError(t, err)
@@ -41,9 +41,9 @@ func TestVerify(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, p.InclusionProof.Match(s.key))
 	require.Nil(t, p.Verify(s.genesis.SkipChainID()))
-	key, val, _, _, err := p.KeyValue()
+	instKey, val, _, _, err := p.KeyValue()
 	require.NoError(t, err)
-	require.Equal(t, s.key, key)
+	require.Equal(t, s.key, instKey)
 	require.Equal(t, s.value, val)
 
 	require.True(t, xerrors.Is(p.Verify(s.genesis2.SkipChainID()), ErrorVerifySkipchain))
@@ -134,7 +134,9 @@ func genForwardLink(t *testing.T, from, to *skipchain.SkipBlock, privs []kyber.S
 		From: from.Hash,
 		To:   to.Hash,
 	}
-	if !from.Roster.ID.Equal(to.Roster.ID) {
+	equals, err := from.Roster.Equal(to.Roster)
+	require.NoError(t, err)
+	if !equals {
 		fwd.NewRoster = to.Roster
 	}
 	sig, err := bls.Sign(pairing.NewSuiteBn256(), privs[0], fwd.Hash())

--- a/byzcoin/rostsimul.go
+++ b/byzcoin/rostsimul.go
@@ -2,6 +2,7 @@ package byzcoin
 
 import (
 	"errors"
+	"fmt"
 
 	"golang.org/x/xerrors"
 
@@ -148,7 +149,7 @@ func (s *ROSTSimul) CreateSCB(sa StateAction, cID string, id InstanceID,
 	value interface{}, darcID darc.ID) (err error) {
 	valueBuf, err := protobuf.Encode(value)
 	if err != nil {
-		err = xerrors.Errorf("couldn't encode coin: %+v", err)
+		return fmt.Errorf("couldn't encode coin: %v", err)
 	}
 	if darcID == nil {
 		darcID = make([]byte, 32)

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -1664,7 +1664,9 @@ func TestService_SetConfigRosterKeepLeader(t *testing.T) {
 		log.Lvl2("Verifying the correct roster is in place")
 		latest, err := s.service().db().GetLatestByID(s.genesis.Hash)
 		require.NoError(t, err)
-		require.True(t, latest.Roster.ID.Equal(rosterR.ID), "roster has not been updated")
+		equals, err := latest.Roster.Equal(rosterR)
+		require.NoError(t, err)
+		require.True(t, equals, "roster has not been updated")
 	}
 }
 
@@ -1683,7 +1685,9 @@ func TestService_SetConfigRosterNewLeader(t *testing.T) {
 		log.Lvl2("Verifying the correct roster is in place")
 		latest, err := s.service().db().GetLatestByID(s.genesis.Hash)
 		require.NoError(t, err)
-		require.True(t, latest.Roster.ID.Equal(rosterR.ID), "roster has not been updated")
+		equals, err := latest.Roster.Equal(rosterR)
+		require.NoError(t, err)
+		require.True(t, equals, "roster has not been updated")
 	}
 }
 
@@ -1735,7 +1739,9 @@ func TestService_SetConfigRosterNewNodes(t *testing.T) {
 		log.Lvl2("Verifying the correct roster is in place")
 		latest, err := s.service().db().GetLatestByID(s.genesis.Hash)
 		require.NoError(t, err)
-		require.True(t, latest.Roster.ID.Equal(rosterR.ID), "roster has not been updated")
+		equals, err := latest.Roster.Equal(rosterR)
+		require.NoError(t, err)
+		require.True(t, equals, "roster has not been updated")
 		// Get latest genesis darc and verify the 'view_change' rule is updated
 		st, err := s.service().GetReadOnlyStateTrie(s.genesis.Hash)
 		require.NoError(t, err)

--- a/byzcoin/statetrie_test.go
+++ b/byzcoin/statetrie_test.go
@@ -197,5 +197,5 @@ func TestDarcRetrieval(t *testing.T) {
 		err = darc.EvalExprDarc(rootSign, getDarcs, true, darcID.String())
 		require.NoError(t, err)
 	}
-	log.Lvl1("time to search:", time.Now().Sub(start))
+	log.Lvl1("time to search:", time.Since(start))
 }

--- a/byzcoin/struct.go
+++ b/byzcoin/struct.go
@@ -116,12 +116,6 @@ func (s *stateChangeStorage) setMaxSize(size int) {
 	s.maxSize = size
 }
 
-// setMaxNbrBlock enables the cleaning of state changes belonging
-// to blocks with an old index.
-func (s *stateChangeStorage) setMaxNbrBlock(nbr int) {
-	s.maxNbrBlock = nbr
-}
-
 // calculateSize reads the entries in the database and sums up their
 // sizes
 func (s *stateChangeStorage) calculateSize() error {
@@ -179,7 +173,7 @@ func (s *stateChangeStorage) cleanBySize() error {
 		// loop until enough blocks have been cleaned
 		for size > thres {
 			// Each pair at this level is a bucket assigned to a skipchain
-			err := b.ForEach(func(scid, v []byte) error {
+			err := b.ForEach(func(scid, _ []byte) error {
 				scb := b.Bucket(scid)
 				if scb == nil {
 					return nil
@@ -189,7 +183,7 @@ func (s *stateChangeStorage) cleanBySize() error {
 				oldestIndex := int64(-1)
 				var idx int64
 				c := scb.Cursor()
-				k, v := c.First()
+				k, _ := c.First()
 				for k != nil {
 					buf := bytes.NewBuffer(k[prefixLength+versionLength:])
 
@@ -203,11 +197,11 @@ func (s *stateChangeStorage) cleanBySize() error {
 					}
 
 					// go to the next instance
-					k, v = c.Seek(s.keyOfLast(k[:prefixLength]))
+					k, _ = c.Seek(s.keyOfLast(k[:prefixLength]))
 				}
 
 				// ... and we clean it
-				k, v = c.First()
+				k, v := c.First()
 				for k != nil {
 					buf := bytes.NewBuffer(k[prefixLength+versionLength:])
 

--- a/byzcoin/tx_pipeline.go
+++ b/byzcoin/tx_pipeline.go
@@ -381,8 +381,8 @@ func (p *txPipeline) processTxs(initialState *txProcessorState) {
 		interval := p.processor.GetInterval()
 		return time.After(interval)
 	}
+	p.wg.Add(1)
 	go func() {
-		p.wg.Add(1)
 		defer p.wg.Done()
 		intervalChan := getInterval()
 		var txHashes [][]byte
@@ -444,8 +444,8 @@ func (p *txPipeline) processTxs(initialState *txProcessorState) {
 				var inState *txProcessorState
 				currentState, inState = proposeInputState(currentState)
 
+				p.wg.Add(1)
 				go func(state *txProcessorState) {
-					p.wg.Add(1)
 					defer p.wg.Done()
 					if state != nil {
 						// NOTE: ProposeBlock might block for a long time,
@@ -476,7 +476,7 @@ func (p *txPipeline) processTxs(initialState *txProcessorState) {
 				}
 				txh := tx.Instructions.HashWithSignatures()
 				for _, txHash := range txHashes {
-					if bytes.Compare(txHash, txh) == 0 {
+					if bytes.Equal(txHash, txh) {
 						log.Lvl2("Got a duplicate transaction, ignoring it")
 						continue leaderLoop
 					}

--- a/byzcoin/viewchange/viewchange.go
+++ b/byzcoin/viewchange/viewchange.go
@@ -374,7 +374,9 @@ func NewNewViewReq(old *onet.Roster, proofs []InitReq) (*NewViewReq, error) {
 // Hash computes the digest of the request.
 func (req NewViewReq) Hash() []byte {
 	h := sha256.New()
-	h.Write(req.Roster.ID[:])
+	id, err := req.Roster.GetID()
+	log.ErrFatal(err)
+	h.Write(id[:])
 	for _, p := range req.Proof {
 		h.Write(p.Hash())
 	}


### PR DESCRIPTION
To make sure the upcoming rollup-protocol branch is correct, I'm using
staticcheck from https://github.com/dominikh/go-tools .
This pass is over the master branch before the rollup-protocol, so that I
have to consider only the errors shown by the rollup-protocol branch.

Currently, staticcheck complains about two things that I didn't fix here:
- `blscosi` is deprecated - but I don't want to change the consensus-protocol at this stage
- unused methods when using `t.Skip` - so this is kind of right, but still didn't fix