### PR TITLE
Don't import buffer

### DIFF
--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@dedis/cothority",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "description": "A typescript implementation of the cothority",
   "main": "index.js",
   "browser": "bundle.min.js",

--- a/external/js/cothority/src/log.ts
+++ b/external/js/cothority/src/log.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "buffer/";
 import util from "util";
 
 const defaultLvl = 2;


### PR DESCRIPTION
There was a superfluous buffer-import in log.ts which might confuse stackblitz. Also bumps cothority-version.