### PR TITLE
Use golang-docker to create docker-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ proto:
 	./proto.sh
 	make -C external
 
-# 	docker run -t -v $(PWD):/cothority neilotoole/xcgo \
-
 docker:
 	docker run -t -v $(PWD):/cothority golang:1.15-buster \
 		bash -c "cd /cothority; go build -o external/docker/conode ./conode"

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 EXCLUDE_LINT := should be.*UI
 
+TEST_IMAGE_NAME = dedis/conode-test
+
 Coding/bin/Makefile.base:
 	git clone https://github.com/dedis/Coding
 include Coding/bin/Makefile.base
@@ -25,9 +27,13 @@ proto:
 	./proto.sh
 	make -C external
 
+# 	docker run -t -v $(PWD):/cothority neilotoole/xcgo \
+
 docker:
-	cd conode/; make docker_dev
-	cd external/docker/; make docker_test
+	docker run -t -v $(PWD):/cothority golang:1.15-buster \
+		bash -c "cd /cothority; go build -o external/docker/conode ./conode"
+	cp conode/run_nodes.sh external/docker
+	docker build -t $(TEST_IMAGE_NAME) external/docker
 
 docker_test_run: docker
 	docker run -ti -p7770-7777:7770-7777 dedis/conode-test

--- a/external/docker/Dockerfile
+++ b/external/docker/Dockerfile
@@ -2,9 +2,7 @@ FROM golang:1.15-buster
 RUN apt update && apt install -y procps ca-certificates && apt clean
 WORKDIR /root/
 
-EXPOSE 7770 7771
-
-# EXPOSE 7771 7773 7775 7777 7779 7781 7783
+EXPOSE 7770 7771 7772 7773 7774 7775 7776 7777 7778 7779 7780 7781 7782 7783
 
 COPY co1/*.toml co1/
 COPY co2/*.toml co2/

--- a/external/docker/Dockerfile
+++ b/external/docker/Dockerfile
@@ -1,4 +1,8 @@
-FROM dedis/conode:dev
+FROM golang:1.15-buster
+RUN apt update && apt install -y procps ca-certificates && apt clean
+WORKDIR /root/
+
+EXPOSE 7770 7771
 
 # EXPOSE 7771 7773 7775 7777 7779 7781 7783
 
@@ -9,10 +13,12 @@ COPY co4/*.toml co4/
 COPY co5/*.toml co5/
 COPY co6/*.toml co6/
 COPY co7/*.toml co7/
+COPY conode /usr/local/bin/
+COPY conode /root
+COPY run_nodes.sh /root
 
 # local - run this as a set of local nodes in the docker
 # 4 - number of nodes to run
 # 2 - debug-level: 0 - none .. 5 - a lot
 # -wait - don't return from script when all nodes are started
-RUN cp ./conode /usr/local/bin/
 CMD ["env", "GODEBUG=gctrace=0", "COTHORITY_ALLOW_INSECURE_ADMIN=1", "./run_nodes.sh", "-n 4", "-v 2", "-t", "-f", "-s", "-c" ]

--- a/external/docker/Makefile
+++ b/external/docker/Makefile
@@ -1,4 +1,0 @@
-TEST_IMAGE_NAME = dedis/conode-test
-
-docker_test:
-	docker build -t $(TEST_IMAGE_NAME) .


### PR DESCRIPTION
Under MacOSX, the docker-test image doesn't contain the bevm contract, which makes it
impossible to run all tests in external/js/cothority.
This PR uses golang-docker to create the docker-test image, so that also under MacOSX
all tests from external/js/cothority can be run.
