### PR TITLE
Convert websocket error-codes to text

### DIFF
--- a/external/js/cothority/spec/network/websocket-test-adapter.ts
+++ b/external/js/cothority/spec/network/websocket-test-adapter.ts
@@ -30,7 +30,7 @@ export default class TestWebSocket extends WebSocketAdapter {
 
     onClose(callback: (code: number, reason: string) => void): void {
         if (this.code) {
-            callback(this.code, "reason to close");
+            callback(this.code, "onClose called");
         } else {
             this.onclose = callback;
         }

--- a/external/js/cothority/src/network/websocket.ts
+++ b/external/js/cothority/src/network/websocket.ts
@@ -151,7 +151,7 @@ export class WebSocketConnection implements IConnection {
                             err = `Endpoint terminated the connection due to a protocol error.`;
                             break;
                         case 1003:
-                            err = `Endpoint is terminated the connection
+                            err = `Endpoint terminated the connection
                             because it has received a type of data it cannot accept (e.g., an
                             endpoint that understands only text data MAY send this if it
                             receives a binary message).`;

--- a/external/js/cothority/src/network/websocket.ts
+++ b/external/js/cothority/src/network/websocket.ts
@@ -141,7 +141,68 @@ export class WebSocketConnection implements IConnection {
                 // nativescript-websocket on iOS doesn't return error-code 1002 in case of error, but sets the 'reason'
                 // to non-null in case of error.
                 if (code !== 1000 || (reason && reason !== "")) {
-                    sub.error(new Error(reason));
+                    let err = "Unknown close error";
+                    switch (code) {
+                        case 1001:
+                            err = `Endpoint is "going away": server going down or a browser
+                            having navigated away from the page.`;
+                            break;
+                        case 1002:
+                            err = `Endpoint is terminated the connection due to a protocol error.`;
+                            break;
+                        case 1003:
+                            err = `Endpoint is terminated the connection
+                            because it has received a type of data it cannot accept (e.g., an
+                            endpoint that understands only text data MAY send this if it
+                            receives a binary message).`;
+                            break;
+                        case 1004:
+                            err = `Reserved. The specific meaning might be defined in the future.`;
+                            break;
+                        case 1005:
+                            err = `No status code was actually present.`;
+                            break;
+                        case 1006:
+                            err = `Connection was closed abnormally, e.g., without sending or
+                            receiving a Close control frame.`;
+                            break;
+                        case 1007:
+                            err = `Endpoint terminated the connection
+                            because it has received data within a message that was not
+                            consistent with the type of the message (e.g., non-UTF-8 [RFC3629]
+                            data within a text message).`;
+                            break;
+                        case 1008:
+                            err = `Endpoint terminated the connection
+                            because it has received a message that violates its policy.`;
+                            break;
+                        case 1009:
+                            err = `Endpoint terminated the connection
+                            because it has received a message that is too big for it to
+                            process.`;
+                            break;
+                        case 1010:
+                            err = `Endpoint terminated the
+                            connection because it has expected the server to negotiate one or
+                            more extension, but the server didn't return them in the response
+                            message of the WebSocket handshake.`;
+                            break;
+                        case 1011:
+                            err = `Server terminated the connection because
+                            it encountered an unexpected condition that prevented it from
+                            fulfilling the request.`;
+                            break;
+                        case 1015:
+                            err = `Connection was closed due to a failure to perform a TLS handshake
+                            (e.g., the server certificate can't be verified).`;
+                            break;
+                    }
+                    if (reason && reason !== "") {
+                        err += " Reason: " + reason;
+                    }
+
+                    sub.error(new Error(err.replace(/\n/g, "").
+                        replace(/ +/g, " ")));
                 } else {
                     sub.complete();
                 }

--- a/external/js/cothority/src/network/websocket.ts
+++ b/external/js/cothority/src/network/websocket.ts
@@ -148,7 +148,7 @@ export class WebSocketConnection implements IConnection {
                             having navigated away from the page.`;
                             break;
                         case 1002:
-                            err = `Endpoint is terminated the connection due to a protocol error.`;
+                            err = `Endpoint terminated the connection due to a protocol error.`;
                             break;
                         case 1003:
                             err = `Endpoint is terminated the connection


### PR DESCRIPTION
Took https://tools.ietf.org/html/rfc6455 to convert the error-codes of the
websocket to text.

Closes #2396 