### PR TITLE
Making TestViewChange_Basic3 working on Jenkins

### DIFF
--- a/byzcoin/viewchange.go
+++ b/byzcoin/viewchange.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -143,11 +144,30 @@ func (s *Service) sendViewChangeReq(view viewchange.View) error {
 			continue
 		}
 		go func(id *network.ServerIdentity) {
-			if err := s.SendRaw(id, &req); err != nil {
-				// Having an error here is fine because not all the
-				// nodes are guaranteed to be online. So we log a
-				// warning instead of returning an error.
-				log.Warn(s.ServerIdentity(), "Couldn't send view-change request to", id.Address, err)
+			// Calculate a random delay between
+			// [BlockInterval/2..BlockInterval] to wait before re-sending the
+			// message.
+			// At least in testing it often happens that a message gets lost
+			// (travis and jenkins).
+			delay := time.Second
+			bi, err := s.LoadConfig(view.ID)
+			if err != nil {
+				log.Errorf("couldn't get config: %+v", err)
+			} else {
+				factor := time.Duration(1000 + rand.Intn(1000))
+				delay = bi.BlockInterval * factor / time.Duration(2000)
+			}
+			for i := 0; i < 2; i++ {
+				log.Print(s.ServerIdentity(), i)
+				if err := s.SendRaw(id, &req); err != nil {
+					// Having an error here is fine because not all the
+					// nodes are guaranteed to be online. So we log a
+					// warning instead of returning an error.
+					log.Warn(s.ServerIdentity(), "Couldn't send view-change request to", id.Address, err)
+				}
+				if i == 0 {
+					time.Sleep(delay)
+				}
 			}
 		}(sid)
 	}

--- a/byzcoin/viewchange_test.go
+++ b/byzcoin/viewchange_test.go
@@ -53,6 +53,8 @@ func testViewChange(t *testing.T, nHosts, nFailures int) {
 	bArgs := defaultBCTArgs
 	bArgs.Nodes = nHosts
 	bArgs.RotationWindow = 3
+	// Give some more time on Travis to do the verifications
+	bArgs.PropagationInterval = 2 * bArgs.PropagationInterval
 	b := newBCTRun(t, &bArgs)
 	defer b.CloseAll()
 


### PR DESCRIPTION
The Basic3 test runs 10 nodes, then stops 3, and waits for a view-change by the
remaining 7 nodes. This needs a lot of messages, and some time. While locally
it ran all right, on Jenkins it failed for two reasons:

1. the view-change block took too long to be verified, so it failed
2. sometimes view-change request messages got lost

This PR fixes it like this:

1. Increase the PropagationInterval for the view-change tests
2. Re-send view-change request message after a random delay between
[PropagationInterval/2..PropagationInterval]
