### PR TITLE
Update to Kyber v3.0.13.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/urfave/cli v1.22.3
-	go.dedis.ch/kyber/v3 v3.0.12
+	go.dedis.ch/kyber/v3 v3.0.13
 	go.dedis.ch/onet/v3 v3.2.4
 	go.dedis.ch/protobuf v1.0.11
 	go.etcd.io/bbolt v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -208,6 +208,8 @@ go.dedis.ch/kyber/v3 v3.0.4/go.mod h1:OzvaEnPvKlyrWyp3kGXlFdp7ap1VC6RkZDTaPikqhs
 go.dedis.ch/kyber/v3 v3.0.9/go.mod h1:rhNjUUg6ahf8HEg5HUvVBYoWY4boAafX8tYxX+PS+qg=
 go.dedis.ch/kyber/v3 v3.0.12 h1:15d61EyBcBoFIS97kS2c/Vz4o3FR8ALnZ2ck9J/ebYM=
 go.dedis.ch/kyber/v3 v3.0.12/go.mod h1:kXy7p3STAurkADD+/aZcsznZGKVHEqbtmdIzvPfrs1U=
+go.dedis.ch/kyber/v3 v3.0.13 h1:s5Lm8p2/CsTMueQHCN24gPpZ4couBBeKU7r2Yl6r32o=
+go.dedis.ch/kyber/v3 v3.0.13/go.mod h1:kXy7p3STAurkADD+/aZcsznZGKVHEqbtmdIzvPfrs1U=
 go.dedis.ch/onet/v3 v3.2.4 h1:PBRghpPadMUGllzbys42t+AvpxjacLOLeEIWHnP4/8Q=
 go.dedis.ch/onet/v3 v3.2.4/go.mod h1:rKEuXJJiH44kj1VwlgmjT9PnqVItC5jos1W4/t1TMXQ=
 go.dedis.ch/protobuf v1.0.5/go.mod h1:eIV4wicvi6JK0q/QnfIEGeSFNG0ZeB24kzut5+HaRLo=


### PR DESCRIPTION
Kyber's signature verification was potentially allowing malleable signatures with certain public keys. This version disallows those keys.

The public ByzCoin chain still replays correctly with this change in place.