### PR TITLE
Fix multiple recoveries

### DIFF
--- a/personhood/service_test.go
+++ b/personhood/service_test.go
@@ -180,12 +180,24 @@ func TestService_EmailRecover(t *testing.T) {
 	require.Equal(t, uint64(2000), newUserCoin.Value)
 	require.Equal(t, contracts.SpawnerCoin, newUserCoin.Name)
 
+	// Test wrong email
 	reply, err := ts.s.EmailRecover(&EmailRecover{
 		Email: "linus.gasser2@epfl.ch",
 	})
 	require.Error(t, err)
 	require.Equal(t, EREUnknown, reply.Status)
 
+	// Test correct email
+	ts.dummyEmail.Reset()
+	reply, err = ts.s.EmailRecover(&EmailRecover{
+		Email: "linus.gasser@epfl.ch",
+	})
+	// Need to wait for the update to go through the network.
+	require.NoError(t, err)
+	require.Equal(t, ERERecovered, reply.Status)
+	time.Sleep(time.Second)
+
+	// Test correct email a 2nd time
 	ts.dummyEmail.Reset()
 	reply, err = ts.s.EmailRecover(&EmailRecover{
 		Email: "linus.gasser@epfl.ch",

--- a/personhood/user/user_test.go
+++ b/personhood/user/user_test.go
@@ -146,8 +146,18 @@ func TestUser_Recover(t *testing.T) {
 
 	recoverStr, err := user.Recover(user2.CredIID, "https://something.com")
 	require.NoError(t, err)
+	require.NoError(t, user2.UpdateSignerDarc())
 
 	user2recover, err := NewFromURL(ut.Client, recoverStr)
+	require.NoError(t, err)
+	require.Equal(t, user2.CredIID, user2recover.CredIID)
+	require.NoError(t, user2.UpdateSignerDarc())
+
+	// Recover a second time
+	recoverStr, err = user.Recover(user2.CredIID, "https://something.com")
+	require.NoError(t, err)
+
+	user2recover, err = NewFromURL(ut.Client, recoverStr)
 	require.NoError(t, err)
 	require.Equal(t, user2.CredIID, user2recover.CredIID)
 }


### PR DESCRIPTION
The evolve-instruction was badly calculated, and thus only one recovery was
possible.

Unfortunately all accounts with a recovery cannot be recovered :(