### PR TITLE
Add debug timing

### DIFF
--- a/unit_test.sh
+++ b/unit_test.sh
@@ -4,10 +4,13 @@ set -e
 
 echo "Running tests with tag '$1'"
 
+export DEBUG_TIME=true
+
 for d in $( find . -name "*go" | xargs -n 1 dirname | sort -u ); do
 	# Do each directory on its own, but exclude if 'experimental' is found in
 	# the first line.
 	if sed -n 1p $d/*.go | grep -q -v experimental; then
+		echo "Testing directory $d at $(date)"
 		go test -tags $1 -p=1 -count=1 -v -race -timeout 30m $d || exit 1
 	fi
 done


### PR DESCRIPTION
Adds `DEBUG_TIME=true` and the current testing directory to the jenkins-test, to better debug why it's failing on the main test.