### PR TITLE
Correctly recover users

### DIFF
--- a/personhood/user/builder.go
+++ b/personhood/user/builder.go
@@ -123,14 +123,14 @@ func (ub *Builder) createDarcs() error {
 	deviceDarcID := darc.NewIdentityDarc(ub.darcDevice.GetBaseID())
 
 	devicesExp := expression.Expr(deviceDarcID.String())
+	signerRules := darc.NewRules()
+	if err := signerRules.AddRule("_sign", devicesExp); err != nil {
+		return xerrors.Errorf("while updating sign: %v", err)
+	}
 	for _, recovery := range ub.credentialStruct.Get(contracts.CERecoveries).
 		Attributes {
 		devicesExp = devicesExp.AddOrElement(
 			darc.NewIdentityDarc(recovery.Value).String())
-	}
-	signerRules := darc.NewRules()
-	if err := signerRules.AddRule("_sign", devicesExp); err != nil {
-		return xerrors.Errorf("while updating sign: %v", err)
 	}
 	if err := signerRules.AddRule(byzcoin.ContractDarcInvokeEvolve,
 		devicesExp); err != nil {


### PR DESCRIPTION
Corrected the following things to make it behave like the web-frontend:
- when adding a recovery to a new user, only add it to the 'evolve' rule of the signer-darc
- when recovering an existing user
  - add the new darc using the admin-signer
  - add the darc-ID to the recovered user with the ephemeral key as signer