### PR TITLE
testing travis-failing test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,118 +29,13 @@ _:
 dist: trusty
 
 stages:
-  - lint
-  - build
   - test
-  - deploy
 
 jobs:
   include:
-    - stage: lint
-      name: "protobuf"
-      language: minimal
-      script: make test_proto
-    - name: pre-commit
-      language: python
-      python: "3.6"
-      before_install:
-        - gimme 1.15
-        - . ${HOME}/.gimme/envs/go1.15.env
-        - GO111MODULE=off go get -u golang.org/x/lint/golint
-      install: pip install pre-commit
-      script: pre-commit run --all-files --verbose --show-diff-on-failure
-    - <<: *language_go_1_14
-      script:
-        - make -C conode verify
-        - GO111MODULE=on make test_{fmt,lint}
-    - <<: *language_go_1_15
-      script:
-        - make -C conode verify
-        - GO111MODULE=on make test_{fmt,lint}
-    - name: "js > kyber"
-      <<: *language_js
-      script:
-        - cd external/js/kyber
-        - npm ci
-        - npm run linter
-    - name: "js > cothority"
-      <<: *language_js
-      script:
-        - cd external/js/cothority
-        - npm ci
-        - npm run linter
-
-    - stage: build
-      <<:
-        - *stage_build_go
-        - *language_go_1_14
-    - <<:
-        - *stage_build_go
-        - *language_go_1_15
-
-    - name: "js > kyber"
-      <<: *language_js
-      script:
-        - cd external/js/kyber
-        - npm ci
-        - npm run build
-    - name: "js > cothority"
-      <<: *language_js
-      script:
-        - *gen_link_kyber
-        - cd external/js/cothority
-        - npm ci
-        - npm link @dedis/kyber
-        - npm run build
-
     - stage: test
       <<: *language_go_1_15
-      script: GO111MODULE=on make test_goveralls
-    - name: "java"
-      language: java
-      install: *get_go
-      script: make test_java
-    - name: "js > kyber"
-      <<: *language_js
-      script:
-        - cd external/js/kyber
-        - npm ci
-        - npm test
-    - name: "js > cothority"
-      <<: *language_js
-      install: *get_go
-      before_script:
-        - make docker
-        - *gen_link_kyber
-      script:
-        - cd external/js/cothority
-        - npm ci
-        - npm link @dedis/kyber
-        - npm test
-
-    - stage: deploy
-      name: "NPM: js > kyber"
-      <<: *stage_deploy_npm
-      deploy:
-        on:
-          branch: master
-        provider: script
-        script: >-
-          cd external/js/kyber &&
-          npm ci &&
-          npm version prerelease --preid=p`date +%y%m.%d%H.%M%S` &&
-          ./publish.sh --tag dev
-    - name: "NPM: js > cothority"
-      <<: *stage_deploy_npm
-      deploy:
-        on:
-          branch: master
-        provider: script
-        script: >-
-          cd external/js/cothority &&
-          npm ci &&
-          npm version prerelease --preid=p`date +%y%m.%d%H.%M%S` &&
-          ./publish.sh --tag dev
+      script: GO111MODULE=on make test_playground
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 
 EXCLUDE_LINT := should be.*UI
 #TESTS := TestViewChange_Basic3\$$
-TESTS := SecureDarc|TestDeferred_WrongSignature|TestViewChange_Basic|TestDeferred_DefaultExpireBlockIdx
+#TESTS := SecureDarc|TestDeferred_WrongSignature|TestViewChange_Basic|TestDeferred_DefaultExpireBlockIdx
+TESTS :=
 
 Coding/bin/Makefile.base:
 	git clone https://github.com/dedis/Coding

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .DEFAULT_GOAL := test
 
 EXCLUDE_LINT := should be.*UI
+#TESTS := TestViewChange_Basic3\$$
+TESTS := SecureDarc|TestDeferred_WrongSignature|TestViewChange_Basic|TestDeferred_DefaultExpireBlockIdx
 
 Coding/bin/Makefile.base:
 	git clone https://github.com/dedis/Coding
@@ -11,8 +13,11 @@ include Coding/bin/Makefile.base
 # to `make test_playground`.
 test_playground:
 	cd byzcoin; \
-	for a in $$( seq 100 ); do \
-		if DEBUG_TIME=true go test -v -race > log.txt 2>&1; then \
+	export DEBUG_COLOR=1; \
+	for a in $$( seq 1000 ); do \
+		if DEBUG_TIME=true go test -short -v -race -count=1 -run \
+			"(${TESTS})" \
+			 ./... > log.txt 2>&1; then \
 			echo Successfully ran \#$$a at $$(date); \
 		else \
 			echo Failed at $$(date); \

--- a/blscosi/protocol/sub_protocol.go
+++ b/blscosi/protocol/sub_protocol.go
@@ -101,6 +101,8 @@ func NewSubBlsCosi(n *onet.TreeNodeInstance, vf VerificationFn, suite *pairing.S
 func (p *SubBlsCosi) Dispatch() error {
 	defer p.Done()
 
+	log.Printf("%s: has %s", p.ServerIdentity(), p.Tree().Dump())
+
 	// Send announcement to start sending signatures
 	if p.IsRoot() {
 		return p.dispatchRoot()

--- a/blscosi/protocol/sub_protocol.go
+++ b/blscosi/protocol/sub_protocol.go
@@ -101,6 +101,8 @@ func NewSubBlsCosi(n *onet.TreeNodeInstance, vf VerificationFn, suite *pairing.S
 func (p *SubBlsCosi) Dispatch() error {
 	defer p.Done()
 
+	log.Printf("%s: has %s", p.ServerIdentity(), p.Tree().Dump())
+
 	// Send announcement to start sending signatures
 	if p.IsRoot() {
 		return p.dispatchRoot()
@@ -214,8 +216,8 @@ func (p *SubBlsCosi) dispatchRoot() error {
 	case <-time.After(p.Timeout):
 		// It might be only the subleader then we send a notification
 		// to let the parent protocol take actions
-		log.Warn(p.ServerIdentity(),
-			"timed out while waiting for subleader response")
+		log.Warnf("%s: timed out while waiting for subleader response while %s",
+			p.ServerIdentity(), p.Tree().Dump())
 		p.subleaderNotResponding <- true
 	}
 

--- a/blscosi/protocol/sub_protocol.go
+++ b/blscosi/protocol/sub_protocol.go
@@ -101,8 +101,6 @@ func NewSubBlsCosi(n *onet.TreeNodeInstance, vf VerificationFn, suite *pairing.S
 func (p *SubBlsCosi) Dispatch() error {
 	defer p.Done()
 
-	log.Printf("%s: has %s", p.ServerIdentity(), p.Tree().Dump())
-
 	// Send announcement to start sending signatures
 	if p.IsRoot() {
 		return p.dispatchRoot()

--- a/byzcoin/api.go
+++ b/byzcoin/api.go
@@ -699,7 +699,7 @@ func (c *Client) ResolveInstanceID(darcID darc.ID, name string) (InstanceID, err
 func (c *Client) WaitPropagation(index int) error {
 	var sb skipchain.SkipBlock
 	sb.SkipBlockFix = &skipchain.SkipBlockFix{}
-	if index > 0 {
+	if index >= 0 {
 		sb.Index = index
 	}
 searchLatest:
@@ -715,7 +715,8 @@ searchLatest:
 			}
 			pr, err := c.GetProof(make([]byte, 32))
 			if err != nil {
-				log.Warn("error while searching for node - ignoring")
+				log.Warnf("error while querying node %s - ignoring",
+					c.Roster.List[node])
 				continue
 			}
 			if pr.Proof.Latest.Index > sb.Index {

--- a/byzcoin/api_test.go
+++ b/byzcoin/api_test.go
@@ -120,7 +120,7 @@ func TestClient_CreateTransaction(t *testing.T) {
 func TestClient_GetProof(t *testing.T) {
 	l := onet.NewTCPTest(cothority.Suite)
 	servers, roster, _ := l.GenTree(3, true)
-	registerDummy(t, servers)
+	registerContracts(servers)
 	defer l.CloseAll()
 
 	// Initialise the genesis message and send it to the service.
@@ -200,7 +200,7 @@ func TestClient_GetProofCorrupted(t *testing.T) {
 func TestClient_Streaming(t *testing.T) {
 	l := onet.NewTCPTest(cothority.Suite)
 	servers, roster, _ := l.GenTree(3, true)
-	registerDummy(t, servers)
+	registerContracts(servers)
 	defer l.CloseAll()
 
 	// Initialise the genesis message and send it to the service.
@@ -277,7 +277,7 @@ func TestClient_Streaming(t *testing.T) {
 func TestClient_NoPhantomSkipchain(t *testing.T) {
 	l := onet.NewTCPTest(cothority.Suite)
 	servers, roster, _ := l.GenTree(3, true)
-	registerDummy(t, servers)
+	registerContracts(servers)
 	defer l.CloseAll()
 
 	// Initialise the genesis message and send it to the service.

--- a/byzcoin/bcadmin/lib/utils.go
+++ b/byzcoin/bcadmin/lib/utils.go
@@ -144,7 +144,7 @@ func WaitPropagation(c *cli.Context, cl *byzcoin.Client) error {
 		return nil
 	}
 
-	return cl.WaitPropagation(0)
+	return cl.WaitPropagation(-1)
 }
 
 // We are recursively building the leaves of a tree that contains every

--- a/byzcoin/byzcoin_test.go
+++ b/byzcoin/byzcoin_test.go
@@ -1,0 +1,285 @@
+package byzcoin
+
+import (
+	"encoding/hex"
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/cothority/v3/darc"
+	"go.dedis.ch/cothority/v3/skipchain"
+	"go.dedis.ch/onet/v3"
+	"go.dedis.ch/onet/v3/log"
+	"go.etcd.io/bbolt"
+	"testing"
+	"time"
+)
+
+type BCTest struct {
+	Local               *onet.LocalTest
+	Servers             []*onet.Server
+	Roster              *onet.Roster
+	Services            []*Service
+	Genesis             *skipchain.SkipBlock
+	Value               []byte
+	GenesisDarc         *darc.Darc
+	Signer              darc.Signer
+	CTx                 ClientTransaction
+	PropagationInterval time.Duration
+	Client              *Client
+	t                   *testing.T
+}
+
+type BCTestArgs struct {
+	Step                int
+	PropagationInterval time.Duration
+	Nodes               int
+	RotationWindow      int
+	Version             Version
+}
+
+// NewBCTestArgs returns a default BCTestArgs structure.
+// The values in here guarantee a fast but still passable test in travis.
+func NewBCTestArgs() BCTestArgs {
+	return BCTestArgs{1,
+		500 * time.Millisecond,
+		3,
+		// use this value as a rotation window to make it impossible to trigger a view change
+		9999,
+		CurrentVersion}
+}
+
+// NewBCTest returns a default and initialized BCTest structure.
+// It already started a testing byzcoin instance.
+func NewBCTest(t *testing.T) *BCTest {
+	return NewBCTestWithArgs(t, NewBCTestArgs())
+}
+
+// NewBCTestWithArgs takes a BCTestArgs to override the default values.
+func NewBCTestWithArgs(t *testing.T, ba BCTestArgs) *BCTest {
+	b := &BCTest{
+		t:      t,
+		Local:  onet.NewLocalTestT(tSuite, t),
+		Value:  []byte("anyvalue"),
+		Signer: darc.NewSignerEd25519(nil, nil),
+	}
+	b.Servers, b.Roster, _ = b.Local.GenTree(ba.Nodes, true)
+	for _, sv := range b.Local.GetServices(b.Servers, ByzCoinID) {
+		service := sv.(*Service)
+		service.rotationWindow = ba.RotationWindow
+		service.defaultVersion = ba.Version
+		b.Services = append(b.Services, service)
+	}
+	registerDummy(t, b.Servers)
+
+	genesisMsg, err := DefaultGenesisMsg(CurrentVersion, b.Roster,
+		[]string{
+			"spawn:" + dummyContract,
+			"spawn:" + invalidContract,
+			"spawn:" + panicContract,
+			"spawn:" + slowContract,
+			"spawn:" + versionContract,
+			"spawn:" + stateChangeCacheContract,
+			"delete:" + dummyContract,
+		}, b.Signer.Identity())
+	require.NoError(t, err)
+	b.GenesisDarc = &genesisMsg.GenesisDarc
+
+	genesisMsg.BlockInterval = ba.PropagationInterval
+	b.PropagationInterval = genesisMsg.BlockInterval
+
+	for i := 0; i < ba.Step; i++ {
+		switch i {
+		case 0:
+			resp, err := b.Service().CreateGenesisBlock(genesisMsg)
+			require.NoError(t, err)
+			b.Genesis = resp.Skipblock
+			b.WaitPropagation(0)
+			b.Client = NewClient(b.Genesis.SkipChainID(), *b.Roster)
+		case 1:
+			tx, err := createOneClientTx(b.GenesisDarc.GetBaseID(), dummyContract, b.Value, b.Signer)
+			require.NoError(t, err)
+			b.CTx = tx
+			resp, err := b.Service().AddTransaction(&AddTxRequest{
+				Version:       CurrentVersion,
+				SkipchainID:   b.Genesis.SkipChainID(),
+				Transaction:   tx,
+				InclusionWait: 10,
+			})
+			transactionOK(t, resp, err)
+			b.WaitPropagation(1)
+		default:
+			require.Fail(t, "no such step")
+		}
+	}
+	return b
+}
+
+func (b *BCTest) CloseAll() {
+	b.WaitPropagation(-1)
+	b.Local.CloseAll()
+}
+
+func (b *BCTest) Service() *Service {
+	return b.Services[0]
+}
+
+func (b *BCTest) WaitProof(id InstanceID) Proof {
+	return b.WaitProofWithIdx(id.Slice(), 0)
+}
+
+func (b *BCTest) WaitProofWithIdx(key []byte, idx int) Proof {
+	var pr Proof
+	var ok bool
+	for i := 0; i < 10; i++ {
+		resp, err := b.Services[idx].GetProof(&GetProof{
+			Version: CurrentVersion,
+			Key:     key,
+			ID:      b.Genesis.SkipChainID(),
+		})
+		if err == nil {
+			pr = resp.Proof
+			if pr.InclusionProof.Match(key) {
+				ok = true
+				break
+			}
+		}
+
+		// wait for the block to be processed
+		time.Sleep(2 * b.PropagationInterval)
+	}
+
+	require.True(b.t, ok, "got not match")
+	return pr
+}
+
+func (b *BCTest) SendTx(ctx ClientTransaction) {
+	b.SendTxTo(ctx, 0)
+}
+
+func (b *BCTest) SendTxTo(ctx ClientTransaction, idx int) {
+	b.SendTxToAndWait(ctx, idx, 0)
+}
+
+func (b *BCTest) SendTxWaitPropagation(ctx ClientTransaction, idx int) {
+	b.SendTxToAndWait(ctx, idx, 20)
+	b.WaitPropagation(-1)
+}
+
+func (b *BCTest) SendTxAndWait(ctx ClientTransaction, wait int) {
+	b.SendTxToAndWait(ctx, 0, wait)
+}
+
+func (b *BCTest) SendTxToAndWait(ctx ClientTransaction, idx int, wait int) {
+	resp, err := b.Services[idx].AddTransaction(&AddTxRequest{
+		Version:       CurrentVersion,
+		SkipchainID:   b.Genesis.SkipChainID(),
+		Transaction:   ctx,
+		InclusionWait: wait,
+	})
+	transactionOK(b.t, resp, err)
+}
+
+func (b *BCTest) SendDummyTx(node int, counter uint64, wait int) {
+	tx1, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(),
+		dummyContract, b.Value, b.Signer, counter)
+	require.NoError(b.t, err)
+	b.SendTxToAndWait(tx1, node, wait)
+}
+
+func (b *BCTest) SendDummyTxWaitPropagation(node int, counter uint64) {
+	b.SendDummyTx(node, counter, 20)
+	b.WaitPropagation(-1)
+}
+
+// caller gives us a darc, and we try to make an evolution request.
+func (b *BCTest) TestDarcEvolution(d2 darc.Darc, fail bool) (pr *Proof) {
+	counterResponse, err := b.Service().GetSignerCounters(&GetSignerCounters{
+		SignerIDs:   []string{b.Signer.Identity().String()},
+		SkipchainID: b.Genesis.SkipChainID(),
+	})
+	require.NoError(b.t, err)
+
+	ctx := b.DarcToTx(d2, counterResponse.Counters[0]+1)
+	b.SendTx(ctx)
+	for i := 0; i < 10; i++ {
+		resp, err := b.Service().GetProof(&GetProof{
+			Version: CurrentVersion,
+			Key:     d2.GetBaseID(),
+			ID:      b.Genesis.SkipChainID(),
+		})
+		require.NoError(b.t, err)
+		pr = &resp.Proof
+		_, v0, _, _, err := pr.KeyValue()
+		require.NoError(b.t, err)
+		d, err := darc.NewFromProtobuf(v0)
+		require.NoError(b.t, err)
+		if d.Equal(&d2) {
+			return
+		}
+		time.Sleep(b.PropagationInterval)
+	}
+	if !fail {
+		b.t.Fatal("couldn't store new darc")
+	}
+	return
+}
+
+func (b *BCTest) DeleteDBs(index int) {
+	bc := b.Services[index]
+	log.Lvlf1("%s: Deleting DB of node %d", bc.ServerIdentity(), index)
+	bc.TestClose()
+	for scid := range bc.stateTries {
+		require.NoError(b.t, deleteDB(bc.ServiceProcessor, []byte(scid)))
+		idStr := hex.EncodeToString([]byte(scid))
+		require.NoError(b.t, deleteDB(bc.ServiceProcessor, []byte(idStr)))
+	}
+	require.NoError(b.t, deleteDB(bc.ServiceProcessor, storageID))
+	sc := bc.Service(skipchain.ServiceName).(*skipchain.Service)
+	require.NoError(b.t, deleteDB(sc.ServiceProcessor, []byte("skipblocks")))
+	require.NoError(b.t, deleteDB(sc.ServiceProcessor, []byte("skipchainconfig")))
+	require.NoError(b.t, bc.TestRestart())
+}
+
+// Waits to have a coherent view in all nodes with at least the block
+// 'index' held by all nodes.
+func (b *BCTest) WaitPropagation(index int) {
+	if b.Genesis != nil && b.Roster != nil {
+		require.NoError(b.t, NewClient(b.Genesis.Hash,
+			*b.Roster).WaitPropagation(index))
+	}
+}
+
+func (b *BCTest) DarcToTx(d2 darc.Darc, ctr uint64) ClientTransaction {
+	d2Buf, err := d2.ToProto()
+	require.NoError(b.t, err)
+	invoke := Invoke{
+		ContractID: ContractDarcID,
+		Command:    cmdDarcEvolve,
+		Args: []Argument{
+			{
+				Name:  "darc",
+				Value: d2Buf,
+			},
+		},
+	}
+	instr := Instruction{
+		InstanceID:    NewInstanceID(d2.GetBaseID()),
+		Invoke:        &invoke,
+		SignerCounter: []uint64{ctr},
+		version:       CurrentVersion,
+	}
+	ctx, err := combineInstrsAndSign(b.Signer, instr)
+	require.NoError(b.t, err)
+	return ctx
+}
+
+func deleteDB(s *onet.ServiceProcessor, key []byte) error {
+	db, stBucket := s.GetAdditionalBucket(key)
+	return db.Update(func(tx *bbolt.Tx) error {
+		return tx.DeleteBucket(stBucket)
+	})
+}
+
+func transactionOK(t *testing.T, resp *AddTxResponse, err error) {
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Empty(t, resp.Error)
+}

--- a/byzcoin/contract_darc_test.go
+++ b/byzcoin/contract_darc_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestSecureDarc(t *testing.T) {
-	b := NewBCTest(t)
+	b := newBCTRun(t, nil)
 	defer b.CloseAll()
 
 	restrictedSigner := darc.NewSignerEd25519(nil, nil)

--- a/byzcoin/contracts/contract_deferred_test.go
+++ b/byzcoin/contracts/contract_deferred_test.go
@@ -850,6 +850,7 @@ func TestDeferred_WrongSignature(t *testing.T) {
 
 	cl, _, err := byzcoin.NewLedger(genesisMsg, false)
 	require.NoError(t, err)
+	defer require.NoError(t, cl.WaitPropagation(-1))
 
 	// ------------------------------------------------------------------------
 	// 1. Spawn

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -4,14 +4,12 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
-	"go.etcd.io/bbolt"
 	"golang.org/x/xerrors"
 
 	"github.com/stretchr/testify/assert"
@@ -31,10 +29,6 @@ import (
 )
 
 var tSuite = suites.MustFind("Ed25519")
-var testInterval = 500 * time.Millisecond
-
-// use this value as a rotation window to make it impossible to trigger a view change
-var disableViewChange = time.Duration(9999)
 
 const dummyContract = "dummy"
 const slowContract = "slow"
@@ -49,17 +43,17 @@ func TestMain(m *testing.M) {
 }
 
 func TestService_GetAllByzCoinIDs(t *testing.T) {
-	s := newSerN(t, 1, testInterval, 4, disableViewChange)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
-	service := s.services[0]
+	service := b.Services[0]
 
 	resp, err := service.GetAllByzCoinIDs(&GetAllByzCoinIDsRequest{})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(resp.IDs))
 
 	nb := skipchain.NewSkipBlock()
-	nb.Roster = s.roster
+	nb.Roster = b.Roster
 	nb.MaximumHeight = 1
 	nb.BaseHeight = 1
 	_, err = service.skService().StoreSkipBlockInternal(&skipchain.StoreSkipBlock{NewBlock: nb})
@@ -71,28 +65,30 @@ func TestService_GetAllByzCoinIDs(t *testing.T) {
 }
 
 func TestService_CreateGenesisBlock(t *testing.T) {
-	s := newSerN(t, 0, testInterval, 4, disableViewChange)
-	defer s.local.CloseAll()
+	bArgs := NewBCTestArgs()
+	bArgs.Step = 0
+	b := NewBCTestWithArgs(t, bArgs)
+	defer b.CloseAll()
 
-	service := s.services[1]
+	service := b.Services[1]
 
 	// invalid version, missing transaction
 	_, err := service.CreateGenesisBlock(&CreateGenesisBlock{
 		Version: 0,
-		Roster:  *s.roster,
+		Roster:  *b.Roster,
 	})
 	require.Error(t, err)
 
 	// invalid: max block too small, big
 	_, err = service.CreateGenesisBlock(&CreateGenesisBlock{
 		Version:      0,
-		Roster:       *s.roster,
+		Roster:       *b.Roster,
 		MaxBlockSize: 3000,
 	})
 	require.Error(t, err)
 	_, err = service.CreateGenesisBlock(&CreateGenesisBlock{
 		Version:      0,
-		Roster:       *s.roster,
+		Roster:       *b.Roster,
 		MaxBlockSize: 30 * 1e6,
 	})
 	require.Error(t, err)
@@ -100,14 +96,14 @@ func TestService_CreateGenesisBlock(t *testing.T) {
 	// invalid darc
 	_, err = service.CreateGenesisBlock(&CreateGenesisBlock{
 		Version:     CurrentVersion,
-		Roster:      *s.roster,
+		Roster:      *b.Roster,
 		GenesisDarc: darc.Darc{},
 	})
 	require.Error(t, err)
 
 	// create valid darc
 	signer := darc.NewSignerEd25519(nil, nil)
-	genesisMsg, err := DefaultGenesisMsg(CurrentVersion, s.roster, []string{"spawn:dummy"}, signer.Identity())
+	genesisMsg, err := DefaultGenesisMsg(CurrentVersion, b.Roster, []string{"spawn:dummy"}, signer.Identity())
 	require.NoError(t, err)
 	genesisMsg.BlockInterval = 100 * time.Millisecond
 	genesisMsg.MaxBlockSize = 1 * 1e6
@@ -136,95 +132,91 @@ func TestService_CreateGenesisBlock(t *testing.T) {
 }
 
 func TestService_AddTransaction(t *testing.T) {
-	testAddTransaction(t, testInterval, 0, false)
+	testAddTransaction(t, 0, false)
 }
 
 func TestService_AddTransaction_ToFollower(t *testing.T) {
-	testAddTransaction(t, testInterval, 1, false)
+	testAddTransaction(t, 1, false)
 }
 
 func TestService_AddTransaction_WithFailure(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Keep edge cases for Jenkins")
 	}
-	testAddTransaction(t, testInterval, 0, true)
+	testAddTransaction(t, 0, true)
 }
 
 func TestService_AddTransaction_WithFailure_OnFollower(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Keep edge cases for Jenkins")
 	}
-	testAddTransaction(t, testInterval, 1, true)
+	testAddTransaction(t, 1, true)
 }
 
-func transactionOK(t *testing.T, resp *AddTxResponse, err error) {
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	require.Empty(t, resp.Error)
-}
-
-func testAddTransaction(t *testing.T, blockInterval time.Duration, sendToIdx int, failure bool) {
-	var s *ser
+func testAddTransaction(t *testing.T, sendToIdx int, failure bool) {
+	var b *BCTest
 	if failure {
-		s = newSerN(t, 1, blockInterval, 4, disableViewChange)
-		for _, service := range s.services {
-			service.SetPropagationTimeout(blockInterval * 2)
+		bArgs := NewBCTestArgs()
+		bArgs.Nodes = 4
+		b = NewBCTestWithArgs(t, bArgs)
+		for _, service := range b.Services {
+			service.SetPropagationTimeout(b.PropagationInterval * 2)
 		}
 	} else {
-		s = newSer(t, 1, testInterval)
+		b = NewBCTest(t)
 	}
-	defer s.local.CloseAll()
+	defer b.CloseAll()
 
 	// wrong version
-	_, err := s.service().AddTransaction(&AddTxRequest{
+	_, err := b.Service().AddTransaction(&AddTxRequest{
 		Version: CurrentVersion + 1,
 	})
 	require.Error(t, err)
 
 	// missing skipchain
-	_, err = s.service().AddTransaction(&AddTxRequest{
+	_, err = b.Service().AddTransaction(&AddTxRequest{
 		Version: CurrentVersion,
 	})
 	require.Error(t, err)
 
 	// missing transaction
-	_, err = s.service().AddTransaction(&AddTxRequest{
+	_, err = b.Service().AddTransaction(&AddTxRequest{
 		Version:     CurrentVersion,
-		SkipchainID: s.genesis.SkipChainID(),
+		SkipchainID: b.Genesis.SkipChainID(),
 	})
 	require.Error(t, err)
 
 	if failure {
 		// kill a child conode and adding tx should still succeed
-		log.Lvl1("Pausing (killing) conode", s.hosts[len(s.hosts)-1].Address())
-		s.services[len(s.hosts)-1].TestClose()
-		s.hosts[len(s.hosts)-1].Pause()
+		log.Lvl1("Pausing (killing) conode", b.Servers[len(b.Servers)-1].Address())
+		b.Services[len(b.Servers)-1].TestClose()
+		b.Servers[len(b.Servers)-1].Pause()
 	}
 
 	// the operations below should succeed
 	// add the first tx
 	log.Lvl1("adding the first tx")
-	tx1, err := createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, s.value, s.signer, 1)
+	tx1, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), dummyContract, b.Value, b.Signer, 1)
 	require.NoError(t, err)
-	akvresp, err := s.service().AddTransaction(&AddTxRequest{
+	akvresp, err := b.Service().AddTransaction(&AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx1,
 		InclusionWait: 10,
 	})
 	transactionOK(t, akvresp, err)
 	require.Equal(t, CurrentVersion, akvresp.Version)
 	require.NotNil(t, akvresp.Proof)
-	require.NoError(t, akvresp.Proof.VerifyFromBlock(s.genesis))
+	require.NoError(t, akvresp.Proof.VerifyFromBlock(b.Genesis))
 
 	// add the second tx
 	log.Lvl1("adding the second tx")
 	value2 := []byte("value2")
-	tx2, err := createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, value2, s.signer, 2)
+	tx2, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), dummyContract, value2, b.Signer, 2)
 	require.NoError(t, err)
-	akvresp, err = s.services[sendToIdx].AddTransaction(&AddTxRequest{
+	akvresp, err = b.Services[sendToIdx].AddTransaction(&AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx2,
 		InclusionWait: 10,
 	})
@@ -238,18 +230,18 @@ func testAddTransaction(t *testing.T, blockInterval time.Duration, sendToIdx int
 		if i == 1 {
 			// Now read the key/values from a new service
 			log.Lvl1("Recreate services and fetch keys again")
-			s.service().TestClose()
-			require.NoError(t, s.service().TestRestart())
+			b.Service().TestClose()
+			require.NoError(t, b.Service().TestRestart())
 		}
 		for _, tx := range txs {
-			pr := s.waitProofWithIdx(t, tx.Instructions[0].Hash(), 0)
-			require.Nil(t, pr.Verify(s.genesis.SkipChainID()))
+			pr := b.WaitProofWithIdx(tx.Instructions[0].Hash(), 0)
+			require.Nil(t, pr.Verify(b.Genesis.SkipChainID()))
 			_, v0, _, _, err := pr.KeyValue()
 			require.NoError(t, err)
 			require.True(t, bytes.Equal(tx.Instructions[0].Spawn.Args[0].Value, v0))
 
 			// check that the database has this new block's index recorded
-			st, err := s.services[0].getStateTrie(pr.Latest.SkipChainID())
+			st, err := b.Services[0].getStateTrie(pr.Latest.SkipChainID())
 			require.NoError(t, err)
 			idx := st.GetIndex()
 			require.Equal(t, pr.Latest.Index, idx)
@@ -259,17 +251,17 @@ func testAddTransaction(t *testing.T, blockInterval time.Duration, sendToIdx int
 	// Bring the failed node back up and it should also see the transactions.
 	if failure {
 		log.Lvl1("bringing the failed node back up")
-		s.hosts[len(s.hosts)-1].Unpause()
-		require.NoError(t, s.services[len(s.hosts)-1].TestRestart())
+		b.Servers[len(b.Servers)-1].Unpause()
+		require.NoError(t, b.Services[len(b.Servers)-1].TestRestart())
 
 		for _, tx := range txs {
-			pr := s.waitProofWithIdx(t, tx.Instructions[0].Hash(), len(s.hosts)-1)
-			require.Nil(t, pr.Verify(s.genesis.SkipChainID()))
+			pr := b.WaitProofWithIdx(tx.Instructions[0].Hash(), len(b.Servers)-1)
+			require.Nil(t, pr.Verify(b.Genesis.SkipChainID()))
 			_, v0, _, _, err := pr.KeyValue()
 			require.NoError(t, err)
 			require.True(t, bytes.Equal(tx.Instructions[0].Spawn.Args[0].Value, v0))
 			// check that the database has this new block's index recorded
-			st, err := s.services[len(s.hosts)-1].getStateTrie(pr.Latest.SkipChainID())
+			st, err := b.Services[len(b.Servers)-1].getStateTrie(pr.Latest.SkipChainID())
 			require.NoError(t, err)
 			idx := st.GetIndex()
 			require.Equal(t, pr.Latest.Index, idx)
@@ -278,35 +270,34 @@ func testAddTransaction(t *testing.T, blockInterval time.Duration, sendToIdx int
 		// Try to add a new transaction to the node that failed (but is
 		// now running) and it should work.
 		log.Lvl1("making a last transaction")
-		pr, k, resp, err, err2 := sendTransaction(t, s, len(s.hosts)-1, dummyContract, 10)
+		pr, k, resp, err, err2 := sendTransaction(t, b, len(b.Servers)-1, dummyContract, 10)
 		transactionOK(t, resp, err)
 		require.NoError(t, err2)
 		require.True(t, pr.InclusionProof.Match(k))
 
 		log.Lvl1("done")
 		// Wait for tasks to finish.
-		time.Sleep(blockInterval)
+		time.Sleep(b.PropagationInterval)
 	}
-	s.waitPropagation(t, 0)
 }
 
 func TestService_AddTransaction_WrongNode(t *testing.T) {
 	defer log.SetShowTime(log.ShowTime())
 	log.SetShowTime(true)
-	s := newSerN(t, 1, testInterval, 4, disableViewChange)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
-	outsideServer := s.local.GenServers(1)[0]
+	outsideServer := b.Local.GenServers(1)[0]
 	outside := outsideServer.Service(ServiceName).(*Service)
 	registerDummy(t, []*onet.Server{outsideServer})
 
 	// add the first tx to outside server
 	log.Lvl1("adding the first tx - this should fail")
-	tx1, err := createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, s.value, s.signer, 1)
+	tx1, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), dummyContract, b.Value, b.Signer, 1)
 	require.NoError(t, err)
 	atx := &AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx1,
 		InclusionWait: 5,
 	}
@@ -315,20 +306,20 @@ func TestService_AddTransaction_WrongNode(t *testing.T) {
 
 	// Adding outside to roster
 	log.Lvl1("Adding new node to the roster")
-	rosterR := onet.NewRoster(append(s.roster.List, outside.ServerIdentity()))
-	ctx, _ := createConfigTxWithCounter(t, testInterval, *rosterR, defaultMaxBlockSize, s, 1)
-	s.sendTxAndWait(t, ctx, 10)
+	rosterR := onet.NewRoster(append(b.Roster.List, outside.ServerIdentity()))
+	ctx, _ := createConfigTxWithCounter(t, b.PropagationInterval, *rosterR, defaultMaxBlockSize, b, 1)
+	b.SendTxAndWait(ctx, 10)
 
 	// force the synchronization as the new node needs to get the
 	// propagation to know about the skipchain but we're not testing that
 	// here
-	proof, err := s.service().db().GetProof(s.genesis.Hash)
+	proof, err := b.Service().db().GetProof(b.Genesis.Hash)
 	require.NoError(t, err)
 	_, err = outside.db().StoreBlocks(proof)
 	require.NoError(t, err)
 
 	log.Lvl1("adding tx to now included node")
-	atx.Transaction, err = createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, s.value, s.signer, 2)
+	atx.Transaction, err = createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), dummyContract, b.Value, b.Signer, 2)
 	require.NoError(t, err)
 	resp, err := outside.AddTransaction(atx)
 	transactionOK(t, resp, err)
@@ -339,44 +330,44 @@ func TestService_AddTransaction_WrongNode(t *testing.T) {
 func TestService_AddTransaction_ValidInvalid(t *testing.T) {
 	defer log.SetShowTime(log.ShowTime())
 	log.SetShowTime(true)
-	s := newSerN(t, 1, testInterval, 4, disableViewChange)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	// add the first tx to create the instance
 	log.Lvl1("Adding the first tx")
 	dcID := random.Bits(256, false, random.New())
-	tx1, err := createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, dcID, s.signer, 1)
+	tx1, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), dummyContract, dcID, b.Signer, 1)
 	require.NoError(t, err)
 	atx := &AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx1,
 		InclusionWait: 5,
 	}
-	resp, err := s.service().AddTransaction(atx)
+	resp, err := b.Service().AddTransaction(atx)
 	transactionOK(t, resp, err)
 
 	// add a second tx that holds two instructions: one valid and one invalid (creates the same contract)
 	log.Lvl1("Adding the second tx")
 	instr1 := createInvokeInstr(NewInstanceID(dcID), ContractDarcID, cmdDarcEvolve, "data", dcID)
-	instr1.SignerIdentities = []darc.Identity{s.signer.Identity()}
+	instr1.SignerIdentities = []darc.Identity{b.Signer.Identity()}
 	instr1.SignerCounter = []uint64{2}
-	instr2 := createSpawnInstr(s.darc.GetBaseID(), dummyContract, "data", dcID)
-	instr2.SignerIdentities = []darc.Identity{s.signer.Identity()}
+	instr2 := createSpawnInstr(b.GenesisDarc.GetBaseID(), dummyContract, "data", dcID)
+	instr2.SignerIdentities = []darc.Identity{b.Signer.Identity()}
 	instr2.SignerCounter = []uint64{3}
 	tx2 := NewClientTransaction(CurrentVersion, instr1, instr2)
 	h := tx2.Instructions.Hash()
 	for i := range tx2.Instructions {
-		err := tx2.Instructions[i].SignWith(h, s.signer)
+		err := tx2.Instructions[i].SignWith(h, b.Signer)
 		require.NoError(t, err)
 	}
 	atx = &AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx2,
 		InclusionWait: 5,
 	}
-	resp, err = s.service().AddTransaction(atx)
+	resp, err = b.Service().AddTransaction(atx)
 	require.NoError(t, err)
 	require.Contains(t, resp.Error, "contract darc tried to create existing instanceID")
 
@@ -384,20 +375,20 @@ func TestService_AddTransaction_ValidInvalid(t *testing.T) {
 	log.Lvl1("Adding a third, valid tx")
 	instr1 = createInvokeInstr(NewInstanceID(dcID), ContractDarcID, cmdDarcEvolve, "data", dcID)
 	instr1.SignerCounter = []uint64{2}
-	instr1.SignerIdentities = []darc.Identity{s.signer.Identity()}
+	instr1.SignerIdentities = []darc.Identity{b.Signer.Identity()}
 	dcID2 := random.Bits(256, true, random.New())
-	instr2 = createSpawnInstr(s.darc.GetBaseID(), dummyContract, "data", dcID2)
+	instr2 = createSpawnInstr(b.GenesisDarc.GetBaseID(), dummyContract, "data", dcID2)
 	instr2.SignerCounter = []uint64{3}
-	instr2.SignerIdentities = []darc.Identity{s.signer.Identity()}
+	instr2.SignerIdentities = []darc.Identity{b.Signer.Identity()}
 	tx3 := NewClientTransaction(CurrentVersion, instr1, instr2)
-	tx3.SignWith(s.signer)
+	tx3.SignWith(b.Signer)
 	atx = &AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx3,
 		InclusionWait: 5,
 	}
-	resp, err = s.service().AddTransaction(atx)
+	resp, err = b.Service().AddTransaction(atx)
 	transactionOK(t, resp, err)
 }
 
@@ -406,34 +397,35 @@ func TestService_AddTransaction_ValidInvalid(t *testing.T) {
 func TestService_AddTransaction_Parallel(t *testing.T) {
 	defer log.SetShowTime(log.ShowTime())
 	log.SetShowTime(true)
-	s := newSerN(t, 1, testInterval, 4, disableViewChange)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	// add the first tx to create the instance
 	log.Lvl1("Adding a tx twice")
 	dcID := random.Bits(256, false, random.New())
-	tx1, err := createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, dcID, s.signer, 1)
+	tx1, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), dummyContract, dcID, b.Signer, 1)
 	require.NoError(t, err)
 	atx := &AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx1,
 		InclusionWait: 0,
 	}
 
 	// This is somewhat racy, as we could just fall between the creation of a block. So fingers crossed that
 	// both transactions are sent to the same block.
-	resp, err := s.service().AddTransaction(atx)
+	resp, err := b.Service().AddTransaction(atx)
 	transactionOK(t, resp, err)
-	atx.InclusionWait = 5
-	resp, err = s.services[1].AddTransaction(atx)
+	atx2 := atx
+	atx2.InclusionWait = 5
+	resp, err = b.Services[1].AddTransaction(atx2)
 	transactionOK(t, resp, err)
 
 	// Get latest block and count the number of transactions
-	proof, err := s.service().GetProof(&GetProof{
+	proof, err := b.Service().GetProof(&GetProof{
 		Version: CurrentVersion,
 		Key:     tx1.Instructions[0].DeriveID("").Slice(),
-		ID:      s.genesis.Hash,
+		ID:      b.Genesis.Hash,
 	})
 	require.NoError(t, err)
 	var payload DataBody
@@ -443,22 +435,22 @@ func TestService_AddTransaction_Parallel(t *testing.T) {
 	// Test if the same transaction is still rejected a block later - it should be rejected.
 	log.Lvl1("Adding same tx again")
 	atx.InclusionWait = 0
-	resp, err = s.services[1].AddTransaction(atx)
+	resp, err = b.Services[1].AddTransaction(atx)
 	transactionOK(t, resp, err)
 
 	log.Lvl1("Adding another transaction to create block")
 	dcID = random.Bits(256, false, random.New())
-	atx.Transaction, err = createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, dcID, s.signer, 2)
+	atx.Transaction, err = createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), dummyContract, dcID, b.Signer, 2)
 	require.NoError(t, err)
 	atx.InclusionWait = 5
-	resp, err = s.services[1].AddTransaction(atx)
+	resp, err = b.Services[1].AddTransaction(atx)
 	transactionOK(t, resp, err)
 
 	// Get latest block and make sure that it didn't get added
-	proof, err = s.service().GetProof(&GetProof{
+	proof, err = b.Service().GetProof(&GetProof{
 		Version: CurrentVersion,
 		Key:     tx1.Instructions[0].DeriveID("").Slice(),
-		ID:      s.genesis.Hash,
+		ID:      b.Genesis.Hash,
 	})
 	require.NoError(t, err)
 	// No idea why the payload needs to be reset here - probably an error in the protobuf library.
@@ -472,58 +464,62 @@ func TestService_AddTransactionVersion(t *testing.T) {
 	testNoUpgradeBlockVersion = true
 	defer func() { testNoUpgradeBlockVersion = false }()
 
-	s := newSerWithVersion(t, 1, testInterval, 4, disableViewChange, 0)
-	defer s.local.CloseAll()
+	bArgs := NewBCTestArgs()
+	bArgs.Version = 0
+	b := NewBCTestWithArgs(t, bArgs)
+	defer b.CloseAll()
 
 	// Send the first tx with a version 0 of the ByzCoin protocol. The contract
 	// checks that the value is equal to the version.
-	tx1, err := createOneClientTxWithCounter(s.darc.GetBaseID(), versionContract, []byte{0}, s.signer, 1)
+	tx1, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), versionContract, []byte{0}, b.Signer, 1)
 	require.NoError(t, err)
 	atx := &AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx1,
 		InclusionWait: 10,
 	}
-	_, err = s.service().AddTransaction(atx)
+	_, err = b.Service().AddTransaction(atx)
 	require.NoError(t, err)
 
 	// Upgrade the chain with a special block.
 	testNoUpgradeBlockVersion = false
-	_, err = s.service().createUpgradeVersionBlock(s.genesis.Hash, 1)
+	_, err = b.Service().createUpgradeVersionBlock(b.Genesis.Hash, 1)
 	testNoUpgradeBlockVersion = true
 	require.NoError(t, err)
 
 	// Send another tx this time for the version 1 of the ByzCoin protocol.
-	tx2, err := createOneClientTxWithCounter(s.darc.GetBaseID(), versionContract, []byte{1}, s.signer, 2)
+	tx2, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), versionContract, []byte{1}, b.Signer, 2)
 	require.NoError(t, err)
 	atx = &AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx2,
 		InclusionWait: 10,
 	}
-	_, err = s.service().AddTransaction(atx)
+	_, err = b.Service().AddTransaction(atx)
 	require.NoError(t, err)
 
 	// This one will fail as the version must be 1.
-	tx3, err := createOneClientTxWithCounter(s.darc.GetBaseID(), versionContract, []byte{0}, s.signer, 3)
+	tx3, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), versionContract, []byte{0}, b.Signer, 3)
 	require.NoError(t, err)
 	atx = &AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx3,
 		InclusionWait: 10,
 	}
-	reply, err := s.service().AddTransaction(atx)
+	reply, err := b.Service().AddTransaction(atx)
 	require.NoError(t, err)
 	require.Contains(t, reply.Error, "wrong byzcoin version")
 }
 
 func TestService_AutomaticVersionUpgrade(t *testing.T) {
 	// Creates a chain starting with version 0.
-	s := newSerWithVersion(t, 1, testInterval, 4, disableViewChange, 0)
-	defer s.local.CloseAll()
+	bArgs := NewBCTestArgs()
+	bArgs.Version = 0
+	b := NewBCTestWithArgs(t, bArgs)
+	defer b.CloseAll()
 
 	closing := make(chan bool)
 	wg := sync.WaitGroup{}
@@ -542,15 +538,15 @@ func TestService_AutomaticVersionUpgrade(t *testing.T) {
 			default:
 			}
 
-			tx, err := createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, []byte{}, s.signer, c)
+			tx, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), dummyContract, []byte{}, b.Signer, c)
 			require.NoError(t, err)
 			atx := &AddTxRequest{
 				Version:       CurrentVersion,
-				SkipchainID:   s.genesis.SkipChainID(),
+				SkipchainID:   b.Genesis.SkipChainID(),
 				Transaction:   tx,
 				InclusionWait: wait,
 			}
-			_, err = s.service().AddTransaction(atx)
+			_, err = b.Service().AddTransaction(atx)
 			require.NoError(t, err)
 
 			c++
@@ -558,22 +554,22 @@ func TestService_AutomaticVersionUpgrade(t *testing.T) {
 		}
 	}(closing)
 
-	time.Sleep(testInterval)
+	time.Sleep(b.PropagationInterval)
 
 	// Simulate an upgrade of the conodes.
-	for _, srv := range s.services {
+	for _, srv := range b.Services {
 		srv.defaultVersionLock.Lock()
 		srv.defaultVersion = CurrentVersion
 		srv.defaultVersionLock.Unlock()
 	}
 
 	for i := 0; i < 10; i++ {
-		time.Sleep(testInterval)
+		time.Sleep(b.PropagationInterval)
 
-		proof, err := s.service().GetProof(&GetProof{
+		proof, err := b.Service().GetProof(&GetProof{
 			Version: CurrentVersion,
 			Key:     NewInstanceID([]byte{}).Slice(),
-			ID:      s.genesis.Hash,
+			ID:      b.Genesis.Hash,
 		})
 		require.NoError(t, err)
 
@@ -593,19 +589,21 @@ func TestService_AutomaticVersionUpgrade(t *testing.T) {
 }
 
 func TestService_GetProof(t *testing.T) {
-	s := newSer(t, 2, testInterval)
-	defer s.local.CloseAll()
+	bArgs := NewBCTestArgs()
+	bArgs.Step = 2
+	b := NewBCTestWithArgs(t, bArgs)
+	defer b.CloseAll()
 
-	serKey := s.tx.Instructions[0].Hash()
+	serKey := b.CTx.Instructions[0].Hash()
 
 	var rep *GetProofResponse
 	var i int
 	for i = 0; i < 10; i++ {
-		time.Sleep(2 * s.interval)
+		time.Sleep(2 * b.PropagationInterval)
 		var err error
-		rep, err = s.service().GetProof(&GetProof{
+		rep, err = b.Service().GetProof(&GetProof{
 			Version: CurrentVersion,
-			ID:      s.genesis.SkipChainID(),
+			ID:      b.Genesis.SkipChainID(),
 			Key:     serKey,
 		})
 		require.NoError(t, err)
@@ -617,26 +615,26 @@ func TestService_GetProof(t *testing.T) {
 	key, v0, _, _, err := rep.Proof.KeyValue()
 	require.Equal(t, key, serKey)
 	require.NoError(t, err)
-	require.Nil(t, rep.Proof.Verify(s.genesis.SkipChainID()))
+	require.Nil(t, rep.Proof.Verify(b.Genesis.SkipChainID()))
 	require.Equal(t, serKey, key)
-	require.Equal(t, s.value, v0)
+	require.Equal(t, b.Value, v0)
 
 	// Modify the key and we should not be able to get the proof.
 	wrongKey := append(serKey, byte(0))
-	rep, err = s.service().GetProof(&GetProof{
+	rep, err = b.Service().GetProof(&GetProof{
 		Version: CurrentVersion,
-		ID:      s.genesis.SkipChainID(),
+		ID:      b.Genesis.SkipChainID(),
 		Key:     wrongKey,
 	})
 	require.NoError(t, err)
-	require.NoError(t, rep.Proof.Verify(s.genesis.SkipChainID()))
+	require.NoError(t, rep.Proof.Verify(b.Genesis.SkipChainID()))
 	_, _, _, err = rep.Proof.Get(wrongKey)
 	require.Error(t, err)
 }
 
 func TestService_DarcProxy(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	email := "test@example.com"
 	ed := eddsa.NewEdDSA(cothority.Suite.RandomStream())
@@ -646,11 +644,11 @@ func TestService_DarcProxy(t *testing.T) {
 	id := signer.Identity()
 
 	// Evolve the genesis Darc to have a rule for OpenID signing
-	d2 := s.darc.Copy()
-	require.Nil(t, d2.EvolveFrom(s.darc))
+	d2 := b.GenesisDarc.Copy()
+	require.Nil(t, d2.EvolveFrom(b.GenesisDarc))
 	err := d2.Rules.UpdateRule("spawn:dummy", expression.Expr(id.String()))
 	require.NoError(t, err)
-	s.testDarcEvolution(t, *d2, false)
+	b.TestDarcEvolution(*d2, false)
 
 	ga := func(msg []byte) ([]byte, error) {
 		h := sha256.New()
@@ -684,9 +682,9 @@ func TestService_DarcProxy(t *testing.T) {
 	err = ctx.FillSignersAndSignWith(signer)
 	require.NoError(t, err)
 
-	resp, err := s.service().AddTransaction(&AddTxRequest{
+	resp, err := b.Service().AddTransaction(&AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   ctx,
 		InclusionWait: 10,
 	})
@@ -694,38 +692,38 @@ func TestService_DarcProxy(t *testing.T) {
 }
 
 func TestService_WrongSigner(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
-	in1 := createSpawnInstr(s.darc.GetBaseID(), dummyContract, "data", []byte("whatever"))
+	in1 := createSpawnInstr(b.GenesisDarc.GetBaseID(), dummyContract, "data", []byte("whatever"))
 	in1.SignerCounter = []uint64{1}
 
 	signer := darc.NewSignerEd25519(nil, nil)
 	tx, err := combineInstrsAndSign(signer, in1)
 	require.NoError(t, err)
 
-	resp, err := s.services[0].AddTransaction(&AddTxRequest{
+	resp, err := b.Services[0].AddTransaction(&AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx,
 		InclusionWait: 2,
 	})
-	// Expect it to not be accepted, because only s.signer is in the Darc
+	// Expect it to not be accepted, because only b.signer is in the Darc
 	require.NoError(t, err)
 	require.Contains(t, resp.Error, "instruction verification failed: evaluating darc: expression evaluated to false")
 }
 
 // Test that inter-instruction dependencies are correctly handled.
 func TestService_Depending(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	// Create a client tx with two instructions in it where the second one
 	// depends on the first one having executed.
 
 	// First instruction: spawn a dummy value.
-	in1 := createSpawnInstr(s.darc.GetBaseID(), dummyContract, "data", []byte("something to delete"))
-	in1.SignerIdentities = []darc.Identity{s.signer.Identity()}
+	in1 := createSpawnInstr(b.GenesisDarc.GetBaseID(), dummyContract, "data", []byte("something to delete"))
+	in1.SignerIdentities = []darc.Identity{b.Signer.Identity()}
 	in1.SignerCounter = []uint64{1}
 
 	// Second instruction: delete the value we just spawned.
@@ -735,21 +733,21 @@ func TestService_Depending(t *testing.T) {
 			ContractID: dummyContract,
 		},
 	}
-	in2.SignerIdentities = []darc.Identity{s.signer.Identity()}
+	in2.SignerIdentities = []darc.Identity{b.Signer.Identity()}
 	in2.SignerCounter = []uint64{2}
 
-	tx, err := combineInstrsAndSign(s.signer, in1, in2)
+	tx, err := combineInstrsAndSign(b.Signer, in1, in2)
 	require.NoError(t, err)
 
-	resp, err := s.services[0].AddTransaction(&AddTxRequest{
+	resp, err := b.Services[0].AddTransaction(&AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx,
 		InclusionWait: 2,
 	})
 	transactionOK(t, resp, err)
 
-	cdb, err := s.service().getStateTrie(s.genesis.SkipChainID())
+	cdb, err := b.Service().getStateTrie(b.Genesis.SkipChainID())
 	require.NoError(t, err)
 	_, _, _, _, err = cdb.GetValues(in1.Hash())
 	require.Error(t, err)
@@ -763,10 +761,10 @@ func TestService_Depending(t *testing.T) {
 }
 
 func TestService_BadDataHeader(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
-	ser := s.services[0]
+	ser := b.Services[0]
 	c := ser.Context
 	err := skipchain.RegisterVerification(c, Verify, func(newID []byte, newSB *skipchain.SkipBlock) bool {
 		// Hack up the DataHeader to make the TrieRoot the wrong size.
@@ -782,11 +780,11 @@ func TestService_BadDataHeader(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	tx, err := createOneClientTx(s.darc.GetBaseID(), dummyContract, s.value, s.signer)
+	tx, err := createOneClientTx(b.GenesisDarc.GetBaseID(), dummyContract, b.Value, b.Signer)
 	require.NoError(t, err)
 	_, err = ser.AddTransaction(&AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx,
 		InclusionWait: 5,
 	})
@@ -815,18 +813,21 @@ func TestService_WaitInclusion(t *testing.T) {
 }
 
 func waitInclusion(t *testing.T, client int) {
-	s := newSer(t, 2, 2*time.Second)
-	defer s.local.CloseAll()
+	bArgs := NewBCTestArgs()
+	bArgs.Step = 2
+	bArgs.PropagationInterval = 2 * time.Second
+	b := NewBCTestWithArgs(t, bArgs)
+	defer b.CloseAll()
 
 	// Get counter
-	counterResponse, err := s.service().GetSignerCounters(&GetSignerCounters{
-		SignerIDs:   []string{s.signer.Identity().String()},
-		SkipchainID: s.genesis.SkipChainID(),
+	counterResponse, err := b.Service().GetSignerCounters(&GetSignerCounters{
+		SignerIDs:   []string{b.Signer.Identity().String()},
+		SkipchainID: b.Genesis.SkipChainID(),
 	})
 	require.NoError(t, err)
 	counter := uint64(counterResponse.Counters[0])
 
-	cl := NewClient(s.genesis.SkipChainID(), *s.roster)
+	cl := NewClient(b.Genesis.SkipChainID(), *b.Roster)
 	success := false
 	for try := 0; try < 10; try++ {
 		// Create a transaction without waiting, we do not use sendTransactionWithCounter
@@ -835,12 +836,12 @@ func waitInclusion(t *testing.T, client int) {
 		log.Lvl1("Create transaction and don't wait")
 		for i := 0; i < 2; i++ {
 			counter++
-			tx, err := createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, s.value, s.signer, counter)
+			tx, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), dummyContract, b.Value, b.Signer, counter)
 			require.NoError(t, err)
-			ser := s.services[client]
+			ser := b.Services[client]
 			resp, err := ser.AddTransaction(&AddTxRequest{
 				Version:       CurrentVersion,
-				SkipchainID:   s.genesis.SkipChainID(),
+				SkipchainID:   b.Genesis.SkipChainID(),
 				Transaction:   tx,
 				InclusionWait: 0,
 			})
@@ -849,7 +850,7 @@ func waitInclusion(t *testing.T, client int) {
 
 		log.Lvl1("Create correct transaction and wait")
 		counter++
-		pr, k, resp, err, err2 := sendTransactionWithCounter(t, s, client, dummyContract, 10, counter)
+		pr, k, resp, err, err2 := sendTransactionWithCounter(t, b, client, dummyContract, 10, counter)
 		transactionOK(t, resp, err)
 		require.NoError(t, err2)
 		require.True(t, pr.InclusionProof.Match(k))
@@ -867,7 +868,7 @@ func waitInclusion(t *testing.T, client int) {
 
 	log.Lvl1("Create wrong transaction and wait")
 	counter++
-	pr, _, resp, err, err2 := sendTransactionWithCounter(t, s, client,
+	pr, _, resp, err, err2 := sendTransactionWithCounter(t, b, client,
 		invalidContract, 10, counter)
 	require.NoError(t, err)
 	require.Contains(t, resp.Error, "this invalid contract always returns an error")
@@ -881,14 +882,14 @@ func waitInclusion(t *testing.T, client int) {
 	require.False(t, txr[0].Accepted)
 
 	log.Lvl1("Create wrong transaction, no wait")
-	_, _, _, err, err2 = sendTransactionWithCounter(t, s, client,
+	_, _, _, err, err2 = sendTransactionWithCounter(t, b, client,
 		invalidContract, 0, counter)
 	require.NoError(t, err)
 	require.NoError(t, err2)
 
 	log.Lvl1("Create second correct transaction and wait")
 	var k []byte
-	pr, k, resp, err, err2 = sendTransactionWithCounter(t, s, client, dummyContract, 10, counter)
+	pr, k, resp, err, err2 = sendTransactionWithCounter(t, b, client, dummyContract, 10, counter)
 	transactionOK(t, resp, err)
 	require.NoError(t, err2)
 	require.True(t, pr.InclusionProof.Match(k))
@@ -902,7 +903,7 @@ func waitInclusion(t *testing.T, client int) {
 		require.True(t, txr[0].Accepted)
 
 		// Look in the previous block for the failed one.
-		prev := s.service().db().GetByID(pr.Latest.BackLinkIDs[0])
+		prev := b.Service().db().GetByID(pr.Latest.BackLinkIDs[0])
 		require.NotNil(t, prev)
 		txr, err = txResultsFromBlock(prev)
 		require.NoError(t, err)
@@ -920,28 +921,30 @@ func waitInclusion(t *testing.T, client int) {
 // Sends too many transactions to the ledger and waits for all blocks to be
 // done.
 func TestService_FloodLedger(t *testing.T) {
-	s := newSer(t, 2, testInterval)
-	defer s.local.CloseAll()
+	bArgs := NewBCTestArgs()
+	bArgs.Step = 2
+	b := NewBCTestWithArgs(t, bArgs)
+	defer b.CloseAll()
 
 	// ask to the root service because of propagation delay
-	before, err := s.service().db().GetLatestByID(s.genesis.Hash)
+	before, err := b.Service().db().GetLatestByID(b.Genesis.Hash)
 	require.NoError(t, err)
 
 	log.Lvl1("Create 10 transactions and don't wait")
 	n := 10
 	for i := 0; i < n; i++ {
-		_, _, resp, err, err2 := sendTransactionWithCounter(t, s, 0, slowContract, 0, uint64(i)+2)
+		_, _, resp, err, err2 := sendTransactionWithCounter(t, b, 0, slowContract, 0, uint64(i)+2)
 		transactionOK(t, resp, err)
 		require.NoError(t, err2)
 	}
 	// Send a last transaction and wait for it to be included
-	_, _, resp, err, err2 := sendTransactionWithCounter(t, s, 0, dummyContract, 10, uint64(n)+2)
+	_, _, resp, err, err2 := sendTransactionWithCounter(t, b, 0, dummyContract, 10, uint64(n)+2)
 	transactionOK(t, resp, err)
 	require.NoError(t, err2)
 
 	// Suppose we need at least 2 blocks (slowContract waits 1/5 interval
 	// for each execution)
-	latest, err := s.service().db().GetLatestByID(s.genesis.Hash)
+	latest, err := b.Service().db().GetLatestByID(b.Genesis.Hash)
 	require.NoError(t, err)
 	if latest.Index-before.Index < 2 {
 		t.Fatalf("didn't get at least 2 blocks: index before %d, index after %v", before.Index, latest.Index)
@@ -953,32 +956,34 @@ func TestService_BigTx(t *testing.T) {
 	// blocks gets to be too close to the edge with the normal short
 	// testing interval, and starts generating
 	// errors-that-might-not-be-errors.
-	s := newSer(t, 1, 2*time.Second)
-	defer s.local.CloseAll()
+	bArgss := NewBCTestArgs()
+	bArgss.PropagationInterval = 2 * time.Second
+	b := NewBCTestWithArgs(t, bArgss)
+	defer b.CloseAll()
 
-	smallVal := s.value
+	smallVal := b.Value
 
 	// Try to send a value so big it will be refused.
-	s.value = make([]byte, defaultMaxBlockSize+1)
-	_, _, _, e1, e2 := sendTransaction(t, s, 0, dummyContract, 0)
+	b.Value = make([]byte, defaultMaxBlockSize+1)
+	_, _, _, e1, e2 := sendTransaction(t, b, 0, dummyContract, 0)
 	require.Error(t, e1)
 	require.Contains(t, "transaction too large", e1.Error())
 	require.NoError(t, e2)
 
 	// Now send values that are 3/4 as big as one block.
-	s.value = make([]byte, defaultMaxBlockSize/4*3)
+	b.Value = make([]byte, defaultMaxBlockSize/4*3)
 
 	log.Lvl1("Create 2 giant transactions and 1 little one, wait for the 3rd one")
-	_, _, resp, e1, e2 := sendTransactionWithCounter(t, s, 0, dummyContract, 0, 1)
+	_, _, resp, e1, e2 := sendTransactionWithCounter(t, b, 0, dummyContract, 0, 1)
 	transactionOK(t, resp, e1)
 	require.NoError(t, e2)
-	_, _, resp, e1, e2 = sendTransactionWithCounter(t, s, 0, dummyContract, 0, 2)
+	_, _, resp, e1, e2 = sendTransactionWithCounter(t, b, 0, dummyContract, 0, 2)
 	transactionOK(t, resp, e1)
 	require.NoError(t, e2)
 
 	// Back to little values again for the last tx.
-	s.value = smallVal
-	p, k, resp, e1, e2 := sendTransactionWithCounter(t, s, 0, dummyContract, 10, 3)
+	b.Value = smallVal
+	p, k, resp, e1, e2 := sendTransactionWithCounter(t, b, 0, dummyContract, 10, 3)
 	transactionOK(t, resp, e1)
 	require.NoError(t, e2)
 	require.True(t, p.InclusionProof.Match(k))
@@ -991,36 +996,36 @@ func TestService_BigTx(t *testing.T) {
 	require.Equal(t, 2, len(txr))
 }
 
-func sendTransaction(t *testing.T, s *ser, client int, kind string, wait int) (Proof, []byte, *AddTxResponse, error, error) {
-	counterResponse, err := s.service().GetSignerCounters(&GetSignerCounters{
-		SignerIDs:   []string{s.signer.Identity().String()},
-		SkipchainID: s.genesis.SkipChainID(),
+func sendTransaction(t *testing.T, s *BCTest, client int, kind string, wait int) (Proof, []byte, *AddTxResponse, error, error) {
+	counterResponse, err := s.Service().GetSignerCounters(&GetSignerCounters{
+		SignerIDs:   []string{s.Signer.Identity().String()},
+		SkipchainID: s.Genesis.SkipChainID(),
 	})
 	require.NoError(t, err)
 	return sendTransactionWithCounter(t, s, client, kind, wait, counterResponse.Counters[0]+1)
 }
 
-func sendTransactionWithCounter(t *testing.T, s *ser, client int, kind string, wait int, counter uint64) (Proof, []byte, *AddTxResponse, error, error) {
-	tx, err := createOneClientTxWithCounter(s.darc.GetBaseID(), kind, s.value, s.signer, counter)
+func sendTransactionWithCounter(t *testing.T, s *BCTest, client int, kind string, wait int, counter uint64) (Proof, []byte, *AddTxResponse, error, error) {
+	tx, err := createOneClientTxWithCounter(s.GenesisDarc.GetBaseID(), kind, s.Value, s.Signer, counter)
 	require.NoError(t, err)
 	key := tx.Instructions[0].Hash()
-	ser := s.services[client]
+	ser := s.Services[client]
 	var resp *AddTxResponse
 	resp, err = ser.AddTransaction(&AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   s.Genesis.SkipChainID(),
 		Transaction:   tx,
 		InclusionWait: wait,
 	})
 
 	for isProcessing := true; isProcessing && wait != 0; {
-		isProcessing = ser.skService().ChainIsProcessing(s.genesis.SkipChainID())
-		time.Sleep(s.interval)
+		isProcessing = ser.skService().ChainIsProcessing(s.Genesis.SkipChainID())
+		time.Sleep(s.PropagationInterval)
 	}
 
 	rep, err2 := ser.GetProof(&GetProof{
 		Version: CurrentVersion,
-		ID:      s.genesis.SkipChainID(),
+		ID:      s.Genesis.SkipChainID(),
 		Key:     key,
 	})
 
@@ -1032,14 +1037,14 @@ func sendTransactionWithCounter(t *testing.T, s *ser, client int, kind string, w
 	return proof, key, resp, err, err2
 }
 
-func (s *ser) sendInstructions(t *testing.T, wait int,
+func (b *BCTest) sendInstructions(t *testing.T, wait int,
 	instr ...Instruction) (resp *AddTxResponse, ctx ClientTransaction) {
 	var err error
-	ctx, err = combineInstrsAndSign(s.signer, instr...)
+	ctx, err = combineInstrsAndSign(b.Signer, instr...)
 	require.NoError(t, err)
-	resp, err = s.service().AddTransaction(&AddTxRequest{
+	resp, err = b.Service().AddTransaction(&AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   ctx,
 		InclusionWait: wait,
 	})
@@ -1048,31 +1053,31 @@ func (s *ser) sendInstructions(t *testing.T, wait int,
 }
 
 func TestService_InvalidVerification(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
-	for _, s := range s.services {
+	for _, s := range b.Services {
 		s.testRegisterContract(panicContract, adaptor(panicContractFunc))
 	}
 
 	// tx0 uses the panicing contract, so it should _not_ be stored.
 	value1 := []byte("a")
-	tx0, err := createOneClientTx(s.darc.GetBaseID(), "panic", value1, s.signer)
+	tx0, err := createOneClientTx(b.GenesisDarc.GetBaseID(), "panic", value1, b.Signer)
 	require.NoError(t, err)
-	akvresp, err := s.service().AddTransaction(&AddTxRequest{
+	akvresp, err := b.Service().AddTransaction(&AddTxRequest{
 		Version:     CurrentVersion,
-		SkipchainID: s.genesis.SkipChainID(),
+		SkipchainID: b.Genesis.SkipChainID(),
 		Transaction: tx0,
 	})
 	transactionOK(t, akvresp, err)
 	require.Equal(t, CurrentVersion, akvresp.Version)
 
 	// tx1 uses the invalid contract, so it should _not_ be stored.
-	tx1, err := createOneClientTx(s.darc.GetBaseID(), invalidContract, value1, s.signer)
+	tx1, err := createOneClientTx(b.GenesisDarc.GetBaseID(), invalidContract, value1, b.Signer)
 	require.NoError(t, err)
-	akvresp, err = s.service().AddTransaction(&AddTxRequest{
+	akvresp, err = b.Service().AddTransaction(&AddTxRequest{
 		Version:     CurrentVersion,
-		SkipchainID: s.genesis.SkipChainID(),
+		SkipchainID: b.Genesis.SkipChainID(),
 		Transaction: tx1,
 	})
 	transactionOK(t, akvresp, err)
@@ -1080,11 +1085,11 @@ func TestService_InvalidVerification(t *testing.T) {
 
 	// tx2 uses the dummy kind, its value should be stored.
 	value2 := []byte("b")
-	tx2, err := createOneClientTx(s.darc.GetBaseID(), dummyContract, value2, s.signer)
+	tx2, err := createOneClientTx(b.GenesisDarc.GetBaseID(), dummyContract, value2, b.Signer)
 	require.NoError(t, err)
-	akvresp, err = s.service().AddTransaction(&AddTxRequest{
+	akvresp, err = b.Service().AddTransaction(&AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx2,
 		InclusionWait: 10,
 	})
@@ -1092,9 +1097,9 @@ func TestService_InvalidVerification(t *testing.T) {
 	require.Equal(t, CurrentVersion, akvresp.Version)
 
 	// Check that tx1 is _not_ stored.
-	pr, err := s.service().GetProof(&GetProof{
+	pr, err := b.Service().GetProof(&GetProof{
 		Version: CurrentVersion,
-		ID:      s.genesis.SkipChainID(),
+		ID:      b.Genesis.SkipChainID(),
 		Key:     tx1.Instructions[0].Hash(),
 	})
 	require.NoError(t, err)
@@ -1102,9 +1107,9 @@ func TestService_InvalidVerification(t *testing.T) {
 	require.False(t, match)
 
 	// Check that tx2 is stored.
-	pr, err = s.service().GetProof(&GetProof{
+	pr, err = b.Service().GetProof(&GetProof{
 		Version: CurrentVersion,
-		ID:      s.genesis.SkipChainID(),
+		ID:      b.Genesis.SkipChainID(),
 		Key:     tx2.Instructions[0].Hash(),
 	})
 	require.NoError(t, err)
@@ -1113,23 +1118,22 @@ func TestService_InvalidVerification(t *testing.T) {
 
 	// TODO: This sleep is required for the same reason as the problem
 	// documented in TestService_CloseAllDeadlock. How to fix it correctly?
-	time.Sleep(2 * s.interval)
+	time.Sleep(2 * b.PropagationInterval)
 }
 
 func TestService_LoadBlockInfo(t *testing.T) {
-	interval := 200 * time.Millisecond
-	s := newSer(t, 1, interval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
-	dur, sz, err := s.service().LoadBlockInfo(s.genesis.SkipChainID())
+	dur, sz, err := b.Service().LoadBlockInfo(b.Genesis.SkipChainID())
 	require.NoError(t, err)
-	require.Equal(t, dur, interval)
+	require.Equal(t, dur, b.PropagationInterval)
 	require.True(t, sz == defaultMaxBlockSize)
 }
 
 func TestService_StateChange(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	var latest int64
 	f := func(cdb ReadOnlyStateTrie, inst Instruction, c []Coin) ([]StateChange, []Coin, error) {
@@ -1181,9 +1185,9 @@ func TestService_StateChange(t *testing.T) {
 		}
 		return nil, nil, xerrors.New("need spawn or invoke")
 	}
-	s.service().testRegisterContract("add", adaptorNoVerify(f))
+	b.Service().testRegisterContract("add", adaptorNoVerify(f))
 
-	cdb, err := s.service().getStateTrie(s.genesis.SkipChainID())
+	cdb, err := b.Service().getStateTrie(b.Genesis.SkipChainID())
 	require.NoError(t, err)
 	require.NotNil(t, cdb)
 
@@ -1225,7 +1229,7 @@ func TestService_StateChange(t *testing.T) {
 	ct2 := ClientTransaction{Instructions: instrs2}
 
 	timestamp := time.Now().UnixNano()
-	_, txOut, scs, _ := s.service().createStateChanges(cdb.MakeStagingStateTrie(), s.genesis.SkipChainID(), NewTxResults(ct1, ct2), noTimeout, CurrentVersion, timestamp)
+	_, txOut, scs, _ := b.Service().createStateChanges(cdb.MakeStagingStateTrie(), b.Genesis.SkipChainID(), NewTxResults(ct1, ct2), noTimeout, CurrentVersion, timestamp)
 	require.Equal(t, 2, len(txOut))
 	require.True(t, txOut[0].Accepted)
 	require.False(t, txOut[1].Accepted)
@@ -1234,8 +1238,8 @@ func TestService_StateChange(t *testing.T) {
 }
 
 func TestService_StateChangeVerification(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	cid := "createSC"
 	iid := NewInstanceID(make([]byte, 32))
@@ -1275,8 +1279,8 @@ func TestService_StateChangeVerification(t *testing.T) {
 			},
 		}, nil, nil
 	}
-	require.NoError(t, s.service().testRegisterContract(cid, adaptorNoVerify(f)))
-	cdb, err := s.service().getStateTrie(s.genesis.SkipChainID())
+	require.NoError(t, b.Service().testRegisterContract(cid, adaptorNoVerify(f)))
+	cdb, err := b.Service().getStateTrie(b.Genesis.SkipChainID())
 	require.NoError(t, err)
 	require.NotNil(t, cdb)
 
@@ -1292,14 +1296,14 @@ func TestService_StateChangeVerification(t *testing.T) {
 	timestamp := time.Now().UnixNano()
 
 	log.Lvl1("Failing updating and removing non-existing instances")
-	mkroot1, txOut, scs, _ := s.service().createStateChanges(cdb.MakeStagingStateTrie(), s.genesis.SkipChainID(), NewTxResults(ClientTransaction{Instructions: Instructions{{
+	mkroot1, txOut, scs, _ := b.Service().createStateChanges(cdb.MakeStagingStateTrie(), b.Genesis.SkipChainID(), NewTxResults(ClientTransaction{Instructions: Instructions{{
 		InstanceID: iid,
 		Invoke:     &Invoke{},
 	}}}), noTimeout, CurrentVersion, timestamp)
 	require.Equal(t, 0, len(scs))
 	require.Equal(t, 1, len(txOut))
 	require.Equal(t, false, txOut[0].Accepted)
-	mkroot2, txOut, scs, _ := s.service().createStateChanges(cdb.MakeStagingStateTrie(), s.genesis.SkipChainID(), NewTxResults(ClientTransaction{Instructions: Instructions{{
+	mkroot2, txOut, scs, _ := b.Service().createStateChanges(cdb.MakeStagingStateTrie(), b.Genesis.SkipChainID(), NewTxResults(ClientTransaction{Instructions: Instructions{{
 		InstanceID: iid,
 		Delete:     &Delete{},
 	}}}), noTimeout, CurrentVersion, timestamp)
@@ -1313,28 +1317,28 @@ func TestService_StateChangeVerification(t *testing.T) {
 		InstanceID: iid,
 		Spawn:      &Spawn{ContractID: cid},
 	}}})
-	mkroot1, txOut, scs, _ = s.service().createStateChanges(cdb.MakeStagingStateTrie(), s.genesis.SkipChainID(), txs, noTimeout, CurrentVersion, timestamp)
+	mkroot1, txOut, scs, _ = b.Service().createStateChanges(cdb.MakeStagingStateTrie(), b.Genesis.SkipChainID(), txs, noTimeout, CurrentVersion, timestamp)
 	require.Equal(t, 3, len(scs))
 	require.Equal(t, 1, len(txOut))
 	require.Equal(t, true, txOut[0].Accepted)
 	require.Nil(t, cdb.StoreAll(scs, 0, CurrentVersion))
 	// Clear cache so that the transactions get re-evaluated
-	delete(s.service().stateChangeCache.cache, string(s.genesis.SkipChainID()))
-	mkroot2, txOut, scs, _ = s.service().createStateChanges(cdb.MakeStagingStateTrie(), s.genesis.SkipChainID(), txs, noTimeout, CurrentVersion, timestamp)
+	delete(b.Service().stateChangeCache.cache, string(b.Genesis.SkipChainID()))
+	mkroot2, txOut, scs, _ = b.Service().createStateChanges(cdb.MakeStagingStateTrie(), b.Genesis.SkipChainID(), txs, noTimeout, CurrentVersion, timestamp)
 	require.Equal(t, 0, len(scs))
 	require.Equal(t, 1, len(txOut))
 	require.Equal(t, false, txOut[0].Accepted)
 	require.True(t, bytes.Equal(mkroot1, mkroot2))
 
 	log.Lvl1("Accept updating and removing existing instance")
-	_, txOut, scs, _ = s.service().createStateChanges(cdb.MakeStagingStateTrie(), s.genesis.SkipChainID(), NewTxResults(ClientTransaction{Instructions: Instructions{{
+	_, txOut, scs, _ = b.Service().createStateChanges(cdb.MakeStagingStateTrie(), b.Genesis.SkipChainID(), NewTxResults(ClientTransaction{Instructions: Instructions{{
 		InstanceID: iid,
 		Invoke:     &Invoke{},
 	}}}), noTimeout, CurrentVersion, timestamp)
 	require.Equal(t, 3, len(scs))
 	require.Equal(t, 1, len(txOut))
 	require.Equal(t, true, txOut[0].Accepted)
-	_, txOut, scs, _ = s.service().createStateChanges(cdb.MakeStagingStateTrie(), s.genesis.SkipChainID(), NewTxResults(ClientTransaction{Instructions: Instructions{{
+	_, txOut, scs, _ = b.Service().createStateChanges(cdb.MakeStagingStateTrie(), b.Genesis.SkipChainID(), NewTxResults(ClientTransaction{Instructions: Instructions{{
 		InstanceID: iid,
 		Delete:     &Delete{},
 	}}}), noTimeout, CurrentVersion, timestamp)
@@ -1344,17 +1348,17 @@ func TestService_StateChangeVerification(t *testing.T) {
 }
 
 func TestService_DarcEvolutionFail(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
-	d2 := s.darc.Copy()
-	require.Nil(t, d2.EvolveFrom(s.darc))
+	d2 := b.GenesisDarc.Copy()
+	require.Nil(t, d2.EvolveFrom(b.GenesisDarc))
 
 	// first try to evolve with the wrong contract ID
 	{
-		counterResponse, err := s.service().GetSignerCounters(&GetSignerCounters{
-			SignerIDs:   []string{s.signer.Identity().String()},
-			SkipchainID: s.genesis.SkipChainID(),
+		counterResponse, err := b.Service().GetSignerCounters(&GetSignerCounters{
+			SignerIDs:   []string{b.Signer.Identity().String()},
+			SkipchainID: b.Genesis.SkipChainID(),
 		})
 		require.NoError(t, err)
 
@@ -1375,13 +1379,13 @@ func TestService_DarcEvolutionFail(t *testing.T) {
 			Invoke:        &invoke,
 			SignerCounter: []uint64{counterResponse.Counters[0] + 1},
 		}
-		resp, _ := s.sendInstructions(t, 10, instr)
+		resp, _ := b.sendInstructions(t, 10, instr)
 		require.Contains(t, resp.Error, "instruction verification failed")
 	}
 
 	// then we create a bad request, i.e., with an invalid version number
 	d2.Version = 11
-	pr := s.testDarcEvolution(t, *d2, true)
+	pr := b.TestDarcEvolution(*d2, true)
 
 	// parse the darc
 	require.True(t, pr.InclusionProof.Match(d2.GetBaseID()))
@@ -1390,20 +1394,20 @@ func TestService_DarcEvolutionFail(t *testing.T) {
 	d22, err := darc.NewFromProtobuf(v0)
 	require.NoError(t, err)
 	require.False(t, d22.Equal(d2))
-	require.True(t, d22.Equal(s.darc))
+	require.True(t, d22.Equal(b.GenesisDarc))
 
 	// finally we do it correctly
 	d2.Version = 1
-	s.testDarcEvolution(t, *d2, false)
+	b.TestDarcEvolution(*d2, false)
 }
 
 func TestService_DarcEvolution(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
-	d2 := s.darc.Copy()
-	require.Nil(t, d2.EvolveFrom(s.darc))
-	pr := s.testDarcEvolution(t, *d2, false)
+	d2 := b.GenesisDarc.Copy()
+	require.Nil(t, d2.EvolveFrom(b.GenesisDarc))
+	pr := b.TestDarcEvolution(*d2, false)
 
 	// parse the darc
 	require.True(t, pr.InclusionProof.Match(d2.GetBaseID()))
@@ -1415,10 +1419,10 @@ func TestService_DarcEvolution(t *testing.T) {
 }
 
 func TestService_DarcSpawn(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
-	id := []darc.Identity{s.signer.Identity()}
+	id := []darc.Identity{b.Signer.Identity()}
 	darc2 := darc.NewDarc(darc.InitRulesWith(id, id, "invoke:"+ContractDarcID+"."+cmdDarcEvolveUnrestriction),
 		[]byte("next darc"))
 	darc2.Rules.AddRule("spawn:rain", darc2.Rules.GetSignExpr())
@@ -1430,7 +1434,7 @@ func TestService_DarcSpawn(t *testing.T) {
 
 	ctx := NewClientTransaction(CurrentVersion,
 		Instruction{
-			InstanceID: NewInstanceID(s.darc.GetBaseID()),
+			InstanceID: NewInstanceID(b.GenesisDarc.GetBaseID()),
 			Spawn: &Spawn{
 				ContractID: ContractDarcID,
 				Args: []Argument{{
@@ -1438,20 +1442,20 @@ func TestService_DarcSpawn(t *testing.T) {
 					Value: darc2Buf,
 				}},
 			},
-			SignerIdentities: []darc.Identity{s.signer.Identity()},
+			SignerIdentities: []darc.Identity{b.Signer.Identity()},
 			SignerCounter:    []uint64{1},
 		},
 	)
-	require.Nil(t, ctx.Instructions[0].SignWith(ctx.Instructions.Hash(), s.signer))
+	require.Nil(t, ctx.Instructions[0].SignWith(ctx.Instructions.Hash(), b.Signer))
 
-	s.sendTx(t, ctx)
-	pr := s.waitProof(t, NewInstanceID(darc2.GetBaseID()))
+	b.SendTx(ctx)
+	pr := b.WaitProof(NewInstanceID(darc2.GetBaseID()))
 	require.True(t, pr.InclusionProof.Match(darc2.GetBaseID()))
 }
 
 func TestService_DarcDelegation(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	// Spawn second darc with a new owner/signer, but delegate its spawn
 	// rule to the first darc
@@ -1459,14 +1463,14 @@ func TestService_DarcDelegation(t *testing.T) {
 	id2 := []darc.Identity{signer2.Identity()}
 	darc2 := darc.NewDarc(darc.InitRules(id2, id2),
 		[]byte("second darc"))
-	darc2.Rules.AddRule("spawn:"+ContractDarcID, expression.InitOrExpr(s.darc.GetIdentityString()))
+	darc2.Rules.AddRule("spawn:"+ContractDarcID, expression.InitOrExpr(b.GenesisDarc.GetIdentityString()))
 	darc2Buf, err := darc2.ToProto()
 	require.NoError(t, err)
 	darc2Copy, err := darc.NewFromProtobuf(darc2Buf)
 	require.NoError(t, err)
 	require.True(t, darc2.Equal(darc2Copy))
 	instr := Instruction{
-		InstanceID: NewInstanceID(s.darc.GetBaseID()),
+		InstanceID: NewInstanceID(b.GenesisDarc.GetBaseID()),
 		Spawn: &Spawn{
 			ContractID: ContractDarcID,
 			Args: []Argument{{
@@ -1476,8 +1480,8 @@ func TestService_DarcDelegation(t *testing.T) {
 		},
 		SignerCounter: []uint64{1},
 	}
-	s.sendInstructions(t, 10, instr)
-	pr := s.waitProof(t, NewInstanceID(darc2.GetBaseID()))
+	b.sendInstructions(t, 10, instr)
+	pr := b.WaitProof(NewInstanceID(darc2.GetBaseID()))
 	require.True(t, pr.InclusionProof.Match(darc2.GetBaseID()))
 
 	// Spawn third darc from the second one, but sign the request with
@@ -1502,14 +1506,14 @@ func TestService_DarcDelegation(t *testing.T) {
 		},
 		SignerCounter: []uint64{2},
 	}
-	s.sendInstructions(t, 10, instr)
-	pr = s.waitProof(t, NewInstanceID(darc3.GetBaseID()))
+	b.sendInstructions(t, 10, instr)
+	pr = b.WaitProof(NewInstanceID(darc3.GetBaseID()))
 	require.True(t, pr.InclusionProof.Match(darc3.GetBaseID()))
 }
 
 func TestService_CheckAuthorization(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	// Spawn second darc with a new owner/signer, but delegate its spawn
 	// rule to the first darc
@@ -1517,14 +1521,14 @@ func TestService_CheckAuthorization(t *testing.T) {
 	id2 := []darc.Identity{signer2.Identity()}
 	darc2 := darc.NewDarc(darc.InitRules(id2, id2),
 		[]byte("second darc"))
-	darc2.Rules.AddRule("spawn:"+ContractDarcID, expression.Expr(s.darc.GetIdentityString()))
+	darc2.Rules.AddRule("spawn:"+ContractDarcID, expression.Expr(b.GenesisDarc.GetIdentityString()))
 	darc2Buf, err := darc2.ToProto()
 	require.NoError(t, err)
 	darc2Copy, err := darc.NewFromProtobuf(darc2Buf)
 	require.NoError(t, err)
 	require.True(t, darc2.Equal(darc2Copy))
 	instr := Instruction{
-		InstanceID: NewInstanceID(s.darc.GetBaseID()),
+		InstanceID: NewInstanceID(b.GenesisDarc.GetBaseID()),
 		Spawn: &Spawn{
 			ContractID: ContractDarcID,
 			Args: []Argument{{
@@ -1534,76 +1538,76 @@ func TestService_CheckAuthorization(t *testing.T) {
 		},
 		SignerCounter: []uint64{1},
 	}
-	s.sendInstructions(t, 10, instr)
-	pr := s.waitProof(t, NewInstanceID(darc2.GetBaseID()))
+	b.sendInstructions(t, 10, instr)
+	pr := b.WaitProof(NewInstanceID(darc2.GetBaseID()))
 	require.True(t, pr.InclusionProof.Match(darc2.GetBaseID()))
 
 	ca := &CheckAuthorization{
 		Version:    CurrentVersion,
-		ByzCoinID:  s.genesis.SkipChainID(),
-		DarcID:     s.darc.GetBaseID(),
-		Identities: []darc.Identity{s.signer.Identity()},
+		ByzCoinID:  b.Genesis.SkipChainID(),
+		DarcID:     b.GenesisDarc.GetBaseID(),
+		Identities: []darc.Identity{b.Signer.Identity()},
 	}
-	resp, err := s.service().CheckAuthorization(ca)
+	resp, err := b.Service().CheckAuthorization(ca)
 	require.NoError(t, err)
 	require.Contains(t, resp.Actions, darc.Action("_sign"))
 
-	ca.Identities[0] = darc.NewIdentityEd25519(s.roster.List[0].Public)
-	resp, err = s.service().CheckAuthorization(ca)
+	ca.Identities[0] = darc.NewIdentityEd25519(b.Roster.List[0].Public)
+	resp, err = b.Service().CheckAuthorization(ca)
 	require.NoError(t, err)
 	require.Contains(t, resp.Actions, darc.Action("invoke:"+ContractConfigID+".view_change"))
 
-	ca.Identities = append(ca.Identities, darc.NewIdentityEd25519(s.roster.List[1].Public))
-	resp, err = s.service().CheckAuthorization(ca)
+	ca.Identities = append(ca.Identities, darc.NewIdentityEd25519(b.Roster.List[1].Public))
+	resp, err = b.Service().CheckAuthorization(ca)
 	require.NoError(t, err)
 	require.Contains(t, resp.Actions, darc.Action("invoke:"+ContractConfigID+".view_change"))
 
 	log.Lvl1("Check delegation of darcs")
 	ca.DarcID = darc2.GetID()
 	ca.Identities[0] = darc.NewSignerEd25519(nil, nil).Identity()
-	resp, err = s.service().CheckAuthorization(ca)
+	resp, err = b.Service().CheckAuthorization(ca)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(resp.Actions))
 
 	ca.DarcID = darc2.GetID()
-	ca.Identities[0] = s.signer.Identity()
-	resp, err = s.service().CheckAuthorization(ca)
+	ca.Identities[0] = b.Signer.Identity()
+	resp, err = b.Service().CheckAuthorization(ca)
 	require.NoError(t, err)
 	require.Contains(t, resp.Actions, darc.Action("spawn:"+ContractDarcID))
 
 	ca.DarcID = darc2.GetID()
-	ca.Identities[0] = darc.NewIdentityDarc(s.darc.GetID())
-	resp, err = s.service().CheckAuthorization(ca)
+	ca.Identities[0] = darc.NewIdentityDarc(b.GenesisDarc.GetID())
+	resp, err = b.Service().CheckAuthorization(ca)
 	require.NoError(t, err)
 	require.Contains(t, resp.Actions, darc.Action("spawn:"+ContractDarcID))
 }
 
 func TestService_GetLeader(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
-	for _, service := range s.services {
+	for _, service := range b.Services {
 		// everyone should have the same leader after the genesis block is stored
-		leader, err := service.getLeader(s.genesis.SkipChainID())
+		leader, err := service.getLeader(b.Genesis.SkipChainID())
 		require.NoError(t, err)
 		require.NotNil(t, leader)
-		require.True(t, leader.Equal(s.services[0].ServerIdentity()))
+		require.True(t, leader.Equal(b.Services[0].ServerIdentity()))
 	}
 }
 
 func TestService_SetConfig(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	interval := 42 * time.Millisecond
 	blocksize := 424242
-	ctx, _ := createConfigTxWithCounter(t, interval, *s.roster, blocksize, s, 1)
-	s.sendTxAndWait(t, ctx, 10)
+	ctx, _ := createConfigTxWithCounter(t, interval, *b.Roster, blocksize, b, 1)
+	b.SendTxAndWait(ctx, 10)
 
-	_, err := s.service().LoadConfig(s.genesis.SkipChainID())
+	_, err := b.Service().LoadConfig(b.Genesis.SkipChainID())
 	require.NoError(t, err)
 
-	newInterval, newBlocksize, err := s.service().LoadBlockInfo(s.genesis.SkipChainID())
+	newInterval, newBlocksize, err := b.Service().LoadBlockInfo(b.Genesis.SkipChainID())
 	require.NoError(t, err)
 	require.Equal(t, interval, newInterval)
 	require.Equal(t, blocksize, newBlocksize)
@@ -1615,19 +1619,21 @@ func TestService_SetConfigRosterKeepLeader(t *testing.T) {
 		n = 2
 	}
 
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	bArgs := NewBCTestArgs()
+	bArgs.Nodes = 4
+	b := NewBCTestWithArgs(t, bArgs)
+	defer b.CloseAll()
 
 	log.Lvl1("Creating blocks to check rotation of the roster while keeping leader")
-	rosterR := s.roster
+	rosterR := b.Roster
 	for i := 0; i < n; i++ {
 		rosterR = onet.NewRoster([]*network.ServerIdentity{
 			rosterR.List[0], rosterR.List[2], rosterR.List[3], rosterR.List[1]})
 		log.Lvl2("Creating block", i)
-		ctx, _ := createConfigTxWithCounter(t, testInterval, *rosterR, defaultMaxBlockSize, s, 1+i)
-		s.sendTxAndWait(t, ctx, 10)
+		ctx, _ := createConfigTxWithCounter(t, b.PropagationInterval, *rosterR, defaultMaxBlockSize, b, 1+i)
+		b.SendTxAndWait(ctx, 10)
 		log.Lvl2("Verifying the correct roster is in place")
-		latest, err := s.service().db().GetLatestByID(s.genesis.Hash)
+		latest, err := b.Service().db().GetLatestByID(b.Genesis.Hash)
 		require.NoError(t, err)
 		equals, err := latest.Roster.Equal(rosterR)
 		require.NoError(t, err)
@@ -1636,19 +1642,21 @@ func TestService_SetConfigRosterKeepLeader(t *testing.T) {
 }
 
 func TestService_SetConfigRosterNewLeader(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	bArgs := NewBCTestArgs()
+	bArgs.Nodes = 4
+	b := NewBCTestWithArgs(t, bArgs)
+	defer b.CloseAll()
 
 	log.Lvl1("Creating blocks to check rotation of the leader")
-	rosterR := s.roster
+	rosterR := b.Roster
 	for i := 0; i < 1; i++ {
 		rosterR = onet.NewRoster([]*network.ServerIdentity{
 			rosterR.List[1], rosterR.List[2], rosterR.List[3], rosterR.List[0]})
 		log.Lvl2("Creating block", i)
-		ctx, _ := createConfigTxWithCounter(t, testInterval, *rosterR, defaultMaxBlockSize, s, 1+i)
-		s.sendTxAndWait(t, ctx, 10)
+		ctx, _ := createConfigTxWithCounter(t, b.PropagationInterval, *rosterR, defaultMaxBlockSize, b, 1+i)
+		b.SendTxAndWait(ctx, 10)
 		log.Lvl2("Verifying the correct roster is in place")
-		latest, err := s.service().db().GetLatestByID(s.genesis.Hash)
+		latest, err := b.Service().db().GetLatestByID(b.Genesis.Hash)
 		require.NoError(t, err)
 		equals, err := latest.Roster.Equal(rosterR)
 		require.NoError(t, err)
@@ -1657,36 +1665,36 @@ func TestService_SetConfigRosterNewLeader(t *testing.T) {
 }
 
 func TestService_SetConfigRosterNewNodes(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	nbrNewNodes := 10
 	if testing.Short() {
 		nbrNewNodes = 2
 	}
-	servers, newRoster, _ := s.local.MakeSRS(cothority.Suite, nbrNewNodes, ByzCoinID)
+	servers, newRoster, _ := b.Local.MakeSRS(cothority.Suite, nbrNewNodes, ByzCoinID)
 
-	ids := []darc.Identity{s.signer.Identity()}
+	ids := []darc.Identity{b.Signer.Identity()}
 	testDarc := darc.NewDarc(darc.InitRules(ids, ids), []byte("testDarc"))
 	testDarcBuf, err := testDarc.ToProto()
 	require.NoError(t, err)
-	instr := createSpawnInstr(s.darc.GetBaseID(), ContractDarcID, "darc", testDarcBuf)
+	instr := createSpawnInstr(b.GenesisDarc.GetBaseID(), ContractDarcID, "darc", testDarcBuf)
 	require.NoError(t, err)
-	s.sendInstructions(t, 10, instr)
+	b.sendInstructions(t, 10, instr)
 
 	log.Lvl1("Creating blocks to check rotation of the leader")
 	leanClient := onet.NewClient(cothority.Suite, ServiceName)
-	rosterR := s.roster
+	rosterR := b.Roster
 	counter := 2
 	for _, newNode := range newRoster.List {
 		var i int
 		for i = 1; i < 10; i++ {
-			time.Sleep(testInterval * time.Duration(i))
+			time.Sleep(b.PropagationInterval * time.Duration(i))
 			log.Lvlf2("Verifying the last node %s has all the data", rosterR.List[len(rosterR.List)-1])
 			reply := &GetProofResponse{}
 			err = leanClient.SendProtobuf(rosterR.List[len(rosterR.List)-1], &GetProof{
 				Version: CurrentVersion,
-				ID:      s.genesis.Hash,
+				ID:      b.Genesis.Hash,
 				Key:     testDarc.GetBaseID(),
 			}, reply)
 			if err == nil && reply.Proof.InclusionProof.Match(testDarc.GetBaseID()) {
@@ -1697,20 +1705,20 @@ func TestService_SetConfigRosterNewNodes(t *testing.T) {
 
 		log.Lvlf2("Adding new node to the roster")
 		rosterR = onet.NewRoster(append(rosterR.List, newNode))
-		ctx, _ := createConfigTxWithCounter(t, testInterval, *rosterR, defaultMaxBlockSize, s, counter)
+		ctx, _ := createConfigTxWithCounter(t, b.PropagationInterval, *rosterR, defaultMaxBlockSize, b, counter)
 		counter++
-		s.sendTxAndWait(t, ctx, 10)
+		b.SendTxAndWait(ctx, 10)
 
 		log.Lvl2("Verifying the correct roster is in place")
-		latest, err := s.service().db().GetLatestByID(s.genesis.Hash)
+		latest, err := b.Service().db().GetLatestByID(b.Genesis.Hash)
 		require.NoError(t, err)
 		equals, err := latest.Roster.Equal(rosterR)
 		require.NoError(t, err)
 		require.True(t, equals, "roster has not been updated")
 		// Get latest genesis darc and verify the 'view_change' rule is updated
-		st, err := s.service().GetReadOnlyStateTrie(s.genesis.Hash)
+		st, err := b.Service().GetReadOnlyStateTrie(b.Genesis.Hash)
 		require.NoError(t, err)
-		val, _, _, _, err := st.GetValues(s.darc.GetBaseID())
+		val, _, _, _, err := st.GetValues(b.GenesisDarc.GetBaseID())
 		require.NoError(t, err)
 		d, err := darc.NewFromProtobuf(val)
 		require.NoError(t, err)
@@ -1721,13 +1729,13 @@ func TestService_SetConfigRosterNewNodes(t *testing.T) {
 	// Make sure the latest node is correctly activated and that the
 	// new conodes are done with catching up
 	for _, ser := range servers {
-		ctx, _ := createConfigTxWithCounter(t, testInterval, *rosterR,
-			defaultMaxBlockSize, s, counter)
+		ctx, _ := createConfigTxWithCounter(t, b.PropagationInterval, *rosterR,
+			defaultMaxBlockSize, b, counter)
 		counter++
 		for i := 0; i < 2; i++ {
 			resp, err := ser.Service(ServiceName).(*Service).AddTransaction(&AddTxRequest{
 				Version:       CurrentVersion,
-				SkipchainID:   s.genesis.SkipChainID(),
+				SkipchainID:   b.Genesis.SkipChainID(),
 				Transaction:   ctx,
 				InclusionWait: 10,
 			})
@@ -1736,7 +1744,7 @@ func TestService_SetConfigRosterNewNodes(t *testing.T) {
 			} else if i == 2 {
 				transactionOK(t, resp, err)
 			}
-			time.Sleep(testInterval)
+			time.Sleep(b.PropagationInterval)
 		}
 	}
 
@@ -1747,7 +1755,7 @@ func TestService_SetConfigRosterNewNodes(t *testing.T) {
 			reply := &GetProofResponse{}
 			err = leanClient.SendProtobuf(node, &GetProof{
 				Version: CurrentVersion,
-				ID:      s.genesis.Hash,
+				ID:      b.Genesis.Hash,
 				Key:     testDarc.GetBaseID(),
 			}, reply)
 			if err == nil {
@@ -1758,86 +1766,85 @@ func TestService_SetConfigRosterNewNodes(t *testing.T) {
 				log.Error("Couldn't get proof for darc:", err)
 				t.FailNow()
 			}
-			time.Sleep(testInterval)
+			time.Sleep(b.PropagationInterval)
 		}
 	}
 }
 
 func TestService_SetConfigRosterSwitchNodes(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
-	newNodes := len(s.roster.List)
+	newNodes := len(b.Roster.List)
 	if testing.Short() {
 		newNodes = 1
 	}
-	_, newRoster, _ := s.local.MakeSRS(cothority.Suite, newNodes, ByzCoinID)
+	_, newRoster, _ := b.Local.MakeSRS(cothority.Suite, newNodes, ByzCoinID)
 
 	log.Lvl1("Don't allow new nodes as new leader")
-	wrongRoster := onet.NewRoster(append(newRoster.List, s.roster.List...))
-	ctx, _ := createConfigTxWithCounter(t, testInterval, *wrongRoster, defaultMaxBlockSize, s, 1)
-	resp, err := s.services[0].AddTransaction(&AddTxRequest{
+	wrongRoster := onet.NewRoster(append(newRoster.List, b.Roster.List...))
+	ctx, _ := createConfigTxWithCounter(t, b.PropagationInterval, *wrongRoster, defaultMaxBlockSize, b, 1)
+	resp, err := b.Services[0].AddTransaction(&AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   ctx,
 		InclusionWait: 10,
 	})
 	require.NoError(t, err)
 	require.Contains(t, resp.Error, "new leader must be in previous roster")
-	s.waitPropagation(t, 0)
+	b.WaitPropagation(-1)
 
 	log.Lvl1("Allow new nodes at the end", newRoster.List)
-	goodRoster := onet.NewRoster(s.roster.List)
+	goodRoster := onet.NewRoster(b.Roster.List)
 	counter := 1
 	for _, si := range newRoster.List {
 		log.Lvl1("Adding", si)
 		goodRoster = onet.NewRoster(append(goodRoster.List, si))
-		ctx, _ = createConfigTxWithCounter(t, testInterval, *goodRoster, defaultMaxBlockSize, s, counter)
+		ctx, _ = createConfigTxWithCounter(t, b.PropagationInterval, *goodRoster, defaultMaxBlockSize, b, counter)
 		counter++
-		s.sendTxAndWait(t, ctx, 10)
+		b.SendTxAndWait(ctx, 10)
 	}
-	s.waitPropagation(t, 0)
 }
 
 // Replaces all nodes from the previous roster with new nodes
 func TestService_SetConfigRosterReplace(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
-	newNodes := len(s.roster.List)
+	newNodes := len(b.Roster.List)
 	if testing.Short() {
 		newNodes = 1
 	}
-	_, newRoster, _ := s.local.MakeSRS(cothority.Suite, newNodes, ByzCoinID)
+	_, newRoster, _ := b.Local.MakeSRS(cothority.Suite, newNodes, ByzCoinID)
 
 	log.Lvl1("Replace with new roster", newRoster.List)
-	goodRoster := onet.NewRoster(s.roster.List)
+	goodRoster := onet.NewRoster(b.Roster.List)
 	counter := 1
 	for _, si := range newRoster.List {
 		log.Lvl1("Adding", si)
 		goodRoster = onet.NewRoster(append(goodRoster.List, si))
-		ctx, _ := createConfigTxWithCounter(t, testInterval, *goodRoster, defaultMaxBlockSize, s, counter)
+		ctx, _ := createConfigTxWithCounter(t, b.PropagationInterval, *goodRoster, defaultMaxBlockSize, b, counter)
 		counter++
-		cl := NewClient(s.genesis.SkipChainID(), *goodRoster)
+		cl := NewClient(b.Genesis.SkipChainID(), *goodRoster)
 		require.NoError(t, cl.UseNode(1))
 		resp, err := cl.AddTransactionAndWait(ctx, 10)
 		transactionOK(t, resp, err)
-		s.waitPropagation(t, -1)
+		b.WaitPropagation(-1)
 
 		log.Lvl1("Removing", goodRoster.List[0])
 		goodRoster = onet.NewRoster(goodRoster.List[1:])
-		ctx, _ = createConfigTxWithCounter(t, testInterval, *goodRoster, defaultMaxBlockSize, s, counter)
+		ctx, _ = createConfigTxWithCounter(t, b.PropagationInterval, *goodRoster, defaultMaxBlockSize, b, counter)
 		counter++
 		resp, err = cl.AddTransactionAndWait(ctx, 10)
 		transactionOK(t, resp, err)
-		s.waitPropagation(t, -1)
+		b.WaitPropagation(-1)
 	}
 }
 
 // Check consistency of the set of valid peers while replacing roster
 func TestService_CheckValidPeers(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	var nbNewServers int
 	if testing.Short() {
@@ -1845,18 +1852,18 @@ func TestService_CheckValidPeers(t *testing.T) {
 	} else {
 		nbNewServers = 4
 	}
-	newServers, newRoster, _ := s.local.MakeSRS(cothority.Suite, nbNewServers,
+	newServers, newRoster, _ := b.Local.MakeSRS(cothority.Suite, nbNewServers,
 		ByzCoinID)
 
 	// Compute the peerSetID for this skipchain
-	onetCtx := s.service().ServiceProcessor.Context
-	peerSetID := onetCtx.NewPeerSetID(s.genesis.SkipChainID())
+	onetCtx := b.Service().ServiceProcessor.Context
+	peerSetID := onetCtx.NewPeerSetID(b.Genesis.SkipChainID())
 
 	// List of all servers involved in the test
-	allServers := append(s.hosts, newServers...)
+	allServers := append(b.Servers, newServers...)
 
 	log.Lvl1("Replace with new roster", newRoster.List)
-	goodRoster := onet.NewRoster(s.roster.List)
+	goodRoster := onet.NewRoster(b.Roster.List)
 	counter := 1
 
 	// Expected valid peers during the test, initialized to the starting roster.
@@ -1870,23 +1877,23 @@ func TestService_CheckValidPeers(t *testing.T) {
 		goodRoster = onet.NewRoster(append(goodRoster.List, si))
 		expectedValidPeers = append(expectedValidPeers, si.ID)
 
-		ctx, _ := createConfigTxWithCounter(t, testInterval, *goodRoster, defaultMaxBlockSize, s, counter)
+		ctx, _ := createConfigTxWithCounter(t, b.PropagationInterval, *goodRoster, defaultMaxBlockSize, b, counter)
 		counter++
-		cl := NewClient(s.genesis.SkipChainID(), *goodRoster)
+		cl := NewClient(b.Genesis.SkipChainID(), *goodRoster)
 		resp, err := cl.AddTransactionAndWait(ctx, 10)
 		transactionOK(t, resp, err)
 
-		s.services = append(s.services,
+		b.Services = append(b.Services,
 			newServers[index].Service(ServiceName).(*Service))
 
 		// Add dummy transaction to ensure new node is updated
-		counter = addDummyTxs(t, s, 1, 1, counter)
+		counter = addDummyTxs(t, b, 1, 1, counter)
 
 		// Wait until all servers have included the block
 		require.NoError(t, cl.WaitPropagation(-1))
 
 		// Check valid peers in all current servers
-		for _, srv := range allServers[index : index+5] {
+		for _, srv := range allServers[index : index+4] {
 			require.ElementsMatch(t,
 				srv.GetValidPeers(peerSetID), expectedValidPeers)
 		}
@@ -1895,29 +1902,29 @@ func TestService_CheckValidPeers(t *testing.T) {
 		goodRoster = onet.NewRoster(goodRoster.List[1:])
 		expectedValidPeers = expectedValidPeers[1:]
 
-		ctx, _ = createConfigTxWithCounter(t, testInterval, *goodRoster, defaultMaxBlockSize, s, counter)
+		ctx, _ = createConfigTxWithCounter(t, b.PropagationInterval, *goodRoster, defaultMaxBlockSize, b, counter)
 		counter++
 		resp, err = cl.AddTransactionAndWait(ctx, 10)
 		transactionOK(t, resp, err)
 
-		s.services = s.services[1:]
+		b.Services = b.Services[1:]
 
 		// Wait until all servers have included the block
 		require.NoError(t, cl.WaitPropagation(-1))
 
 		// Check valid peers in all current servers
-		for _, srv := range allServers[index+1 : index+5] {
+		for _, srv := range allServers[index+1 : index+4] {
 			require.ElementsMatch(t,
 				srv.GetValidPeers(peerSetID), expectedValidPeers)
 		}
 	}
 }
 
-func addDummyTxs(t *testing.T, s *ser, nbr int, perCTx int, counter int) int {
+func addDummyTxs(t *testing.T, s *BCTest, nbr int, perCTx int, counter int) int {
 	return addDummyTxsTo(t, s, nbr, perCTx, counter, 0)
 }
-func addDummyTxsTo(t *testing.T, s *ser, nbr int, perCTx int, counter int, idx int) int {
-	ids := []darc.Identity{s.signer.Identity()}
+func addDummyTxsTo(t *testing.T, s *BCTest, nbr int, perCTx int, counter int, idx int) int {
+	ids := []darc.Identity{s.Signer.Identity()}
 	for i := 0; i < nbr; i++ {
 		var instrs Instructions
 		for j := 0; j < perCTx; j++ {
@@ -1925,21 +1932,21 @@ func addDummyTxsTo(t *testing.T, s *ser, nbr int, perCTx int, counter int, idx i
 			dummyDarc := darc.NewDarc(darc.InitRules(ids, ids), desc)
 			dummyDarcBuf, err := dummyDarc.ToProto()
 			require.NoError(t, err)
-			instr := createSpawnInstr(s.darc.GetBaseID(), ContractDarcID,
+			instr := createSpawnInstr(s.GenesisDarc.GetBaseID(), ContractDarcID,
 				"darc", dummyDarcBuf)
 			instr.SignerCounter[0] = uint64(counter)
 			counter++
 			instrs = append(instrs, instr)
 		}
 		s.sendInstructions(t, 10, instrs...)
-		s.local.WaitDone(time.Second)
+		s.Local.WaitDone(time.Second)
 	}
 	return counter
 }
 
 func TestService_SetConfigRosterDownload(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	cfdb := catchupFetchDBEntries
 	defer func() {
@@ -1947,39 +1954,39 @@ func TestService_SetConfigRosterDownload(t *testing.T) {
 	}()
 	catchupFetchDBEntries = 10
 
-	ids := []darc.Identity{s.signer.Identity()}
+	ids := []darc.Identity{b.Signer.Identity()}
 	testDarc := darc.NewDarc(darc.InitRules(ids, ids), []byte("testDarc"))
 	testDarcBuf, err := testDarc.ToProto()
 	require.NoError(t, err)
-	instr := createSpawnInstr(s.darc.GetBaseID(), ContractDarcID, "darc", testDarcBuf)
+	instr := createSpawnInstr(b.GenesisDarc.GetBaseID(), ContractDarcID, "darc", testDarcBuf)
 	require.NoError(t, err)
-	s.sendInstructions(t, 10, instr)
+	b.sendInstructions(t, 10, instr)
 	// Add other transaction so we're on a new border between forward links
-	ct := addDummyTxs(t, s, 4, 1, 2)
+	ct := addDummyTxs(t, b, 4, 1, 2)
 
 	cda := catchupDownloadAll
 	defer func() {
 		catchupDownloadAll = cda
 	}()
 	catchupDownloadAll = 1
-	_, newRoster, _ := s.local.MakeSRS(cothority.Suite, 1, ByzCoinID)
+	_, newRoster, _ := b.Local.MakeSRS(cothority.Suite, 1, ByzCoinID)
 
-	newRoster = onet.NewRoster(append(s.roster.List, newRoster.List...))
-	ctx, _ := createConfigTxWithCounter(t, testInterval, *newRoster,
-		defaultMaxBlockSize, s, ct)
+	newRoster = onet.NewRoster(append(b.Roster.List, newRoster.List...))
+	ctx, _ := createConfigTxWithCounter(t, b.PropagationInterval, *newRoster,
+		defaultMaxBlockSize, b, ct)
 	ct++
-	s.sendTxAndWait(t, ctx, 10)
+	b.SendTxAndWait(ctx, 10)
 
 	// Create a new block
 	log.Lvl1("Creating two dummy blocks for the new node to catch up")
-	addDummyTxs(t, s, 2, 1, ct)
+	addDummyTxs(t, b, 2, 1, ct)
 
 	log.Lvl1("And getting proof from new node that the testDarc exists")
 	leanClient := onet.NewClient(cothority.Suite, ServiceName)
 	reply := &GetProofResponse{}
 	err = leanClient.SendProtobuf(newRoster.List[len(newRoster.List)-1], &GetProof{
 		Version: CurrentVersion,
-		ID:      s.genesis.Hash,
+		ID:      b.Genesis.Hash,
 		Key:     testDarc.GetBaseID(),
 	}, reply)
 	require.NoError(t, err)
@@ -1987,8 +1994,8 @@ func TestService_SetConfigRosterDownload(t *testing.T) {
 }
 
 func TestService_DownloadState(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	cfdb := catchupFetchDBEntries
 	defer func() {
@@ -1997,38 +2004,38 @@ func TestService_DownloadState(t *testing.T) {
 	catchupFetchDBEntries = 10
 
 	log.Lvl1("Adding dummy transactions")
-	ct := addDummyTxs(t, s, 3, 3, 1)
-	addDummyTxs(t, s, 1, 20, ct)
+	ct := addDummyTxs(t, b, 3, 3, 1)
+	addDummyTxs(t, b, 1, 20, ct)
 
-	config, err := s.service().LoadConfig(s.genesis.SkipChainID())
+	config, err := b.Service().LoadConfig(b.Genesis.SkipChainID())
 	require.NoError(t, err)
-	stateTrie, err := s.service().getStateTrie(s.genesis.SkipChainID())
+	stateTrie, err := b.Service().getStateTrie(b.Genesis.SkipChainID())
 	require.NoError(t, err)
 	merkleRoot := stateTrie.GetRoot()
 
 	// Wrong parameters
 	log.Lvl1("Testing wrong parameters")
-	_, err = s.service().DownloadState(&DownloadState{
+	_, err = b.Service().DownloadState(&DownloadState{
 		ByzCoinID: skipchain.SkipBlockID{},
 	})
 	require.Error(t, err)
-	_, err = s.service().DownloadState(&DownloadState{
+	_, err = b.Service().DownloadState(&DownloadState{
 		ByzCoinID: skipchain.SkipBlockID{},
 		Nonce:     0,
 		Length:    1,
 	})
 	require.Error(t, err)
-	_, err = s.service().DownloadState(&DownloadState{
-		ByzCoinID: s.genesis.SkipChainID(),
+	_, err = b.Service().DownloadState(&DownloadState{
+		ByzCoinID: b.Genesis.SkipChainID(),
 	})
 	require.Error(t, err)
-	_, err = s.service().DownloadState(&DownloadState{
-		ByzCoinID: s.genesis.SkipChainID(),
+	_, err = b.Service().DownloadState(&DownloadState{
+		ByzCoinID: b.Genesis.SkipChainID(),
 		Nonce:     1,
 	})
 	require.Error(t, err)
-	_, err = s.service().DownloadState(&DownloadState{
-		ByzCoinID: s.genesis.SkipChainID(),
+	_, err = b.Service().DownloadState(&DownloadState{
+		ByzCoinID: b.Genesis.SkipChainID(),
 		Nonce:     0,
 	})
 	require.Error(t, err)
@@ -2036,23 +2043,23 @@ func TestService_DownloadState(t *testing.T) {
 	// Start one download and check it is aborted
 	// if we start a second download.
 	log.Lvl1("Check aborting of download and resuming")
-	resp, err := s.service().DownloadState(&DownloadState{
-		ByzCoinID: s.genesis.SkipChainID(),
+	resp, err := b.Service().DownloadState(&DownloadState{
+		ByzCoinID: b.Genesis.SkipChainID(),
 		Nonce:     0,
 		Length:    1,
 	})
 	require.NoError(t, err)
 	nonce1 := resp.Nonce
 	// Continue 1st download
-	_, err = s.service().DownloadState(&DownloadState{
-		ByzCoinID: s.genesis.SkipChainID(),
+	_, err = b.Service().DownloadState(&DownloadState{
+		ByzCoinID: b.Genesis.SkipChainID(),
 		Nonce:     nonce1,
 		Length:    1,
 	})
 	require.NoError(t, err)
 	// Start 2nd download
-	resp, err = s.service().DownloadState(&DownloadState{
-		ByzCoinID: s.genesis.SkipChainID(),
+	resp, err = b.Service().DownloadState(&DownloadState{
+		ByzCoinID: b.Genesis.SkipChainID(),
 		Nonce:     0,
 		Length:    1,
 	})
@@ -2060,15 +2067,15 @@ func TestService_DownloadState(t *testing.T) {
 	nonce2 := resp.Nonce
 	require.NotEqual(t, nonce1, nonce2)
 	// Now 1st download should fail
-	_, err = s.service().DownloadState(&DownloadState{
-		ByzCoinID: s.genesis.SkipChainID(),
+	_, err = b.Service().DownloadState(&DownloadState{
+		ByzCoinID: b.Genesis.SkipChainID(),
 		Nonce:     nonce1,
 		Length:    1,
 	})
 	require.Error(t, err)
 	// And 2nd download should still continue
-	_, err = s.service().DownloadState(&DownloadState{
-		ByzCoinID: s.genesis.SkipChainID(),
+	_, err = b.Service().DownloadState(&DownloadState{
+		ByzCoinID: b.Genesis.SkipChainID(),
 		Nonce:     nonce2,
 		Length:    1,
 	})
@@ -2076,8 +2083,8 @@ func TestService_DownloadState(t *testing.T) {
 
 	// Start downloading
 	log.Lvl1("Partial download")
-	resp, err = s.service().DownloadState(&DownloadState{
-		ByzCoinID: s.genesis.SkipChainID(),
+	resp, err = b.Service().DownloadState(&DownloadState{
+		ByzCoinID: b.Genesis.SkipChainID(),
 		Nonce:     0,
 		Length:    10,
 	})
@@ -2090,8 +2097,8 @@ func TestService_DownloadState(t *testing.T) {
 	length := 0
 	var nonce uint64
 	for {
-		resp, err = s.service().DownloadState(&DownloadState{
-			ByzCoinID: s.genesis.SkipChainID(),
+		resp, err = b.Service().DownloadState(&DownloadState{
+			ByzCoinID: b.Genesis.SkipChainID(),
 			Nonce:     nonce,
 			Length:    10,
 		})
@@ -2106,10 +2113,10 @@ func TestService_DownloadState(t *testing.T) {
 	// are copied, so we cannot know in advance how many
 	// entries we copy...
 	require.True(t, length > 40)
-	configDown, err := s.service().LoadConfig(s.genesis.SkipChainID())
+	configDown, err := b.Service().LoadConfig(b.Genesis.SkipChainID())
 	require.NoError(t, err)
 	require.Equal(t, config, configDown)
-	stateTrieDown, err := s.service().getStateTrie(s.genesis.SkipChainID())
+	stateTrieDown, err := b.Service().getStateTrie(b.Genesis.SkipChainID())
 	require.NoError(t, err)
 	merkleRootDown := stateTrieDown.GetRoot()
 	require.Equal(t, merkleRoot, merkleRootDown)
@@ -2119,12 +2126,12 @@ func TestService_DownloadState(t *testing.T) {
 	// do it twice
 	for i := 0; i < 2; i++ {
 		log.Lvl1("Full download on new node, try-#", i+1)
-		servers, _, _ := s.local.MakeSRS(cothority.Suite, 1, ByzCoinID)
-		services := s.local.GetServices(servers, ByzCoinID)
+		servers, _, _ := b.Local.MakeSRS(cothority.Suite, 1, ByzCoinID)
+		services := b.Local.GetServices(servers, ByzCoinID)
 		service := services[0].(*Service)
-		err := service.downloadDB(s.genesis)
+		err := service.downloadDB(b.Genesis)
 		require.NoError(t, err)
-		st, err := service.getStateTrie(s.genesis.Hash)
+		st, err := service.getStateTrie(b.Genesis.Hash)
 		require.NoError(t, err)
 		val, _, _, _, err := st.GetValues(make([]byte, 32))
 		require.NoError(t, err)
@@ -2133,7 +2140,7 @@ func TestService_DownloadState(t *testing.T) {
 		err = protobuf.DecodeWithConstructors(val, &configCopy, network.DefaultConstructors(cothority.Suite))
 		require.NoError(t, err)
 		require.Equal(t, config, &configCopy)
-		stateTrieDown, err := service.getStateTrie(s.genesis.SkipChainID())
+		stateTrieDown, err := service.getStateTrie(b.Genesis.SkipChainID())
 		require.NoError(t, err)
 		merkleRootDown := stateTrieDown.GetRoot()
 		require.Equal(t, merkleRoot, merkleRootDown)
@@ -2155,38 +2162,38 @@ func TestService_DownloadStateRunning(t *testing.T) {
 		catchupDownloadAll = cda
 	}()
 	catchupDownloadAll = 3
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	log.Lvl1("Adding dummy transactions")
-	addDummyTxs(t, s, 3, 1, 1)
+	addDummyTxs(t, b, 3, 1, 1)
 
 	counter := 4
-	for i := range s.services {
+	for i := range b.Services {
 		if i == 0 {
 			log.Lvl1("Not deleting leader")
 			continue
 		}
 		log.Lvl1("Deleting node", i, "and adding new transaction")
-		s.deleteDBs(t, i)
+		b.DeleteDBs(i)
 
-		addDummyTxsTo(t, s, 1, 1, counter, (i+1)%len(s.services))
+		addDummyTxsTo(t, b, 1, 1, counter, (i+1)%len(b.Services))
 		counter++
 	}
 }
 
 func TestService_SetBadConfig(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	// send in a bad new block size
-	ctx, badConfig := createBadConfigTx(t, s, false, true)
-	s.sendTx(t, ctx)
+	ctx, badConfig := createBadConfigTx(t, b, false, true)
+	b.SendTx(ctx)
 
 	// wait for a change, which should not happen
 	for i := 0; i < 5; i++ {
-		time.Sleep(s.interval)
-		config, err := s.service().LoadConfig(s.genesis.SkipChainID())
+		time.Sleep(b.PropagationInterval)
+		config, err := b.Service().LoadConfig(b.Genesis.SkipChainID())
 		require.NoError(t, err)
 
 		if badConfig.Roster.List[0].Equal(config.Roster.List[0]) {
@@ -2195,13 +2202,13 @@ func TestService_SetBadConfig(t *testing.T) {
 	}
 
 	// send in a bad new interval
-	ctx, badConfig = createBadConfigTx(t, s, true, false)
-	s.sendTx(t, ctx)
+	ctx, badConfig = createBadConfigTx(t, b, true, false)
+	b.SendTx(ctx)
 
 	// wait for a change, which should not happen
 	for i := 0; i < 5; i++ {
-		time.Sleep(s.interval)
-		config, err := s.service().LoadConfig(s.genesis.SkipChainID())
+		time.Sleep(b.PropagationInterval)
+		config, err := b.Service().LoadConfig(b.Genesis.SkipChainID())
 		require.NoError(t, err)
 
 		if badConfig.Roster.List[0].Equal(config.Roster.List[0]) {
@@ -2211,20 +2218,20 @@ func TestService_SetBadConfig(t *testing.T) {
 }
 
 func TestService_DarcToSc(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
-	darcID := s.darc.GetBaseID()
-	scID := s.genesis.SkipChainID()
+	darcID := b.GenesisDarc.GetBaseID()
+	scID := b.Genesis.SkipChainID()
 
 	// check that the mapping is correct
-	for _, service := range s.services {
+	for _, service := range b.Services {
 		require.True(t, service.darcToSc[string(darcID)].Equal(scID))
 	}
 
 	// remove the mapping and then load it again
 	log.Lvl1("Reloading all services")
-	for _, service := range s.services {
+	for _, service := range b.Services {
 		service.darcToSc = make(map[string]skipchain.SkipBlockID)
 		service.TestClose()
 		service.closed = false
@@ -2233,14 +2240,14 @@ func TestService_DarcToSc(t *testing.T) {
 
 	// check that the mapping is still correct
 	log.Lvl1("Verifying mapping is still correct")
-	for _, service := range s.services {
+	for _, service := range b.Services {
 		require.True(t, service.darcToSc[string(darcID)].Equal(scID))
 	}
 }
 
 func TestService_StateChangeCache(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	// Register a stateful contract, so we can monitor how many times that
 	// the contract gets called. Using the state change cache, we should
@@ -2251,25 +2258,25 @@ func TestService_StateChangeCache(t *testing.T) {
 		ctr++
 		return []StateChange{}, []Coin{}, nil
 	}
-	require.NoError(t, s.service().testRegisterContract(contractID, adaptor(contract)))
+	require.NoError(t, b.Service().testRegisterContract(contractID, adaptor(contract)))
 
-	scID := s.genesis.SkipChainID()
-	st, err := s.service().getStateTrie(scID)
+	scID := b.Genesis.SkipChainID()
+	st, err := b.Service().getStateTrie(scID)
 	require.NoError(t, err)
 	sst := st.MakeStagingStateTrie()
-	tx1, err := createOneClientTxWithCounter(s.darc.GetBaseID(), contractID, []byte{}, s.signer, 1)
+	tx1, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), contractID, []byte{}, b.Signer, 1)
 	require.NoError(t, err)
 
 	// Add a second tx that is invalid because it is for an unknown contract.
 	log.Lvl1("Calling invalid invoke on contract")
-	tx2, err := createOneClientTxWithCounter(s.darc.GetBaseID(), contractID+"x", []byte{}, s.signer, 2)
+	tx2, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), contractID+"x", []byte{}, b.Signer, 2)
 	require.NoError(t, err)
 
 	timestamp := time.Now().UnixNano()
 
 	txs := NewTxResults(tx1, tx2)
 	require.NoError(t, err)
-	root, txOut, states, _ := s.service().createStateChanges(sst, scID, txs, noTimeout, CurrentVersion, timestamp)
+	root, txOut, states, _ := b.Service().createStateChanges(sst, scID, txs, noTimeout, CurrentVersion, timestamp)
 	require.Equal(t, 2, len(txOut))
 	require.Equal(t, 1, ctr)
 	// we expect one state change to increment the signature counter
@@ -2282,7 +2289,7 @@ func TestService_StateChangeCache(t *testing.T) {
 	// createStateChanges when making the block), then it should load it from the
 	// cache, which means that ctr is still one (we do not call the
 	// contract twice).
-	root1, txOut1, states1, _ := s.service().createStateChanges(sst, scID, txOut, noTimeout, CurrentVersion, timestamp)
+	root1, txOut1, states1, _ := b.Service().createStateChanges(sst, scID, txOut, noTimeout, CurrentVersion, timestamp)
 	require.Equal(t, 1, ctr)
 	require.Equal(t, root, root1)
 	require.Equal(t, txOut, txOut1)
@@ -2290,9 +2297,9 @@ func TestService_StateChangeCache(t *testing.T) {
 
 	// If we remove the cache, then we expect the contract to be called
 	// again, i.e., ctr == 2.
-	s.service().stateChangeCache = newStateChangeCache()
+	b.Service().stateChangeCache = newStateChangeCache()
 	require.NoError(t, err)
-	root2, txOut2, states2, _ := s.service().createStateChanges(sst, scID, txs, noTimeout, CurrentVersion, timestamp)
+	root2, txOut2, states2, _ := b.Service().createStateChanges(sst, scID, txs, noTimeout, CurrentVersion, timestamp)
 	require.Equal(t, root, root2)
 	require.Equal(t, txOut, txOut2)
 	require.Equal(t, states, states2)
@@ -2301,12 +2308,12 @@ func TestService_StateChangeCache(t *testing.T) {
 
 // Check that we got no error from an existing state trie
 func TestService_UpdateTrieCallback(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	// already announced but it should exit silently
 	// as the trie index is different
-	err := s.service().updateTrieCallback(s.genesis.SkipChainID())
+	err := b.Service().updateTrieCallback(b.Genesis.SkipChainID())
 	require.NoError(t, err)
 }
 
@@ -2314,9 +2321,9 @@ func TestService_UpdateTrieCallback(t *testing.T) {
 // store them and increase the versions accordingly over
 // several transactions and instructions
 func TestService_StateChangeStorage(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
-	signerIID := NewInstanceID(publicVersionKey(s.signer.Identity().String()))
+	b := NewBCTest(t)
+	defer b.CloseAll()
+	signerIID := NewInstanceID(publicVersionKey(b.Signer.Identity().String()))
 
 	n := 2
 	iid := genID()
@@ -2340,12 +2347,13 @@ func TestService_StateChangeStorage(t *testing.T) {
 		})
 		return scs, []Coin{}, nil
 	}
-	for _, s := range s.services {
-		s.testRegisterContract(contractID, adaptor(contract))
+	for _, s := range b.Services {
+		require.NoError(t, s.testRegisterContract(contractID,
+			adaptor(contract)))
 	}
 
 	for i := 0; i < n; i++ {
-		tx, err := createClientTxWithTwoInstrWithCounter(s.darc.GetBaseID(), contractID, []byte{}, s.signer, uint64(i*2+1))
+		tx, err := createClientTxWithTwoInstrWithCounter(b.GenesisDarc.GetBaseID(), contractID, []byte{}, b.Signer, uint64(i*2+1))
 		require.NoError(t, err)
 
 		// Queue all transactions, except for the last one
@@ -2353,17 +2361,17 @@ func TestService_StateChangeStorage(t *testing.T) {
 		if i == n-1 {
 			wait = 10
 		}
-		resp, err := s.service().AddTransaction(&AddTxRequest{
+		resp, err := b.Service().AddTransaction(&AddTxRequest{
 			Version:       CurrentVersion,
-			SkipchainID:   s.genesis.SkipChainID(),
+			SkipchainID:   b.Genesis.SkipChainID(),
 			Transaction:   tx,
 			InclusionWait: wait,
 		})
 		transactionOK(t, resp, err)
 	}
 
-	scID := s.genesis.SkipChainID()
-	for _, service := range s.services {
+	scID := b.Genesis.SkipChainID()
+	for _, service := range b.Services {
 		log.Lvl1("Checking service", service.ServerIdentity())
 		// Waiting for other nodes to include the latest
 		// statechanges.
@@ -2379,7 +2387,7 @@ func TestService_StateChangeStorage(t *testing.T) {
 			}
 			// Even if the leader got the block, the other nodes still need time to
 			// apply the block
-			time.Sleep(testInterval)
+			time.Sleep(b.PropagationInterval)
 		}
 
 		res, err := service.GetAllInstanceVersion(&GetAllInstanceVersion{
@@ -2443,35 +2451,35 @@ func TestService_StateChangeStorageCatchUp(t *testing.T) {
 	// we don't want a db download
 	catchupDownloadAll = 100
 
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	n := 2
 	for i := 0; i < n; i++ {
-		tx, err := createClientTxWithTwoInstrWithCounter(s.darc.GetBaseID(), dummyContract, []byte{}, s.signer, uint64(i*2+1))
+		tx, err := createClientTxWithTwoInstrWithCounter(b.GenesisDarc.GetBaseID(), dummyContract, []byte{}, b.Signer, uint64(i*2+1))
 		require.NoError(t, err)
 
-		resp, err := s.service().AddTransaction(&AddTxRequest{
+		resp, err := b.Service().AddTransaction(&AddTxRequest{
 			Version:       CurrentVersion,
-			SkipchainID:   s.genesis.SkipChainID(),
+			SkipchainID:   b.Genesis.SkipChainID(),
 			Transaction:   tx,
 			InclusionWait: 10,
 		})
 		transactionOK(t, resp, err)
 	}
 
-	newServer, newRoster, newService := s.local.MakeSRS(cothority.Suite, 1, ByzCoinID)
+	newServer, newRoster, newService := b.Local.MakeSRS(cothority.Suite, 1, ByzCoinID)
 	registerDummy(t, newServer)
 
-	newRoster = onet.NewRoster(append(s.roster.List, newRoster.List...))
-	ctx, _ := createConfigTxWithCounter(t, testInterval, *newRoster, defaultMaxBlockSize, s, 5)
+	newRoster = onet.NewRoster(append(b.Roster.List, newRoster.List...))
+	ctx, _ := createConfigTxWithCounter(t, b.PropagationInterval, *newRoster, defaultMaxBlockSize, b, 5)
 	log.Lvl1("Updating config to include new roster")
-	s.sendTxAndWait(t, ctx, 10)
+	b.SendTxAndWait(ctx, 10)
 
 	for i := 0; i < 10; i++ {
 		log.Lvl1("Sleeping for 1 second...")
 		time.Sleep(time.Second)
-		scs, _ := newService.(*Service).stateChangeStorage.getByBlock(s.genesis.Hash, 2)
+		scs, _ := newService.(*Service).stateChangeStorage.getByBlock(b.Genesis.Hash, 2)
 
 		if len(scs) > 0 {
 			require.Equal(t, Create, scs[0].StateChange.StateAction)
@@ -2486,47 +2494,47 @@ func TestService_StateChangeStorageCatchUp(t *testing.T) {
 
 // Tests that a conode can't be overflowed by catching requests
 func TestService_TestCatchUpHistory(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
-	require.Equal(t, 0, len(s.service().catchingUpHistory))
+	require.Equal(t, 0, len(b.Service().catchingUpHistory))
 
-	sc := s.service().Service(skipchain.ServiceName).(*skipchain.Service)
-	sc.Storage.FollowIDs = []skipchain.SkipBlockID{s.genesis.Hash}
+	sc := b.Service().Service(skipchain.ServiceName).(*skipchain.Service)
+	sc.Storage.FollowIDs = []skipchain.SkipBlockID{b.Genesis.Hash}
 
 	// unknown, unfriendly skipchain, we shouldn't try to catch up
-	err := s.service().catchupFromID(s.roster, skipchain.SkipBlockID{}, skipchain.SkipBlockID{})
-	require.Equal(t, 0, len(s.service().catchingUpHistory))
+	err := b.Service().catchupFromID(b.Roster, skipchain.SkipBlockID{}, skipchain.SkipBlockID{})
+	require.Equal(t, 0, len(b.Service().catchingUpHistory))
 	require.NoError(t, err)
 
 	// catch up
-	err = s.service().catchupFromID(s.roster, s.genesis.Hash, s.genesis.Hash)
-	require.Equal(t, 1, len(s.service().catchingUpHistory))
+	err = b.Service().catchupFromID(b.Roster, b.Genesis.Hash, b.Genesis.Hash)
+	require.Equal(t, 1, len(b.Service().catchingUpHistory))
 	require.NoError(t, err)
 
-	ts := s.service().catchingUpHistory[string(s.genesis.Hash)]
+	ts := b.Service().catchingUpHistory[string(b.Genesis.Hash)]
 
 	// ... but not twice
-	err = s.service().catchupFromID(s.roster, s.genesis.Hash, s.genesis.Hash)
-	require.True(t, s.service().catchingUpHistory[string(s.genesis.Hash)].Equal(ts))
+	err = b.Service().catchupFromID(b.Roster, b.Genesis.Hash, b.Genesis.Hash)
+	require.True(t, b.Service().catchingUpHistory[string(b.Genesis.Hash)].Equal(ts))
 	require.Error(t, err)
 }
 
 func TestService_Repair(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	var intermediateStateTrie *stateTrie
 	var finalRoot []byte
 	n := 5
 	for i := 0; i < n; i++ {
-		ctx, err := createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, []byte{}, s.signer, uint64(i+1))
+		ctx, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), dummyContract, []byte{}, b.Signer, uint64(i+1))
 		require.NoError(t, err)
-		s.sendTxAndWait(t, ctx, 10)
+		b.SendTxAndWait(ctx, 10)
 
 		// take a copy of the state trie at the middle
 		if i == 2 {
-			tmpTrie, err := s.service().getStateTrie(s.genesis.SkipChainID())
+			tmpTrie, err := b.Service().getStateTrie(b.Genesis.SkipChainID())
 			require.NoError(t, err)
 			nonce, err := tmpTrie.GetNonce()
 			require.NoError(t, err)
@@ -2541,92 +2549,92 @@ func TestService_Repair(t *testing.T) {
 			intermediateStateTrie = &stateTrie{*intermediateTrie,
 				trieCache{}, sync.Mutex{}}
 		} else if i == n-1 {
-			tmpTrie, err := s.service().getStateTrie(s.genesis.SkipChainID())
+			tmpTrie, err := b.Service().getStateTrie(b.Genesis.SkipChainID())
 			require.NoError(t, err)
 			finalRoot = tmpTrie.GetRoot()
 		}
 	}
 
 	// Introduce an artificial corruption and then try to repair it.
-	genesisHex := fmt.Sprintf("%x", s.genesis.SkipChainID())
-	s.service().stateTriesLock.Lock()
-	s.service().stateTries[genesisHex] = intermediateStateTrie
-	s.service().stateTriesLock.Unlock()
+	genesisHex := fmt.Sprintf("%x", b.Genesis.SkipChainID())
+	b.Service().stateTriesLock.Lock()
+	b.Service().stateTries[genesisHex] = intermediateStateTrie
+	b.Service().stateTriesLock.Unlock()
 
-	err := s.service().fixInconsistencyIfAny(s.genesis.SkipChainID(), intermediateStateTrie)
+	err := b.Service().fixInconsistencyIfAny(b.Genesis.SkipChainID(), intermediateStateTrie)
 	require.NoError(t, err)
 
-	s.service().stateTriesLock.Lock()
-	newRoot := s.service().stateTries[genesisHex].GetRoot()
-	s.service().stateTriesLock.Unlock()
+	b.Service().stateTriesLock.Lock()
+	newRoot := b.Service().stateTries[genesisHex].GetRoot()
+	b.Service().stateTriesLock.Unlock()
 	require.Equal(t, finalRoot, newRoot)
 }
 
 func TestService_GetUpdates(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	req := &GetUpdatesRequest{
 		Instances:     nil,
 		Flags:         0,
 		LatestBlockID: nil,
 	}
-	_, err := s.service().GetUpdates(req)
+	_, err := b.Service().GetUpdates(req)
 	require.Error(t, err)
 
 	req.Instances = []IDVersion{{ConfigInstanceID, 0}}
-	req.LatestBlockID = s.genesis.SkipChainID()
-	gur, err := s.service().GetUpdates(req)
+	req.LatestBlockID = b.Genesis.SkipChainID()
+	gur, err := b.Service().GetUpdates(req)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(gur.Proofs))
 
 	req.Flags = GUFSendVersion0
-	gur, err = s.service().GetUpdates(req)
+	gur, err = b.Service().GetUpdates(req)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(gur.Proofs))
 	require.True(t, gur.Proofs[0].Match(ConfigInstanceID[:]))
 
-	ctx, _ := createConfigTxWithCounter(t, time.Millisecond*100, *s.roster,
-		1e5, s, 1)
-	s.sendTxAndWait(t, ctx, 10)
+	ctx, _ := createConfigTxWithCounter(t, time.Millisecond*100, *b.Roster,
+		1e5, b, 1)
+	b.SendTxAndWait(ctx, 10)
 
 	req.Flags = 0
-	_, err = s.service().GetUpdates(req)
+	_, err = b.Service().GetUpdates(req)
 	require.Error(t, err)
-	latest, err := s.service().db().GetLatest(s.genesis)
+	latest, err := b.Service().db().GetLatest(b.Genesis)
 	req.LatestBlockID = latest.Hash
 	require.NoError(t, err)
 
-	gur, err = s.service().GetUpdates(req)
+	gur, err = b.Service().GetUpdates(req)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(gur.Proofs))
 	require.True(t, gur.Proofs[0].Match(ConfigInstanceID[:]))
 
 	invID := sha256.Sum256([]byte("invalid instance"))
 	req.Instances = append(req.Instances, IDVersion{invID, 0})
-	gur, err = s.service().GetUpdates(req)
+	gur, err = b.Service().GetUpdates(req)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(gur.Proofs))
 
 	req.Flags = GUFSendMissingProofs
-	gur, err = s.service().GetUpdates(req)
+	gur, err = b.Service().GetUpdates(req)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(gur.Proofs))
 	require.False(t, gur.Proofs[1].Match(invID[:]))
 }
 
-func createBadConfigTx(t *testing.T, s *ser, intervalBad, szBad bool) (ClientTransaction, ChainConfig) {
+func createBadConfigTx(t *testing.T, s *BCTest, intervalBad, szBad bool) (ClientTransaction, ChainConfig) {
 	switch {
 	case intervalBad:
-		return createConfigTxWithCounter(t, -1, *s.roster.RandomSubset(s.services[1].ServerIdentity(), 2), defaultMaxBlockSize, s, 1)
+		return createConfigTxWithCounter(t, -1, *s.Roster.RandomSubset(s.Services[1].ServerIdentity(), 2), defaultMaxBlockSize, s, 1)
 	case szBad:
-		return createConfigTxWithCounter(t, 420*time.Millisecond, *s.roster.RandomSubset(s.services[1].ServerIdentity(), 2), 30*1e6, s, 1)
+		return createConfigTxWithCounter(t, 420*time.Millisecond, *s.Roster.RandomSubset(s.Services[1].ServerIdentity(), 2), 30*1e6, s, 1)
 	default:
-		return createConfigTxWithCounter(t, 420*time.Millisecond, *s.roster, 424242, s, 1)
+		return createConfigTxWithCounter(t, 420*time.Millisecond, *s.Roster, 424242, s, 1)
 	}
 }
 
-func createConfigTxWithCounter(t *testing.T, interval time.Duration, roster onet.Roster, size int, s *ser, counter int) (ClientTransaction, ChainConfig) {
+func createConfigTxWithCounter(t *testing.T, interval time.Duration, roster onet.Roster, size int, s *BCTest, counter int) (ClientTransaction, ChainConfig) {
 	config := ChainConfig{
 		BlockInterval:   interval,
 		Roster:          roster,
@@ -2646,239 +2654,14 @@ func createConfigTxWithCounter(t *testing.T, interval time.Duration, roster onet
 				Value: configBuf,
 			}},
 		},
-		SignerIdentities: []darc.Identity{s.signer.Identity()},
+		SignerIdentities: []darc.Identity{s.Signer.Identity()},
 		SignerCounter:    []uint64{uint64(counter)},
 		version:          CurrentVersion,
 	}
-	ctx, err := combineInstrsAndSign(s.signer, instr)
+	ctx, err := combineInstrsAndSign(s.Signer, instr)
 
 	require.NoError(t, err)
 	return ctx, config
-}
-
-func darcToTx(t *testing.T, d2 darc.Darc, signer darc.Signer, ctr uint64) ClientTransaction {
-	d2Buf, err := d2.ToProto()
-	require.NoError(t, err)
-	invoke := Invoke{
-		ContractID: ContractDarcID,
-		Command:    cmdDarcEvolve,
-		Args: []Argument{
-			{
-				Name:  "darc",
-				Value: d2Buf,
-			},
-		},
-	}
-	instr := Instruction{
-		InstanceID:    NewInstanceID(d2.GetBaseID()),
-		Invoke:        &invoke,
-		SignerCounter: []uint64{ctr},
-		version:       CurrentVersion,
-	}
-	ctx, err := combineInstrsAndSign(signer, instr)
-	require.NoError(t, err)
-	return ctx
-}
-
-type ser struct {
-	local    *onet.LocalTest
-	hosts    []*onet.Server
-	roster   *onet.Roster
-	services []*Service
-	genesis  *skipchain.SkipBlock
-	value    []byte
-	darc     *darc.Darc
-	signer   darc.Signer
-	tx       ClientTransaction
-	interval time.Duration
-}
-
-func (s *ser) service() *Service {
-	return s.services[0]
-}
-
-func (s *ser) waitProof(t *testing.T, id InstanceID) Proof {
-	return s.waitProofWithIdx(t, id.Slice(), 0)
-}
-
-func (s *ser) waitProofWithIdx(t *testing.T, key []byte, idx int) Proof {
-	var pr Proof
-	var ok bool
-	for i := 0; i < 10; i++ {
-		resp, err := s.services[idx].GetProof(&GetProof{
-			Version: CurrentVersion,
-			Key:     key,
-			ID:      s.genesis.SkipChainID(),
-		})
-		if err == nil {
-			pr = resp.Proof
-			if pr.InclusionProof.Match(key) {
-				ok = true
-				break
-			}
-		}
-
-		// wait for the block to be processed
-		time.Sleep(2 * s.interval)
-	}
-
-	require.True(t, ok, "got not match")
-	return pr
-}
-
-func (s *ser) sendTx(t *testing.T, ctx ClientTransaction) {
-	s.sendTxTo(t, ctx, 0)
-}
-
-func (s *ser) sendTxTo(t *testing.T, ctx ClientTransaction, idx int) {
-	s.sendTxToAndWait(t, ctx, idx, 0)
-}
-
-func (s *ser) sendTxAndWait(t *testing.T, ctx ClientTransaction, wait int) {
-	s.sendTxToAndWait(t, ctx, 0, wait)
-}
-
-func (s *ser) sendTxToAndWait(t *testing.T, ctx ClientTransaction, idx int, wait int) {
-	resp, err := s.services[idx].AddTransaction(&AddTxRequest{
-		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
-		Transaction:   ctx,
-		InclusionWait: wait,
-	})
-	transactionOK(t, resp, err)
-}
-
-func (s *ser) sendDummyTx(t *testing.T, node int, counter uint64, wait int) {
-	tx1, err := createOneClientTxWithCounter(s.darc.GetBaseID(),
-		dummyContract, s.value, s.signer, counter)
-	require.NoError(t, err)
-	s.sendTxToAndWait(t, tx1, node, wait)
-}
-
-// caller gives us a darc, and we try to make an evolution request.
-func (s *ser) testDarcEvolution(t *testing.T, d2 darc.Darc, fail bool) (pr *Proof) {
-	counterResponse, err := s.service().GetSignerCounters(&GetSignerCounters{
-		SignerIDs:   []string{s.signer.Identity().String()},
-		SkipchainID: s.genesis.SkipChainID(),
-	})
-	require.NoError(t, err)
-
-	ctx := darcToTx(t, d2, s.signer, counterResponse.Counters[0]+1)
-	s.sendTx(t, ctx)
-	for i := 0; i < 10; i++ {
-		resp, err := s.service().GetProof(&GetProof{
-			Version: CurrentVersion,
-			Key:     d2.GetBaseID(),
-			ID:      s.genesis.SkipChainID(),
-		})
-		require.NoError(t, err)
-		pr = &resp.Proof
-		_, v0, _, _, err := pr.KeyValue()
-		require.NoError(t, err)
-		d, err := darc.NewFromProtobuf(v0)
-		require.NoError(t, err)
-		if d.Equal(&d2) {
-			return
-		}
-		time.Sleep(s.interval)
-	}
-	if !fail {
-		t.Fatal("couldn't store new darc")
-	}
-	return
-}
-
-func (s *ser) deleteDBs(t *testing.T, index int) {
-	bc := s.services[index]
-	log.Lvlf1("%s: Deleting DB of node %d", bc.ServerIdentity(), index)
-	bc.TestClose()
-	for scid := range bc.stateTries {
-		require.NoError(t, deleteDB(bc.ServiceProcessor, []byte(scid)))
-		idStr := hex.EncodeToString([]byte(scid))
-		require.NoError(t, deleteDB(bc.ServiceProcessor, []byte(idStr)))
-	}
-	require.NoError(t, deleteDB(bc.ServiceProcessor, storageID))
-	sc := bc.Service(skipchain.ServiceName).(*skipchain.Service)
-	require.NoError(t, deleteDB(sc.ServiceProcessor, []byte("skipblocks")))
-	require.NoError(t, deleteDB(sc.ServiceProcessor, []byte("skipchainconfig")))
-	require.NoError(t, bc.TestRestart())
-}
-
-// Waits to have a coherent view in all nodes with at least the block
-// 'index' held by all nodes.
-func (s *ser) waitPropagation(t *testing.T, index int) {
-	require.NoError(t, NewClient(s.genesis.Hash,
-		*s.roster).WaitPropagation(index))
-}
-
-func deleteDB(s *onet.ServiceProcessor, key []byte) error {
-	db, stBucket := s.GetAdditionalBucket(key)
-	return db.Update(func(tx *bbolt.Tx) error {
-		return tx.DeleteBucket(stBucket)
-	})
-}
-
-func newSer(t *testing.T, step int, interval time.Duration) *ser {
-	return newSerN(t, step, interval, 4, disableViewChange)
-}
-
-func newSerN(t *testing.T, step int, interval time.Duration, n int, rw time.Duration) *ser {
-	return newSerWithVersion(t, step, interval, n, rw, CurrentVersion)
-}
-
-func newSerWithVersion(t *testing.T, step int, interval time.Duration, n int, rw time.Duration, v Version) *ser {
-	s := &ser{
-		local:  onet.NewLocalTestT(tSuite, t),
-		value:  []byte("anyvalue"),
-		signer: darc.NewSignerEd25519(nil, nil),
-	}
-	s.hosts, s.roster, _ = s.local.GenTree(n, true)
-	for _, sv := range s.local.GetServices(s.hosts, ByzCoinID) {
-		service := sv.(*Service)
-		service.rotationWindow = rw
-		service.defaultVersion = v
-		s.services = append(s.services, service)
-	}
-	registerDummy(t, s.hosts)
-
-	genesisMsg, err := DefaultGenesisMsg(CurrentVersion, s.roster,
-		[]string{
-			"spawn:" + dummyContract,
-			"spawn:" + invalidContract,
-			"spawn:" + panicContract,
-			"spawn:" + slowContract,
-			"spawn:" + versionContract,
-			"spawn:" + stateChangeCacheContract,
-			"delete:" + dummyContract,
-		}, s.signer.Identity())
-	require.NoError(t, err)
-	s.darc = &genesisMsg.GenesisDarc
-
-	genesisMsg.BlockInterval = interval
-	s.interval = genesisMsg.BlockInterval
-
-	for i := 0; i < step; i++ {
-		switch i {
-		case 0:
-			resp, err := s.service().CreateGenesisBlock(genesisMsg)
-			require.NoError(t, err)
-			s.genesis = resp.Skipblock
-		case 1:
-			tx, err := createOneClientTx(s.darc.GetBaseID(), dummyContract, s.value, s.signer)
-			require.NoError(t, err)
-			s.tx = tx
-			resp, err := s.service().AddTransaction(&AddTxRequest{
-				Version:       CurrentVersion,
-				SkipchainID:   s.genesis.SkipChainID(),
-				Transaction:   tx,
-				InclusionWait: 10,
-			})
-			transactionOK(t, resp, err)
-		default:
-			require.Fail(t, "no such step")
-		}
-	}
-	return s
 }
 
 type contractAdaptor struct {
@@ -2975,9 +2758,13 @@ func dummyContractFunc(cdb ReadOnlyStateTrie, inst Instruction, c []Coin) ([]Sta
 }
 
 func slowContractFunc(cdb ReadOnlyStateTrie, inst Instruction, c []Coin) ([]StateChange, []Coin, error) {
-	// This has to sleep for less than testInterval / 2 or else it will
+	// This has to sleep for less than BlockInterval / 2 or else it will
 	// block the system from processing txs. See #1359.
-	time.Sleep(testInterval / 5)
+	cfg, err := cdb.LoadConfig()
+	if err != nil {
+		return nil, nil, xerrors.Errorf("couldn't get config: %v", err)
+	}
+	time.Sleep(cfg.BlockInterval / 5)
 	return dummyContractFunc(cdb, inst, c)
 }
 

--- a/byzcoin/statereplay_test.go
+++ b/byzcoin/statereplay_test.go
@@ -14,37 +14,37 @@ import (
 
 // Test the expected use case
 func TestService_StateReplay(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
 	n := 2
 	for i := 0; i < n; i++ {
-		tx, err := createClientTxWithTwoInstrWithCounter(s.darc.GetBaseID(), dummyContract, []byte{}, s.signer, uint64(i*2+1))
+		tx, err := createClientTxWithTwoInstrWithCounter(b.GenesisDarc.GetBaseID(), dummyContract, []byte{}, b.Signer, uint64(i*2+1))
 		require.NoError(t, err)
 
-		_, err = s.service().AddTransaction(&AddTxRequest{
+		_, err = b.Service().AddTransaction(&AddTxRequest{
 			Version:       CurrentVersion,
-			SkipchainID:   s.genesis.SkipChainID(),
+			SkipchainID:   b.Genesis.SkipChainID(),
 			Transaction:   tx,
 			InclusionWait: 10,
 		})
 		require.NoError(t, err)
 	}
 
-	_, err := s.service().ReplayState(s.genesis.Hash, stdFetcher{},
+	_, err := b.Service().ReplayState(b.Genesis.Hash, stdFetcher{},
 		ReplayStateOptions{})
 	require.NoError(t, err)
 }
 
-func tryReplayBlock(t *testing.T, s *ser, sbID skipchain.SkipBlockID, msg string) {
-	_, err := s.service().ReplayState(sbID, stdFetcher{},
+func tryReplayBlock(t *testing.T, s *BCTest, sbID skipchain.SkipBlockID, msg string) {
+	_, err := s.Service().ReplayState(sbID, stdFetcher{},
 		ReplayStateOptions{MaxBlocks: 1})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), msg)
 }
 
-func forceStoreBlock(s *ser, sb *skipchain.SkipBlock) error {
-	return s.service().db().Update(func(tx *bbolt.Tx) error {
+func forceStoreBlock(s *BCTest, sb *skipchain.SkipBlock) error {
+	return s.Service().db().Update(func(tx *bbolt.Tx) error {
 		buf, err := network.Marshal(sb)
 		if err != nil {
 			return err
@@ -56,62 +56,62 @@ func forceStoreBlock(s *ser, sb *skipchain.SkipBlock) error {
 
 // Test that it catches failing chains and return meaningful errors
 func TestService_StateReplayFailures(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
-	tx, err := createClientTxWithTwoInstrWithCounter(s.darc.GetBaseID(), dummyContract, []byte{}, s.signer, uint64(1))
+	tx, err := createClientTxWithTwoInstrWithCounter(b.GenesisDarc.GetBaseID(), dummyContract, []byte{}, b.Signer, uint64(1))
 	require.NoError(t, err)
 
-	_, err = s.service().AddTransaction(&AddTxRequest{
+	_, err = b.Service().AddTransaction(&AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx,
 		InclusionWait: 10,
 	})
 	require.NoError(t, err)
 
 	// 1. error when fetching the genesis block
-	tryReplayBlock(t, s, skipchain.SkipBlockID{},
+	tryReplayBlock(t, b, skipchain.SkipBlockID{},
 		"failed to get the first block")
 
 	// 2. not a genesis block for the first block
-	genesis := s.service().db().GetByID(s.genesis.Hash)
-	tryReplayBlock(t, s, genesis.ForwardLink[0].To,
+	genesis := b.Service().db().GetByID(b.Genesis.Hash)
+	tryReplayBlock(t, b, genesis.ForwardLink[0].To,
 		"must start from genesis block")
 
 	// 3. bad payload
 	sb := skipchain.NewSkipBlock()
-	sb.Roster = s.roster
+	sb.Roster = b.Roster
 	sb.Payload = []byte{1, 1, 1, 1, 1}
 	sb.ForwardLink = []*skipchain.ForwardLink{{}}
-	require.NoError(t, forceStoreBlock(s, sb))
-	tryReplayBlock(t, s, sb.Hash, "Error while decoding field")
+	require.NoError(t, forceStoreBlock(b, sb))
+	tryReplayBlock(t, b, sb.Hash, "Error while decoding field")
 
 	// 4. bad data
 	sb.Payload = genesis.Payload
 	sb.Data = []byte{1, 1, 1, 1, 1}
-	require.NoError(t, forceStoreBlock(s, sb))
-	tryReplayBlock(t, s, sb.Hash, "Error while decoding field")
+	require.NoError(t, forceStoreBlock(b, sb))
+	tryReplayBlock(t, b, sb.Hash, "Error while decoding field")
 
 	// 5. non matching hash
 	sb.Data = []byte{}
 	sb.ForwardLink = []*skipchain.ForwardLink{{}}
-	require.NoError(t, forceStoreBlock(s, sb))
-	tryReplayBlock(t, s, sb.Hash, "client transaction hash does not match")
+	require.NoError(t, forceStoreBlock(b, sb))
+	tryReplayBlock(t, b, sb.Hash, "client transaction hash does not match")
 
 	// 6. mismatching merkle trie root
-	sb = s.service().db().GetByID(s.genesis.SkipChainID())
+	sb = b.Service().db().GetByID(b.Genesis.SkipChainID())
 	var dHead DataHeader
 	require.NoError(t, protobuf.Decode(sb.Data, &dHead))
 	dHead.TrieRoot = []byte{1, 2, 3}
 	buf, err := protobuf.Encode(&dHead)
 	require.NoError(t, err)
 	sb.Data = buf
-	require.NoError(t, forceStoreBlock(s, sb))
-	tryReplayBlock(t, s, sb.Hash, "merkle tree root doesn't match with trie root")
+	require.NoError(t, forceStoreBlock(b, sb))
+	tryReplayBlock(t, b, sb.Hash, "merkle tree root doesn't match with trie root")
 
 	// 7. failing instruction
-	sb = s.service().db().GetByID(s.genesis.SkipChainID())
+	sb = b.Service().db().GetByID(b.Genesis.SkipChainID())
 	var dBody DataBody
 	require.NoError(t, protobuf.Decode(sb.Payload, &dBody))
 	dBody.TxResults = append(dBody.TxResults, TxResult{
@@ -128,8 +128,8 @@ func TestService_StateReplayFailures(t *testing.T) {
 	buf, err = protobuf.Encode(&dHead)
 	require.NoError(t, err)
 	sb.Data = buf
-	require.NoError(t, forceStoreBlock(s, sb))
-	tryReplayBlock(t, s, sb.Hash, "instruction verification failed")
+	require.NoError(t, forceStoreBlock(b, sb))
+	tryReplayBlock(t, b, sb.Hash, "instruction verification failed")
 }
 
 // stdFetcher is a fetcher method that outputs using the onet.log library.

--- a/byzcoin/statetrie_test.go
+++ b/byzcoin/statetrie_test.go
@@ -24,10 +24,10 @@ import (
 // TestStateTrie is a sanity check for setting and retrieving keys, values and
 // index. The main functionalities are tested in the trie package.
 func TestStateTrie(t *testing.T) {
-	b := NewBCTest(t)
+	b := newBCTRun(t, nil)
 	defer b.CloseAll()
 
-	st, err := b.Service().getStateTrie(b.Genesis.SkipChainID())
+	st, err := b.Services[0].getStateTrie(b.Genesis.SkipChainID())
 	require.NoError(t, err)
 	require.NotNil(t, st)
 	require.NotEqual(t, -1, st.GetIndex())
@@ -95,15 +95,15 @@ func TestDarcRetrieval(t *testing.T) {
 	darcWidth := 10
 	entries := 1000
 
-	bArgs := NewBCTestArgs()
+	bArgs := defaultBCTArgs
 	bArgs.PropagationInterval = 10 * time.Second
-	b := NewBCTestWithArgs(t, bArgs)
+	b := newBCTRun(t, &bArgs)
 	defer b.CloseAll()
 	// When running with `-cpuprofile`, additional go-routines are added,
 	// which should be ignored.
 	log.AddUserUninterestingGoroutine("/runtime/cpuprof.go")
 
-	st, err := b.Service().getStateTrie(b.Genesis.SkipChainID())
+	st, err := b.Services[0].getStateTrie(b.Genesis.SkipChainID())
 	require.NoError(t, err)
 	require.NotEqual(t, -1, st.GetIndex())
 

--- a/byzcoin/statetrie_test.go
+++ b/byzcoin/statetrie_test.go
@@ -24,10 +24,10 @@ import (
 // TestStateTrie is a sanity check for setting and retrieving keys, values and
 // index. The main functionalities are tested in the trie package.
 func TestStateTrie(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := NewBCTest(t)
+	defer b.CloseAll()
 
-	st, err := s.service().getStateTrie(s.genesis.SkipChainID())
+	st, err := b.Service().getStateTrie(b.Genesis.SkipChainID())
 	require.NoError(t, err)
 	require.NotNil(t, st)
 	require.NotEqual(t, -1, st.GetIndex())
@@ -95,13 +95,15 @@ func TestDarcRetrieval(t *testing.T) {
 	darcWidth := 10
 	entries := 1000
 
-	s := newSer(t, 1, 10*time.Second)
-	defer s.local.CloseAll()
+	bArgs := NewBCTestArgs()
+	bArgs.PropagationInterval = 10 * time.Second
+	b := NewBCTestWithArgs(t, bArgs)
+	defer b.CloseAll()
 	// When running with `-cpuprofile`, additional go-routines are added,
 	// which should be ignored.
 	log.AddUserUninterestingGoroutine("/runtime/cpuprof.go")
 
-	st, err := s.service().getStateTrie(s.genesis.SkipChainID())
+	st, err := b.Service().getStateTrie(b.Genesis.SkipChainID())
 	require.NoError(t, err)
 	require.NotEqual(t, -1, st.GetIndex())
 

--- a/byzcoin/streaming_test.go
+++ b/byzcoin/streaming_test.go
@@ -12,9 +12,9 @@ var chanTimeout = time.Millisecond * 100
 
 func TestStreamingService_PaginateBlocks(t *testing.T) {
 	// Creating a service with only the genesis block
-	b := NewBCTest(t)
+	b := newBCTRun(t, nil)
 	defer b.CloseAll()
-	service := b.Service()
+	service := b.Services[0]
 
 	// We should be able to get 1 page with one item, which is the genesis block
 	paginateRequest := &PaginateRequest{
@@ -111,10 +111,9 @@ func TestStreamingService_PaginateBlocks(t *testing.T) {
 
 	// Adding a new block so we can fetch a page of two blocks, or two pages
 	// with one item each.
-	tx, err := createOneClientTx(b.GenesisDarc.GetBaseID(), dummyContract, b.Value, b.Signer)
+	tx, err := createOneClientTx(b.GenesisDarc.GetBaseID(), DummyContractName, b.Value, b.Signer)
 	require.NoError(t, err)
-	b.CTx = tx
-	resp, err := b.Service().AddTransaction(&AddTxRequest{
+	resp, err := b.Services[0].AddTransaction(&AddTxRequest{
 		Version:       CurrentVersion,
 		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx,

--- a/byzcoin/struct.go
+++ b/byzcoin/struct.go
@@ -639,6 +639,14 @@ func (bc *bcNotifications) unregisterForBlocks(ch waitChannel) {
 
 	for i, listener := range bc.blockListeners {
 		if listener == ch {
+		emptyChannel:
+			for {
+				select {
+				case <-ch:
+				default:
+					break emptyChannel
+				}
+			}
 			bc.blockListeners = append(bc.blockListeners[0:i], bc.blockListeners[i+1:]...)
 		}
 	}

--- a/byzcoin/viewchange.go
+++ b/byzcoin/viewchange.go
@@ -224,7 +224,7 @@ func (s *Service) computeInitialDuration(scID skipchain.SkipBlockID) (time.Durat
 	if err != nil {
 		return 0, xerrors.Errorf("loading block info: %v", err)
 	}
-	return s.rotationWindow * interval, nil
+	return time.Duration(s.rotationWindow) * interval, nil
 }
 
 func (s *Service) getSignatureThreshold(sbID skipchain.SkipBlockID) int {

--- a/byzcoin/viewchange_test.go
+++ b/byzcoin/viewchange_test.go
@@ -2,7 +2,6 @@ package byzcoin
 
 import (
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -22,27 +21,25 @@ import (
 // followers. Finally, we bring the failed nodes back up and they should
 // contain the transactions that they missed.
 func TestViewChange_Basic(t *testing.T) {
-	testViewChange(t, 4, 1, testInterval)
+	testViewChange(t, 4, 1)
 }
 
 func TestViewChange_Basic2(t *testing.T) {
 	if testing.Short() {
-		// Block interval needs to be big enough so that the protocol
-		// timeout is big enough but the test takes too much time then.
-		t.Skip("protocol timeout too short for Travis")
+		t.Skip("too many messages - travis looses some of the packets")
 	}
 
-	testViewChange(t, 7, 2, testInterval)
+	testViewChange(t, 7, 2)
 }
 
 func TestViewChange_Basic3(t *testing.T) {
 	if testing.Short() {
-		t.Skip("protocol timeout too short for Travis")
+		t.Skip("too many messages - travis looses some of the packets")
 	}
 
 	// Enough nodes and failing ones to test what happens when propagation
 	// fails due to offline nodes in the higher level of the tree.
-	testViewChange(t, 10, 3, 2*testInterval)
+	testViewChange(t, 10, 3)
 }
 
 // This test is brittle with regard to timeouts:
@@ -52,177 +49,166 @@ func TestViewChange_Basic3(t *testing.T) {
 //     - calculating the timeouts when asking for a signature
 //     - the time to wait to propagate to children
 // So it's using the `SetPropagationTimeout` to tweak it a bit.
-func testViewChange(t *testing.T, nHosts, nFailures int, interval time.Duration) {
-	rw := time.Duration(3)
-	s := newSerN(t, 1, interval, nHosts, rw)
-	defer s.local.CloseAll()
+func testViewChange(t *testing.T, nHosts, nFailures int) {
+	bArgs := NewBCTestArgs()
+	bArgs.Nodes = nHosts
+	bArgs.RotationWindow = 3
+	b := NewBCTestWithArgs(t, bArgs)
+	defer b.CloseAll()
+
+	propTimeout := time.Duration(4) * b.PropagationInterval
 
 	// The propagation interval needs to be high enough so that the
-	// subleaders and the leaves have the time to make sure the
+	// sub-leaders and the leaves have the time to make sure the
 	// transactions are correct.
-	for _, service := range s.services {
-		service.SetPropagationTimeout(4 * interval)
+	for _, service := range b.Services {
+		service.SetPropagationTimeout(propTimeout)
 	}
 
 	log.Lvl1("Wait for all the genesis config to be written on all nodes.")
 	genesisInstanceID := InstanceID{}
-	for i := range s.services {
-		s.waitProofWithIdx(t, genesisInstanceID.Slice(), i)
+	for i := range b.Services {
+		b.WaitProofWithIdx(genesisInstanceID.Slice(), i)
 	}
 
 	// Stop the first nFailures hosts then the node at index nFailures
 	// should take over.
 	for i := 0; i < nFailures; i++ {
 		log.Lvl1("stopping node at index", i)
-		s.services[i].TestClose()
-		s.hosts[i].Pause()
+		b.Services[i].TestClose()
+		b.Servers[i].Pause()
 	}
 
 	log.Lvl1("creating a first tx to trigger the view-change")
-	tx0, err := createOneClientTx(s.darc.GetBaseID(), dummyContract,
-		NewInstanceID([]byte{1}).Slice(), s.signer)
+	tx0, err := createOneClientTx(b.GenesisDarc.GetBaseID(), dummyContract,
+		NewInstanceID([]byte{1}).Slice(), b.Signer)
 	require.NoError(t, err)
-	s.sendTxTo(t, tx0, nFailures)
+	b.SendTxWaitPropagation(tx0, nFailures)
 
-	sl := s.interval * rw * time.Duration(math.Pow(2, float64(nFailures)))
-	log.Lvl1("Waiting for the propagation to be finished during", sl)
-	time.Sleep(sl)
-	s.waitPropagation(t, 1)
-	gucr, err := s.services[nFailures].skService().GetUpdateChain(&skipchain.
-		GetUpdateChain{LatestID: s.genesis.SkipChainID()})
+	gucr, err := b.Services[nFailures].skService().GetUpdateChain(&skipchain.
+		GetUpdateChain{LatestID: b.Genesis.SkipChainID()})
 	require.NoError(t, err)
 
 	newRoster := gucr.Update[len(gucr.Update)-1].Roster
 	log.Lvl1("Verifying roster", newRoster)
-	sameRoster, err := newRoster.Equal(s.roster)
+	sameRoster, err := newRoster.Equal(b.Roster)
 	require.NoError(t, err)
 	require.False(t, sameRoster)
 	require.True(t, newRoster.List[0].Equal(
-		s.services[nFailures].ServerIdentity()))
+		b.Services[nFailures].ServerIdentity()))
 
 	// try to send a transaction to the node on index nFailures+1, which is
 	// a follower (not the new leader)
 	log.Lvl1("Sending a transaction to the node after the new leader")
 	tx1ID := NewInstanceID([]byte{2}).Slice()
 	counter := uint64(2)
-	tx1, err := createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, tx1ID,
-		s.signer, counter)
+	tx1, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), dummyContract, tx1ID,
+		b.Signer, counter)
 	counter++
 	require.NoError(t, err)
-	s.sendTxTo(t, tx1, nFailures+1)
+	b.SendTxWaitPropagation(tx1, nFailures+1)
 
 	// check that the leader is updated for all nodes
 	// Note: check is done after a tx has been sent so that nodes catch up if the
 	// propagation failed
-	log.Lvl1("Waiting for the new transaction to go through")
-	s.waitPropagation(t, -1)
-	for _, service := range s.services[nFailures:] {
+	log.Lvl1("Verifying leader is updated everywhere")
+	for _, service := range b.Services[nFailures:] {
 		// everyone should have the same leader after the genesis block is stored
-		leader, err := service.getLeader(s.genesis.SkipChainID())
+		leader, err := service.getLeader(b.Genesis.SkipChainID())
 		require.NoError(t, err)
 		require.NotNil(t, leader)
-		require.True(t, leader.Equal(s.services[nFailures].ServerIdentity()), fmt.Sprintf("%v", leader))
+		require.True(t, leader.Equal(b.Services[nFailures].ServerIdentity()), fmt.Sprintf("%v", leader))
 	}
 
 	log.Lvl1("Creating new TX")
-	s.sendDummyTx(t, nFailures+1, counter, 4)
+	b.SendDummyTxWaitPropagation(nFailures+1, counter)
 	counter++
-
-	log.Lvl1("waiting for the tx to be stored")
-	// wait for the transaction to be stored everywhere
-	for i := nFailures; i < nHosts; i++ {
-		pr := s.waitProofWithIdx(t, tx1ID, i)
-		require.True(t, pr.InclusionProof.Match(tx1ID))
-	}
 
 	// We need to bring the failed (the first nFailures) nodes back up and
 	// check that they can synchronise to the latest state.
 	for i := 0; i < nFailures; i++ {
 		log.Lvl1("starting node at index", i)
-		s.hosts[i].Unpause()
-		require.NoError(t, s.services[i].TestRestart())
+		b.Servers[i].Unpause()
+		require.NoError(t, b.Services[i].TestRestart())
+		b.Services[i].SetPropagationTimeout(propTimeout)
 	}
-
-	time.Sleep(3 * time.Second)
+	b.WaitPropagation(4)
 
 	log.Lvl1("Adding two new tx for the resurrected nodes to catch up")
 	for tx := 0; tx < 2; tx++ {
-		s.sendDummyTx(t, nFailures, counter, 4)
+		b.SendDummyTxWaitPropagation(nFailures, counter)
 		counter++
 	}
 
-	log.Lvl1("Make sure resurrected nodes have caught up")
-	for i := 0; i < nFailures; i++ {
-		pr := s.waitProofWithIdx(t, tx1ID, i)
-		require.True(t, pr.InclusionProof.Match(tx1ID))
-	}
-	s.waitPropagation(t, 0)
-
-	log.Lvl1("Two final transactions")
-	for tx := 0; tx < 2; tx++ {
-		s.sendDummyTx(t, nFailures, counter, 4)
-		counter++
-	}
-
-	log.Lvl1("Sent two tx")
-	s.waitPropagation(t, -1)
+	log.Lvl1("Check that last block has index == 6")
+	pr, err := b.Client.GetProof(b.GenesisDarc.GetBaseID())
+	require.NoError(t, err)
+	require.Equal(t, 6, pr.Proof.Latest.Index)
 }
 
 // Tests that a view change can happen when the leader index is out of bound
 func TestViewChange_LeaderIndex(t *testing.T) {
-	s := newSerN(t, 1, time.Second, 5, defaultRotationWindow)
-	defer s.local.CloseAll()
+	bArgs := NewBCTestArgs()
+	bArgs.PropagationInterval = time.Second
+	bArgs.Nodes = 5
+	bArgs.RotationWindow = defaultRotationWindow
+	b := NewBCTestWithArgs(t, bArgs)
+	defer b.CloseAll()
 
-	err := s.services[0].sendViewChangeReq(viewchange.View{LeaderIndex: -1})
+	err := b.Services[0].sendViewChangeReq(viewchange.View{LeaderIndex: -1})
 	require.Error(t, err)
 	require.Equal(t, "leader index must be positive", err.Error())
 
 	view := viewchange.View{
-		ID:          s.genesis.SkipChainID(),
-		Gen:         s.genesis.SkipChainID(),
+		ID:          b.Genesis.SkipChainID(),
+		Gen:         b.Genesis.SkipChainID(),
 		LeaderIndex: 7,
 	}
 	for i := 0; i < 5; i++ {
-		s.services[i].viewChangeMan.addReq(viewchange.InitReq{
-			SignerID: s.services[i].ServerIdentity().ID,
+		b.Services[i].viewChangeMan.addReq(viewchange.InitReq{
+			SignerID: b.Services[i].ServerIdentity().ID,
 			View:     view,
 		})
-		err := s.services[i].sendViewChangeReq(view)
+		err := b.Services[i].sendViewChangeReq(view)
 		require.NoError(t, err)
 	}
 
-	time.Sleep(2 * s.interval)
+	time.Sleep(2 * b.PropagationInterval)
 
-	for _, service := range s.services {
+	for _, service := range b.Services {
 		// everyone should have the same leader after the genesis block is stored
-		leader, err := service.getLeader(s.genesis.SkipChainID())
+		leader, err := service.getLeader(b.Genesis.SkipChainID())
 		require.NoError(t, err)
 		require.NotNil(t, leader)
-		require.True(t, leader.Equal(s.services[2].ServerIdentity()))
+		require.True(t, leader.Equal(b.Services[2].ServerIdentity()))
 	}
 }
 
 // Test that old states of a view change that got stuck in the middle of the protocol
 // are correctly cleaned if a new block is discovered.
 func TestViewChange_LostSync(t *testing.T) {
-	s := newSerN(t, 1, time.Second, 5, defaultRotationWindow)
-	defer s.local.CloseAll()
+	bArgs := NewBCTestArgs()
+	bArgs.Nodes = 5
+	bArgs.PropagationInterval = time.Second
+	bArgs.RotationWindow = defaultRotationWindow
+	b := NewBCTestWithArgs(t, bArgs)
+	defer b.CloseAll()
 
-	target := s.hosts[1].ServerIdentity
+	target := b.Servers[1].ServerIdentity
 
 	// Simulate the beginning of a view change
 	req := &viewchange.InitReq{
-		SignerID: s.services[0].ServerIdentity().ID,
+		SignerID: b.Services[0].ServerIdentity().ID,
 		View: viewchange.View{
-			ID:          s.genesis.Hash,
-			Gen:         s.genesis.Hash,
+			ID:          b.Genesis.Hash,
+			Gen:         b.Genesis.Hash,
 			LeaderIndex: 3,
 		},
 		Signature: []byte{},
 	}
-	require.NoError(t, req.Sign(s.services[0].ServerIdentity().GetPrivate()))
+	require.NoError(t, req.Sign(b.Services[0].ServerIdentity().GetPrivate()))
 
-	err := s.services[0].SendRaw(target, req)
+	err := b.Services[0].SendRaw(target, req)
 	require.NoError(t, err)
 
 	// worst case scenario where the conode lost connectivity
@@ -230,11 +216,11 @@ func TestViewChange_LostSync(t *testing.T) {
 	// conode is still waiting for requests
 
 	// then new blocks have been added
-	tx1, err := createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, s.value, s.signer, 1)
+	tx1, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), dummyContract, b.Value, b.Signer, 1)
 	require.NoError(t, err)
-	_, err = s.services[1].AddTransaction(&AddTxRequest{
+	_, err = b.Services[1].AddTransaction(&AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx1,
 		InclusionWait: 5,
 	})
@@ -243,25 +229,25 @@ func TestViewChange_LostSync(t *testing.T) {
 	// give enough time for the propagation to be processed
 	time.Sleep(1 * time.Second)
 
-	sb, err := s.services[1].db().GetLatestByID(s.genesis.Hash)
+	sb, err := b.Services[1].db().GetLatestByID(b.Genesis.Hash)
 	require.NoError(t, err)
-	require.NotEqual(t, sb.Hash, s.genesis.Hash)
+	require.NotEqual(t, sb.Hash, b.Genesis.Hash)
 
 	// Start a new view change with a different block ID
 	req = &viewchange.InitReq{
-		SignerID: s.services[0].ServerIdentity().ID,
+		SignerID: b.Services[0].ServerIdentity().ID,
 		View: viewchange.View{
 			ID:          sb.Hash,
-			Gen:         s.genesis.SkipChainID(),
+			Gen:         b.Genesis.SkipChainID(),
 			LeaderIndex: 3,
 		},
 	}
-	require.NoError(t, req.Sign(s.services[0].ServerIdentity().GetPrivate()))
+	require.NoError(t, req.Sign(b.Services[0].ServerIdentity().GetPrivate()))
 
 	log.OutputToBuf()
 	defer log.OutputToOs()
 
-	err = s.services[0].SendRaw(target, req)
+	err = b.Services[0].SendRaw(target, req)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second) // request handler is asynchronous
@@ -271,28 +257,28 @@ func TestViewChange_LostSync(t *testing.T) {
 	// make sure a view change can still happen later
 	view := viewchange.View{
 		ID:          sb.Hash,
-		Gen:         s.genesis.SkipChainID(),
+		Gen:         b.Genesis.SkipChainID(),
 		LeaderIndex: 3,
 	}
 	for i := 0; i < 4; i++ {
-		err := s.services[i].sendViewChangeReq(view)
+		err := b.Services[i].sendViewChangeReq(view)
 		require.NoError(t, err)
 	}
 	for i := 0; i < 4; i++ {
-		s.services[i].viewChangeMan.addReq(viewchange.InitReq{
-			SignerID: s.services[i].ServerIdentity().ID,
+		b.Services[i].viewChangeMan.addReq(viewchange.InitReq{
+			SignerID: b.Services[i].ServerIdentity().ID,
 			View:     view,
 		})
 	}
 
 	log.Lvl1("Waiting for the new block to be propagated")
-	s.waitPropagation(t, 2)
-	for _, service := range s.services {
+	b.WaitPropagation(2)
+	for _, service := range b.Services {
 		// everyone should have the same leader after the genesis block is stored
-		leader, err := service.getLeader(s.genesis.SkipChainID())
+		leader, err := service.getLeader(b.Genesis.SkipChainID())
 		require.NoError(t, err)
 		require.NotNil(t, leader)
-		require.True(t, leader.Equal(s.services[3].ServerIdentity()))
+		require.True(t, leader.Equal(b.Services[3].ServerIdentity()))
 	}
 }
 
@@ -302,49 +288,51 @@ func TestViewChange_LostSync(t *testing.T) {
 //  - Node0 - leader - stopped after creation of block #1
 //  - Node3 - misses block #1, unpaused after creation of block #1
 func TestViewChange_NeedCatchUp(t *testing.T) {
-	rw := time.Duration(3)
 	nodes := 4
-	s := newSerN(t, 1, testInterval, nodes, rw)
-	defer s.local.CloseAll()
+	bArgs := NewBCTestArgs()
+	bArgs.Nodes = nodes
+	bArgs.RotationWindow = 3
+	b := NewBCTestWithArgs(t, bArgs)
+	defer b.CloseAll()
 
-	for _, service := range s.services {
-		service.SetPropagationTimeout(2 * testInterval)
+	for _, service := range b.Services {
+		service.SetPropagationTimeout(2 * b.PropagationInterval)
 	}
 
-	s.hosts[nodes-1].Pause()
+	b.Servers[nodes-1].Pause()
 
 	// Create a block that host 4 will miss
 	log.Lvl1("Send block that node 4 will miss")
-	tx1, err := createOneClientTx(s.darc.GetBaseID(), dummyContract, s.value, s.signer)
+	tx1, err := createOneClientTx(b.GenesisDarc.GetBaseID(), dummyContract, b.Value, b.Signer)
 	require.NoError(t, err)
-	s.sendTxToAndWait(t, tx1, 0, 10)
+	b.SendTxToAndWait(tx1, 0, 10)
 
 	// Kill the leader, and unpause the sleepy node
-	s.services[0].TestClose()
-	s.hosts[0].Pause()
-	s.hosts[nodes-1].Unpause()
+	b.Services[0].TestClose()
+	b.Servers[0].Pause()
+	b.Servers[nodes-1].Unpause()
 
 	// Trigger a viewchange
 	log.Lvl1("Trigger the viewchange")
-	tx1, err = createOneClientTx(s.darc.GetBaseID(), dummyContract, s.value, s.signer)
+	tx1, err = createOneClientTx(b.GenesisDarc.GetBaseID(), dummyContract, b.Value, b.Signer)
 	require.NoError(t, err)
-	s.sendTxTo(t, tx1, nodes-1)
+	b.SendTxTo(tx1, nodes-1)
 
 	log.Lvl1("Wait for the block to propagate")
-	require.NoError(t, NewClient(s.genesis.SkipChainID(),
-		*s.roster).WaitPropagation(1))
+	require.NoError(t, NewClient(b.Genesis.SkipChainID(),
+		*b.Roster).WaitPropagation(1))
 
 	// Send the block again
 	log.Lvl1("Sending block again")
-	s.sendTxTo(t, tx1, nodes-1)
+	b.SendTxTo(tx1, nodes-1)
 
 	log.Lvl1("Wait for the transaction to be included")
-	require.NoError(t, NewClient(s.genesis.SkipChainID(),
-		*s.roster).WaitPropagation(2))
+	require.NoError(t, NewClient(b.Genesis.SkipChainID(),
+		*b.Roster).WaitPropagation(2))
 
 	// Check that a view change was finally executed
-	leader, err := s.services[nodes-1].getLeader(s.genesis.SkipChainID())
+	leader, err := b.Services[nodes-1].getLeader(b.Genesis.SkipChainID())
 	require.NoError(t, err)
 	require.NotNil(t, leader)
-	require.False(t, leader.Equal(s.services[0].ServerIdentity()))
+	require.False(t, leader.Equal(b.Services[0].ServerIdentity()))
 }

--- a/byzcoinx/byzcoinx.go
+++ b/byzcoinx/byzcoinx.go
@@ -157,7 +157,7 @@ func (bft *ByzCoinX) Dispatch() error {
 		return fmt.Errorf("non-root should not start this protocol")
 	}
 
-	log.LLvl2(bft.ServerIdentity(), "Starting prepare phase")
+	log.Lvl2(bft.ServerIdentity(), "Starting prepare phase")
 	// prepare phase (part 2)
 	prepSig := <-bft.prepSigChan
 	err := bft.verifier(bft.suite, bft.Msg, prepSig, bft.publics)
@@ -166,10 +166,10 @@ func (bft *ByzCoinX) Dispatch() error {
 		bft.FinalSignatureChan <- FinalSignature{nil, nil}
 		return nil
 	}
-	log.LLvl2(bft.ServerIdentity(), "Finished prepare phase")
+	log.Lvl2(bft.ServerIdentity(), "Finished prepare phase")
 
 	// commit phase
-	log.LLvl2(bft.ServerIdentity(), "Starting commit phase")
+	log.Lvl2(bft.ServerIdentity(), "Starting commit phase")
 	commitProto, err := bft.initCosiProtocol(phaseCommit)
 	if err != nil {
 		return err
@@ -183,7 +183,7 @@ func (bft *ByzCoinX) Dispatch() error {
 	var commitSig []byte
 	select {
 	case commitSig = <-commitProto.FinalSignature:
-		log.LLvl2(bft.ServerIdentity(), "Finished commit phase")
+		log.Lvl2(bft.ServerIdentity(), "Finished commit phase")
 	case <-time.After(bft.Timeout / time.Duration(2) * time.Duration(bft.SubleaderFailures+1)):
 		// Waiting for bft.Timeout is too long here but used as a safeguard in
 		// case the commitProto does not return in time.

--- a/byzcoinx/byzcoinx.go
+++ b/byzcoinx/byzcoinx.go
@@ -157,6 +157,7 @@ func (bft *ByzCoinX) Dispatch() error {
 		return fmt.Errorf("non-root should not start this protocol")
 	}
 
+	log.LLvl2(bft.ServerIdentity(), "Starting prepare phase")
 	// prepare phase (part 2)
 	prepSig := <-bft.prepSigChan
 	err := bft.verifier(bft.suite, bft.Msg, prepSig, bft.publics)
@@ -165,10 +166,10 @@ func (bft *ByzCoinX) Dispatch() error {
 		bft.FinalSignatureChan <- FinalSignature{nil, nil}
 		return nil
 	}
-	log.Lvl3("Finished prepare phase")
+	log.LLvl2(bft.ServerIdentity(), "Finished prepare phase")
 
 	// commit phase
-	log.Lvl3("Starting commit phase")
+	log.LLvl2(bft.ServerIdentity(), "Starting commit phase")
 	commitProto, err := bft.initCosiProtocol(phaseCommit)
 	if err != nil {
 		return err
@@ -182,7 +183,7 @@ func (bft *ByzCoinX) Dispatch() error {
 	var commitSig []byte
 	select {
 	case commitSig = <-commitProto.FinalSignature:
-		log.Lvl3("Finished commit phase")
+		log.LLvl2(bft.ServerIdentity(), "Finished commit phase")
 	case <-time.After(bft.Timeout / time.Duration(2) * time.Duration(bft.SubleaderFailures+1)):
 		// Waiting for bft.Timeout is too long here but used as a safeguard in
 		// case the commitProto does not return in time.
@@ -192,7 +193,7 @@ func (bft *ByzCoinX) Dispatch() error {
 	err = bft.verifier(bft.suite, bft.Msg, commitSig, bft.publics)
 	if err != nil {
 		bft.FinalSignatureChan <- FinalSignature{nil, nil}
-		return errors.New("Commit signature is wrong")
+		return errors.New("commit signature is wrong")
 	}
 
 	bft.FinalSignatureChan <- FinalSignature{bft.Msg, commitSig}


### PR DESCRIPTION
This PR renames the previous `ser` structure for byzcoin testing to `BCTest` and adds a nice builder and runner, so that it can also be run from other byzcoin subdirectories.
The goal is to have a correct shutdown of the failing tests in #2367 .
It is quite a big PR as it needs a lot of refactoring. There are no changes in the byzcoin-code (except cleanups), only in the tests.

The entrypoint for code review is `byzcoin/bctest.go`. It is part of the main-package, which is not ideal, but I'd like it to be used also in other packages. Any idea how to make that happen is welcome.