### PR TITLE
Remove two gopkg.in

### DIFF
--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/satori/go.uuid"
 	"go.dedis.ch/cothority/v3"
 	"go.dedis.ch/cothority/v3/blscosi/protocol"
 	"go.dedis.ch/cothority/v3/byzcoin/trie"
@@ -31,7 +32,6 @@ import (
 	"go.dedis.ch/protobuf"
 	"go.etcd.io/bbolt"
 	"golang.org/x/xerrors"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 var pairingSuite = suites.MustFind("bn256.adapter").(*pairing.SuiteBn256)

--- a/cosi/service/cosi.go
+++ b/cosi/service/cosi.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/satori/go.uuid"
 	"go.dedis.ch/cothority/v3/cosi/protocol"
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
-	"gopkg.in/satori/go.uuid.v1"
 )
 
 // This file contains all the code to run a CoSi service. It is used to reply to

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	golang.org/x/sys v0.0.0-20200523222454-059865788121
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
-	gopkg.in/satori/go.uuid.v1 v1.2.0
 	gopkg.in/square/go-jose.v2 v2.4.1 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/cothority/v3"
@@ -19,7 +20,6 @@ import (
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	bbolt "go.etcd.io/bbolt"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 func init() {

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -22,8 +22,8 @@ import (
 	"go.dedis.ch/onet/v3/network"
 	"golang.org/x/xerrors"
 
+	uuid "github.com/satori/go.uuid"
 	bbolt "go.etcd.io/bbolt"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 // ErrorInconsistentForwardLink is triggered when the target of a forward-link

--- a/skipchain/struct_test.go
+++ b/skipchain/struct_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/cothority/v3"
@@ -21,7 +22,6 @@ import (
 	"go.dedis.ch/onet/v3/log"
 	"go.dedis.ch/onet/v3/network"
 	bbolt "go.etcd.io/bbolt"
-	uuid "gopkg.in/satori/go.uuid.v1"
 )
 
 var pairingSuite = pairing.NewSuiteBn256()


### PR DESCRIPTION
Both urfave/cli and satori/uuid are now available as go-modules.