### PR TITLE
Change the encoding of the IdentityTSM

### DIFF
--- a/byzcoin/bctest.go
+++ b/byzcoin/bctest.go
@@ -244,6 +244,38 @@ func (b *BCTest) TransferCoin(args *TxArgs, coinSrc, coinDst InstanceID,
 	})
 }
 
+// SpawnDarc spawns a new darc on byzcoin.
+func (b *BCTest) SpawnDarc(args *TxArgs, d *darc.Darc) {
+	buf, err := d.ToProto()
+	require.NoError(b.T, err)
+	b.SendInst(args, Instruction{
+		InstanceID: NewInstanceID(b.GenesisDarc.GetBaseID()),
+		Spawn: &Spawn{
+			ContractID: "darc",
+			Args: Arguments{
+				{Name: "darc", Value: buf},
+			},
+		},
+	})
+}
+
+// EvolveDarc invokes 'evolve' on the given darc. The darc must have a
+// 'version' greater than the already existing darc.
+func (b *BCTest) EvolveDarc(args *TxArgs, d *darc.Darc) {
+	buf, err := d.ToProto()
+	require.NoError(b.T, err)
+	b.SendInst(args, Instruction{
+		InstanceID: NewInstanceID(b.GenesisDarc.GetBaseID()),
+		Invoke: &Invoke{
+			ContractID: "darc",
+			Command:    "evolve",
+			Args: Arguments{
+				{Name: "darc", Value: buf},
+			},
+		},
+	})
+}
+
 // DummyContractName is the name of the dummy contract.
 const DummyContractName = "dummy"
 

--- a/byzcoin/service.go
+++ b/byzcoin/service.go
@@ -598,7 +598,8 @@ func (s *Service) GetProof(req *GetProof) (*GetProofResponse, error) {
 // fulfill a given rule of a given darc. Because all darcs are now used in
 // an online fashion, we need to offer this check.
 func (s *Service) CheckAuthorization(req *CheckAuthorization) (resp *CheckAuthorizationResponse, err error) {
-	log.Lvlf2("%s getting authorizations of darc %x", s.ServerIdentity(), req.DarcID)
+	log.Lvlf2("%s getting authorizations of darc %x for identities %v",
+		s.ServerIdentity(), req.DarcID, req.Identities)
 
 	resp = &CheckAuthorizationResponse{}
 	st, err := s.GetReadOnlyStateTrie(req.ByzCoinID)

--- a/darc/darc.go
+++ b/darc/darc.go
@@ -929,8 +929,7 @@ func (id Identity) String() string {
 	case 5:
 		return fmt.Sprintf("%s:%s", id.TypeString(), id.DID.DID)
 	case 6:
-		buf, _ := id.TSM.MarshalBinary()
-		return fmt.Sprintf("%s:%x", id.TypeString(), buf)
+		return fmt.Sprintf("%s:%x", id.TypeString(), id.TSM.PublicKey)
 	default:
 		return "No identity"
 	}
@@ -1061,17 +1060,6 @@ func (ide *IdentityTSM) Verify(msg []byte, sig []byte) error {
 	if !valid {
 		return errors.New("Signature failed to verify")
 	}
-	return nil
-}
-
-// MarshalBinary returns the compressed public key
-func (ide IdentityTSM) MarshalBinary() ([]byte, error) {
-	return ide.PublicKey, nil
-}
-
-// UnmarshalBinary stores the compressed public key
-func (ide *IdentityTSM) UnmarshalBinary(data []byte) error {
-	ide.PublicKey = data
 	return nil
 }
 
@@ -1533,16 +1521,16 @@ type SignerTSM struct {
 // If a nil key is given, then a random key is generated.
 // This is mostly used for testing, as the real TSM is a hardware device
 // and not supported in tests.
-func NewSignerTSM(private ecdsa.PrivateKey) Signer {
-	if private.D == nil {
+func NewSignerTSM(private *ecdsa.PrivateKey) Signer {
+	if private == nil {
 		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		if err != nil {
 			panic("couldn't generate key: " + err.Error())
 		}
-		private = *priv
+		private = priv
 	}
 	return Signer{tsm: &SignerTSM{
-		PrivateKey: private,
+		PrivateKey: *private,
 	}}
 }
 

--- a/darc/darc_test.go
+++ b/darc/darc_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"go.dedis.ch/protobuf"
 	"math/big"
 	"net/url"
 	"strings"
@@ -767,7 +768,7 @@ func testIdentity(t *testing.T, sig Signer) {
 // Test the different identities available - currently only Ed25519.
 func TestIdentities(t *testing.T) {
 	testIdentity(t, NewSignerEd25519(nil, nil))
-	testIdentity(t, NewSignerTSM(ecdsa.PrivateKey{}))
+	testIdentity(t, NewSignerTSM(nil))
 }
 
 // Test a signature from the TSM
@@ -794,10 +795,10 @@ func TestTSMSignature(t *testing.T) {
 
 // Make sure Marshalling and Unmarshalling work
 func TestTSMMarshalling(t *testing.T) {
-	id := NewSignerTSM(ecdsa.PrivateKey{}).Identity()
-	buf, err := id.TSM.MarshalBinary()
+	id := NewSignerTSM(nil).Identity()
+	buf, err := protobuf.Encode(&id)
 	require.NoError(t, err)
-	var id2 IdentityTSM
-	require.NoError(t, id2.UnmarshalBinary(buf))
-	require.True(t, id.Equal(&Identity{TSM: &id2}))
+	var id2 Identity
+	require.NoError(t, protobuf.Decode(buf, &id2))
+	require.True(t, id.Equal(&id2))
 }

--- a/external/js/cothority/src/darc/identity-tsm.ts
+++ b/external/js/cothority/src/darc/identity-tsm.ts
@@ -1,0 +1,37 @@
+import { Message, Properties } from "protobufjs/light";
+import { EMPTY_BUFFER, registerMessage } from "../protobuf";
+import IdentityWrapper, { IIdentity } from "./identity-wrapper";
+
+/**
+ * Identity based on a TSM
+ */
+export default class IdentityTsm extends Message<IdentityTsm> implements IIdentity {
+    /**
+     * @see README#Message classes
+     */
+    static register() {
+        registerMessage("IdentityTSM", IdentityTsm);
+    }
+
+    readonly publickey: Buffer;
+
+    constructor(props?: Properties<IdentityTsm>) {
+        super(props);
+        this.publickey = Buffer.from(this.publickey || EMPTY_BUFFER);
+    }
+
+    /** @inheritdoc */
+    verify(msg: Buffer, signature: Buffer): boolean {
+        throw new Error("Not implemented");
+    }
+
+    /** @inheritdoc */
+    toBytes(): Buffer {
+        return Buffer.from(this.toString());
+    }
+
+    /** @inheritdoc */
+    toString(): string {
+        return `tsm:${this.publickey.toString("hex")}`;
+    }
+}

--- a/external/js/cothority/src/darc/identity-wrapper.ts
+++ b/external/js/cothority/src/darc/identity-wrapper.ts
@@ -4,6 +4,7 @@ import { registerMessage } from "../protobuf";
 import IdentityDarc from "./identity-darc";
 import IdentityDid from "./identity-did";
 import IdentityEd25519 from "./identity-ed25519";
+import IdentityTsm from "./identity-tsm";
 
 /**
  * Protobuf representation of an identity
@@ -13,7 +14,7 @@ export default class IdentityWrapper extends Message<IdentityWrapper> {
      * @see README#Message classes
      */
     static register() {
-      registerMessage("Identity", IdentityWrapper, IdentityEd25519, IdentityDarc, IdentityDid);
+      registerMessage("Identity", IdentityWrapper, IdentityEd25519, IdentityDarc, IdentityDid, IdentityTsm);
     }
 
     /**
@@ -42,6 +43,11 @@ export default class IdentityWrapper extends Message<IdentityWrapper> {
             const id = new IdentityDid({method: Buffer.from(field[1]), did: Buffer.from(field[2]) });
             return new IdentityWrapper({did: id});
         }
+        if (idStr.startsWith("tsm:")) {
+            const field = idStr.split(":", 2);
+            const tsm = new IdentityTsm({publickey: Buffer.from(field[1], "hex")});
+            return new IdentityWrapper({tsm});
+        }
     }
 
     /**
@@ -54,6 +60,7 @@ export default class IdentityWrapper extends Message<IdentityWrapper> {
     readonly ed25519: IdentityEd25519;
     readonly darc: IdentityDarc;
     readonly did: IdentityDid;
+    readonly tsm: IdentityTsm;
 
     /**
      * Get the inner identity as bytes
@@ -68,6 +75,9 @@ export default class IdentityWrapper extends Message<IdentityWrapper> {
         }
         if (this.did) {
             return this.did.toBytes();
+        }
+        if (this.tsm) {
+            return this.tsm.toBytes();
         }
 
         return Buffer.from([]);
@@ -86,6 +96,9 @@ export default class IdentityWrapper extends Message<IdentityWrapper> {
         }
         if (this.did) {
             return this.did.toString();
+        }
+        if (this.tsm) {
+            return this.tsm.toString();
         }
 
         return "empty signer";

--- a/external/js/cothority/src/darc/index.ts
+++ b/external/js/cothority/src/darc/index.ts
@@ -2,6 +2,7 @@ import Darc from "./darc";
 import IdentityDarc from "./identity-darc";
 import IdentityDid from "./identity-did";
 import IdentityEd25519 from "./identity-ed25519";
+import IdentityTsm from "./identity-tsm";
 import IdentityWrapper, { IIdentity } from "./identity-wrapper";
 import Rules, { Rule } from "./rules";
 import Signer from "./signer";
@@ -13,6 +14,7 @@ export {
     IdentityDarc,
     IdentityDid,
     IdentityEd25519,
+    IdentityTsm,
     IdentityWrapper,
     Rule,
     Rules,

--- a/external/js/cothority/tsconfig.json
+++ b/external/js/cothority/tsconfig.json
@@ -14,7 +14,17 @@
     "typeRoots": [
       "../types",
       "./node_modules/@types"
-    ]
+    ],
+    "paths": {
+      "@dedis/kyber": [
+        "node_modules/@dedis/kyber/dist",
+        "node_modules/@dedis/kyber"
+      ],
+      "@dedis/kyber/*": [
+        "node_modules/@dedis/kyber/dist/*",
+        "node_modules/@dedis/kyber/*"
+      ]
+    }
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
The first PR to implement the IdentityTSM used a (Un)MarshalBinary that was not compatible
with the protobuf-encoding we were doing.

This PR contains also some tests used to discover this discrepancy.

Because there is no TSM-identity stored in binary form, this should not break anything.