### PR TITLE
Changing address for CC

### DIFF
--- a/personhood/email.go
+++ b/personhood/email.go
@@ -69,7 +69,7 @@ type emailConfig struct {
 // SendMail sends an email to the given address. As the EPFL SMTP server
 // supports sending without authentication, the steps need to be done
 // manually.
-func (ec emailConfig) SendMail(to, subject, body string) error {
+func (ec emailConfig) SendMail(to, cc, subject, body string) error {
 	if ec.dummy != nil {
 		_, err := fmt.Fprintf(ec.dummy, "Sending email to %s: %s\n%s\n",
 			to, subject, body)
@@ -98,8 +98,7 @@ func (ec emailConfig) SendMail(to, subject, body string) error {
 	if err := client.Rcpt(to); err != nil {
 		return xerrors.Errorf("failed to set to: %v", err)
 	}
-	hardcodedCC := "c4dt-services@listes.epfl.ch"
-	if err := client.Rcpt(hardcodedCC); err != nil {
+	if err := client.Rcpt(cc); err != nil {
 		return xerrors.Errorf("failed to set cc: %v", err)
 	}
 	data, err := client.Data()
@@ -111,7 +110,7 @@ func (ec emailConfig) SendMail(to, subject, body string) error {
 		"CC: %s\r\n"+
 		"From: %s\r\n"+
 		"Subject: %s\r\n\r\n%s\r\n",
-		to, ec.SMTPReplyTo, hardcodedCC, ec.SMTPReplyTo, subject, body))
+		to, ec.SMTPReplyTo, cc, ec.SMTPReplyTo, subject, body))
 	if _, err := data.Write(msg); err != nil {
 		return xerrors.Errorf("failed to write data: %v", err)
 	}

--- a/personhood/service.go
+++ b/personhood/service.go
@@ -588,8 +588,9 @@ func (s *Service) EmailSignup(rq *EmailSignup) (*EmailSignupReply, error) {
 	}
 
 	log.Lvl2("Signing up new user: sending email")
+	cc := u.GetCredentialsCopy().GetPublic(contracts.APEmail)
 	err = s.storage.EmailConfig.SendMail(
-		rq.Email, "DEDIS/EPFL byzcoin setup",
+		rq.Email, string(cc), "DEDIS/EPFL byzcoin setup",
 		"This email is to inform you that you have been signed up for\r\n"+
 			"the DEDIS/Byzcoin blockchain.\r\n\n"+
 			"Please click on the following link to set up your account:\r\n\r\n"+
@@ -656,8 +657,9 @@ func (s *Service) EmailRecover(rq *EmailRecover) (*EmailRecoverReply, error) {
 			}
 
 			log.Lvl2("Recovering user: sending email")
+			cc := u.GetCredentialsCopy().GetPublic(contracts.APEmail)
 			err = s.storage.EmailConfig.SendMail(
-				rq.Email, "DEDIS/EPFL byzcoin recovery",
+				rq.Email, string(cc), "DEDIS/EPFL byzcoin recovery",
 				"This email is to recover your byzcoin account from\r\n"+
 					"the DEDIS/Byzcoin blockchain.\r\n\n"+
 					"Please click on the following link to recover your"+

--- a/personhood/service_test.go
+++ b/personhood/service_test.go
@@ -209,7 +209,8 @@ func TestEmailConfig_SendMail(t *testing.T) {
 		SMTPFrom:    "noreply@epfl.ch",
 		SMTPReplyTo: "c4dt-services@listes.epfl.ch",
 	}
-	require.NoError(t, ec.SendMail("linus.gasser@epfl.ch", "Test",
+	require.NoError(t, ec.SendMail("linus.gasser@epfl.ch",
+		"c4dt-services@listes.epfl.ch", "Test",
 		fmt.Sprintf("This is a test message at %s",
 			time.Now().Format(time.RFC3339))))
 }
@@ -218,9 +219,10 @@ func TestEmailConfig_SendMailDummy(t *testing.T) {
 	var dummy bytes.Buffer
 	ec := emailConfig{dummy: &dummy}
 	to := "linus.gasser@epfl.ch"
+	cc := "c4dt-services@listes.epfl.ch"
 	subject := "Test"
 	body := "This is a test message"
-	require.NoError(t, ec.SendMail(to, subject, body))
+	require.NoError(t, ec.SendMail(to, cc, subject, body))
 	msg := dummy.String()
 	require.True(t, strings.Contains(msg, to))
 	require.True(t, strings.Contains(msg, subject))


### PR DESCRIPTION
Instead of using a hardcoded CC address, use the one from the registered user during setup.
