### PR TITLE
@cothority/byzcoin meaningful instruction print

### DIFF
--- a/external/js/cothority/package-lock.json
+++ b/external/js/cothority/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedis/cothority",
-  "version": "3.5.6",
+  "version": "3.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1306,6 +1306,14 @@
       "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.3.tgz",
       "integrity": "sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw==",
       "dev": true
+    },
+    "@types/varint": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/varint/-/varint-5.0.0.tgz",
+      "integrity": "sha512-dIJiYqeDnYQ5Bc4mv+E5prqFIQlUTM1yDzwC5VQfL29pcYlm/5q1shY/MjbBT1FQAU5gzKE10DdGbu8B2EoFQg==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/ws": {
       "version": "6.0.1",
@@ -8070,6 +8078,11 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
       "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
       "dev": true
+    },
+    "varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
     "verror": {
       "version": "1.10.0",

--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@dedis/cothority",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "A typescript implementation of the cothority",
   "main": "index.js",
   "browser": "bundle.min.js",
@@ -37,6 +37,7 @@
     "@ethersproject/bignumber": "^5.0.5",
     "@stablelib/blake2xs": "^0.10.4",
     "@types/ethereumjs-abi": "^0.6.3",
+    "@types/varint": "^5.0.0",
     "buffer": "^5.2.1",
     "crypto-browserify": "^3.12.0",
     "elliptic": "^6.5.3",
@@ -56,6 +57,7 @@
     "tslib": "^1.10.0",
     "url-parse": "^1.4.7",
     "util": "^0.11.1",
+    "varint": "^6.0.0",
     "ws": "^6.1.2"
   },
   "devDependencies": {

--- a/external/js/cothority/src/byzcoin/beautifier/config.ts
+++ b/external/js/cothority/src/byzcoin/beautifier/config.ts
@@ -36,6 +36,9 @@ export class ConfigBeautifier {
                 case "darc_contracts":
                     res.push({name: "darc_contracts", value: arg.value.toString("hex")});
                     break;
+                default:
+                    res.push({name: arg.name, value: "unspecified", full: arg.value.toString("hex")});
+                    break;
             }
         });
 
@@ -52,6 +55,9 @@ export class ConfigBeautifier {
                     // const config = ChainConfig.decode(arg.value);
                     // res.push({name: "darc", value: "chain config", full: config.toString()});
                     res.push({name: "darc", value: "chain config"});
+                    break;
+                default:
+                    res.push({name: arg.name, value: "unspecified", full: arg.value.toString("hex")});
                     break;
             }
         });

--- a/external/js/cothority/src/byzcoin/beautifier/config.ts
+++ b/external/js/cothority/src/byzcoin/beautifier/config.ts
@@ -1,0 +1,61 @@
+import { Darc } from "../../darc";
+import { Roster } from "../../network";
+import { Argument } from "../index";
+import { ChainConfig } from "../index";
+import { IBeautifyArgument } from "./utils";
+// tslint:disable-next-line
+const varint = require("varint");
+
+/**
+ * Arrange arguments for a config contract, ie. provide a meaningful
+ * representation of its arguments.
+ */
+export class ConfigBeautifier {
+    static Spawn(args: Argument[]): IBeautifyArgument[] {
+        const res = Array<IBeautifyArgument>();
+
+        args.forEach((arg) => {
+            switch (arg.name) {
+                case "darc":
+                    const darc = Darc.decode(arg.value);
+                    res.push({name: "darc", value: darc.description.toString(), full: darc.toString()});
+                    break;
+                case "block_interval":
+                    res.push({name: "block_interval", value: `${varint.decode(arg.value, 0) / 1e6} ms`});
+                    break;
+                case "max_block_size":
+                    res.push({name: "max_block_size", value: `${varint.decode(arg.value, 0)} bytes`});
+                    break;
+                case "roster":
+                    const r = Roster.decode(arg.value);
+                    res.push({name: "roster", value: r.id.toString("hex"), full: r.toTOML()});
+                    break;
+                case "trie_nonce":
+                    res.push({name: "trie_nonce", value: `${varint.decode(arg.value, 0)}`});
+                    break;
+                case "darc_contracts":
+                    res.push({name: "darc_contracts", value: arg.value.toString("hex")});
+                    break;
+            }
+        });
+
+        return res;
+    }
+
+    static Invoke(args: Argument[]): IBeautifyArgument[] {
+        const res = Array<IBeautifyArgument>();
+
+        args.forEach((arg) => {
+            switch (arg.name) {
+                case "config":
+                    // Calypso tests won't pass if we use ChainConfig.
+                    // const config = ChainConfig.decode(arg.value);
+                    // res.push({name: "darc", value: "chain config", full: config.toString()});
+                    res.push({name: "darc", value: "chain config"});
+                    break;
+            }
+        });
+
+        return res;
+    }
+}

--- a/external/js/cothority/src/byzcoin/beautifier/darc.ts
+++ b/external/js/cothority/src/byzcoin/beautifier/darc.ts
@@ -1,0 +1,39 @@
+import { Darc as d } from "../../darc";
+import { Roster } from "../../network";
+import { Argument } from "../index";
+import { IBeautifyArgument } from "./utils";
+
+/**
+ * Arrange arguments for a Darc contract, ie. provide a meaningful
+ * representation of its arguments.
+ */
+export class DarcBeautifier {
+    static Spawn(args: Argument[]): IBeautifyArgument[] {
+        const res = Array<IBeautifyArgument>();
+
+        args.forEach((arg) => {
+            switch (arg.name) {
+                case "darc":
+                    const darc = d.decode(arg.value);
+                    res.push({name: "darc", value: darc.description.toString(), full: darc.toString()});
+                    break;
+            }
+        });
+
+        return res;
+    }
+    static Invoke(args: Argument[]): IBeautifyArgument[] {
+        const res = Array<IBeautifyArgument>();
+
+        args.forEach((arg) => {
+            switch (arg.name) {
+                case "darc":
+                    const darc = d.decode(arg.value);
+                    res.push({name: "darc", value: darc.description.toString(), full: darc.toString()});
+                    break;
+            }
+        });
+
+        return res;
+    }
+}

--- a/external/js/cothority/src/byzcoin/beautifier/darc.ts
+++ b/external/js/cothority/src/byzcoin/beautifier/darc.ts
@@ -17,6 +17,9 @@ export class DarcBeautifier {
                     const darc = d.decode(arg.value);
                     res.push({name: "darc", value: darc.description.toString(), full: darc.toString()});
                     break;
+                default:
+                    res.push({name: arg.name, value: "unspecified", full: arg.value.toString("hex")});
+                    break;
             }
         });
 
@@ -30,6 +33,9 @@ export class DarcBeautifier {
                 case "darc":
                     const darc = d.decode(arg.value);
                     res.push({name: "darc", value: darc.description.toString(), full: darc.toString()});
+                    break;
+                default:
+                    res.push({name: arg.name, value: "unspecified", full: arg.value.toString("hex")});
                     break;
             }
         });

--- a/external/js/cothority/src/byzcoin/beautifier/default.ts
+++ b/external/js/cothority/src/byzcoin/beautifier/default.ts
@@ -1,0 +1,17 @@
+import { Argument } from "../index";
+import { IBeautifyArgument } from "./utils";
+
+/**
+ * Default representation of arguments
+ */
+export class DefaultBeautifier {
+    static Hex(args: Argument[]): IBeautifyArgument[] {
+        const res = Array<IBeautifyArgument>();
+
+        args.forEach((arg) => {
+            res.push({name: arg.name, value: arg.value.toString("hex")});
+        });
+
+        return res;
+    }
+}

--- a/external/js/cothority/src/byzcoin/beautifier/index.ts
+++ b/external/js/cothority/src/byzcoin/beautifier/index.ts
@@ -1,0 +1,12 @@
+import { ConfigBeautifier } from "./config";
+import { DarcBeautifier } from "./darc";
+import { DefaultBeautifier } from "./default";
+import { IBeautifierSchema, IBeautifyArgument } from "./utils";
+
+export {
+    DefaultBeautifier,
+    DarcBeautifier,
+    ConfigBeautifier,
+    IBeautifierSchema,
+    IBeautifyArgument,
+};

--- a/external/js/cothority/src/byzcoin/beautifier/utils.ts
+++ b/external/js/cothority/src/byzcoin/beautifier/utils.ts
@@ -2,7 +2,7 @@ import { Argument } from "../index";
 
 export interface IBeautifierSchema {
     status: 0 | 1;
-    type: "spawn" | "invoke" | "delete" | "UNKNOWN";
+    type: "spawn" | "invoke" | "delete";
     contract: string;
     args: IBeautifyArgument[];
 }

--- a/external/js/cothority/src/byzcoin/beautifier/utils.ts
+++ b/external/js/cothority/src/byzcoin/beautifier/utils.ts
@@ -1,0 +1,14 @@
+import { Argument } from "../index";
+
+export interface IBeautifierSchema {
+    status: 0 | 1;
+    type: "spawn" | "invoke" | "delete" | "UNKNOWN";
+    contract: string;
+    args: IBeautifyArgument[];
+}
+
+export interface IBeautifyArgument {
+    name: string;
+    value: string;
+    full?: string;
+}

--- a/external/js/cothority/src/byzcoin/config.ts
+++ b/external/js/cothority/src/byzcoin/config.ts
@@ -46,6 +46,19 @@ export default class ChainConfig extends Message<ChainConfig> {
             },
         });
     }
+
+    /**
+     * Return a string representation of a config
+     */
+    toString(): string {
+        let res = "Chainconfig:\n";
+        res += "- roster:\n";
+        res += this.roster.toTOML() + "\n";
+        res += "- blockInterval: " + this.blockInterval + "\n";
+        res += "- maxBlockSize: " + this.maxBlockSize + "\n";
+
+        return res;
+    }
 }
 
 ChainConfig.register();


### PR DESCRIPTION
**What this PR does**

This PR implements a `instruction.getArranged()` function on @cothority/byzcoin that returns a general-purpose JSON representation of an instruction. This representation is contract aware in the sense that arguments should have a meaningful string representation, based on each different contract.

The JSON has the following structure:

```
     *  {
     *      status: 0 | 1,   // Non-zero means an error occured
     *      type: "spawn|invoke|delete|UNKNOWN",
     *      contract: "config|darc|...",
     *      args: [
     *          {
     *              "name": "<NAME>",
     *              "value": "<VALUE>",    // Arg value or its summary
     *              "full": "<FULL VALUE>" // Optional. useful if the argument
     *                                     // have a very long representation.
     *          }
     *          ...
     *      ]
     *  }
```

This functionality is much needed for the Columbus project (blockchain browser). I suggest we include that as an experimental feature until the end of that project (January 2021), where at that point we will have a definitive structure.

Feel free to discuss, I'm open to discussion.

@ineiti's requests:
- [ ] Use an abstract class that the Beautifiers have to implement. Perhaps something like this would work: https://stackoverflow.com/questions/43723313/typescript-abstract-class-static-method-not-enforced
- [x] Give longer names to the classes, this will also avoid any name-clashing:
    - `Config` -> `ConfigBeautify`
    - `Darc` -> `DarcBeautify`
- [x] The tests should pass.
- [x] Squash the commits to have 1 or 2 commits.
- [x] add a `beautifier/index.ts` and import only this. That way you're free to re-arrange any files in there and the user can treat each sub-directory as a package without having to care about the files
