### PR TITLE
Removes a race in byzcoin.GetUpdates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ docker:
 	cd conode/; make docker_dev
 	cd external/docker/; make docker_test
 
+docker_test_run: docker
+	docker run -ti -p7770-7777:7770-7777 dedis/conode-test
+
 test_java: docker
 	cd external/java; mvn test
 

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -608,6 +608,14 @@ func (s *Service) GetSignerCounters(req *GetSignerCounters) (*GetSignerCountersR
 // GetUpdates returns instances that have a newer versions than the ones
 // passed to it.
 func (s *Service) GetUpdates(pr *GetUpdatesRequest) (*GetUpdatesReply, error) {
+	s.catchingLock.Lock()
+	s.updateTrieLock.Lock()
+
+	defer func() {
+		s.updateTrieLock.Unlock()
+		s.catchingLock.Unlock()
+	}()
+
 	sb := s.db().GetByID(pr.LatestBlockID)
 	if sb == nil {
 		return nil, xerrors.New("cannot find skipblock while getting proof")

--- a/external/js/cothority/src/byzcoin/proto/requests.ts
+++ b/external/js/cothority/src/byzcoin/proto/requests.ts
@@ -241,7 +241,10 @@ export class IDVersion extends Message<IDVersion> {
  * The reply will only hold proofs for instances that have a higher version than the ones given here.
  */
 export class GetUpdatesRequest extends Message<GetUpdatesRequest> {
+    // send all instances with version 0, even those that are note updated.
     static readonly sendVersion0 = Long.fromNumber(1);
+    // send proofs for missing instances. If not present, missing instances are ignored.
+    static readonly sendMissingProofs = Long.fromNumber(2);
 
     static register() {
         registerMessage("GetUpdatesRequest", GetUpdatesRequest, IDVersion);


### PR DESCRIPTION
If byzcoin.GetUpdates is called while a block is confirmed, it might be that the block
is already in the database, but the state is not updated yet.
This PR locks the mutex to make sure this does not happen during byzcoin.GetUpdates.