### PR TITLE
Enable automatic viewchange

### DIFF
--- a/byzcoin/messages.go
+++ b/byzcoin/messages.go
@@ -24,7 +24,7 @@ func init() {
 type Version int
 
 // CurrentVersion is what we're running now
-const CurrentVersion Version = VersionRollup
+const CurrentVersion Version = VersionAutoViewchange
 
 const (
 	// VersionInstructionHash is the first version and indicates that a new,
@@ -44,4 +44,8 @@ const (
 	// VersionRollup indicates that the followers send their transactions to
 	// the leader, instead of polling by the leader.
 	VersionRollup = 7
+	// VersionAutoViewchange allows the nodes to propose themselves as a new
+	// leader after some interval that can be configured in the genesis
+	// configuration.
+	VersionAutoViewchange = 8
 )

--- a/byzcoin/proto.go
+++ b/byzcoin/proto.go
@@ -177,6 +177,13 @@ type ChainConfig struct {
 	Roster          onet.Roster
 	MaxBlockSize    int
 	DarcContractIDs []string
+	// LeaderRotation indicates how many seconds the next node in the roster
+	// must wait before it's allowed to request a leader-rotation.
+	// If it's 0 or not given, auto leader rotation is not allowed.
+	LeaderRotation int `proto:"opt"`
+	// LastViewchange holds the index of the last successful viewchange.
+	// Either because of a failing leader, or because of an auto viewchange.
+	LastViewchange int `proto:"opt"`
 }
 
 // Proof represents everything necessary to verify a given


### PR DESCRIPTION
As the chain gets more and more stable, the leader can stay up for a long time. The worst thing with this is that I'm often not sure if the viewchange still works ;)

So this PR allows the next node in the roster to force a viewchange after a given interval. So an active node can request a viewchange, while an inactive node will just do nothing and not force a viewchange that will fail.