### PR TITLE
Cleaning up mutexes in byzcoin.Service

### DIFF
--- a/byzcoin/api_test.go
+++ b/byzcoin/api_test.go
@@ -315,7 +315,6 @@ func newTestService(c *onet.Context) (onet.Service, error) {
 		stateChangeStorage: newStateChangeStorage(c),
 		viewChangeMan:      newViewChangeManager(),
 		streamingMan:       streamingManager{},
-		closed:             true,
 	}
 
 	cs := &corruptedService{Service: s}

--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -549,9 +549,9 @@ func TestService_AutomaticVersionUpgrade(t *testing.T) {
 
 	// Simulate an upgrade of the conodes.
 	for _, srv := range b.Services {
-		srv.defaultVersionLock.Lock()
+		srv.defaultVersionMutex.Lock()
 		srv.defaultVersion = CurrentVersion
-		srv.defaultVersionLock.Unlock()
+		srv.defaultVersionMutex.Unlock()
 	}
 
 	for i := 0; i < 10; i++ {
@@ -2524,16 +2524,16 @@ func TestService_Repair(t *testing.T) {
 
 	// Introduce an artificial corruption and then try to repair it.
 	genesisHex := fmt.Sprintf("%x", b.Genesis.SkipChainID())
-	b.Services[0].stateTriesLock.Lock()
+	b.Services[0].stateTriesMutex.Lock()
 	b.Services[0].stateTries[genesisHex] = intermediateStateTrie
-	b.Services[0].stateTriesLock.Unlock()
+	b.Services[0].stateTriesMutex.Unlock()
 
 	err := b.Services[0].fixInconsistencyIfAny(b.Genesis.SkipChainID(), intermediateStateTrie)
 	require.NoError(t, err)
 
-	b.Services[0].stateTriesLock.Lock()
+	b.Services[0].stateTriesMutex.Lock()
 	newRoot := b.Services[0].stateTries[genesisHex].GetRoot()
-	b.Services[0].stateTriesLock.Unlock()
+	b.Services[0].stateTriesMutex.Unlock()
 	require.Equal(t, finalRoot, newRoot)
 }
 

--- a/byzcoin/streaming.go
+++ b/byzcoin/streaming.go
@@ -106,14 +106,10 @@ func (s *Service) StreamTransactions(msg *StreamingRequest) (chan *StreamingResp
 	outChan := s.streamingMan.newListener(key)
 
 	go func() {
-		s.closedMutex.Lock()
-		if s.closed {
-			s.closedMutex.Unlock()
+		if !s.tasks.Add(1) {
 			return
 		}
-		s.working.Add(1)
-		defer s.working.Done()
-		s.closedMutex.Unlock()
+		defer s.tasks.Done()
 
 		// Either the service is closing and we force the connection to stop or
 		// the streaming connection is closed upfront.

--- a/byzcoin/streaming.go
+++ b/byzcoin/streaming.go
@@ -106,10 +106,10 @@ func (s *Service) StreamTransactions(msg *StreamingRequest) (chan *StreamingResp
 	outChan := s.streamingMan.newListener(key)
 
 	go func() {
-		if !s.tasks.Add(1) {
+		if !s.tasks.add(1) {
 			return
 		}
-		defer s.tasks.Done()
+		defer s.tasks.done()
 
 		// Either the service is closing and we force the connection to stop or
 		// the streaming connection is closed upfront.

--- a/byzcoin/viewchange.go
+++ b/byzcoin/viewchange.go
@@ -208,11 +208,11 @@ func (s *Service) sendNewView(proof []viewchange.InitReq) error {
 		return fmt.Errorf("couldn't get header of block: %+v", err)
 	}
 
-	if !s.tasks.Add(1) {
+	if !s.tasks.add(1) {
 		return xerrors.New("cannot start while in closing state")
 	}
 	go func() {
-		defer s.tasks.Done()
+		defer s.tasks.done()
 		var sig []byte
 		// Only version < VersionViewchange uses the signing of the view-change
 		// request.

--- a/byzcoin/viewchange_test.go
+++ b/byzcoin/viewchange_test.go
@@ -298,6 +298,7 @@ func TestViewChange_NeedCatchUp(t *testing.T) {
 	// Kill the leader, and unpause the sleepy node
 	b.Services[0].TestClose()
 	b.Servers[0].Pause()
+	log.Lvl1("Unpause latest node")
 	b.Servers[nodes-1].Unpause()
 	require.NoError(t, b.Services[nodes-1].TestRestart())
 


### PR DESCRIPTION
The use of mutexes in byzcoin.Service got somehow out of hand.
This PR cleans up the use of 'Service.close' and 'Service.working' by
adding two new structures that do all the locking.
It also contains minimal changes to the tests to make them pass.

For review: can you please look at the two structures `runSingleWG` and `tasksWG` in `byzcoin/struct.go` and tell me if they look OK? It simplifies a lot the locking in the `byzcoin.Service`. I hope the tests are relevant ;)
I tried to think of how to merge the two