### PR TITLE
Adding SkipchainDB.GetProofFromIndex

### DIFF
--- a/byzcoin/service_test.go
+++ b/byzcoin/service_test.go
@@ -299,7 +299,7 @@ func TestService_AddTransaction_WrongNode(t *testing.T) {
 	// force the synchronization as the new node needs to get the
 	// propagation to know about the skipchain but we're not testing that
 	// here
-	proof, err := b.Services[0].db().GetProof(b.Genesis.Hash)
+	proof, err := b.Services[0].db().GetProofForLatest(b.Genesis.Hash)
 	require.NoError(t, err)
 	_, err = outside.db().StoreBlocks(proof)
 	require.NoError(t, err)

--- a/skipchain/skipchain.go
+++ b/skipchain/skipchain.go
@@ -681,11 +681,15 @@ func (s *Service) GetSingleBlock(id *GetSingleBlock) (*SkipBlock, error) {
 // GetSingleBlockByIndex searches for the given block and returns it. If no such block is
 // found, a nil is returned.
 func (s *Service) GetSingleBlockByIndex(id *GetSingleBlockByIndex) (*GetSingleBlockByIndexReply, error) {
-	links, sbs, err := s.db.GetFullProof(id.Genesis, id.Index)
+	pr, err := s.db.GetProofFromIndex(id.Genesis, id.Index)
 	if err != nil {
 		return nil, xerrors.Errorf("couldn't get path to block: %v", err)
 	}
-	return &GetSingleBlockByIndexReply{sbs[len(sbs)-1], links}, nil
+	links, err := pr.GetForwardLinks()
+	if err != nil {
+		return nil, xerrors.Errorf("couldn't get forward-links: %v", err)
+	}
+	return &GetSingleBlockByIndexReply{pr[len(pr)-1], links}, nil
 }
 
 // GetAllSkipchains currently returns a list of all the known blocks.
@@ -1131,7 +1135,7 @@ func (s *Service) forwardLinkLevel0(src, dst *SkipBlock) error {
 
 	// We send the shortest chain to the new conodes to let
 	// them know they joined the cothority
-	proof, err := s.db.GetProof(src.SkipChainID())
+	proof, err := s.db.GetProofForLatest(src.SkipChainID())
 	if err != nil {
 		return err
 	}
@@ -1615,7 +1619,7 @@ func (s *Service) propagateForwardLinkHandler(msg network.Message) error {
 // PropagateProof is a simple function that will build the proof of a given
 // skipchain and send it the given roster.
 func (s *Service) PropagateProof(roster *onet.Roster, sid SkipBlockID) error {
-	proof, err := s.db.GetProof(sid)
+	proof, err := s.db.GetProofForLatest(sid)
 	if err != nil {
 		return err
 	}

--- a/skipchain/skipchain_test.go
+++ b/skipchain/skipchain_test.go
@@ -725,7 +725,7 @@ func createSkipchain(service *Service, ro *onet.Roster) (Proof, error) {
 		}
 	}
 
-	blocks, err := service.db.GetProof(sbRoot.SkipChainID())
+	blocks, err := service.db.GetProofForLatest(sbRoot.SkipChainID())
 	return Proof(blocks), err
 }
 


### PR DESCRIPTION
Previously the GetByID was only available as a service-endpoint, but as it is
a handy method in general, this PR moves it to the SkipchainDB as `GetFullProof`,
which can do much more.

Also contains a fix to SkipBlock.pathForIndex