### PR TITLE
Improve db checking

### DIFF
--- a/byzcoin/bcadmin/cmd_db.go
+++ b/byzcoin/bcadmin/cmd_db.go
@@ -530,7 +530,7 @@ func dbCheck(c *cli.Context) error {
 			}
 			errStrFl := fmt.Sprintf("%s forwardLink at height %d", errStr, i)
 
-			if i > sb.GetForwardLen() || sb.ForwardLink[i].IsEmpty() {
+			if i >= sb.GetForwardLen() || sb.ForwardLink[i].IsEmpty() {
 				log.Warnf("%s missing: should point to %d", errStrFl,
 					index)
 				continue

--- a/byzcoin/bcadmin/commands.go
+++ b/byzcoin/bcadmin/commands.go
@@ -724,6 +724,10 @@ var cmds = cli.Commands{
 						Usage: "show process indicator every n blocks",
 						Value: 100,
 					},
+					cli.BoolFlag{
+						Name:  "skipSig",
+						Usage: "skip verifying of signatures",
+					},
 				},
 			},
 		},

--- a/skipchain/struct.go
+++ b/skipchain/struct.go
@@ -279,6 +279,19 @@ type SkipBlockFix struct {
 	Roster *onet.Roster
 }
 
+// GetFLIndexes returns the block-Indexes of the forwardlinks that are/will
+// be present in the block.
+func (sbf *SkipBlockFix) GetFLIndexes() []int {
+	indexes := make([]int, sbf.Height)
+	index := sbf.Index
+	mult := 1
+	for h := range indexes {
+		indexes[h] = index + mult
+		mult *= sbf.BaseHeight
+	}
+	return indexes
+}
+
 // Copy returns a deep copy of SkipBlockFix
 func (sbf *SkipBlockFix) Copy() *SkipBlockFix {
 	backLinkIDs := make([]SkipBlockID, len(sbf.BackLinkIDs))


### PR DESCRIPTION
This PR improves a bit the output of the 'bcadmin db check' command by
removing superfluous messages and differentiating between warnings and
errors.