### PR TITLE
Setting LTS timeout

### DIFF
--- a/external/js/cothority/package.json
+++ b/external/js/cothority/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@dedis/cothority",
-  "version": "3.6.5",
+  "version": "3.6.6",
   "description": "A typescript implementation of the cothority",
   "main": "index.js",
   "browser": "bundle.min.js",

--- a/external/js/cothority/src/calypso/calypso-rpc.ts
+++ b/external/js/cothority/src/calypso/calypso-rpc.ts
@@ -100,6 +100,8 @@ export class LongTermSecret extends OnChainSecretRPC {
             roster = LtsInstanceInfo.decode(instBS.getValue().value).roster;
         }
         const conn = new RosterWSConnection(roster, OnChainSecretRPC.serviceID);
+        // As the LTS servers can be down, timeout quite quickly.
+        conn.setTimeout(2000);
         const reply = await conn.send<CreateLTSReply>(new GetLTSReply({ltsid}), CreateLTSReply);
         return new LongTermSecret(bc, ltsid, reply.X, roster);
     }

--- a/external/js/cothority/src/network/nodes.ts
+++ b/external/js/cothority/src/network/nodes.ts
@@ -190,6 +190,7 @@ export class Nodes {
  */
 export class Node {
     private services: Map<string, IConnection> = new Map<string, IConnection>();
+    private timeout: undefined | number;
 
     constructor(readonly address: string) {
     }
@@ -203,7 +204,11 @@ export class Node {
         if (this.services.has(name)) {
             return this.services.get(name);
         }
-        this.services.set(name, new WebSocketConnection(this.address, name));
+        const conn = new WebSocketConnection(this.address, name);
+        if (this.timeout !== undefined) {
+            conn.setTimeout(this.timeout);
+        }
+        this.services.set(name, conn);
         return this.getService(name);
     }
 
@@ -211,6 +216,7 @@ export class Node {
      * Sets the timeout for all connections of this node.
      */
     setTimeout(t: number) {
+        this.timeout = t;
         this.services.forEach((conn) => conn.setTimeout(t));
     }
 }

--- a/external/js/cothority/src/network/rosterwsconnection.ts
+++ b/external/js/cothority/src/network/rosterwsconnection.ts
@@ -86,9 +86,7 @@ export class RosterWSConnection implements IConnection {
                 do {
                     const idStr = `${this.connNbr}/${msgNbr.toString()}: ${conn.getURL()}`;
                     try {
-                        Log.lvl3(idStr, "sending");
                         const sub = await conn.send(message, reply);
-                        Log.lvl3(idStr, "received OK");
 
                         if (list.done(conn) === 0) {
                             Log.lvl3(idStr, "first to receive");


### PR DESCRIPTION
This PR sets a much shorter timeout for contacting the LTS servers.
It also includes a fix so that timeouts set apply to all services
that haven't been contacted yet.