### PR TITLE
Replace URL with url-parse

### DIFF
--- a/external/js/cothority/package-lock.json
+++ b/external/js/cothority/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedis/cothority",
-  "version": "3.5.4",
+  "version": "3.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6660,6 +6660,11 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -6849,6 +6854,11 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.10.0",
@@ -8008,6 +8018,15 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
+      }
+    },
+    "url-parse": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "use": {

--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@dedis/cothority",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "A typescript implementation of the cothority",
   "main": "index.js",
   "browser": "bundle.min.js",
@@ -54,6 +54,7 @@
     "sprintf-js": "^1.1.2",
     "toml": "^2.3.5",
     "tslib": "^1.10.0",
+    "url-parse": "^1.4.7",
     "util": "^0.11.1",
     "ws": "^6.1.2"
   },

--- a/external/js/cothority/src/network/websocket.ts
+++ b/external/js/cothority/src/network/websocket.ts
@@ -1,5 +1,6 @@
 import { Message } from "protobufjs";
 import { Observable } from "rxjs";
+import URL from "url-parse";
 import Log from "../log";
 import { IConnection } from "./nodes";
 import { Roster } from "./proto";
@@ -39,18 +40,18 @@ export class WebSocketConnection implements IConnection {
         // by the fact that URL will not allow you to have an empty pathname,
         // which will always equal to "/" if there isn't any
         if (url.pathname.slice(-1) !== "/") {
-            url.pathname = url.pathname + "/";
+            url.set("pathname", url.pathname + "/");
         }
         if (url.username !== "" || url.password !== "") {
             throw new Error("addr contains authentication, which is not supported");
         }
-        if (url.search !== "" || url.hash !== "") {
+        if (url.hash !== "") {
             throw new Error("addr contains more data than the origin");
         }
 
         if (typeof globalThis !== "undefined" && typeof globalThis.location !== "undefined") {
             if (globalThis.location.protocol === "https:") {
-                url.protocol = "wss";
+                url.set("protocol", "wss");
             }
         }
 
@@ -112,7 +113,7 @@ export class WebSocketConnection implements IConnection {
 
         return new Observable((sub) => {
             const url = new URL(this.url.href);
-            url.pathname += `${this.service}/${message.$type.name.replace(/.*\./, "")}`;
+            url.set("pathname", url.pathname + `${this.service}/${message.$type.name.replace(/.*\./, "")}`);
             Log.lvl4(`Socket: new WebSocket(${url.href})`);
             const ws = factory(url.href);
             const bytes = Buffer.from(message.$type.encode(message).finish());

--- a/external/js/cothority/src/network/websocket.ts
+++ b/external/js/cothority/src/network/websocket.ts
@@ -45,7 +45,7 @@ export class WebSocketConnection implements IConnection {
         if (url.username !== "" || url.password !== "") {
             throw new Error("addr contains authentication, which is not supported");
         }
-        if (url.hash !== "") {
+        if (Object.entries(url.query).length > 0 || url.hash !== "") {
             throw new Error("addr contains more data than the origin");
         }
 


### PR DESCRIPTION
As the dedis/cothority is not only used in the browser, but also in node
and nativescript, URL cannot be used reliably.

This PR replaces URL with the url-parse implementation.