### PR TITLE
Extract BCTest

### DIFF
--- a/byzcoin/api_test.go
+++ b/byzcoin/api_test.go
@@ -118,41 +118,21 @@ func TestClient_CreateTransaction(t *testing.T) {
 }
 
 func TestClient_GetProof(t *testing.T) {
-	l := onet.NewTCPTest(cothority.Suite)
-	servers, roster, _ := l.GenTree(3, true)
-	registerDummy(t, servers)
-	defer l.CloseAll()
-
-	// Initialise the genesis message and send it to the service.
-	signer := darc.NewSignerEd25519(nil, nil)
-	msg, err := DefaultGenesisMsg(CurrentVersion, roster, []string{"spawn:dummy"}, signer.Identity())
-	msg.BlockInterval = 100 * time.Millisecond
-	require.NoError(t, err)
-
-	// The darc inside it should be valid.
-	d := msg.GenesisDarc
-	require.Nil(t, d.Verify(true))
-
-	c, csr, err := NewLedger(msg, false)
-	require.NoError(t, err)
-
-	gac, err := c.GetAllByzCoinIDs(roster.List[1])
-	require.NoError(t, err)
-	require.Equal(t, 1, len(gac.IDs))
+	b := newBCTRun(t, nil)
+	defer b.CloseAll()
 
 	// Create a new transaction.
 	value := []byte{5, 6, 7, 8}
-	kind := "dummy"
-	tx, err := createOneClientTx(d.GetBaseID(), kind, value, signer)
+	tx, err := createOneClientTx(b.GenesisDarc.GetBaseID(), DummyContractName, value, b.Signer)
 	require.NoError(t, err)
-	atr, err := c.AddTransactionAndWait(tx, 10)
+	atr, err := b.Client.AddTransactionAndWait(tx, 10)
 	require.NoError(t, err)
 
 	// We should have a proof of our transaction in the skipchain.
 	newID := tx.Instructions[0].Hash()
-	p, err := c.GetProofAfter(newID, true, &atr.Proof.Latest)
+	p, err := b.Client.GetProofAfter(newID, true, &atr.Proof.Latest)
 	require.NoError(t, err)
-	require.Nil(t, p.Proof.Verify(csr.Skipblock.SkipChainID()))
+	require.Nil(t, p.Proof.Verify(b.Genesis.SkipChainID()))
 	require.Equal(t, 2, len(p.Proof.Links))
 	k, v0, _, _, err := p.Proof.KeyValue()
 	require.NoError(t, err)
@@ -160,7 +140,7 @@ func TestClient_GetProof(t *testing.T) {
 	require.Equal(t, value, v0)
 
 	// The proof should now be smaller as we learnt about the block
-	p, err = c.GetProofAfter(newID, false, &atr.Proof.Latest)
+	p, err = b.Client.GetProofAfter(newID, false, &atr.Proof.Latest)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(p.Proof.Links))
 }
@@ -198,41 +178,25 @@ func TestClient_GetProofCorrupted(t *testing.T) {
 // Create a streaming client and add blocks in the background. The client
 // should receive valid blocks.
 func TestClient_Streaming(t *testing.T) {
-	l := onet.NewTCPTest(cothority.Suite)
-	servers, roster, _ := l.GenTree(3, true)
-	registerDummy(t, servers)
-	defer l.CloseAll()
-
-	// Initialise the genesis message and send it to the service.
-	signer := darc.NewSignerEd25519(nil, nil)
-	msg, err := DefaultGenesisMsg(CurrentVersion, roster, []string{"spawn:dummy"}, signer.Identity())
-	msg.BlockInterval = time.Second
-	require.NoError(t, err)
-
-	// The darc inside it should be valid.
-	d := msg.GenesisDarc
-	require.Nil(t, d.Verify(true))
-
-	c, csr, err := NewLedger(msg, false)
-	require.NoError(t, err)
+	b := newBCTRun(t, nil)
+	defer b.CloseAll()
 
 	n := 2
 	go func() {
 		time.Sleep(100 * time.Millisecond)
 		for i := 0; i < n; i++ {
 			value := []byte{5, 6, 7, 8}
-			kind := "dummy"
-			tx, err := createOneClientTxWithCounter(d.GetBaseID(), kind, value, signer, uint64(i)+1)
+			tx, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), DummyContractName, value, b.Signer, uint64(i)+1)
 			// Need log.ErrFatal here, else it races with the rest of the code that
 			// uses 't'.
 			require.NoError(t, err)
-			_, err = c.AddTransaction(tx)
+			_, err = b.Client.AddTransaction(tx)
 			require.NoError(t, err)
 		}
 	}()
 
 	// Start collecting transactions
-	c1 := NewClientKeep(csr.Skipblock.Hash, *roster)
+	c1 := NewClientKeep(b.Genesis.Hash, *b.Roster)
 	var xMut sync.Mutex
 	var x int
 	done := make(chan bool)
@@ -263,48 +227,31 @@ func TestClient_Streaming(t *testing.T) {
 	}
 
 	go func() {
-		err = c1.StreamTransactions(cb)
+		err := c1.StreamTransactions(cb)
 		require.NoError(t, err)
 	}()
 	select {
 	case <-done:
-	case <-time.After(time.Duration(10) * msg.BlockInterval):
+	case <-time.After(time.Duration(10) * b.GenesisMessage.BlockInterval):
 		require.Fail(t, "should have got n transactions")
 	}
 	require.NoError(t, c1.Close())
 }
 
 func TestClient_NoPhantomSkipchain(t *testing.T) {
-	l := onet.NewTCPTest(cothority.Suite)
-	servers, roster, _ := l.GenTree(3, true)
-	registerDummy(t, servers)
-	defer l.CloseAll()
-
-	// Initialise the genesis message and send it to the service.
-	signer := darc.NewSignerEd25519(nil, nil)
-	msg, err := DefaultGenesisMsg(CurrentVersion, roster, []string{"spawn:dummy"}, signer.Identity())
-	msg.BlockInterval = 100 * time.Millisecond
-	require.NoError(t, err)
-
-	d := msg.GenesisDarc
-
-	c, _, err := NewLedger(msg, false)
-	require.NoError(t, err)
-
-	gac, err := c.GetAllByzCoinIDs(roster.List[0])
-	require.NoError(t, err)
-	require.Equal(t, 1, len(gac.IDs))
+	b := newBCTRun(t, nil)
+	defer b.CloseAll()
 
 	// Create a new transaction.
-	tx, err := createOneClientTx(d.GetBaseID(), "dummy", []byte{}, signer)
+	tx, err := createOneClientTx(b.GenesisDarc.GetBaseID(), DummyContractName,
+		[]byte{}, b.Signer)
 	require.NoError(t, err)
-	_, err = c.AddTransactionAndWait(tx, 10)
+	_, err = b.Client.AddTransactionAndWait(tx, 10)
 	require.NoError(t, err)
 
-	gac, err = c.GetAllByzCoinIDs(roster.List[0])
+	gac, err := b.Client.GetAllByzCoinIDs(b.Roster.List[0])
 	require.NoError(t, err)
 	require.Equal(t, 1, len(gac.IDs))
-	require.NoError(t, l.WaitDone(time.Second))
 }
 
 // Insure that the decoder will return an error if the reply

--- a/byzcoin/bctest.go
+++ b/byzcoin/bctest.go
@@ -1,0 +1,244 @@
+package byzcoin
+
+import (
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/cothority/v3/darc"
+	"go.dedis.ch/cothority/v3/darc/expression"
+	"go.dedis.ch/cothority/v3/skipchain"
+	"go.dedis.ch/kyber/v3/suites"
+	"go.dedis.ch/onet/v3"
+	"testing"
+	"time"
+)
+
+// BCTest structure represents commonly used elements when doing integration
+// tests in ByzCoin.
+// The different methods use the testing.T field
+// to reduce manual error checking.
+type BCTest struct {
+	Local               *onet.LocalTest
+	Servers             []*onet.Server
+	Roster              *onet.Roster
+	Services            []*Service
+	Genesis             *skipchain.SkipBlock
+	Value               []byte
+	GenesisDarc         *darc.Darc
+	Signer              darc.Signer
+	SignerCounter       uint64
+	PropagationInterval time.Duration
+	Client              *Client
+	GenesisMessage      *CreateGenesisBlock
+	T                   *testing.T
+}
+
+// NewBCTestDefault creates a new structure with default values.
+func NewBCTestDefault(t *testing.T) *BCTest {
+	return NewBCTest(t, 500*time.Millisecond, 3)
+}
+
+// NewBCTest creates a new structure for the test, initializing the nodes,
+// but not yet starting the byzcoin instance.
+func NewBCTest(t *testing.T, propagation time.Duration, nodes int) *BCTest {
+	b := &BCTest{
+		T:             t,
+		Local:         onet.NewLocalTestT(suites.MustFind("Ed25519"), t),
+		Value:         []byte("anyvalue"),
+		Signer:        darc.NewSignerEd25519(nil, nil),
+		SignerCounter: 1,
+	}
+
+	b.Servers, b.Roster, _ = b.Local.GenTree(nodes, true)
+	for _, sv := range b.Local.GetServices(b.Servers, ByzCoinID) {
+		service := sv.(*Service)
+		b.Services = append(b.Services, service)
+	}
+
+	var err error
+	b.GenesisMessage, err = DefaultGenesisMsg(CurrentVersion, b.Roster,
+		[]string{
+			"spawn:" + DummyContractName,
+			"delete:" + DummyContractName,
+		},
+		b.Signer.Identity())
+	require.NoError(t, err)
+	b.GenesisDarc = &b.GenesisMessage.GenesisDarc
+
+	b.GenesisMessage.BlockInterval = propagation
+	b.PropagationInterval = b.GenesisMessage.BlockInterval
+
+	return b
+}
+
+// AddGenesisRules can be used before CreateByzCoin to add rules to the
+// genesis darc.
+func (b *BCTest) AddGenesisRules(rules ...string) {
+	require.Nil(b.T, b.Genesis, "cannot add rules after CreateByzCoin")
+	ownerExpr := expression.Expr(b.Signer.Identity().String())
+	for _, r := range rules {
+		require.NoError(b.T, b.GenesisMessage.GenesisDarc.Rules.AddRule(
+			darc.Action(r), ownerExpr))
+	}
+}
+
+// CreateByzCoin starts the byzcoin instance and updates the Genesis and
+// Client fields.
+func (b *BCTest) CreateByzCoin() {
+	require.Nil(b.T, b.Genesis, "CreateByzCoin can only be called once")
+	resp, err := b.Services[0].CreateGenesisBlock(b.GenesisMessage)
+	require.NoError(b.T, err)
+	b.Genesis = resp.Skipblock
+	b.Client = NewClient(b.Genesis.SkipChainID(), *b.Roster)
+	require.NoError(b.T, b.Client.WaitPropagation(0))
+}
+
+// NodeStop simulates a node that is down.
+func (b *BCTest) NodeStop(index int) {
+	b.Services[index].TestClose()
+	b.Servers[index].Pause()
+}
+
+// NodeRestart simulates a node that goes up.
+func (b *BCTest) NodeRestart(index int) {
+	b.Servers[index].Unpause()
+	require.NoError(b.T, b.Services[index].TestRestart())
+}
+
+// CloseAll must be used when the test is done.
+// It makes sure that the system is in an idle state before shutting it down.
+func (b *BCTest) CloseAll() {
+	if b.Client != nil {
+		require.NoError(b.T, b.Client.WaitPropagation(-1))
+	}
+	b.Local.CloseAll()
+}
+
+// TxArgs can be used to define in more detail how the transactions should be
+// sent to the ledger.
+type TxArgs struct {
+	Node            int
+	Wait            int
+	WaitPropagation bool
+	RequireSuccess  bool
+}
+
+// TxArgsDefault represent sensible defaults for new transactions.
+// They are used if the args=nil.
+var TxArgsDefault = TxArgs{
+	Node:            0,
+	Wait:            10,
+	WaitPropagation: true,
+	RequireSuccess:  true,
+}
+
+// SendInst takes the instructions, adds the counters,
+// and signs them using the b.Signer. If b.Signer is used
+// outside of SendInst and SendTx,
+// b.SignerCounter needs to be updated by the test.
+// If args == nil, TxArgsDefault is used.
+func (b *BCTest) SendInst(args *TxArgs,
+	inst ...Instruction) (ClientTransaction, AddTxResponse) {
+
+	for i := range inst {
+		inst[i].SignerIdentities = []darc.Identity{b.Signer.Identity()}
+		inst[i].SignerCounter = []uint64{b.SignerCounter}
+		b.SignerCounter++
+	}
+	ctx := NewClientTransaction(CurrentVersion, inst...)
+	h := ctx.Instructions.Hash()
+	for i := range ctx.Instructions {
+		require.NoError(b.T, ctx.Instructions[i].SignWith(h, b.Signer))
+	}
+
+	return ctx, b.SendTx(args, ctx)
+}
+
+// SendTx calls the service of the node given in args and adds a transaction.
+// Depending on args,
+// it checks for success and waits for the transaction to be stored in all
+// nodes.
+// If args == nil, TxArgsDefault is used.
+func (b *BCTest) SendTx(args *TxArgs, ctx ClientTransaction) AddTxResponse {
+	if args == nil {
+		args = &TxArgsDefault
+	}
+
+	resp, err := b.Services[args.Node].AddTransaction(&AddTxRequest{
+		Version:       CurrentVersion,
+		SkipchainID:   b.Genesis.SkipChainID(),
+		Transaction:   ctx,
+		InclusionWait: args.Wait,
+	})
+	require.NoError(b.T, err)
+	require.NotNil(b.T, resp)
+	if args.RequireSuccess {
+		require.Empty(b.T, resp.Error)
+	}
+	if args.WaitPropagation {
+		require.NoError(b.T, b.Client.WaitPropagation(-1))
+	}
+	return *resp
+}
+
+// SpawnDummy creates a new dummy-instance with the value "anyvalue".
+// If args == nil, TxArgsDefault is used.
+func (b *BCTest) SpawnDummy(args *TxArgs) (ClientTransaction, AddTxResponse) {
+	return b.SendInst(args, Instruction{
+		InstanceID: NewInstanceID(b.GenesisDarc.GetBaseID()),
+		Spawn: &Spawn{
+			ContractID: DummyContractName,
+			Args:       Arguments{{Name: "data", Value: []byte("anyvalue")}},
+		},
+	})
+}
+
+// DummyContractName is the name of the dummy contract.
+const DummyContractName = "dummy"
+
+// dummyContract is a copy of the value-contract
+type dummyContract struct {
+	BasicContract
+	Data []byte
+}
+
+func dummyContractFromBytes(in []byte) (Contract, error) {
+	return &dummyContract{Data: in}, nil
+}
+
+func (dc *dummyContract) Spawn(cdb ReadOnlyStateTrie, inst Instruction, c []Coin) ([]StateChange, []Coin, error) {
+	_, _, _, darcID, err := cdb.GetValues(inst.InstanceID.Slice())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(inst.Spawn.Args.Search("data")) == 32 {
+		return []StateChange{
+			NewStateChange(Create, NewInstanceID(inst.Spawn.Args.Search("data")), inst.Spawn.ContractID,
+				[]byte{}, darcID),
+		}, nil, nil
+	}
+	return []StateChange{
+		NewStateChange(Create, NewInstanceID(inst.Hash()), inst.Spawn.ContractID, inst.Spawn.Args[0].Value, darcID),
+	}, nil, nil
+}
+
+func (dc *dummyContract) Invoke(cdb ReadOnlyStateTrie, inst Instruction, c []Coin) ([]StateChange, []Coin, error) {
+	_, _, _, darcID, err := cdb.GetValues(inst.InstanceID.Slice())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return []StateChange{
+		NewStateChange(Update, inst.InstanceID, DummyContractName, inst.Invoke.Args[0].Value, darcID),
+	}, nil, nil
+}
+
+func (dc *dummyContract) Delete(cdb ReadOnlyStateTrie, inst Instruction, c []Coin) ([]StateChange, []Coin, error) {
+	_, _, _, darcID, err := cdb.GetValues(inst.InstanceID.Slice())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return []StateChange{
+		NewStateChange(Remove, inst.InstanceID, "", nil, darcID),
+	}, nil, nil
+}

--- a/byzcoin/contract_darc_test.go
+++ b/byzcoin/contract_darc_test.go
@@ -2,30 +2,18 @@ package byzcoin
 
 import (
 	"testing"
-	"time"
 
 	"go.dedis.ch/cothority/v3"
 	"go.dedis.ch/cothority/v3/darc"
 	"go.dedis.ch/cothority/v3/skipchain"
-	"go.dedis.ch/onet/v3"
 	"go.dedis.ch/onet/v3/log"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestSecureDarc(t *testing.T) {
-	local := onet.NewTCPTest(cothority.Suite)
-	defer local.CloseAll()
-
-	signer := darc.NewSignerEd25519(nil, nil)
-	_, roster, _ := local.GenTree(3, true)
-
-	genesisMsg, err := DefaultGenesisMsg(CurrentVersion, roster, []string{}, signer.Identity())
-	require.NoError(t, err)
-	gDarc := &genesisMsg.GenesisDarc
-	genesisMsg.BlockInterval = time.Second
-	cl, _, err := NewLedger(genesisMsg, false)
-	require.NoError(t, err)
+	b := newBCTRun(t, nil)
+	defer b.CloseAll()
 
 	restrictedSigner := darc.NewSignerEd25519(nil, nil)
 	unrestrictedSigner := darc.NewSignerEd25519(nil, nil)
@@ -33,12 +21,12 @@ func TestSecureDarc(t *testing.T) {
 	invokeEvolveUnrestricted := darc.Action("invoke:" + ContractDarcID + "." + cmdDarcEvolveUnrestriction)
 
 	log.Lvl1("spawn a new secure darc with spawn:insecure_darc - fail")
-	secDarc := gDarc.Copy()
+	secDarc := b.GenesisDarc.Copy()
 	require.NoError(t, secDarc.Rules.AddRule("spawn:insecure_darc", []byte(restrictedSigner.Identity().String())))
 	secDarcBuf, err := secDarc.ToProto()
 	require.NoError(t, err)
-	ctx, err := cl.CreateTransaction(Instruction{
-		InstanceID: NewInstanceID(gDarc.GetBaseID()),
+	ctx, err := b.Client.CreateTransaction(Instruction{
+		InstanceID: NewInstanceID(b.GenesisDarc.GetBaseID()),
 		Spawn: &Spawn{
 			ContractID: ContractDarcID,
 			Args: []Argument{{
@@ -49,8 +37,8 @@ func TestSecureDarc(t *testing.T) {
 		SignerCounter: []uint64{1},
 	})
 	require.NoError(t, err)
-	require.NoError(t, ctx.FillSignersAndSignWith(signer))
-	_, err = cl.AddTransactionAndWait(ctx, 10)
+	require.NoError(t, ctx.FillSignersAndSignWith(b.Signer))
+	_, err = b.Client.AddTransactionAndWait(ctx, 10)
 	require.Error(t, err)
 
 	log.Lvl1("do the same but without spawn:insecure_darc - pass")
@@ -59,8 +47,8 @@ func TestSecureDarc(t *testing.T) {
 	require.NoError(t, secDarc.Rules.UpdateRule(invokeEvolveUnrestricted, []byte(unrestrictedSigner.Identity().String())))
 	secDarcBuf, err = secDarc.ToProto()
 	require.NoError(t, err)
-	ctx, err = cl.CreateTransaction(Instruction{
-		InstanceID: NewInstanceID(gDarc.GetBaseID()),
+	ctx, err = b.Client.CreateTransaction(Instruction{
+		InstanceID: NewInstanceID(b.GenesisDarc.GetBaseID()),
 		Spawn: &Spawn{
 			ContractID: ContractDarcID,
 			Args: []Argument{{
@@ -71,16 +59,16 @@ func TestSecureDarc(t *testing.T) {
 		SignerCounter: []uint64{1},
 	})
 	require.NoError(t, err)
-	require.NoError(t, ctx.FillSignersAndSignWith(signer))
-	_, err = cl.AddTransactionAndWait(ctx, 10)
+	require.NoError(t, ctx.FillSignersAndSignWith(b.Signer))
+	_, err = b.Client.AddTransactionAndWait(ctx, 10)
 	require.NoError(t, err)
 
 	log.Lvl1("spawn a darc with a version > 0 - fail")
 	secDarc.Version = 1
 	secDarcBuf, err = secDarc.ToProto()
 	require.NoError(t, err)
-	ctx, err = cl.CreateTransaction(Instruction{
-		InstanceID: NewInstanceID(gDarc.GetBaseID()),
+	ctx, err = b.Client.CreateTransaction(Instruction{
+		InstanceID: NewInstanceID(b.GenesisDarc.GetBaseID()),
 		Spawn: &Spawn{
 			ContractID: ContractDarcID,
 			Args: []Argument{{
@@ -91,8 +79,8 @@ func TestSecureDarc(t *testing.T) {
 		SignerCounter: []uint64{2},
 	})
 	require.NoError(t, err)
-	require.NoError(t, ctx.FillSignersAndSignWith(signer))
-	_, err = cl.AddTransactionAndWait(ctx, 10)
+	require.NoError(t, ctx.FillSignersAndSignWith(b.Signer))
+	_, err = b.Client.AddTransactionAndWait(ctx, 10)
 	require.Error(t, err)
 
 	secDarc.Version = 0
@@ -103,7 +91,7 @@ func TestSecureDarc(t *testing.T) {
 		require.NoError(t, secDarc2.Rules.AddRule("spawn:coin", secDarc.Rules.Get(invokeEvolveUnrestricted)))
 		secDarc2Buf, err := secDarc2.ToProto()
 		require.NoError(t, err)
-		ctx2, err := cl.CreateTransaction(Instruction{
+		ctx2, err := b.Client.CreateTransaction(Instruction{
 			InstanceID: NewInstanceID(secDarc.GetBaseID()),
 			Invoke: &Invoke{
 				ContractID: ContractDarcID,
@@ -117,7 +105,7 @@ func TestSecureDarc(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NoError(t, ctx2.FillSignersAndSignWith(restrictedSigner))
-		_, err = cl.AddTransactionAndWait(ctx2, 10)
+		_, err = b.Client.AddTransactionAndWait(ctx2, 10)
 		require.Error(t, err)
 	}
 
@@ -129,7 +117,7 @@ func TestSecureDarc(t *testing.T) {
 		require.NoError(t, secDarc2.Rules.UpdateRule(invokeEvolveUnrestricted, []byte(restrictedSigner.Identity().String())))
 		secDarc2Buf, err := secDarc2.ToProto()
 		require.NoError(t, err)
-		ctx2, err := cl.CreateTransaction(Instruction{
+		ctx2, err := b.Client.CreateTransaction(Instruction{
 			InstanceID: NewInstanceID(secDarc.GetBaseID()),
 			Invoke: &Invoke{
 				ContractID: ContractDarcID,
@@ -143,7 +131,7 @@ func TestSecureDarc(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NoError(t, ctx2.FillSignersAndSignWith(restrictedSigner))
-		_, err = cl.AddTransactionAndWait(ctx2, 10)
+		_, err = b.Client.AddTransactionAndWait(ctx2, 10)
 		require.Error(t, err)
 	}
 
@@ -155,7 +143,7 @@ func TestSecureDarc(t *testing.T) {
 		require.NoError(t, secDarc2.EvolveFrom(secDarc))
 		secDarc2Buf, err := secDarc2.ToProto()
 		require.NoError(t, err)
-		ctx2, err := cl.CreateTransaction(Instruction{
+		ctx2, err := b.Client.CreateTransaction(Instruction{
 			InstanceID: NewInstanceID(secDarc.GetBaseID()),
 			Invoke: &Invoke{
 				ContractID: ContractDarcID,
@@ -169,20 +157,20 @@ func TestSecureDarc(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NoError(t, ctx2.FillSignersAndSignWith(restrictedSigner))
-		atr, err := cl.AddTransactionAndWait(ctx2, 10)
+		atr, err := b.Client.AddTransactionAndWait(ctx2, 10)
 		require.NoError(t, err)
 
 		barrier = &atr.Proof.Latest
 	}
 
 	// get the latest darc
-	resp, err := cl.GetProofAfter(secDarc.GetBaseID(), false, barrier)
+	resp, err := b.Client.GetProofAfter(secDarc.GetBaseID(), false, barrier)
 	require.NoError(t, err)
 	myDarc := darc.Darc{}
 	require.NoError(t, resp.Proof.VerifyAndDecode(cothority.Suite, ContractDarcID, &myDarc))
 	// secDarc is copied from genesis DARC, after one evolution the version
 	// should increase by one
-	require.Equal(t, myDarc.Version, gDarc.Version+1)
+	require.Equal(t, myDarc.Version, b.GenesisDarc.Version+1)
 
 	log.Lvl1("evolve_unrestricted fails with the wrong signer")
 	{
@@ -191,7 +179,7 @@ func TestSecureDarc(t *testing.T) {
 		require.NoError(t, myDarc2.Rules.AddRule("spawn:coin", myDarc.Rules.Get(invokeEvolveUnrestricted)))
 		myDarc2Buf, err := myDarc2.ToProto()
 		require.NoError(t, err)
-		ctx2, err := cl.CreateTransaction(Instruction{
+		ctx2, err := b.Client.CreateTransaction(Instruction{
 			InstanceID: NewInstanceID(myDarc.GetBaseID()),
 			Invoke: &Invoke{
 				ContractID: ContractDarcID,
@@ -205,7 +193,7 @@ func TestSecureDarc(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NoError(t, ctx2.FillSignersAndSignWith(restrictedSigner)) // here we use the wrong signer
-		_, err = cl.AddTransactionAndWait(ctx2, 10)
+		_, err = b.Client.AddTransactionAndWait(ctx2, 10)
 		require.Error(t, err)
 	}
 
@@ -216,7 +204,7 @@ func TestSecureDarc(t *testing.T) {
 		require.NoError(t, myDarc2.Rules.AddRule("spawn:coin", myDarc2.Rules.Get(invokeEvolveUnrestricted)))
 		myDarc2Buf, err := myDarc2.ToProto()
 		require.NoError(t, err)
-		ctx2, err := cl.CreateTransaction(Instruction{
+		ctx2, err := b.Client.CreateTransaction(Instruction{
 			InstanceID: NewInstanceID(myDarc.GetBaseID()),
 			Invoke: &Invoke{
 				ContractID: ContractDarcID,
@@ -230,20 +218,19 @@ func TestSecureDarc(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NoError(t, ctx2.FillSignersAndSignWith(unrestrictedSigner)) // here we use the correct signer
-		atr, err := cl.AddTransactionAndWait(ctx2, 10)
+		atr, err := b.Client.AddTransactionAndWait(ctx2, 10)
 		require.NoError(t, err)
 
 		barrier = &atr.Proof.Latest
 	}
 
 	// try to get the DARC again and it should have the "spawn:coin" rule
+	log.Lvl1("Checking darc rules")
 	{
-		resp, err := cl.GetProofAfter(secDarc.GetBaseID(), false, barrier)
+		resp, err := b.Client.GetProofAfter(secDarc.GetBaseID(), false, barrier)
 		require.NoError(t, err)
 		myDarc := darc.Darc{}
 		require.NoError(t, resp.Proof.VerifyAndDecode(cothority.Suite, ContractDarcID, &myDarc))
 		require.Equal(t, myDarc.Rules.Get("spawn:coin"), myDarc.Rules.Get("invoke:darc."+cmdDarcEvolveUnrestriction))
 	}
-
-	require.NoError(t, local.WaitDone(5*genesisMsg.BlockInterval))
 }

--- a/byzcoin/statetrie_test.go
+++ b/byzcoin/statetrie_test.go
@@ -24,10 +24,10 @@ import (
 // TestStateTrie is a sanity check for setting and retrieving keys, values and
 // index. The main functionalities are tested in the trie package.
 func TestStateTrie(t *testing.T) {
-	s := newSer(t, 1, testInterval)
-	defer s.local.CloseAll()
+	b := newBCTRun(t, nil)
+	defer b.CloseAll()
 
-	st, err := s.service().getStateTrie(s.genesis.SkipChainID())
+	st, err := b.Services[0].getStateTrie(b.Genesis.SkipChainID())
 	require.NoError(t, err)
 	require.NotNil(t, st)
 	require.NotEqual(t, -1, st.GetIndex())
@@ -95,13 +95,15 @@ func TestDarcRetrieval(t *testing.T) {
 	darcWidth := 10
 	entries := 1000
 
-	s := newSer(t, 1, 10*time.Second)
-	defer s.local.CloseAll()
+	bArgs := defaultBCTArgs
+	bArgs.PropagationInterval = 10 * time.Second
+	b := newBCTRun(t, &bArgs)
+	defer b.CloseAll()
 	// When running with `-cpuprofile`, additional go-routines are added,
 	// which should be ignored.
 	log.AddUserUninterestingGoroutine("/runtime/cpuprof.go")
 
-	st, err := s.service().getStateTrie(s.genesis.SkipChainID())
+	st, err := b.Services[0].getStateTrie(b.Genesis.SkipChainID())
 	require.NoError(t, err)
 	require.NotEqual(t, -1, st.GetIndex())
 

--- a/byzcoin/streaming_test.go
+++ b/byzcoin/streaming_test.go
@@ -12,13 +12,13 @@ var chanTimeout = time.Millisecond * 100
 
 func TestStreamingService_PaginateBlocks(t *testing.T) {
 	// Creating a service with only the genesis block
-	s := newSerN(t, 1, testInterval, 4, disableViewChange)
-	defer s.local.CloseAll()
-	service := s.service()
+	b := newBCTRun(t, nil)
+	defer b.CloseAll()
+	service := b.Services[0]
 
 	// We should be able to get 1 page with one item, which is the genesis block
 	paginateRequest := &PaginateRequest{
-		StartID:  s.genesis.Hash,
+		StartID:  b.Genesis.Hash,
 		PageSize: 1,
 		NumPages: 1,
 		Backward: false,
@@ -33,7 +33,7 @@ func TestStreamingService_PaginateBlocks(t *testing.T) {
 				"the messages: %v", response.ErrorCode, response.ErrorText)
 		}
 		require.Equal(t, 1, len(response.Blocks))
-		require.Equal(t, response.Blocks[0].Hash, s.genesis.Hash)
+		require.Equal(t, response.Blocks[0].Hash, b.Genesis.Hash)
 	case <-time.After(chanTimeout):
 		t.Fatal("didn't get a papginateResponse in the channel after timeout")
 	}
@@ -48,7 +48,7 @@ func TestStreamingService_PaginateBlocks(t *testing.T) {
 	// Trying to fetch 2 items per page should raise an error since there is
 	// only the genesis block
 	paginateRequest = &PaginateRequest{
-		StartID:  s.genesis.Hash,
+		StartID:  b.Genesis.Hash,
 		PageSize: 2,
 		NumPages: 1,
 		Backward: false,
@@ -74,7 +74,7 @@ func TestStreamingService_PaginateBlocks(t *testing.T) {
 	// Trying to fetch 2 pages should raise an error in the second page since
 	// there is only the genesis block
 	paginateRequest = &PaginateRequest{
-		StartID:  s.genesis.Hash,
+		StartID:  b.Genesis.Hash,
 		PageSize: 1,
 		NumPages: 2,
 		Backward: false,
@@ -89,7 +89,7 @@ func TestStreamingService_PaginateBlocks(t *testing.T) {
 				"the messages: %v", response.ErrorCode, response.ErrorText)
 		}
 		require.Equal(t, 1, len(response.Blocks))
-		require.Equal(t, response.Blocks[0].Hash, s.genesis.Hash)
+		require.Equal(t, response.Blocks[0].Hash, b.Genesis.Hash)
 	case <-time.After(chanTimeout):
 		t.Fatal("didn't get a papginateResponse in the channel after timeout")
 	}
@@ -111,12 +111,11 @@ func TestStreamingService_PaginateBlocks(t *testing.T) {
 
 	// Adding a new block so we can fetch a page of two blocks, or two pages
 	// with one item each.
-	tx, err := createOneClientTx(s.darc.GetBaseID(), dummyContract, s.value, s.signer)
+	tx, err := createOneClientTx(b.GenesisDarc.GetBaseID(), DummyContractName, b.Value, b.Signer)
 	require.NoError(t, err)
-	s.tx = tx
-	resp, err := s.service().AddTransaction(&AddTxRequest{
+	resp, err := b.Services[0].AddTransaction(&AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx,
 		InclusionWait: 10,
 	})
@@ -124,7 +123,7 @@ func TestStreamingService_PaginateBlocks(t *testing.T) {
 
 	// Fetching two items in one page
 	paginateRequest = &PaginateRequest{
-		StartID:  s.genesis.Hash,
+		StartID:  b.Genesis.Hash,
 		PageSize: 2,
 		NumPages: 1,
 		Backward: false,
@@ -140,7 +139,7 @@ func TestStreamingService_PaginateBlocks(t *testing.T) {
 				"the messages: %v", response.ErrorCode, response.ErrorText)
 		}
 		require.Equal(t, 2, len(response.Blocks))
-		require.Equal(t, response.Blocks[0].Hash, s.genesis.Hash)
+		require.Equal(t, response.Blocks[0].Hash, b.Genesis.Hash)
 		secondBlockHash = response.Blocks[1].Hash
 	case <-time.After(chanTimeout):
 		t.Fatal("didn't get a papginateResponse in the channel after timeout")
@@ -155,7 +154,7 @@ func TestStreamingService_PaginateBlocks(t *testing.T) {
 
 	// Fecthing two pages with 1 item each
 	paginateRequest = &PaginateRequest{
-		StartID:  s.genesis.Hash,
+		StartID:  b.Genesis.Hash,
 		PageSize: 1,
 		NumPages: 2,
 		Backward: false,
@@ -170,7 +169,7 @@ func TestStreamingService_PaginateBlocks(t *testing.T) {
 				"the messages: %v", response.ErrorCode, response.ErrorText)
 		}
 		require.Equal(t, 1, len(response.Blocks))
-		require.Equal(t, response.Blocks[0].Hash, s.genesis.Hash)
+		require.Equal(t, response.Blocks[0].Hash, b.Genesis.Hash)
 	case <-time.After(chanTimeout):
 		t.Fatal("didn't get a papginateResponse in the channel after timeout")
 	}
@@ -196,7 +195,7 @@ func TestStreamingService_PaginateBlocks(t *testing.T) {
 	// If we get the page in reverse order from the genesis block we should get
 	// an error
 	paginateRequest = &PaginateRequest{
-		StartID:  s.genesis.Hash,
+		StartID:  b.Genesis.Hash,
 		PageSize: 2,
 		NumPages: 1,
 		Backward: true,
@@ -228,7 +227,7 @@ func TestStreamingService_PaginateBlocks(t *testing.T) {
 	// Trying to fetch 2 pages from the genesis block in reverse order should
 	// raise an error in the second page
 	paginateRequest = &PaginateRequest{
-		StartID:  s.genesis.Hash,
+		StartID:  b.Genesis.Hash,
 		PageSize: 1,
 		NumPages: 2,
 		Backward: true,
@@ -243,7 +242,7 @@ func TestStreamingService_PaginateBlocks(t *testing.T) {
 				"the messages: %v", response.ErrorCode, response.ErrorText)
 		}
 		require.Equal(t, 1, len(response.Blocks))
-		require.Equal(t, response.Blocks[0].Hash, s.genesis.Hash)
+		require.Equal(t, response.Blocks[0].Hash, b.Genesis.Hash)
 	case <-time.After(chanTimeout):
 		t.Fatal("didn't get a papginateResponse in the channel after timeout")
 	}
@@ -281,7 +280,7 @@ func TestStreamingService_PaginateBlocks(t *testing.T) {
 		}
 		require.Equal(t, 2, len(response.Blocks))
 		require.Equal(t, response.Blocks[0].Hash, secondBlockHash)
-		require.Equal(t, response.Blocks[1].Hash, s.genesis.Hash)
+		require.Equal(t, response.Blocks[1].Hash, b.Genesis.Hash)
 	case <-time.After(chanTimeout):
 		t.Fatal("didn't get a papginateResponse in the channel after timeout")
 	}
@@ -322,7 +321,7 @@ func TestStreamingService_PaginateBlocks(t *testing.T) {
 				"the messages: %v", response.ErrorCode, response.ErrorText)
 		}
 		require.Equal(t, 1, len(response.Blocks))
-		require.Equal(t, response.Blocks[0].Hash, s.genesis.Hash)
+		require.Equal(t, response.Blocks[0].Hash, b.Genesis.Hash)
 	case <-time.After(chanTimeout):
 		t.Fatal("didn't get a papginateResponse in the channel after timeout")
 	}
@@ -336,7 +335,7 @@ func TestStreamingService_PaginateBlocks(t *testing.T) {
 
 	// Using a wrong page size should return an error 2
 	paginateRequest = &PaginateRequest{
-		StartID:  s.genesis.Hash,
+		StartID:  b.Genesis.Hash,
 		PageSize: 0,
 		NumPages: 1,
 		Backward: false,

--- a/byzcoin/transaction_test.go
+++ b/byzcoin/transaction_test.go
@@ -154,8 +154,7 @@ func createSpawnInstr(dID darc.ID, contractID string, argName string, value []by
 			ContractID: contractID,
 			Args:       Arguments{{Name: argName, Value: value}},
 		},
-		SignerCounter: []uint64{1},
-		version:       CurrentVersion,
+		version: CurrentVersion,
 	}
 }
 

--- a/byzcoin/viewchange_test.go
+++ b/byzcoin/viewchange_test.go
@@ -2,7 +2,6 @@ package byzcoin
 
 import (
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -22,27 +21,25 @@ import (
 // followers. Finally, we bring the failed nodes back up and they should
 // contain the transactions that they missed.
 func TestViewChange_Basic(t *testing.T) {
-	testViewChange(t, 4, 1, testInterval)
+	testViewChange(t, 4, 1)
 }
 
 func TestViewChange_Basic2(t *testing.T) {
 	if testing.Short() {
-		// Block interval needs to be big enough so that the protocol
-		// timeout is big enough but the test takes too much time then.
-		t.Skip("protocol timeout too short for Travis")
+		t.Skip("too many messages - travis looses some of the packets")
 	}
 
-	testViewChange(t, 7, 2, testInterval)
+	testViewChange(t, 7, 2)
 }
 
 func TestViewChange_Basic3(t *testing.T) {
 	if testing.Short() {
-		t.Skip("protocol timeout too short for Travis")
+		t.Skip("too many messages - travis looses some of the packets")
 	}
 
 	// Enough nodes and failing ones to test what happens when propagation
 	// fails due to offline nodes in the higher level of the tree.
-	testViewChange(t, 10, 3, 2*testInterval)
+	testViewChange(t, 10, 3)
 }
 
 // This test is brittle with regard to timeouts:
@@ -52,178 +49,152 @@ func TestViewChange_Basic3(t *testing.T) {
 //     - calculating the timeouts when asking for a signature
 //     - the time to wait to propagate to children
 // So it's using the `SetPropagationTimeout` to tweak it a bit.
-func testViewChange(t *testing.T, nHosts, nFailures int, interval time.Duration) {
-	rw := 3
-	s := newSerN(t, 1, interval, nHosts, rw)
-	defer s.local.CloseAll()
+func testViewChange(t *testing.T, nHosts, nFailures int) {
+	bArgs := defaultBCTArgs
+	bArgs.Nodes = nHosts
+	bArgs.RotationWindow = 3
+	b := newBCTRun(t, &bArgs)
+	defer b.CloseAll()
+
+	propTimeout := time.Duration(4) * b.PropagationInterval
 
 	// The propagation interval needs to be high enough so that the
-	// subleaders and the leaves have the time to make sure the
+	// sub-leaders and the leaves have the time to make sure the
 	// transactions are correct.
-	for _, service := range s.services {
-		service.SetPropagationTimeout(4 * interval)
-	}
-
-	log.Lvl1("Wait for all the genesis config to be written on all nodes.")
-	genesisInstanceID := InstanceID{}
-	for i := range s.services {
-		s.waitProofWithIdx(t, genesisInstanceID.Slice(), i)
+	for _, service := range b.Services {
+		service.SetPropagationTimeout(propTimeout)
 	}
 
 	// Stop the first nFailures hosts then the node at index nFailures
 	// should take over.
 	for i := 0; i < nFailures; i++ {
 		log.Lvl1("stopping node at index", i)
-		s.services[i].TestClose()
-		s.hosts[i].Pause()
+		b.Services[i].TestClose()
+		b.Servers[i].Pause()
 	}
 
 	log.Lvl1("creating a first tx to trigger the view-change")
-	tx0, err := createOneClientTx(s.darc.GetBaseID(), dummyContract,
-		NewInstanceID([]byte{1}).Slice(), s.signer)
-	require.NoError(t, err)
-	s.sendTxTo(t, tx0, nFailures)
+	txArgs := TxArgsDefault
+	txArgs.Node = nFailures
+	b.SpawnDummy(&txArgs)
 
-	sl := s.interval * time.Duration(float64(rw)*
-		math.Pow(2, float64(nFailures)))
-	log.Lvl1("Waiting for the propagation to be finished during", sl)
-	time.Sleep(sl)
-	s.waitPropagation(t, 1)
-	gucr, err := s.services[nFailures].skService().GetUpdateChain(&skipchain.
-		GetUpdateChain{LatestID: s.genesis.SkipChainID()})
+	gucr, err := b.Services[nFailures].skService().GetUpdateChain(&skipchain.
+		GetUpdateChain{LatestID: b.Genesis.SkipChainID()})
 	require.NoError(t, err)
 
 	newRoster := gucr.Update[len(gucr.Update)-1].Roster
 	log.Lvl1("Verifying roster", newRoster)
-	sameRoster, err := newRoster.Equal(s.roster)
+	sameRoster, err := newRoster.Equal(b.Roster)
 	require.NoError(t, err)
 	require.False(t, sameRoster)
 	require.True(t, newRoster.List[0].Equal(
-		s.services[nFailures].ServerIdentity()))
+		b.Services[nFailures].ServerIdentity()))
 
 	// try to send a transaction to the node on index nFailures+1, which is
 	// a follower (not the new leader)
 	log.Lvl1("Sending a transaction to the node after the new leader")
-	tx1ID := NewInstanceID([]byte{2}).Slice()
-	counter := uint64(2)
-	tx1, err := createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, tx1ID,
-		s.signer, counter)
-	counter++
-	require.NoError(t, err)
-	s.sendTxTo(t, tx1, nFailures+1)
+	txArgs.Node = nFailures + 1
+	b.SpawnDummy(&txArgs)
 
 	// check that the leader is updated for all nodes
 	// Note: check is done after a tx has been sent so that nodes catch up if the
 	// propagation failed
-	log.Lvl1("Waiting for the new transaction to go through")
-	s.waitPropagation(t, -1)
-	for _, service := range s.services[nFailures:] {
+	log.Lvl1("Verifying leader is updated everywhere")
+	for _, service := range b.Services[nFailures:] {
 		// everyone should have the same leader after the genesis block is stored
-		leader, err := service.getLeader(s.genesis.SkipChainID())
+		leader, err := service.getLeader(b.Genesis.SkipChainID())
 		require.NoError(t, err)
 		require.NotNil(t, leader)
-		require.True(t, leader.Equal(s.services[nFailures].ServerIdentity()), fmt.Sprintf("%v", leader))
+		require.True(t, leader.Equal(b.Services[nFailures].ServerIdentity()), fmt.Sprintf("%v", leader))
 	}
 
 	log.Lvl1("Creating new TX")
-	s.sendDummyTx(t, nFailures+1, counter, 4)
-	counter++
-
-	log.Lvl1("waiting for the tx to be stored")
-	// wait for the transaction to be stored everywhere
-	for i := nFailures; i < nHosts; i++ {
-		pr := s.waitProofWithIdx(t, tx1ID, i)
-		require.True(t, pr.InclusionProof.Match(tx1ID))
-	}
+	b.SpawnDummy(&txArgs)
 
 	// We need to bring the failed (the first nFailures) nodes back up and
 	// check that they can synchronise to the latest state.
 	for i := 0; i < nFailures; i++ {
 		log.Lvl1("starting node at index", i)
-		s.hosts[i].Unpause()
-		require.NoError(t, s.services[i].TestRestart())
+		b.Servers[i].Unpause()
+		require.NoError(t, b.Services[i].TestRestart())
+		b.Services[i].SetPropagationTimeout(propTimeout)
 	}
-
-	time.Sleep(3 * time.Second)
+	b.Client.WaitPropagation(4)
 
 	log.Lvl1("Adding two new tx for the resurrected nodes to catch up")
 	for tx := 0; tx < 2; tx++ {
-		s.sendDummyTx(t, nFailures, counter, 4)
-		counter++
+		b.SpawnDummy(&txArgs)
 	}
 
-	log.Lvl1("Make sure resurrected nodes have caught up")
-	for i := 0; i < nFailures; i++ {
-		pr := s.waitProofWithIdx(t, tx1ID, i)
-		require.True(t, pr.InclusionProof.Match(tx1ID))
-	}
-	s.waitPropagation(t, -1)
-
-	log.Lvl1("Two final transactions")
-	for tx := 0; tx < 2; tx++ {
-		s.sendDummyTx(t, nFailures, counter, 4)
-		counter++
-	}
-
-	log.Lvl1("Sent two tx")
-	s.waitPropagation(t, -1)
+	log.Lvl1("Check that last block has index == 6")
+	pr, err := b.Client.GetProof(b.GenesisDarc.GetBaseID())
+	require.NoError(t, err)
+	require.Equal(t, 6, pr.Proof.Latest.Index)
 }
 
 // Tests that a view change can happen when the leader index is out of bound
 func TestViewChange_LeaderIndex(t *testing.T) {
-	s := newSerN(t, 1, time.Second, 5, defaultRotationWindow)
-	defer s.local.CloseAll()
+	bArgs := defaultBCTArgs
+	bArgs.PropagationInterval = time.Second
+	bArgs.Nodes = 5
+	bArgs.RotationWindow = defaultRotationWindow
+	b := newBCTRun(t, &bArgs)
+	defer b.CloseAll()
 
-	err := s.services[0].sendViewChangeReq(viewchange.View{LeaderIndex: -1})
+	err := b.Services[0].sendViewChangeReq(viewchange.View{LeaderIndex: -1})
 	require.Error(t, err)
 	require.Equal(t, "leader index must be positive", err.Error())
 
 	view := viewchange.View{
-		ID:          s.genesis.SkipChainID(),
-		Gen:         s.genesis.SkipChainID(),
+		ID:          b.Genesis.SkipChainID(),
+		Gen:         b.Genesis.SkipChainID(),
 		LeaderIndex: 7,
 	}
 	for i := 0; i < 5; i++ {
-		s.services[i].viewChangeMan.addReq(viewchange.InitReq{
-			SignerID: s.services[i].ServerIdentity().ID,
+		b.Services[i].viewChangeMan.addReq(viewchange.InitReq{
+			SignerID: b.Services[i].ServerIdentity().ID,
 			View:     view,
 		})
-		err := s.services[i].sendViewChangeReq(view)
+		err := b.Services[i].sendViewChangeReq(view)
 		require.NoError(t, err)
 	}
 
-	time.Sleep(2 * s.interval)
+	time.Sleep(2 * b.PropagationInterval)
 
-	for _, service := range s.services {
+	for _, service := range b.Services {
 		// everyone should have the same leader after the genesis block is stored
-		leader, err := service.getLeader(s.genesis.SkipChainID())
+		leader, err := service.getLeader(b.Genesis.SkipChainID())
 		require.NoError(t, err)
 		require.NotNil(t, leader)
-		require.True(t, leader.Equal(s.services[2].ServerIdentity()))
+		require.True(t, leader.Equal(b.Services[2].ServerIdentity()))
 	}
 }
 
 // Test that old states of a view change that got stuck in the middle of the protocol
 // are correctly cleaned if a new block is discovered.
 func TestViewChange_LostSync(t *testing.T) {
-	s := newSerN(t, 1, time.Second, 5, defaultRotationWindow)
-	defer s.local.CloseAll()
+	bArgs := defaultBCTArgs
+	bArgs.Nodes = 5
+	bArgs.PropagationInterval = time.Second
+	bArgs.RotationWindow = defaultRotationWindow
+	b := newBCTRun(t, &bArgs)
+	defer b.CloseAll()
 
-	target := s.hosts[1].ServerIdentity
+	target := b.Servers[1].ServerIdentity
 
 	// Simulate the beginning of a view change
 	req := &viewchange.InitReq{
-		SignerID: s.services[0].ServerIdentity().ID,
+		SignerID: b.Services[0].ServerIdentity().ID,
 		View: viewchange.View{
-			ID:          s.genesis.Hash,
-			Gen:         s.genesis.Hash,
+			ID:          b.Genesis.Hash,
+			Gen:         b.Genesis.Hash,
 			LeaderIndex: 3,
 		},
 		Signature: []byte{},
 	}
-	require.NoError(t, req.Sign(s.services[0].ServerIdentity().GetPrivate()))
+	require.NoError(t, req.Sign(b.Services[0].ServerIdentity().GetPrivate()))
 
-	err := s.services[0].SendRaw(target, req)
+	err := b.Services[0].SendRaw(target, req)
 	require.NoError(t, err)
 
 	// worst case scenario where the conode lost connectivity
@@ -231,11 +202,11 @@ func TestViewChange_LostSync(t *testing.T) {
 	// conode is still waiting for requests
 
 	// then new blocks have been added
-	tx1, err := createOneClientTxWithCounter(s.darc.GetBaseID(), dummyContract, s.value, s.signer, 1)
+	tx1, err := createOneClientTxWithCounter(b.GenesisDarc.GetBaseID(), DummyContractName, b.Value, b.Signer, 1)
 	require.NoError(t, err)
-	_, err = s.services[1].AddTransaction(&AddTxRequest{
+	_, err = b.Services[1].AddTransaction(&AddTxRequest{
 		Version:       CurrentVersion,
-		SkipchainID:   s.genesis.SkipChainID(),
+		SkipchainID:   b.Genesis.SkipChainID(),
 		Transaction:   tx1,
 		InclusionWait: 5,
 	})
@@ -244,25 +215,25 @@ func TestViewChange_LostSync(t *testing.T) {
 	// give enough time for the propagation to be processed
 	time.Sleep(1 * time.Second)
 
-	sb, err := s.services[1].db().GetLatestByID(s.genesis.Hash)
+	sb, err := b.Services[1].db().GetLatestByID(b.Genesis.Hash)
 	require.NoError(t, err)
-	require.NotEqual(t, sb.Hash, s.genesis.Hash)
+	require.NotEqual(t, sb.Hash, b.Genesis.Hash)
 
 	// Start a new view change with a different block ID
 	req = &viewchange.InitReq{
-		SignerID: s.services[0].ServerIdentity().ID,
+		SignerID: b.Services[0].ServerIdentity().ID,
 		View: viewchange.View{
 			ID:          sb.Hash,
-			Gen:         s.genesis.SkipChainID(),
+			Gen:         b.Genesis.SkipChainID(),
 			LeaderIndex: 3,
 		},
 	}
-	require.NoError(t, req.Sign(s.services[0].ServerIdentity().GetPrivate()))
+	require.NoError(t, req.Sign(b.Services[0].ServerIdentity().GetPrivate()))
 
 	log.OutputToBuf()
 	defer log.OutputToOs()
 
-	err = s.services[0].SendRaw(target, req)
+	err = b.Services[0].SendRaw(target, req)
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second) // request handler is asynchronous
@@ -272,28 +243,28 @@ func TestViewChange_LostSync(t *testing.T) {
 	// make sure a view change can still happen later
 	view := viewchange.View{
 		ID:          sb.Hash,
-		Gen:         s.genesis.SkipChainID(),
+		Gen:         b.Genesis.SkipChainID(),
 		LeaderIndex: 3,
 	}
 	for i := 0; i < 4; i++ {
-		err := s.services[i].sendViewChangeReq(view)
+		err := b.Services[i].sendViewChangeReq(view)
 		require.NoError(t, err)
 	}
 	for i := 0; i < 4; i++ {
-		s.services[i].viewChangeMan.addReq(viewchange.InitReq{
-			SignerID: s.services[i].ServerIdentity().ID,
+		b.Services[i].viewChangeMan.addReq(viewchange.InitReq{
+			SignerID: b.Services[i].ServerIdentity().ID,
 			View:     view,
 		})
 	}
 
 	log.Lvl1("Waiting for the new block to be propagated")
-	s.waitPropagation(t, 2)
-	for _, service := range s.services {
+	b.Client.WaitPropagation(2)
+	for _, service := range b.Services {
 		// everyone should have the same leader after the genesis block is stored
-		leader, err := service.getLeader(s.genesis.SkipChainID())
+		leader, err := service.getLeader(b.Genesis.SkipChainID())
 		require.NoError(t, err)
 		require.NotNil(t, leader)
-		require.True(t, leader.Equal(s.services[3].ServerIdentity()))
+		require.True(t, leader.Equal(b.Services[3].ServerIdentity()))
 	}
 }
 
@@ -304,47 +275,43 @@ func TestViewChange_LostSync(t *testing.T) {
 //  - Node3 - misses block #1, unpaused after creation of block #1
 func TestViewChange_NeedCatchUp(t *testing.T) {
 	nodes := 4
-	s := newSerN(t, 1, testInterval, nodes, 3)
-	defer s.local.CloseAll()
+	bArgs := defaultBCTArgs
+	bArgs.Nodes = nodes
+	bArgs.RotationWindow = 3
+	b := newBCTRun(t, &bArgs)
+	defer b.CloseAll()
 
-	for _, service := range s.services {
-		service.SetPropagationTimeout(2 * testInterval)
+	for _, service := range b.Services {
+		service.SetPropagationTimeout(2 * b.PropagationInterval)
 	}
 
-	s.hosts[nodes-1].Pause()
+	b.Services[nodes-1].TestClose()
+	b.Servers[nodes-1].Pause()
 
 	// Create a block that host 4 will miss
 	log.Lvl1("Send block that node 4 will miss")
-	tx1, err := createOneClientTx(s.darc.GetBaseID(), dummyContract, s.value, s.signer)
-	require.NoError(t, err)
-	s.sendTxToAndWait(t, tx1, 0, 10)
+	b.SpawnDummy(nil)
 
+	log.Lvl1("Kill the leader")
 	// Kill the leader, and unpause the sleepy node
-	s.services[0].TestClose()
-	s.hosts[0].Pause()
-	s.hosts[nodes-1].Unpause()
+	b.Services[0].TestClose()
+	b.Servers[0].Pause()
+	b.Servers[nodes-1].Unpause()
+	require.NoError(t, b.Services[nodes-1].TestRestart())
 
 	// Trigger a viewchange
 	log.Lvl1("Trigger the viewchange")
-	tx1, err = createOneClientTx(s.darc.GetBaseID(), dummyContract, s.value, s.signer)
-	require.NoError(t, err)
-	s.sendTxTo(t, tx1, nodes-1)
-
-	log.Lvl1("Wait for the block to propagate")
-	require.NoError(t, NewClient(s.genesis.SkipChainID(),
-		*s.roster).WaitPropagation(1))
+	txArgs := TxArgsDefault
+	txArgs.Node = nodes - 1
+	b.SpawnDummy(&txArgs)
 
 	// Send the block again
 	log.Lvl1("Sending block again")
-	s.sendTxTo(t, tx1, nodes-1)
-
-	log.Lvl1("Wait for the transaction to be included")
-	require.NoError(t, NewClient(s.genesis.SkipChainID(),
-		*s.roster).WaitPropagation(2))
+	b.SpawnDummy(&txArgs)
 
 	// Check that a view change was finally executed
-	leader, err := s.services[nodes-1].getLeader(s.genesis.SkipChainID())
+	leader, err := b.Services[nodes-1].getLeader(b.Genesis.SkipChainID())
 	require.NoError(t, err)
 	require.NotNil(t, leader)
-	require.False(t, leader.Equal(s.services[0].ServerIdentity()))
+	require.False(t, leader.Equal(b.Services[0].ServerIdentity()))
 }


### PR DESCRIPTION
This PR makes a nicer BCTest structure that can be used in the different tests.
Its main purpose was to have a correct 'CloseAll' method that waits for all
activity to stop.
But finally it also cleans up a lot of trailing cruft in different tests.

The goal is to have a BCTest structure that can also be used by other modules.
For this reason BCTest is exported in the main package.
For any idea how to make this cleaner, comments are welcome :)

Ran the tests from #2387 in a loop here:
https://travis-ci.com/github/dedis/cothority/jobs/394084093
https://travis-ci.com/github/dedis/cothority/builds/187765748

Closes #2387 