### PR TITLE
Fixes timeout in Websocket

### DIFF
--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -12,6 +12,7 @@
   "types": "index.d.ts",
   "scripts": {
     "build": "npm run protobuf && tsc",
+    "watch": "tsc --watch",
     "linter": "tslint 'src/{,**/}*.ts' 'spec/{,**/}*.ts' && prettier --check *.html",
     "linter:fix": "tslint --fix 'src/{,**/}*.ts' 'spec/{,**/}*.ts' && prettier --write *.html",
     "test": "npm run linter && npm run cover",

--- a/external/js/cothority/spec/helpers/bctest.ts
+++ b/external/js/cothority/spec/helpers/bctest.ts
@@ -39,6 +39,8 @@ export class BCTest {
         try {
             const ws = new RosterWSConnection(roster4, StatusRPC.serviceName);
             ws.setParallel(1);
+            ws.setTimeout(999999);
+
             await ws.send(new StatusRequest(), StatusResponse);
             Log.warn("Using already running nodes for test!");
             usesDocker = false;

--- a/external/js/cothority/spec/network/connection.spec.ts
+++ b/external/js/cothority/spec/network/connection.spec.ts
@@ -114,6 +114,8 @@ describe("WebSocketAdapter Tests", () => {
         });
 
         const conn = new RosterWSConnection(roster, "");
+        conn.setTimeout(999999);
+
         const reply = await conn.send(roster, Roster);
 
         expect(reply instanceof Roster).toBeTruthy();
@@ -135,6 +137,7 @@ describe("WebSocketAdapter Tests", () => {
         });
 
         const conn = new RosterWSConnection(roster, "");
+        conn.setTimeout(999999);
 
         await expectAsync(conn.send(roster, Roster)).toBeRejected();
     });

--- a/external/js/cothority/spec/network/connection.spec.ts
+++ b/external/js/cothority/spec/network/connection.spec.ts
@@ -197,7 +197,10 @@ describe("WebSocketAdapter Tests with sendStream", () => {
     it("should send and receive data", async (done) => {
         const ret = Buffer.from(Roster.encode(new Roster()).finish());
         setFactory(() => new TestWebSocket(ret, null, null));
+
         const conn = new WebSocketConnection("http://example.com", "");
+        conn.setTimeout(999999);
+
         const msg = new Roster();
 
         conn.sendStream(msg, Roster).subscribe({

--- a/external/js/cothority/spec/skipchain/skipchain-rpc.spec.ts
+++ b/external/js/cothority/spec/skipchain/skipchain-rpc.spec.ts
@@ -64,6 +64,8 @@ describe("SkipchainRPC Tests", () => {
             // nodes in order.
             for (const node of roster.list) {
                 const c = new RosterWSConnection(new Roster({list: [node]}), "");
+                c.setTimeout(999999);
+
                 const update = await new SkipchainRPC(c).getUpdateChain(genesis.hash, false);
                 expect(update.length).toBe(blocks);
             }


### PR DESCRIPTION
Clearing the timeout doesn't set it back. This would make the websocket connection have a connection error (coming from Onet I guess..?) instead of the expected timeout.

Also added a `npm run watch` to automatically compile files on changes.

Fixes https://github.com/dedis/columbus-united/issues/40