### PR TITLE
Remove LLvl

### DIFF
--- a/.github/workflows/lint_build_test.yaml
+++ b/.github/workflows/lint_build_test.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Running lint and formatting
         run: |
           make -C conode verify
-          make test_{fmt,lint}
+          make test_{fmt,lint,llvl}
 
       - name: Building everything
         run: go build ./...

--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,8 @@ test_proto:
 		echo "Please update proto-files with 'make proto'"; \
 		exit 1; \
 	fi
+
+test_llvl:
+	@if find . -name "*.go" | xargs grep -r log.LLvl; then \
+		echo "LLvl is only for debugging"; exit 1; \
+	fi

--- a/bypros/browse/paginate/mod.go
+++ b/bypros/browse/paginate/mod.go
@@ -159,7 +159,7 @@ func (p *Paginate) handlePages(ctx context.Context, numPages int, ws *websocket.
 	}
 
 	if len(block.ForwardLink) == 0 {
-		log.LLvl1("we're at the end of the chain")
+		log.Lvl1("we're at the end of the chain")
 		return nil, nil
 	}
 
@@ -176,7 +176,7 @@ func (p *Paginate) checkError(ctx context.Context, resp byzcoin.PaginateResponse
 	// at then end. It could also mean the very first block we're trying
 	// to get doesn't exist.
 	if resp.ErrorCode == byzcoin.PaginatePageFailed {
-		log.LLvl1("done with the chain")
+		log.Lvl1("done with the chain")
 		return true, nil
 	}
 
@@ -191,7 +191,7 @@ func (p *Paginate) checkError(ctx context.Context, resp byzcoin.PaginateResponse
 			return false, xerrors.Errorf("failed to read paginate response: %v", err)
 		}
 
-		log.LLvlf1("reached the end, loading remaining %d blocks", index)
+		log.Lvlf1("reached the end, loading remaining %d blocks", index)
 
 		if block == nil {
 			// this is a special case where the first block of the first

--- a/bypros/proxy.go
+++ b/bypros/proxy.go
@@ -29,7 +29,7 @@ const (
 func (s *Service) Follow(req *Follow) (*EmptyReply, error) {
 	select {
 	case <-s.follow:
-		log.LLvl1("proxy following")
+		log.Lvl1("proxy following")
 	default:
 		return nil, xerrors.Errorf("already following")
 	}
@@ -68,7 +68,7 @@ func (s *Service) Follow(req *Follow) (*EmptyReply, error) {
 		conn.Close()
 
 		waitDone.Wait()
-		log.LLvl1("done following")
+		log.Lvl1("done following")
 		s.following = false
 		s.follow <- struct{}{}
 	}()
@@ -268,7 +268,7 @@ func (s *Service) followCallback(sr byzcoin.StreamingResponse, err error) {
 
 // parseBlock updates the database with the block is not already found.
 func (s *Service) parseBlock(block *skipchain.SkipBlock) error {
-	log.LLvl3("parsing block", block.Index)
+	log.Lvl3("parsing block", block.Index)
 
 	blockID, err := s.storage.GetBlock(block.Hash)
 	if err != nil {
@@ -276,7 +276,7 @@ func (s *Service) parseBlock(block *skipchain.SkipBlock) error {
 	}
 
 	if blockID != -1 {
-		log.LLvlf3("block with index %d already exist: skipping", block.Index)
+		log.Lvlf3("block with index %d already exist: skipping", block.Index)
 		return nil
 	}
 

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -1605,7 +1605,7 @@ func (s *Service) catchUp(sb *skipchain.SkipBlock) {
 		log.Errorf("Couldn't update chain: %+v", err)
 	}
 
-	log.LLvlf2("%v Done catch up %x / %d", s.ServerIdentity(),
+	log.Lvlf2("%v Done catch up %x / %d", s.ServerIdentity(),
 		sb.SkipChainID(), trieIndex)
 }
 

--- a/byzcoin/statereplay.go
+++ b/byzcoin/statereplay.go
@@ -75,7 +75,7 @@ func (s *Service) ReplayState(id skipchain.SkipBlockID,
 		if err != nil {
 			return nil, fmt.Errorf("couldn't copy db-trie to mem-trie: %v", err)
 		}
-		log.LLvl2("Getting latest block:", st.GetIndex()+1)
+		log.Lvl2("Getting latest block:", st.GetIndex()+1)
 		rep, err := s.skService().GetSingleBlockByIndex(&skipchain.
 			GetSingleBlockByIndex{
 			Genesis: sb.SkipChainID(),


### PR DESCRIPTION
LLvl are used for debugging and should not be used in the final code.
Adds a test_llvl target to the Makefile.
