### PR TITLE
Fix subleader handling

### DIFF
--- a/blscosi/protocol/protocol.go
+++ b/blscosi/protocol/protocol.go
@@ -99,13 +99,14 @@ func DefaultThreshold(n int) int {
 }
 
 // DefaultSubLeaders returns the number of sub-leaders, which is the
-// cube-root of the number of nodes.
+// square root of the number of nodes - 1.
 func DefaultSubLeaders(nodes int) int {
-	// As `math.Pow` calculates `8 ** (1/3) < 2`,
+	if nodes == 1 {
+		return 1
+	}
+	// As `math.Pow` calculates `9 ** (1/2) < 3`,
 	// we add 0.0001 for the rounding error.
-	// This works for up to 57 ** 3 = 185'193, which should be enough
-	// nodes.
-	return int(math.Pow(float64(nodes), 1.0/3.0) + 0.0001)
+	return int(math.Pow(float64(nodes-1), 1.0/2.0) + 0.0001)
 }
 
 // NewBlsCosi method is used to define the blscosi protocol.

--- a/blscosi/protocol/protocol.go
+++ b/blscosi/protocol/protocol.go
@@ -104,9 +104,7 @@ func DefaultSubLeaders(nodes int) int {
 	if nodes == 1 {
 		return 1
 	}
-	// As `math.Pow` calculates `9 ** (1/2) < 3`,
-	// we add 0.0001 for the rounding error.
-	return int(math.Pow(float64(nodes-1), 1.0/2.0) + 0.0001)
+	return int(math.Pow(float64(nodes-1), 1.0/2.0))
 }
 
 // NewBlsCosi method is used to define the blscosi protocol.

--- a/blscosi/protocol/protocol_test.go
+++ b/blscosi/protocol/protocol_test.go
@@ -192,7 +192,7 @@ func TestProtocol_FailingLeaves_25_9(t *testing.T) {
 func TestDefaultSubLeaders(t *testing.T) {
 	require.Equal(t, DefaultSubLeaders(1), 1)
 	for subleaders := 2; subleaders < 58; subleaders++ {
-		nodes := int(math.Pow(float64(subleaders), 3.0))
+		nodes := int(math.Pow(float64(subleaders), 2.0)) + 1
 		require.Equal(t, DefaultSubLeaders(nodes-1), subleaders-1)
 		require.Equal(t, DefaultSubLeaders(nodes), subleaders)
 	}

--- a/blscosi/protocol/sub_protocol.go
+++ b/blscosi/protocol/sub_protocol.go
@@ -190,36 +190,43 @@ func (p *SubBlsCosi) dispatchRoot() error {
 		return nil
 	}
 
-	// Only one child anyway
-	err := p.SendToChildren(&Announcement{
-		Msg:       p.Msg,
-		Data:      p.Data,
-		Timeout:   p.Timeout,
-		Threshold: p.Threshold,
-	})
-	if err != nil {
-		// Only log what happened so we can try to finish the protocol
-		// (e.g. one child is offline)
-		log.Warnf("Error when broadcasting to children: %s", err.Error())
-	}
+	subLeaderActive := make(chan error, 1)
+	// Because SendToChildren blocks on some firewalls instead of returning
+	// an error, this call is put in a go-routine.
+	go func() {
+		subLeaderActive <- p.SendToChildren(&Announcement{
+			Msg:       p.Msg,
+			Data:      p.Data,
+			Timeout:   p.Timeout,
+			Threshold: p.Threshold,
+		})
+	}()
 
-	select {
-	case <-p.closeChan:
-		return nil
-	case reply := <-p.ChannelResponse:
-		if reply.Equal(p.Root().Children[0]) {
-			// Transfer the response to the parent protocol
-			p.subResponse <- reply
+	for {
+		select {
+		case err := <-subLeaderActive:
+			if err != nil {
+				p.subleaderNotResponding <- true
+				log.Warnf("Couldn't contact subleader: %v", err)
+				return nil
+			}
+		case <-p.closeChan:
+			return nil
+		case reply := <-p.ChannelResponse:
+			if reply.Equal(p.Root().Children[0]) {
+				// Transfer the response to the parent protocol
+				p.subResponse <- reply
+			}
+			return nil
+		case <-time.After(p.Timeout):
+			// It might be only the subleader then we send a notification
+			// to let the parent protocol take actions
+			log.Warnf("%s: timed out while waiting for subleader response while %s",
+				p.ServerIdentity(), p.Tree().Dump())
+			p.subleaderNotResponding <- true
+			return nil
 		}
-	case <-time.After(p.Timeout):
-		// It might be only the subleader then we send a notification
-		// to let the parent protocol take actions
-		log.Warnf("%s: timed out while waiting for subleader response while %s",
-			p.ServerIdentity(), p.Tree().Dump())
-		p.subleaderNotResponding <- true
 	}
-
-	return nil
 }
 
 // dispatchSubLeader takes care of synchronizing the children
@@ -238,10 +245,7 @@ func (p *SubBlsCosi) dispatchSubLeader() error {
 		return err
 	}
 
-	errs := p.SendToChildrenInParallel(a)
-	if len(errs) > 0 {
-		log.Error(errs)
-	}
+	p.sendToChildren(a)
 
 	responses := make(ResponseMap)
 	for _, c := range p.Children() {
@@ -264,9 +268,7 @@ func (p *SubBlsCosi) dispatchSubLeader() error {
 	// we need to timeout the children faster than the root timeout to let it
 	// know the subleader is alive, but some children are failing
 	timeout := time.After(p.Timeout / 2)
-	// If an error happens when sending the announcement, we can assume there
-	// will be a timeout from this node
-	done := len(errs)
+	done := 0
 	for done < len(p.Children()) {
 		select {
 		case <-p.closeChan:
@@ -444,4 +446,17 @@ func (p *SubBlsCosi) checkIntegrity() error {
 	}
 
 	return nil
+}
+
+// sendToChildren does not collect error messages,
+// but doesn't block on nodes with a non-rejecting firewall in front of them.
+func (p *SubBlsCosi) sendToChildren(msg interface{}) {
+	for _, c := range p.Children() {
+		go func(tn *onet.TreeNode) {
+			err := p.SendTo(tn, msg)
+			if err != nil {
+				log.Warnf("Error while sending to children: %v", err)
+			}
+		}(c)
+	}
 }

--- a/byzcoinx/byzcoinx_test.go
+++ b/byzcoinx/byzcoinx_test.go
@@ -200,7 +200,7 @@ func runProtocol(t *testing.T, nbrHosts int, nbrFault int, refuseIndex int, prot
 	log.Lvl3("Added counter", counters.size()-1, refuseIndex)
 
 	require.True(t, int(math.Pow(float64(bftCosiProto.nSubtrees),
-		3.0)) <= nbrHosts)
+		2.0)) <= nbrHosts)
 
 	// kill the leafs first
 	nbrFault = min(nbrFault, len(servers))


### PR DESCRIPTION
This PR does the following:
- increase the number of subleaders to sqrt(roster.len - 1), according
  to the OmniLedger paper
- put all calls to Send in the blscosi protocol in a go-routine, so that
  a blocking subleader doesn't stop the protocol