### PR TITLE
Handle large numeric return values in view method calls

### DIFF
--- a/bevm/api.go
+++ b/bevm/api.go
@@ -690,15 +690,13 @@ func EncodeEvmResult(result interface{}, outputs abi.Arguments) (string, error) 
 				"to be of length %v", len(resultArr), len(outputs))
 		}
 
-		encodedResult := []interface{}{}
+		encodedResult := make([]interface{}, len(outputs))
 		for i, output := range outputs {
 			abiType := output.Type.String()
-			encodedValue, err := encodeEvmValue(abiType, resultArr[i])
+			encodedResult[i], err = encodeEvmValue(abiType, resultArr[i])
 			if err != nil {
 				return "", xerrors.Errorf("failed to encode EVM value: %v", err)
 			}
-
-			encodedResult = append(encodedResult, encodedValue)
 		}
 
 		jsonData, err = json.Marshal(encodedResult)

--- a/bevm/bevmclient/cmd_imp.go
+++ b/bevm/bevmclient/cmd_imp.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
-	"reflect"
 	"strconv"
 
 	"golang.org/x/xerrors"
@@ -292,8 +291,12 @@ func executeCall(ctx *cli.Context) error {
 		return xerrors.Errorf("failed to execute view method: %v", err)
 	}
 
-	_, err = fmt.Fprintf(ctx.App.Writer, "call return value: %v [%s]\n",
-		result, reflect.TypeOf(result))
+	resultJSON, err := bevm.EncodeEvmResult(result, methodAbi.Outputs)
+	if err != nil {
+		return xerrors.Errorf("failed to encode view method result: %v", err)
+	}
+
+	_, err = fmt.Fprintf(ctx.App.Writer, "call result: %v\n", resultJSON)
 	if err != nil {
 		return xerrors.Errorf("failed to write report msg: %v", err)
 	}

--- a/bevm/bevmclient/cmd_imp.go
+++ b/bevm/bevmclient/cmd_imp.go
@@ -291,7 +291,7 @@ func executeCall(ctx *cli.Context) error {
 		return xerrors.Errorf("failed to execute view method: %v", err)
 	}
 
-	resultJSON, err := bevm.EncodeEvmResult(result, methodAbi.Outputs)
+	resultJSON, err := bevm.EncodeEvmReturnValue(result, methodAbi.Outputs)
 	if err != nil {
 		return xerrors.Errorf("failed to encode view method result: %v", err)
 	}

--- a/bevm/bevmclient/test.sh
+++ b/bevm/bevmclient/test.sh
@@ -122,7 +122,7 @@ testBevmInteraction(){
         '"100"'
 
     # Check Candy balance
-    testGrep " 100 " runBevmClient call \
+    testGrep '"100"' runBevmClient call \
         --sign "${BEVM_USER}" \
         getRemainingCandies
 
@@ -133,7 +133,7 @@ testBevmInteraction(){
         '"58"'
 
     # Check Candy balance
-    testGrep " 42 " runBevmClient call \
+    testGrep '"42"' runBevmClient call \
         --sign "${BEVM_USER}" \
         getRemainingCandies
 

--- a/bevm/service.go
+++ b/bevm/service.go
@@ -203,7 +203,7 @@ func (service *Service) PerformCall(req *CallRequest) (*CallResponse,
 
 	log.Lvlf4("Returning: %v", result)
 
-	resultJSON, err := EncodeEvmResult(result, methodAbi.Outputs)
+	resultJSON, err := EncodeEvmReturnValue(result, methodAbi.Outputs)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to marshal result to JSON: %v", err)
 	}

--- a/bevm/service_test.go
+++ b/bevm/service_test.go
@@ -340,7 +340,8 @@ func TestService_Call(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	expectedResult, err := json.Marshal(candySupply)
+	// uint256 is encoded as a JSON string to keep precision
+	expectedResult, err := json.Marshal(candySupply.String())
 	require.NoError(t, err)
 	require.Equal(t, resp.Result, string(expectedResult))
 }

--- a/external/js/cothority/spec/bevm/client.spec.ts
+++ b/external/js/cothority/spec/bevm/client.spec.ts
@@ -133,6 +133,6 @@ describe("BEvmClient", async () => {
             0,
             "getRemainingCandies",
             [],
-        )).toBeResolvedTo(expectedRemainingCoins);
+        )).toBeResolvedTo(String(expectedRemainingCoins));
     }, 60000); // Extend Jasmine default timeout interval to 1 minute
 });

--- a/external/js/cothority/src/bevm/client.ts
+++ b/external/js/cothority/src/bevm/client.ts
@@ -251,8 +251,8 @@ export class BEvmClient extends Instance {
      *   --------------------------------------------
      *   uint, uint256, uint128 | string    | "12345"
      *   int, int256, int128    | string    | "-12345"
-     *   uint32, uint16, uint128| number    | 12345
-     *   int32, int16, int128   | number    | -12345
+     *   uint32, uint16, uint8  | number    | 12345
+     *   int32, int16, int8     | number    | -12345
      *   address                | string    | "112233445566778899aabbccddeeff0011223344"
      *   string                 | string    | "look at me I am a string"
      *   array, e.g. uint[2]    | array     | ["123", "456"]


### PR DESCRIPTION
**What this PR does**

*See commit message*

These changes make the mechanism symmetrical to how arguments are passed to view methods, transactions or contract deployments: it uses strings to encode numbers with a large range (such as `uint256`), so as to preserve precision. The client can decide how to handle the string, e.g. in JavaScript it can be converted to a `BigInt` or a `Long`.

Closes c4dt/TODO#161

---

🙅‍ Friendly checklist:

- [x] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [x] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [x] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [x] 3. Code comments are added on tests to explain what they do.
- [x] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%v` verb.
- [x] 5. Hard limit of 80 chars is always respected.
- [x] 6. Changes are backward compatible.
- [x] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [x] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [x] 9. There are no magic values.
