### PR TITLE
Feature: connectivity check

### DIFF
--- a/connectivity/api.go
+++ b/connectivity/api.go
@@ -1,0 +1,27 @@
+package connectivity
+
+import (
+	"go.dedis.ch/cothority/v3"
+	"go.dedis.ch/onet/v3"
+	"go.dedis.ch/onet/v3/network"
+	"golang.org/x/xerrors"
+)
+
+type Client struct {
+	*onet.Client
+}
+
+func NewClient() *Client {
+	return &Client{
+		Client: onet.NewClient(cothority.Suite, Name),
+	}
+}
+
+func (c *Client) Check(dst *network.ServerIdentity, r *onet.Roster) (*CheckReply, error) {
+	reply := &CheckReply{}
+	err := c.SendProtobuf(dst, &CheckRequest{Roster: r}, reply)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to send CheckRequest: %v", err)
+	}
+	return reply, nil
+}

--- a/connectivity/api_test.go
+++ b/connectivity/api_test.go
@@ -1,0 +1,34 @@
+package connectivity_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.dedis.ch/cothority/v3"
+	"go.dedis.ch/cothority/v3/connectivity"
+	"go.dedis.ch/onet/v3"
+	"go.dedis.ch/onet/v3/log"
+)
+
+func TestMain(m *testing.M) {
+	log.MainTest(m)
+}
+
+func TestCheck(t *testing.T) {
+	local := onet.NewTCPTest(cothority.Suite)
+	defer local.CloseAll()
+
+	_, roster, _ := local.GenTree(3, true)
+
+	c := connectivity.NewClient()
+	r, err := c.Check(roster.Get(0), roster)
+	assert.NoError(t, err)
+
+	for node, state := range r.Status {
+		assert.False(t, state.Down, fmt.Sprintf("%s is down", node))
+	}
+
+	time.Sleep(5 * time.Second)
+}

--- a/connectivity/protocol.go
+++ b/connectivity/protocol.go
@@ -1,0 +1,64 @@
+package connectivity
+
+import (
+	"go.dedis.ch/onet/v3"
+	"go.dedis.ch/onet/v3/log"
+	"go.dedis.ch/onet/v3/network"
+	"golang.org/x/xerrors"
+)
+
+func init() {
+	network.RegisterMessage(Ping{})
+	network.RegisterMessage(Pong{})
+	_, err := onet.GlobalProtocolRegister(Name, NewProtocol)
+	if err != nil {
+		panic(err)
+	}
+}
+
+type ConnectivityProtocol struct {
+	*onet.TreeNodeInstance
+	pingChan chan pingWrapper
+	pongChan chan []pongWrapper
+	failure  chan error
+}
+
+func NewProtocol(n *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
+	t := &ConnectivityProtocol{
+		TreeNodeInstance: n,
+		failure:          make(chan error),
+	}
+
+	if err := n.RegisterChannels(&t.pingChan, &t.pingChan); err != nil {
+		return nil, xerrors.Errorf("error registering channel: %v", err)
+	}
+
+	t.RegisterHandlers(t.onPong)
+
+	return t, nil
+}
+
+func (p *ConnectivityProtocol) Start() error {
+	log.Lvl3(p.ServerIdentity(), "Starting ConnectivityProtocol")
+	return p.SendTo(p.TreeNode(), &Ping{})
+}
+
+func (p *ConnectivityProtocol) Dispatch() error {
+	defer p.Done()
+	defer close(p.failure)
+
+	ping := <-p.pingChan
+	if p.IsRoot() {
+		errs := p.SendToChildrenInParallel(&ping.Ping)
+		for _, err := range errs {
+			p.failure <- err
+		}
+		return nil
+	} else {
+		return p.SendToParent(&Pong{})
+	}
+}
+
+func (p *ConnectivityProtocol) onPong(pong pongWrapper) error {
+	return nil
+}

--- a/connectivity/service.go
+++ b/connectivity/service.go
@@ -1,0 +1,161 @@
+package connectivity
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"go.dedis.ch/onet/v3"
+	"go.dedis.ch/onet/v3/log"
+	"go.dedis.ch/onet/v3/network"
+	"golang.org/x/xerrors"
+)
+
+var serviceID onet.ServiceID
+
+func init() {
+	var err error
+	serviceID, err = onet.RegisterNewService(Name, newService)
+	log.ErrFatal(err)
+	network.RegisterMessage(&storage{})
+}
+
+// Service is our template-service
+type Service struct {
+	// We need to embed the ServiceProcessor, so that incoming messages
+	// are correctly handled.
+	*onet.ServiceProcessor
+
+	storage *storage
+}
+
+// storageID reflects the data we're storing - we could store more
+// than one structure.
+var storageID = []byte("main")
+
+// storage is used to save our data.
+type storage struct {
+	sync.Mutex
+	ConnectivityMatrix
+	// CacheExpiryDuration stores the cache expiry interval
+	CacheExpiryDuration time.Duration
+	// CacheExpiresAt stores the expiry time of the cache
+	cacheExpiresAt time.Time
+}
+
+func (s *Service) NewProtocol(tn *onet.TreeNodeInstance, conf *onet.GenericConfig) (onet.ProtocolInstance, error) {
+	log.Lvl3("Not templated yet")
+	return nil, nil
+}
+
+// saves all data.
+func (s *Service) save() {
+	s.storage.Lock()
+	defer s.storage.Unlock()
+	err := s.Save(storageID, s.storage)
+	if err != nil {
+		log.Error("Couldn't save data:", err)
+	}
+}
+
+// Tries to load the configuration and updates the data in the service
+// if it finds a valid config-file.
+func (s *Service) tryLoad() error {
+	s.storage = &storage{}
+	msg, err := s.Load(storageID)
+	if err != nil {
+		return err
+	}
+	if msg == nil {
+		return nil
+	}
+	var ok bool
+	s.storage, ok = msg.(*storage)
+	if !ok {
+		return errors.New("Data of wrong type")
+	}
+	return nil
+}
+
+// newService receives the context that holds information about the node it's
+// running on. Saving and loading can be done using the context. The data will
+// be stored in memory for tests and simulations, and on disk for real deployments.
+func newService(c *onet.Context) (onet.Service, error) {
+	connectivityTTL := os.Getenv("CONNECTIVITY_TTL")
+	var cacheExpiryDuration time.Duration
+	if connectivityTTL == "" {
+		cacheExpiryDuration = 5 * time.Minute
+	} else {
+		ttl, err := strconv.Atoi(connectivityTTL)
+		if err != nil {
+			return nil, xerrors.Errorf("error parsing $CONNECTIVITY_TTL: %v", err)
+		}
+		cacheExpiryDuration = time.Duration(ttl) * time.Second
+	}
+
+	s := &Service{
+		ServiceProcessor: onet.NewServiceProcessor(c),
+	}
+	if err := s.RegisterHandlers(s.Check); err != nil {
+		return nil, errors.New("Couldn't register messages")
+	}
+	if err := s.tryLoad(); err != nil {
+		log.Error(err)
+		return nil, err
+	}
+	s.storage.cacheExpiresAt = time.Now()
+	s.storage.CacheExpiryDuration = cacheExpiryDuration
+	return s, nil
+}
+
+func (s *Service) Check(req *CheckRequest) (*CheckReply, error) {
+	s.storage.Lock()
+	defer s.storage.Unlock()
+
+	if time.Now().Before(s.storage.cacheExpiresAt) {
+		return &CheckReply{
+			ConnectivityMatrix: s.storage.ConnectivityMatrix,
+		}, nil
+	}
+
+	tree := req.Roster.GenerateNaryTreeWithRoot(len(req.Roster.List)-1, s.ServerIdentity())
+	if tree == nil {
+		return nil, xerrors.Errorf("couldn't generate tree")
+	}
+
+	pi, err := s.CreateProtocol(Name, tree)
+	if err != nil {
+		return nil, xerrors.Errorf("couldn't create protocol: %v", err)
+	}
+
+	probeTime := time.Now()
+	if s.storage.ConnectivityMatrix.Status == nil {
+		s.storage.ConnectivityMatrix.Status = make(map[string]*state)
+	}
+	matrix := s.storage.ConnectivityMatrix.Status
+	for _, node := range req.Roster.List {
+		if _, ok := matrix[node.String()]; !ok {
+			matrix[node.String()] = &state{}
+		}
+	}
+	s.storage.ConnectivityMatrix.LastCheckedAt = probeTime
+
+	pi.Start()
+
+	for err := range pi.(*ConnectivityProtocol).failure {
+		// TODO: depends on the error returned from TreeNodeInstance.SendToAllChildren
+		name := strings.Split(err.Error(), ": ")[0]
+		matrix[name].Down = true
+		matrix[name].LastErrorAt = probeTime.Unix()
+	}
+
+	s.storage.cacheExpiresAt = time.Now().Add(s.storage.CacheExpiryDuration)
+
+	// TODO: Can we prevent a copy here?
+	return &CheckReply{
+		ConnectivityMatrix: s.storage.ConnectivityMatrix,
+	}, nil
+}

--- a/connectivity/service_test.go
+++ b/connectivity/service_test.go
@@ -1,0 +1,40 @@
+package connectivity
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.dedis.ch/cothority/v3"
+	"go.dedis.ch/onet/v3"
+)
+
+func TestService(t *testing.T) {
+	os.Setenv("CONNECTIVITY_TTL", "1")
+	local := onet.NewLocalTest(cothority.Suite)
+	defer local.CloseAll()
+
+	nodes, roster, _ := local.GenTree(7, true)
+
+	s0 := local.GetServices(nodes, serviceID)[0].(*Service)
+	cr, err := s0.Check(&CheckRequest{Roster: roster})
+	assert.NoError(t, err)
+
+	for node, state := range cr.Status {
+		assert.False(t, state.Down, fmt.Sprintf("%s is down", node))
+	}
+
+	time.Sleep(2 * time.Second)
+
+	err = nodes[1].Stop()
+	assert.NoError(t, err)
+
+	time.Sleep(2 * time.Second)
+
+	cr, err = s0.Check(&CheckRequest{Roster: roster})
+	assert.NoError(t, err)
+
+	assert.True(t, cr.Status[nodes[1].Address().String()].Down)
+}

--- a/connectivity/struct.go
+++ b/connectivity/struct.go
@@ -1,0 +1,45 @@
+package connectivity
+
+import (
+	"go.dedis.ch/onet/v3"
+	"time"
+)
+
+const Name = "connectivity"
+
+// Ping is used to check connectivity with children
+type Ping struct {
+}
+
+type pingWrapper struct {
+	*onet.TreeNode
+	Ping
+}
+
+// Pong is used to acknowledge a ping
+type Pong struct {
+}
+
+type pongWrapper struct {
+	*onet.TreeNode
+	Pong
+}
+
+type state struct {
+	Name        string
+	Down        bool
+	LastErrorAt int64
+}
+
+type CheckRequest struct {
+	Roster *onet.Roster
+}
+
+type CheckReply struct {
+	ConnectivityMatrix
+}
+
+type ConnectivityMatrix struct {
+	Status        map[string]*state
+	LastCheckedAt time.Time
+}


### PR DESCRIPTION
This PR adds a new protocol that checks connectivity with all other nodes in the roster. The results of the check are cached by default and controlled using the `CONNECTIVITY_TTL` environment variable.

Still a WIP. Need to remove `time.Sleep` in the tests

---

🙅‍ Friendly checklist:

- [ ] 0. Code comments are added (or updated) when/where needed and explain the WHY of the code.
- [ ] 1. Design choices, user documentation and any additional doc are added (or updated) in READMEs.
- [ ] 2. Any new behaviour is tested and small units of code that can be are unit tested.
- [ ] 3. Code comments are added on tests to explain what they do.
- [ ] 4. Errors are systematically wrapped with a meaningful message using `xerrors.Errorf` and the `%v` verb.
- [ ] 5. Hard limit of 80 chars is always respected.
- [ ] 6. Changes are backward compatible.
- [ ] 7. Indentation level does not exceed 5, although 4 is already suspicious.
- [ ] 8. Functions, files, and packages are kept to a manageable size and decomposed into smaller units if needed.
- [ ] 9. There are no magic values.
