### PR TITLE
js/kyber: mv bn.js to deps

### DIFF
--- a/external/js/kyber/package-lock.json
+++ b/external/js/kyber/package-lock.json
@@ -5218,7 +5218,7 @@
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },

--- a/external/js/kyber/package.json
+++ b/external/js/kyber/package.json
@@ -33,13 +33,13 @@
   "homepage": "https://github.com/dedis/cothority",
   "dependencies": {
     "@stablelib/blake2xs": "^0.10.4",
+    "@types/bn.js": "^4.11.6",
     "bn.js": "^5.1.2",
     "crypto-browserify": "^3.12.0",
     "elliptic": "^6.4.1",
     "hash.js": "^1.1.3"
   },
   "devDependencies": {
-    "@types/bn.js": "^4.11.6",
     "@types/elliptic": "^6.4.1",
     "@types/jasmine": "^3.3.5",
     "@types/lodash": "^4.14.139",


### PR DESCRIPTION
As js/kyber exposes some BN types, it needs to have its type definition. Having it in devs deps doesn't publihs it alongside it. Moving it to normal deps should help.