### PR TITLE
Backporting some of the rollup work

### DIFF
--- a/byzcoin/RosterChange.md
+++ b/byzcoin/RosterChange.md
@@ -18,7 +18,7 @@ with the new leader at the beginning of the roster. It is more difficult, howeve
 to add a new node to the roster, as the new node will have to get the new state
 before being able to participate in the consensus.
 
-There are two cases for the new block:
+There are two cases for the new node:
 1. it already has a version of the global state that is not older than
 a given threshold of blocks
 2. it doesn't have a version, or it is too old to be considered

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -1360,7 +1360,7 @@ func (s *Service) catchupAll() error {
 		for i, node := range sb.Roster.List {
 			cl.UseNode(i)
 			replyTmp, err := cl.GetUpdateChain(sb.Roster, sb.Hash)
-			if err != nil || replyTmp == nil {
+			if err != nil {
 				log.Warn("couldn't get update from", node)
 				continue
 			}

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -379,13 +379,20 @@ func (s *Service) prepareTxResponse(req *AddTxRequest, tx *TxResult) (*AddTxResp
 // error value to find out if an error has occured. The caller must also check
 // AddTxResponse.Error even if the error return value is nil.
 func (s *Service) AddTransaction(req *AddTxRequest) (*AddTxResponse, error) {
+	s.closedMutex.Lock()
+	if s.closed {
+		s.closedMutex.Unlock()
+		return nil, xerrors.New("node is closed")
+	}
+	s.closedMutex.Unlock()
+
 	if len(req.Transaction.Instructions) == 0 {
 		return nil, xerrors.New("no transactions to add")
 	}
 
 	gen := s.db().GetByID(req.SkipchainID)
 	if gen == nil || gen.Index != 0 {
-		return nil, xerrors.New("skipchain ID is does not exist")
+		return nil, xerrors.New("skipchain ID does not exist")
 	}
 
 	latest, err := s.db().GetLatest(gen)
@@ -1349,12 +1356,24 @@ func (s *Service) catchupAll() error {
 
 		cl := skipchain.NewClient()
 		// Get the latest block known by the Cothority.
-		reply, err := cl.GetUpdateChain(sb.Roster, sb.Hash)
-		if err != nil {
+		var reply *skipchain.GetUpdateChainReply
+		for i, node := range sb.Roster.List {
+			cl.UseNode(i)
+			replyTmp, err := cl.GetUpdateChain(sb.Roster, sb.Hash)
+			if err != nil || replyTmp == nil {
+				log.Warn("couldn't get update from", node)
+				continue
+			}
+			if reply == nil || len(replyTmp.Update) > len(reply.Update) {
+				reply = replyTmp
+			}
+		}
+
+		if reply == nil {
 			// Might be that the other nodes are not yet up,
 			// so just continue with the other chains.
 			// Call to s.catchup will probably also fail, so skip it.
-			log.Errorf("couldn't get update chain: %+v", err)
+			log.Error("couldn't get a new latest block")
 			continue
 		}
 
@@ -1362,7 +1381,9 @@ func (s *Service) catchupAll() error {
 			return xerrors.New("no block found in chain update")
 		}
 
-		s.catchUp(reply.Update[len(reply.Update)-1])
+		sb = reply.Update[len(reply.Update)-1]
+		log.Lvl2("Catching up with latest block:", sb.Index)
+		s.catchUp(sb)
 	}
 	return nil
 }

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -287,6 +287,7 @@ func testAddTransaction(t *testing.T, blockInterval time.Duration, sendToIdx int
 		// Wait for tasks to finish.
 		time.Sleep(blockInterval)
 	}
+	s.waitPropagation(t, 0)
 }
 
 func TestService_AddTransaction_WrongNode(t *testing.T) {
@@ -987,6 +988,7 @@ func sendTransaction(t *testing.T, s *ser, client int, kind string, wait int) (P
 func sendTransactionWithCounter(t *testing.T, s *ser, client int, kind string, wait int, counter uint64) (Proof, []byte, *AddTxResponse, error, error) {
 	tx, err := createOneClientTxWithCounter(s.darc.GetBaseID(), kind, s.value, s.signer, counter)
 	require.NoError(t, err)
+	key := tx.Instructions[0].Hash()
 	ser := s.services[client]
 	var resp *AddTxResponse
 	resp, err = ser.AddTransaction(&AddTxRequest{
@@ -1004,7 +1006,7 @@ func sendTransactionWithCounter(t *testing.T, s *ser, client int, kind string, w
 	rep, err2 := ser.GetProof(&GetProof{
 		Version: CurrentVersion,
 		ID:      s.genesis.SkipChainID(),
-		Key:     tx.Instructions[0].Hash(),
+		Key:     key,
 	})
 
 	var proof Proof
@@ -1012,7 +1014,7 @@ func sendTransactionWithCounter(t *testing.T, s *ser, client int, kind string, w
 		proof = rep.Proof
 	}
 
-	return proof, tx.Instructions[0].Hash(), resp, err, err2
+	return proof, key, resp, err, err2
 }
 
 func (s *ser) sendInstructions(t *testing.T, wait int,
@@ -1846,8 +1848,10 @@ func TestService_SetConfigRosterReplace(t *testing.T) {
 		ctx, _ := createConfigTxWithCounter(t, testInterval, *goodRoster, defaultMaxBlockSize, s, counter)
 		counter++
 		cl := NewClient(s.genesis.SkipChainID(), *goodRoster)
+		require.NoError(t, cl.UseNode(1))
 		resp, err := cl.AddTransactionAndWait(ctx, 10)
 		transactionOK(t, resp, err)
+		s.waitPropagation(t, -1)
 
 		log.Lvl1("Removing", goodRoster.List[0])
 		goodRoster = onet.NewRoster(goodRoster.List[1:])
@@ -1855,6 +1859,7 @@ func TestService_SetConfigRosterReplace(t *testing.T) {
 		counter++
 		resp, err = cl.AddTransactionAndWait(ctx, 10)
 		transactionOK(t, resp, err)
+		s.waitPropagation(t, -1)
 	}
 }
 
@@ -2757,12 +2762,7 @@ func (s *ser) sendTx(t *testing.T, ctx ClientTransaction) {
 }
 
 func (s *ser) sendTxTo(t *testing.T, ctx ClientTransaction, idx int) {
-	resp, err := s.services[idx].AddTransaction(&AddTxRequest{
-		Version:     CurrentVersion,
-		SkipchainID: s.genesis.SkipChainID(),
-		Transaction: ctx,
-	})
-	transactionOK(t, resp, err)
+	s.sendTxToAndWait(t, ctx, idx, 0)
 }
 
 func (s *ser) sendTxAndWait(t *testing.T, ctx ClientTransaction, wait int) {
@@ -2777,6 +2777,13 @@ func (s *ser) sendTxToAndWait(t *testing.T, ctx ClientTransaction, idx int, wait
 		InclusionWait: wait,
 	})
 	transactionOK(t, resp, err)
+}
+
+func (s *ser) sendDummyTx(t *testing.T, node int, counter uint64, wait int) {
+	tx1, err := createOneClientTxWithCounter(s.darc.GetBaseID(),
+		dummyContract, s.value, s.signer, counter)
+	require.NoError(t, err)
+	s.sendTxToAndWait(t, tx1, node, wait)
 }
 
 // caller gives us a darc, and we try to make an evolution request.

--- a/byzcoin/struct.go
+++ b/byzcoin/struct.go
@@ -623,7 +623,9 @@ func (bc *bcNotifications) informBlock(block *skipchain.SkipBlock, txs TxResults
 	bc.Lock()
 	defer bc.Unlock()
 	for _, x := range bc.blockListeners {
-		x <- notif
+		go func(wc waitChannel) {
+			wc <- notif
+		}(x)
 	}
 }
 

--- a/messaging/propagate.go
+++ b/messaging/propagate.go
@@ -205,14 +205,14 @@ func (p *Propagate) Dispatch() error {
 			}
 			log.Lvl3(p.ServerIdentity(), "Sending to children", p.Children())
 			if errs = p.SendToChildrenInParallel(&msg.PropagateSendData); len(errs) != 0 {
-				var errsStr []string
-				for _, e := range errs {
-					errsStr = append(errsStr, e.Error())
+				errsStr := make([]string, len(errs))
+				for i, e := range errs {
+					errsStr[i] = e.Error()
 				}
+				log.Lvl2("Error while sending to children:", errsStr)
 				if len(errs) > p.allowedFailures {
 					return errors.New(strings.Join(errsStr, "\n"))
 				}
-				log.Lvl2("Error while sending to children:", errsStr)
 			}
 		case <-p.ChannelReply:
 			if !gotSendData {

--- a/messaging/propagate.go
+++ b/messaging/propagate.go
@@ -149,15 +149,14 @@ func propagateStartAndWait(pi onet.ProtocolInstance, msg network.Message, to tim
 // Start will contact everyone and make the connections
 func (p *Propagate) Start() error {
 	log.Lvl4("going to contact", p.Root().ServerIdentity)
-	p.SendTo(p.Root(), p.sd)
-	return nil
+	return p.SendTo(p.Root(), p.sd)
 }
 
 // Dispatch can handle timeouts
 func (p *Propagate) Dispatch() error {
 	process := true
 	var received int
-	log.Lvl4(p.ServerIdentity(), "Start dispatch")
+	log.Lvl4(p.ServerIdentity(), "Starting dispatch as root:", p.IsRoot())
 	defer p.Done()
 	defer func() {
 		if p.IsRoot() {
@@ -183,7 +182,8 @@ func (p *Propagate) Dispatch() error {
 				continue
 			}
 			gotSendData = true
-			log.Lvl3(p.ServerIdentity(), "Got data from", msg.ServerIdentity, "and setting timeout to", msg.Timeout)
+			log.Lvl3(p.ServerIdentity(), "Got data from",
+				msg.ServerIdentity, "and setting timeout to", msg.Timeout)
 			p.sd.Timeout = msg.Timeout
 			if p.onData != nil {
 				_, netMsg, err := network.Unmarshal(msg.Data, p.Suite())
@@ -201,21 +201,18 @@ func (p *Propagate) Dispatch() error {
 				if err := p.SendToParent(&PropagateReply{}); err != nil {
 					return err
 				}
-			}
-			if p.IsLeaf() {
 				process = false
-			} else {
-				log.Lvl3(p.ServerIdentity(), "Sending to children")
-				if errs = p.SendToChildrenInParallel(&msg.PropagateSendData); len(errs) != 0 {
-					var errsStr []string
-					for _, e := range errs {
-						errsStr = append(errsStr, e.Error())
-					}
-					if len(errs) > p.allowedFailures {
-						return errors.New(strings.Join(errsStr, "\n"))
-					}
-					log.Lvl2("Error while sending to children:", errsStr)
+			}
+			log.Lvl3(p.ServerIdentity(), "Sending to children", p.Children())
+			if errs = p.SendToChildrenInParallel(&msg.PropagateSendData); len(errs) != 0 {
+				var errsStr []string
+				for _, e := range errs {
+					errsStr = append(errsStr, e.Error())
 				}
+				if len(errs) > p.allowedFailures {
+					return errors.New(strings.Join(errsStr, "\n"))
+				}
+				log.Lvl2("Error while sending to children:", errsStr)
 			}
 		case <-p.ChannelReply:
 			if !gotSendData {
@@ -236,9 +233,8 @@ func (p *Propagate) Dispatch() error {
 		case <-time.After(timeout):
 			if received+1 < subtreeCount-p.allowedFailures {
 				_, _, err := network.Unmarshal(p.sd.Data, p.Suite())
-				return fmt.Errorf("timeout of %s reached, got %v but need %v,"+
-					" err: %v", timeout, received,
-					subtreeCount-p.allowedFailures, err)
+				return fmt.Errorf("Timeout of %s reached, got %v but need %v, err: %v",
+					timeout, received, subtreeCount-p.allowedFailures, err)
 			}
 			process = false
 		case <-p.closing:


### PR DESCRIPTION
This are different things I found when working on rollup:
- typo in byzcoin/RosterChange.md
- byzcoin/Service.AddTransaction need for checking if the node is closing (less test-failures)
- byzcoin/Service.catchupAll iterating over all nodes to get the latest chain
- byzcoin/*_test.go simplifications and more stability for some tests
- messaging/propagate.go use a start propagation instead of a tree propagation, as the latter cannot handle failures