### PR TITLE
Use @ethersproject/abi instead of ethereumjs-abi

### DIFF
--- a/external/js/cothority/package-lock.json
+++ b/external/js/cothority/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedis/cothority",
-  "version": "3.4.7",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -984,6 +984,127 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
           "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
         }
+      }
+    },
+    "@ethersproject/abi": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.2.tgz",
+      "integrity": "sha512-Z+5f7xOgtRLu/W2l9Ry5xF7ehh9QVQ0m1vhynmTcS7DMfHgqTd1/PDFC62aw91ZPRCRZsYdZJu8ymokC5e1JSw==",
+      "requires": {
+        "@ethersproject/address": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/hash": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0"
+      }
+    },
+    "@ethersproject/address": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.2.tgz",
+      "integrity": "sha512-+rz26RKj7ujGfQynys4V9VJRbR+wpC6eL8F22q3raWMH3152Ha31GwJPWzxE/bEA+43M/zTNVwY0R53gn53L2Q==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/rlp": "^5.0.0",
+        "bn.js": "^4.4.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        }
+      }
+    },
+    "@ethersproject/bignumber": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.5.tgz",
+      "integrity": "sha512-24ln7PV0g8ZzjcVZiLW9Wod0i+XCmK6zKkAaxw5enraTIT1p7gVOcSXFSzNQ9WYAwtiFQPvvA+TIO2oEITZNJA==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "bn.js": "^4.4.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        }
+      }
+    },
+    "@ethersproject/bytes": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.3.tgz",
+      "integrity": "sha512-AyPMAlY+Amaw4Zfp8OAivm1xYPI8mqiUYmEnSUk1CnS2NrQGHEMmFJFiOJdS3gDDpgSOFhWIjZwxKq2VZpqNTA==",
+      "requires": {
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/constants": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.2.tgz",
+      "integrity": "sha512-nNoVlNP6bgpog7pQ2EyD1xjlaXcy1Cl4kK5v1KoskHj58EtB6TK8M8AFGi3GgHTdMldfT4eN3OsoQ/CdOTVNFA==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.0"
+      }
+    },
+    "@ethersproject/hash": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.2.tgz",
+      "integrity": "sha512-dWGvNwmVRX2bxoQQ3ciMw46Vzl1nqfL+5R8+2ZxsRXD3Cjgw1dL2mdjJF7xMMWPvPdrlhKXWSK0gb8VLwHZ8Cw==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0"
+      }
+    },
+    "@ethersproject/keccak256": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.2.tgz",
+      "integrity": "sha512-MbroXutc0gPNYIrUjS4Aw0lDuXabdzI7+l7elRWr1G6G+W0v00e/3gbikWkCReGtt2Jnt4lQSgnflhDwQGcIhA==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "js-sha3": "0.5.7"
+      }
+    },
+    "@ethersproject/logger": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.4.tgz",
+      "integrity": "sha512-alA2LiAy1LdQ/L1SA9ajUC7MvGAEQLsICEfKK4erX5qhkXE1LwLSPIzobtOWFsMHf2yrXGKBLnnpuVHprI3sAw=="
+    },
+    "@ethersproject/properties": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.2.tgz",
+      "integrity": "sha512-FxAisPGAOACQjMJzewl9OJG6lsGCPTm5vpUMtfeoxzAlAb2lv+kHzQPUh9h4jfAILzE8AR1jgXMzRmlhwyra1Q==",
+      "requires": {
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/rlp": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.2.tgz",
+      "integrity": "sha512-oE0M5jqQ67fi2SuMcrpoewOpEuoXaD8M9JeR9md1bXRMvDYgKXUtDHs22oevpEOdnO2DPIRabp6MVHa4aDuWmw==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/strings": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.2.tgz",
+      "integrity": "sha512-oNa+xvSqsFU96ndzog0IBTtsRFGOqGpzrXJ7shXLBT7juVeSEyZA/sYs0DMZB5mJ9FEjHdZKxR/rTyBY91vuXg==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0"
       }
     },
     "@protobufjs/aspromise": {
@@ -2730,22 +2851,6 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "ethereumjs-abi": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
-      "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
-      "requires": {
-        "bn.js": "^4.11.8",
-        "ethereumjs-util": "^6.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        }
-      }
-    },
     "ethereumjs-common": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.1.tgz",
@@ -4450,6 +4555,11 @@
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
       "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
       "dev": true
+    },
+    "js-sha3": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -33,12 +33,12 @@
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "@dedis/kyber": "^3.4.3",
+    "@ethersproject/abi": "^5.0.2",
     "@stablelib/blake2xs": "^0.10.4",
     "@types/ethereumjs-abi": "^0.6.3",
     "buffer": "^5.2.1",
     "crypto-browserify": "^3.12.0",
     "elliptic": "^6.5.3",
-    "ethereumjs-abi": "^0.6.8",
     "ethereumjs-tx": "^2.1.2",
     "isomorphic-ws": "^4.0.1",
     "keccak": "^3.0.0",

--- a/external/js/cothority/src/bevm/index.ts
+++ b/external/js/cothority/src/bevm/index.ts
@@ -1,7 +1,10 @@
+import { BigNumber } from "@ethersproject/bignumber";
 import { BEvmInstance, EvmAccount, EvmContract, WEI_PER_ETHER } from "./bevm-instance";
 import { BEvmRPC } from "./bevm-rpc";
 
 export {
+    BigNumber,
+
     BEvmRPC,
     EvmAccount,
     EvmContract,


### PR DESCRIPTION
**What this PR does**

*See commit message*

The change of library brings back support of the [ABIEncoderV2](https://solidity.readthedocs.io/en/v0.7.0/layout-of-source-files.html#abiencoderv2) (arbitrarily nested arrays and structs).

Closes #2350 