### PR TITLE
Don't loop when latest node in roster is not responsive

### DIFF
--- a/byzcoin/bcadmin/cmd_db.go
+++ b/byzcoin/bcadmin/cmd_db.go
@@ -79,6 +79,9 @@ func dbCatchup(c *cli.Context) error {
 		if err != nil {
 			return xerrors.Errorf("couldn't get blocks from network: %+v", err)
 		}
+		if sb == nil {
+			break
+		}
 		if len(sb.ForwardLink) == 0 {
 			if askAllNodes {
 				// If no further blocks exist,
@@ -103,6 +106,7 @@ func dbCatchup(c *cli.Context) error {
 		latestID = sb.ForwardLink[0].To
 	}
 
+	log.Info("Downloaded all available blocks from the chain")
 	return nil
 }
 
@@ -878,6 +882,9 @@ func (fb *fetchBlocks) gbMulti(startID skipchain.SkipBlockID) (
 		}
 
 		if !ok {
+			if fb.index == len(fb.roster.List)-1 {
+				return nil, nil
+			}
 			fb.nextNode()
 			continue
 		}


### PR DESCRIPTION
The `bcadmin db catchup` had an error where it looped forever if the latest node in the roster was down.

This PR fixes this corner-case.