### PR TITLE
Refine byzcoin

### DIFF
--- a/byzcoin/api_test.go
+++ b/byzcoin/api_test.go
@@ -1,6 +1,7 @@
 package byzcoin
 
 import (
+	"encoding/hex"
 	"sync"
 	"testing"
 	"time"
@@ -293,6 +294,22 @@ func TestClient_SignerCounterDecoder(t *testing.T) {
 	c.Latest.Index = 2
 	// Incorrect scenario where the reply is older.
 	require.Error(t, c.signerCounterDecoder(buf, &reply))
+}
+
+func TestClient_GetNodes(t *testing.T) {
+	t.Skip("This does only work with a running dedis-blockchain")
+	si := &network.ServerIdentity{
+		Address: "tls://conode.c4dt.org:7770",
+		URL:     "https://conode.c4dt.org",
+		Public:  cothority.Suite.Point()}
+	bcID, _ := hex.DecodeString(
+		"9cc36071ccb902a1de7e0d21a2c176d73894b1cf88ae4cc2ba4c95cd76f474f3")
+	reply, err := skipchain.NewClient().GetUpdateChain(onet.NewRoster(
+		[]*network.ServerIdentity{si}), bcID)
+	require.NoError(t, err)
+
+	cl := NewClient(bcID, *reply.Update[len(reply.Update)-1].Roster)
+	cl.UpdateNodes()
 }
 
 const testServiceName = "TestByzCoin"

--- a/byzcoin/bcadmin/main.go
+++ b/byzcoin/bcadmin/main.go
@@ -1725,14 +1725,21 @@ func getInfo(c *cli.Context) error {
 		return xerrors.New("--bc flag is required")
 	}
 
-	cfg, _, err := lib.LoadConfig(bcArg)
+	cfg, cl, err := lib.LoadConfig(bcArg)
 	if err != nil {
 		return err
 	}
 
+	cl.UpdateNodes()
+	var bcCfg byzcoin.ChainConfig
+	if _, err := cl.GetInstance(byzcoin.ConfigInstanceID,
+		byzcoin.ContractConfigID, &bcCfg); err != nil {
+		return xerrors.Errorf("couldn't get chain config: %v", err)
+	}
 	log.Infof("%s\n"+
-		"- BC: %s\n",
-		cfg.String(), bcArg)
+		"- BC: %s\n"+
+		"%v",
+		cfg.String(), bcArg, bcCfg)
 
 	return nil
 }

--- a/personhood/service_test.go
+++ b/personhood/service_test.go
@@ -11,7 +11,6 @@ import (
 	"go.dedis.ch/cothority/v3/personhood/contracts"
 	"go.dedis.ch/cothority/v3/personhood/user"
 	"go.dedis.ch/onet/v3/log"
-	"go.dedis.ch/protobuf"
 	"regexp"
 	"strings"
 	"testing"
@@ -97,10 +96,9 @@ func (ts *testService) callSetup() *EmailSetupReply {
 
 func (ts *testService) updateEmailDarc() {
 	require.NoError(ts, ts.Client.WaitPropagation(-1))
-	edBuf, err := ts.Client.GetInstance(byzcoin.NewInstanceID(ts.emailDarc.
-		GetBaseID()), byzcoin.ContractDarcID)
+	_, err := ts.Client.GetInstance(byzcoin.NewInstanceID(ts.
+		emailDarc.GetBaseID()), byzcoin.ContractDarcID, ts.emailDarc)
 	require.NoError(ts, err)
-	require.NoError(ts, protobuf.Decode(edBuf, ts.emailDarc))
 }
 
 func TestService_EmailSetup(t *testing.T) {

--- a/personhood/user/builder.go
+++ b/personhood/user/builder.go
@@ -83,10 +83,6 @@ func (ub *Builder) CreateFromSpawner(spawner ActiveSpawner) (*User, error) {
 		return nil, xerrors.Errorf("couldn't send transaction: %v", err)
 	}
 
-	if err := spawner.cl.WaitPropagation(-1); err != nil {
-		return nil, xerrors.Errorf("couldn't wait for propagation: %v", err)
-	}
-
 	u, err := New(spawner.cl, ub.UserID)
 	if err != nil {
 		return nil, xerrors.Errorf("couldn't get finished user: %v", err)


### PR DESCRIPTION
This is a collection of patches for byzcoin and skipchain:
- solve a race condition where the bftForwardLinkLevel0Ack has been called before bftForwardLinkLevel0 is done
- allow storing of new SkipBlocks in existing chains, even if a Client has been registered
- changing the byzcoin.Client.GetInstance method to also do the protobuf-decoding
- adding a byzcoin.Client.UpdateNodes in case some of the nodes didn't catch up

This has been tested in production and behaves nicer. Of course there are still some bugs left...