### PR TITLE
js/cothority: rm url-parse

### DIFF
--- a/external/js/cothority/package-lock.json
+++ b/external/js/cothority/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dedis/cothority",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1376,12 +1376,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.1.tgz",
       "integrity": "sha512-h8jF5yPUoHH1QUIDfHgqFs7Y0UykKB5CJ1Z32PHGmHRLmW0pI+kYKAEnXVqeUZ3ygFmDkyvhD4vUZN+RZyTd1w==",
-      "dev": true
-    },
-    "@types/url-parse": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.3.tgz",
-      "integrity": "sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw==",
       "dev": true
     },
     "@types/varint": {
@@ -6745,11 +6739,6 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
-    "querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -6939,11 +6928,6 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.10.0",
@@ -8103,15 +8087,6 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
-      }
-    },
-    "url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "use": {

--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -56,7 +56,6 @@
     "sprintf-js": "^1.1.2",
     "toml": "^2.3.5",
     "tslib": "^1.10.0",
-    "url-parse": "^1.4.7",
     "util": "^0.11.1",
     "varint": "^6.0.0",
     "ws": "^6.1.2"
@@ -74,7 +73,6 @@
     "@types/node": "^12.7.12",
     "@types/shuffle-array": "0.0.28",
     "@types/sprintf-js": "^1.1.1",
-    "@types/url-parse": "^1.4.3",
     "@types/ws": "^6.0.1",
     "babel-loader": "^8.0.5",
     "bn.js": "^5.1.2",

--- a/external/js/cothority/src/network/websocket.ts
+++ b/external/js/cothority/src/network/websocket.ts
@@ -1,6 +1,5 @@
 import { Message } from "protobufjs";
 import { Observable } from "rxjs";
-import URL from "url-parse";
 import Log from "../log";
 import { IConnection } from "./nodes";
 import { Roster } from "./proto";
@@ -40,18 +39,18 @@ export class WebSocketConnection implements IConnection {
         // by the fact that URL will not allow you to have an empty pathname,
         // which will always equal to "/" if there isn't any
         if (url.pathname.slice(-1) !== "/") {
-            url.set("pathname", url.pathname + "/");
+            url.pathname = `${url.pathname}/`;
         }
         if (url.username !== "" || url.password !== "") {
             throw new Error("addr contains authentication, which is not supported");
         }
-        if (Object.entries(url.query).length > 0 || url.hash !== "") {
+        if (url.search !== "" || url.hash !== "") {
             throw new Error("addr contains more data than the origin");
         }
 
         if (typeof globalThis !== "undefined" && typeof globalThis.location !== "undefined") {
             if (globalThis.location.protocol === "https:") {
-                url.set("protocol", "wss");
+                url.protocol = "wss";
             }
         }
 
@@ -114,7 +113,7 @@ export class WebSocketConnection implements IConnection {
 
         return new Observable((sub) => {
             const url = new URL(this.url.href);
-            url.set("pathname", url.pathname + `${this.service}/${message.$type.name.replace(/.*\./, "")}`);
+            url.pathname = `${url.pathname}${this.service}/${message.$type.name.replace(/.*\./, "")}`;
             Log.lvl4(`Socket: new WebSocket(${url.href})`);
             const ws = factory(url.href);
             const bytes = Buffer.from(message.$type.encode(message).finish());


### PR DESCRIPTION
So, `url-parse` came back to bit my hand, first because `@types/url-parse` was missing yet the `URL` type was exposed, then because I wasn't able to *compile* some of its deps.. It was initially added because webpack doesn't deal well with "subdir imports" and that some platforms doesn't come with the same definition of `URL` (Node, NS, ...). I don't think that the Node target is needed anymore (correct me @nkcr) and we just removed the support for mobile/NS in omniledger. Let's remove (once again) `url-parse`.

I was thinking of finally fixing this webpack issue as a fallback plan, but if this PR is merged, I'll wait until an unfixable issue comes along. (Disclaimer: to fix webpack, I'll probably have to reorganise the whole import hierarchy)